### PR TITLE
Save transform edits regardless of which tab is active when OK is pressed

### DIFF
--- a/UI/Panels/Config/FsuipcConfigPanel.cs
+++ b/UI/Panels/Config/FsuipcConfigPanel.cs
@@ -306,7 +306,7 @@ namespace MobiFlight.UI.Panels.Config
             }
 
             // TODO: refactor this conditional stuff.
-            if (fsuipcMultiplyTextBox.Visible)
+            if (config.Transform.Active)
                 config.Transform.Expression = fsuipcMultiplyTextBox.Text;
             if (SubStringFromTextBox.Text!="")
                 config.Transform.SubStrStart = Byte.Parse(SubStringFromTextBox.Text);


### PR DESCRIPTION
Fixes #516 

Instead of testing against the visibility of the control to determine whether the transform string should be saved use the state of the transform checkbox.