### PR TITLE
#467: Handle exceptions correctly

### DIFF
--- a/UI/Panels/Action/EventIdInputPanel.cs
+++ b/UI/Panels/Action/EventIdInputPanel.cs
@@ -146,6 +146,10 @@ namespace MobiFlight.UI.Panels.Action
                 errorMessage = oEx.Message;
                 e.Cancel = true;
             }
+            catch (Exception)
+            {
+                // Issue 467: Do nothing in this situation since the text box also allows variable replacement
+            }
 
             if (e.Cancel)
             {


### PR DESCRIPTION
Resolves #467.

Add a default exception handler when verifying the value for `Para` on an FSUIPC event handler.