### PR TITLE
Fix typo in _loadPresetData()

### DIFF
--- a/UI/Panels/Config/SimConnectPanel.cs
+++ b/UI/Panels/Config/SimConnectPanel.cs
@@ -74,7 +74,7 @@ namespace MobiFlight.UI.Panels.Config
 
         private void _loadPresetData(String file, String DefaultGroupKey, String Prefix)
         {
-            string[] lines = System.IO.File.ReadAllLines(PresetFile);
+            string[] lines = System.IO.File.ReadAllLines(file);
             String GroupKey = DefaultGroupKey;
             data.Add(DefaultGroupKey, new List<SimVarPreset>());
 


### PR DESCRIPTION
Fixes #429 

Correct a typo in _loadPresetData() that caused duplicate copies of the default simvars to load instead of a copy of the user vars to load.