### PR TITLE
Guard against failed firmware updates

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -285,6 +285,14 @@ namespace MobiFlight
         {
             Log.Instance.log("MobiFlightCache.RegisterModule("+m.Name+":"+ m.Port +")", LogSeverity.Debug);
             
+            // Additional protection added for edge cases where this gets called after a failed firmware update, which resulted
+            // in the exception reported in issue 611.
+            if (String.IsNullOrEmpty(devInfo.Serial))
+            {
+                Log.Instance.log("A module with a null or empty serial number was specified and will not be registered.", LogSeverity.Error);
+                return;
+            }    
+
             if (Modules.ContainsKey(devInfo.Serial))
             {
                 if (replace)

--- a/UI/Forms/FirmwareUpdateProcess.cs
+++ b/UI/Forms/FirmwareUpdateProcess.cs
@@ -108,8 +108,7 @@ namespace MobiFlight.UI.Forms
 
             int timeout = 15000;
             var task = Task<bool>.Run(() => {
-                bool UpdateResult = false;
-                UpdateResult = MobiFlightFirmwareUpdater.Update(module);
+                bool UpdateResult = MobiFlightFirmwareUpdater.Update(module);
                 return UpdateResult;
             });
             if (await Task.WhenAny(task, Task.Delay(timeout)) == task)

--- a/UI/Forms/FirmwareUpdateProcess.cs
+++ b/UI/Forms/FirmwareUpdateProcess.cs
@@ -108,7 +108,8 @@ namespace MobiFlight.UI.Forms
 
             int timeout = 15000;
             var task = Task<bool>.Run(() => {
-                bool UpdateResult = MobiFlightFirmwareUpdater.Update(module);
+                bool UpdateResult = false;
+                UpdateResult = MobiFlightFirmwareUpdater.Update(module);
                 return UpdateResult;
             });
             if (await Task.WhenAny(task, Task.Delay(timeout)) == task)
@@ -125,6 +126,9 @@ namespace MobiFlight.UI.Forms
 
                 if (!task.Result)
                     FailedModules.Add(module);
+                // Fix for issue 611: only call OnAfterFirmwareUpdate for the module if the update was successful.
+                else
+                    OnAfterFirmwareUpdate?.Invoke(module, null);
             }
             else
             {
@@ -136,14 +140,10 @@ namespace MobiFlight.UI.Forms
                                     module.Port,
                                     TotalModuleCount - NumberOfModulesForFirmwareUpdate,
                                     TotalModuleCount
-                                    );
-
-                
+                                    ); 
             };
 
             progressBar1.Value = (int)Math.Round(progressBar1.Maximum * ((TotalModuleCount - NumberOfModulesForFirmwareUpdate) / (float)TotalModuleCount));
-
-            OnAfterFirmwareUpdate?.Invoke(module, null);
 
             if (NumberOfModulesForFirmwareUpdate == 0)
             {

--- a/UI/Forms/FirmwareUpdateProcess.cs
+++ b/UI/Forms/FirmwareUpdateProcess.cs
@@ -125,9 +125,6 @@ namespace MobiFlight.UI.Forms
 
                 if (!task.Result)
                     FailedModules.Add(module);
-                // Fix for issue 611: only call OnAfterFirmwareUpdate for the module if the update was successful.
-                else
-                    OnAfterFirmwareUpdate?.Invoke(module, null);
             }
             else
             {
@@ -143,6 +140,8 @@ namespace MobiFlight.UI.Forms
             };
 
             progressBar1.Value = (int)Math.Round(progressBar1.Maximum * ((TotalModuleCount - NumberOfModulesForFirmwareUpdate) / (float)TotalModuleCount));
+
+            OnAfterFirmwareUpdate?.Invoke(module, null);
 
             if (NumberOfModulesForFirmwareUpdate == 0)
             {

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -895,10 +895,20 @@ namespace MobiFlight.UI.Panels.Settings
             if (module == null)
             {
                 return;
-            }
+            }           
 
             module.Connect();
             MobiFlightModuleInfo newInfo = module.GetInfo() as MobiFlightModuleInfo;
+
+            // Issue 611
+            // If the board definition file is correct but the firmware failed to flash and the result is
+            // a bare module with no MobiFlight firmware on it then the serial number will be null
+            // and the module should not be refreshed.
+            if (String.IsNullOrEmpty(newInfo.Serial))
+            {
+                return;
+            }
+
             mobiflightCache.RefreshModule(module);
 
             OnAfterFirmwareUpdate?.Invoke(module, null);


### PR DESCRIPTION
Fixes #611

* Move when `OnAfterFirmwareUpdate` gets called so it only happens on successful firmware updates
* Add a check for null values to `RegisterModule` to avoid the crash in other situations where the serial number might be null.