### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default CODEOWNERS for the repo
+* @MobiFlight-Admin


### PR DESCRIPTION
Fixes #542

This should be sufficient to make the MobiFlight-Admin account automatically get added to all new pull requests. If not there's one additional checkbox to set in the repo settings.