### PR TITLE
Add script to pull firmware releases from GitHub

### DIFF
--- a/Build/get_firmware.ps1
+++ b/Build/get_firmware.ps1
@@ -1,4 +1,4 @@
-param ($version = "latest", $outDir = "./")
+param ($version = "latest", $outDir = "../firmware")
 
 # Create the output folder if it doesn't exist
 if (!(Test-Path $outDir)) {


### PR DESCRIPTION
Adds a powershell script to pull firmware releases from GitHub, storing them in the firmware folder so they are ready for use with MobiFlightConnector release builds.

By default this will pull the latest version from GitHub. To pull a different version simply specify `-version` on the command line using MobiFlight-style version numbers (e.g. `1.0.0`, notice there is no `v` in front of it).

```powershell
.\get_firmware.ps1 -version 1.0.0
```

Note that pre-release builds are not considered `latest` so to pull down a pre-release firmware you **must** specify the version number of the pre-release build.