### PR TITLE
Remove unnecessary condition when marking used pins

### DIFF
--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -1125,13 +1125,8 @@ namespace MobiFlight
                 }
             }
 
-            foreach (byte i in usedPins)
-            {
-                if (i != 0)
-                {
-                    ResultPins.Find(item => item.Pin == i).Used = true;
-                }                
-            }
+            // Mark all the used pins as used in the result list.
+            usedPins.ForEach(pin => ResultPins.Find(resultPin => resultPin.Pin == pin).Used = true);
 
             if (FreeOnly)
                 ResultPins = ResultPins.FindAll(x => x.Used == false);


### PR DESCRIPTION
Fixes #517 

* Remove the `if (i != 0)` check
* Convert to C#-style ForEach() instead of a loop