### PR TITLE
Add error handling for settings upgrade

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -415,7 +415,17 @@ namespace MobiFlight.UI
         {
             if (Properties.Settings.Default.UpgradeRequired)
             {
-                Properties.Settings.Default.Upgrade();
+                try
+                {
+                    Properties.Settings.Default.Upgrade();
+                }
+                catch
+                {
+                    // If the properties file is corrupted for some reason catch the exception and
+                    // reset back to a default version.
+
+                    Properties.Settings.Default.Reset();
+                }
                 Properties.Settings.Default.UpgradeRequired = false;
                 Properties.Settings.Default.StartedTotal += Properties.Settings.Default.Started;
                 Properties.Settings.Default.Started = 0;


### PR DESCRIPTION
Fixes #531 

Added a try/catch block for settings upgrade.

Since I don't Jaime's original file I can't reproduce the issue but in theory this code will catch the exception and fall back to the default settings instead of crashing.