### PR TITLE
Fix the tab order

### DIFF
--- a/UI/Panels/Action/VariableInputPanel.resx
+++ b/UI/Panels/Action/VariableInputPanel.resx
@@ -138,7 +138,7 @@
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ValueTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+    <value>2</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>VariableInputPanel</value>
@@ -147,7 +147,7 @@
     <value>11, 69</value>
   </data>
   <data name="TypeComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
+    <value>0</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="ValueLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
@@ -335,7 +335,7 @@
     <value>6</value>
   </data>
   <data name="NameTextBox.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
     <value>groupBox1</value>


### PR DESCRIPTION
Fixes #462 

Update the tab order for the three fields on the variable input panel.

