### PR TITLE
Disable the modules button until scan is complete

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -162,6 +162,7 @@ namespace MobiFlight.UI
 
             runToolStripButton.Enabled = false;
             runTestToolStripButton.Enabled = false;
+            settingsToolStripButton.Enabled = false;
             updateNotifyContextMenu(false);
 
             // Reset the Title of the Main Window so that it displays the Version too.
@@ -289,6 +290,7 @@ namespace MobiFlight.UI
             panelMain.Visible = true;
             startupPanel.Visible = false;
             menuStrip.Enabled = true;
+            settingsToolStripButton.Enabled = true;
 
             AutoUpdateChecker.CheckForUpdate(false, true);
 


### PR DESCRIPTION
Fixes #485 

Quick fix to disable the modules button in the toolbar until scanning of connected modules is complete. Leverages all the existing code that disables the run and test buttons until modules are detected.