### PR TITLE
Fix decimal reverse logic for 7-segment LEDs

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -878,7 +878,7 @@ namespace MobiFlight
 
 
                         var val = value.PadRight(cfg.DisplayLedDigits.Count, cfg.DisplayLedPaddingChar[0]);
-                        var decimalPoints = cfg.DisplayLedDecimalPoints;
+                        var decimalPoints = new List<string>(cfg.DisplayLedDecimalPoints);
 
                         if (cfg.DisplayLedPadding) val = value.PadLeft(cfg.DisplayLedPadding ? cfg.DisplayLedDigits.Count : 0, cfg.DisplayLedPaddingChar[0]);
 
@@ -899,7 +899,7 @@ namespace MobiFlight
                             val = new string(val.ToCharArray().Reverse().ToArray());
                             for (int i = 0; i != decimalPoints.Count; i++)
                             {
-                                decimalPoints[i] = (7 - int.Parse(decimalPoints[i])).ToString();
+                                decimalPoints[i] = (cfg.DisplayLedDigits.Count - int.Parse(decimalPoints[i]) - 1).ToString();
                             };
                         }
 


### PR DESCRIPTION
Fixes the problems with flashing decimal points:

* Create a shallow copy of the decimal point list so it doesn't reverse the original configuration every time the display is refreshed
* Use the actual number of digits when reversing instead of hardcoded `7`
* Add a `-1` to the reverse code to ensure the decimal point goes to the correct location

Tested with a 5 digit display and confirmed this works. @kkr0kk confirmed this works with a 7 digit display.