### PR TITLE
Fixed visual truncation issue in Config References combo box

### DIFF
--- a/UI/Panels/Config/ConfigRefPanelItem.cs
+++ b/UI/Panels/Config/ConfigRefPanelItem.cs
@@ -27,6 +27,7 @@ namespace MobiFlight.UI.Panels.Config
             configRefComboBox.DataSource = dv;
             configRefComboBox.ValueMember = "guid";
             configRefComboBox.DisplayMember = "description";
+            configRefComboBox.Width = 395;
         }
 
         public void SetPlaceholder (String placeholder)


### PR DESCRIPTION
Fixes #495 

Increases the width of the Config References combo box to prevent visual truncation shown here
![image](https://user-images.githubusercontent.com/2242776/134629903-4f1cb8f3-5607-498b-867d-3533b34d75b0.png)

After the change:
![image](https://user-images.githubusercontent.com/2242776/134630055-07e77b12-98ee-42c0-ab9d-3ee62d8385e3.png)