### PR TITLE
Change check for whether multiple output pins are selected

### DIFF
--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -141,8 +141,8 @@ namespace MobiFlight.UI.Panels
         virtual internal OutputConfigItem syncToConfig(OutputConfigItem config)
         {
             config.Pin.DisplayPin = displayPortComboBox.Text + displayPinComboBox.Text;
-
-            if (MultiPinSelectPanel.Visible)
+            
+            if (selectMultiplePinsCheckBox.Checked)
                 config.Pin.DisplayPin = MultiPinSelectPanel?.GetSelectedPinString();                       
 
             config.Pin.DisplayPinBrightness = (byte)(255 * ((displayPinBrightnessTrackBar.Value) / (double)(displayPinBrightnessTrackBar.Maximum)));


### PR DESCRIPTION
Fixes #476 

Replace the check for whether the panel was ever visible with a check for whether the checkbox is selected.