### PR TITLE
Support for MinimumFirmwareVersion

### DIFF
--- a/Boards/arduino_mega.board.json
+++ b/Boards/arduino_mega.board.json
@@ -34,6 +34,7 @@
     "DelayAfterFirmwareUpdate": 0,
     "LatestFirmwareVersion": "1.12.1",
     "FriendlyName": "Arduino Mega 2560",
+    "MinimumFirmwareVersion": "0.0.1",
     "MobiFlightType": "MobiFlight Mega"
   },
   "ModuleLimits": {

--- a/Boards/arduino_micro.board.json
+++ b/Boards/arduino_micro.board.json
@@ -24,6 +24,7 @@
     "CanInstallFirmware": true,
     "FriendlyName": "Arduino Micro Pro",
     "LatestFirmwareVersion": "1.12.1",
+    "MinimumFirmwareVersion":  "0.0.1",
     "MobiFlightType": "MobiFlight Micro"
   },
   "ModuleLimits": {

--- a/Boards/arduino_uno.board.json
+++ b/Boards/arduino_uno.board.json
@@ -20,6 +20,7 @@
     "CanInstallFirmware": true,
     "FriendlyName": "Arduino Uno",
     "LatestFirmwareVersion": "1.12.1",
+    "MinimumFirmwareVersion": "0.0.1",
     "MobiFlightType": "MobiFlight Uno"
   },
   "ModuleLimits": {

--- a/Boards/mfboard.schema.json
+++ b/Boards/mfboard.schema.json
@@ -120,6 +120,7 @@
         "CanInstallFirmware",
         "FriendlyName",
         "LatestFirmwareVersion",
+        "MinimumFirmwareVersion",
         "MobiFlightType"
       ],
       "properties": {
@@ -139,7 +140,15 @@
           "$id": "#root/Info/LatestFirmwareVersion",
           "title": "Latestfirmwareversion",
           "description": "The latest supported version of the firmware.",
-          "type": "string"
+          "type": "string",
+          "pattern": "\\d+\\.\\d+\\.\\d+"
+        },
+        "MinimumFirmwareVersion": {
+          "$id": "#root/Info/MinimumFirmwareVersion",
+          "title": "MinimumFirmwareVersion",
+          "description": "The lowest firmware version that works with this board definition.",
+          "type": "string",
+          "pattern": "\\d+\\.\\d+\\.\\d+"
         },
         "MobiFlightType": {
           "$id": "#root/Info/MobiFlightType",

--- a/MobiFlight/Board.cs
+++ b/MobiFlight/Board.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -36,9 +38,9 @@ namespace MobiFlight
         /// </summary>
         /// <param name="latestFirmwareVersion">The version of the firmware, for example "1.14.0".</param>
         /// <returns>The firmware file name using FirmwareBaseName and the specified firmware version.</returns>
-        public string GetFirmwareName(string latestFirmwareVersion)
+        public string GetFirmwareName(Version latestFirmwareVersion)
         {
-            return $"{FirmwareBaseName}_{latestFirmwareVersion.Replace('.', '_')}.hex";
+            return $"{FirmwareBaseName}_{latestFirmwareVersion.ToString().Replace('.', '_')}.hex";
         }
     }
 
@@ -101,7 +103,14 @@ namespace MobiFlight
         /// <summary>
         /// The latest supported version of the firmware.
         /// </summary>
-        public String LatestFirmwareVersion;
+        [JsonConverter(typeof(VersionConverter))]
+        public Version LatestFirmwareVersion = new Version(0, 0, 0);
+
+        /// <summary>
+        /// The lowest firmware version that works with this board definition.
+        /// </summary>
+        [JsonConverter(typeof(VersionConverter))]
+        public Version MinimumFirmwareVersion = new Version(0, 0, 0);
 
         /// <summary>
         /// The type of the board as provided by the MobiFlight firmware.
@@ -190,6 +199,37 @@ namespace MobiFlight
         public override string ToString()
         {
             return $"{Info.MobiFlightType} ({Info.FriendlyName})";
+        }
+    }
+
+    public class VersionConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("Not implemented yet");
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.String)
+            {
+                var versionString = serializer.Deserialize(reader, objectType).ToString();
+                return new Version(versionString);
+            }
+            else
+            {
+                return new Version(0, 0, 0);
+            }
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return false;
         }
     }
 }

--- a/MobiFlight/BoardDefinitions.cs
+++ b/MobiFlight/BoardDefinitions.cs
@@ -61,7 +61,7 @@ namespace MobiFlight
                 return null;
             }
 
-            // Sort the boards in descending order by MinimumFirmwareVersion
+            // Sort the boards in descending order by MinimumFirmwareVersion to find the best match.
             candidateBoards.Sort((y, x) => x.Info.MinimumFirmwareVersion.CompareTo(y.Info.MinimumFirmwareVersion));
 
             // Return the first board in the sorted list, which will be the one with the highest MinimumFirmwareVersion.

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -723,7 +723,7 @@ namespace MobiFlight
             //
             // This check and assignment is done outside of the above if statement to catch cases
             // where there was no firmware installed.
-            devInfo.Board = BoardDefinitions.GetBoardByMobiFlightType(devInfo.Type) ?? Board;
+            devInfo.Board = BoardDefinitions.GetBoardByMobiFlightType(devInfo.Type, devInfo.Version) ?? Board;
             Board = devInfo.Board;
 
             Log.Instance.log($"MobiFlightModule.GetInfo: {Type}, {Name}, {Version}, {Serial}", LogSeverity.Debug);

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -335,9 +335,8 @@ namespace MobiFlight.UI
             {
                 if (module.Board.Info.CanInstallFirmware)
                 {
-                    Version latestVersion = new Version(module.Board.Info.LatestFirmwareVersion);
                     Version currentVersion = new Version(module.Version != null ? module.Version : "0.0.0");
-                    if (currentVersion.CompareTo(latestVersion) < 0)
+                    if (currentVersion.CompareTo(module.Board.Info.LatestFirmwareVersion) < 0)
                     {
                         // Update needed!!!
                         modulesForUpdate.Add(module);

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -98,10 +98,8 @@ namespace MobiFlight.UI.Panels.Settings
                     }
                     else
                     {
-                        Version latestVersion = new Version(module.Board.Info.LatestFirmwareVersion);
-
                         Version currentVersion = new Version(!String.IsNullOrEmpty(module.Version) ? module.Version : "0.0.0");
-                        if (currentVersion.CompareTo(latestVersion) < 0)
+                        if (currentVersion.CompareTo(module.Board.Info.LatestFirmwareVersion) < 0)
                         {
                             node.SelectedImageKey = node.ImageKey = "module-update";
                             node.ToolTipText = i18n._tr("uiMessageSettingsDlgOldFirmware");


### PR DESCRIPTION
* Added `MinimumFirmwareVersion` to the board definition files
* Changed the version properties on the `Info` class to be true `Version` objects
* Add a JSON serializer to convert the string in the board file to real `Version` objects
* Clean up a few places in the code that can now use the version properties directly
* Add additional logic to `BoardDefinitions.GetBoardByMobiFlightType` that takes into account the minimum firmware version
* Add some additional validation to the JSON schema to enforce version format