### PR TITLE
Fixed On Press-On Release conflict for button event

### DIFF
--- a/FirmwareSource/libraries/MF_Modules/MFButton.cpp
+++ b/FirmwareSource/libraries/MF_Modules/MFButton.cpp
@@ -35,6 +35,20 @@ void MFButton::trigger()
         (*_handlerList[btnOnRelease])(btnOnRelease, _pin, _name);
 }
 
+void MFButton::triggerOnPress()
+{
+      if (_state==LOW && _handlerList[btnOnPress]!= NULL) {
+        (*_handlerList[btnOnPress])(btnOnPress, _pin, _name);
+      }
+}
+
+void MFButton::triggerOnRelease()
+{
+      if (_handlerList[btnOnRelease] != NULL) {
+        (*_handlerList[btnOnRelease])(btnOnRelease, _pin, _name);
+      }
+}
+
 void MFButton::attachHandler(byte eventId, buttonEvent newHandler)
 {
   _handlerList[eventId] = newHandler;

--- a/FirmwareSource/libraries/MF_Modules/MFButton.h
+++ b/FirmwareSource/libraries/MF_Modules/MFButton.h
@@ -37,6 +37,8 @@ public:
     MFButton(uint8_t pin = 1, const char * name = "Button");
     void update();
     void trigger();
+    void triggerOnPress();
+    void triggerOnRelease();
     void attachHandler(byte eventId, buttonEvent newHandler);    
     const char *  _name;
     uint8_t       _pin;

--- a/FirmwareSource/mobiflight/mobiflight.ino
+++ b/FirmwareSource/mobiflight/mobiflight.ino
@@ -40,7 +40,8 @@ char foo;
 // 1.11.0: Added Analog support, ShiftRegister Support (kudos to @manfredberry)
 // 1.11.1: minor bugfixes for BETA release
 // 1.11.2: fixed issue with one line LCD freeze
-const char version[8] = "1.11.2";
+// 1.11.3: Created simple prioritization mechanism for button events when using "Retrigger All Switches" (fires release events, then press events)
+const char version[8] = "1.11.3";
 
 //#define DEBUG 1
 #define MTYPE_MEGA 1
@@ -1226,7 +1227,16 @@ void _restoreName() {
 
 void OnTrigger()
 {
+  // Trigger all button release events first...
   for(int i=0; i!=buttonsRegistered; i++) {
-    buttons[i].trigger();
+    buttons[i].triggerOnRelease();
+  }
+  
+  // Introduce a small delay (this ensures the events occur in order)
+  delay(10);
+
+  // ... then trigger all the press events
+  for(int i=0; i!=buttonsRegistered; i++) {
+    buttons[i].triggerOnPress();
   }  
 }


### PR DESCRIPTION
This fixes #497 

Physical switches, such as an On-Off-On rocker switches using On Press events for the on positions (to explicitly set the switch position in-sim), and paired On Release events (to implicitly set the switch position to center in-sim) now set the expected position when using the "Retrigger All Switches" feature of MobiFlight firmware. This is accomplished by firing all Release events first, followed by all Press events.

The following scenarios were tested by purposefully de-synchronizing the physical rocker switch with the in-sim representation, then executing the "Retrigger All Switches" feature to evaluate the result in all possible combinations. For the sake of this example, the switch was placed in a horizontal orientation to match the in-sim representation of the A320 EFIS panel

![image](https://user-images.githubusercontent.com/2242776/134783609-1af014c5-dc98-4055-980e-c1f6531b13b2.png)

Test results:
| Initial Physical Switch State | In Sim Switch State (before retrigger) | In Sim Switch State (after retrigger) |
| --- | --- | --- |
| Left | Left | Left |
| Left | Center | Left |
| Left | Right| Left |
| Center | Left | Center |
| Center | Center | Center |
| Center | Right | Center |
| Right | Left | Right |
| Right | Center | Right |
| Right | Right | Right |