### PR TITLE
Check for corrupt settings on launch

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Threading;
 using MobiFlight.UI;
+using System.Configuration;
 
 namespace MobiFlight
 {
@@ -17,8 +18,10 @@ namespace MobiFlight
         {
             if (mutex.WaitOne(TimeSpan.Zero, true))
             {
-               // if (Environment.OSVersion.Version.Major >= 6)
-              //      SetProcessDPIAware();
+                // if (Environment.OSVersion.Version.Major >= 6)
+                //      SetProcessDPIAware();
+
+                CheckForCorruptSettings();
 
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(true);
@@ -34,6 +37,53 @@ namespace MobiFlight
                     NativeMethods.WM_SHOWME,
                     IntPtr.Zero,
                     IntPtr.Zero);
+            }
+        }
+
+        // The .NET Settings system can result in corrupted settings files if the PC crashes while the app is running.
+        // Unfortunately this is a not uncommon occurrence when using Microsoft Flight Simulator 2020. It's hard to
+        // catch the exception from the underlying settings system so instead the common solution is to test the
+        // validity of the settings file before ever referencing it in code and then deleting if the file is
+        // corrupted. This causes the settings system to automatically load the defaults in the case of a corrupted
+        // file. This solution comes from https://stackoverflow.com/a/18905791.
+        // 
+        // Returns true if a corrupt config was found.
+        private static void CheckForCorruptSettings()
+        {
+            try
+            {
+                var config = ConfigurationManager.OpenExeConfiguration(ConfigurationUserLevel.PerUserRoamingAndLocal);
+            }
+            catch (ConfigurationErrorsException ex)
+            {
+                string filename = string.Empty;
+                if (!string.IsNullOrEmpty(ex.Filename))
+                {
+                    filename = ex.Filename;
+                }
+                else
+                {
+                    var innerEx = ex.InnerException as ConfigurationErrorsException;
+                    if (innerEx != null && !string.IsNullOrEmpty(innerEx.Filename))
+                    {
+                        filename = innerEx.Filename;
+                    }
+                }
+
+                if (!string.IsNullOrEmpty(filename))
+                {
+                    if (System.IO.File.Exists(filename))
+                    {
+                        var fileInfo = new System.IO.FileInfo(filename);
+                        var watcher
+                             = new System.IO.FileSystemWatcher(fileInfo.Directory.FullName, fileInfo.Name);
+                        System.IO.File.Delete(filename);
+                        if (System.IO.File.Exists(filename))
+                        {
+                            watcher.WaitForChanged(System.IO.WatcherChangeTypes.Deleted);
+                        }
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #589 

It's apparently a known thing with the .NET settings framework that the user config file can get corrupted if the PC crashes while an app is running that uses settings.

Unfortunately, Flight Simulator 2020 likes to crash PCs so this isn't as rare for MobiFlight users as one would expect.

The fix is to manually test the settings file for validity before anything in the app references `Settings.Default` and if a corrupt file is detected delete it. This will cause the settings framework to use defaults.