### PR TITLE
Fix errors in isPWM and isI2C pin assignments for the mega board config

### DIFF
--- a/Boards/arduino_mega.board.json
+++ b/Boards/arduino_mega.board.json
@@ -51,74 +51,74 @@
   "Pins": [
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 2
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 3
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 4
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 5
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 6
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 7
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 8
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 9
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 10
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 11
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 12
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 13
     },
     {
@@ -303,20 +303,20 @@
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 44
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 45
     },
     {
       "isAnalog": false,
-      "isI2C": true,
-      "isPWM": false,
+      "isI2C": false,
+      "isPWM": true,
       "Pin": 46
     },
     {


### PR DESCRIPTION
Fixes #189 

* Make the `isI2C` and `isPWM` pin assignments correct based on what was previously assigned in `MobiFlightModuleInfo.cs` before the move to a separate board configuration file

I also reviewed the micro and uno board configs, they were fine.