### PR TITLE
Add Active to list of elements that are tested for Equals()

### DIFF
--- a/MobiFlight/Interpolation.cs
+++ b/MobiFlight/Interpolation.cs
@@ -160,6 +160,7 @@ namespace MobiFlight
                 Max == (obj as Interpolation).Max &&
                 Min == (obj as Interpolation).Min &&
                 Count == (obj as Interpolation).Count &&
+                Active == (obj as Interpolation).Active &&
                 entriesAreSame;
         }
     }

--- a/MobiFlightUnitTests/InterpolationTests.cs
+++ b/MobiFlightUnitTests/InterpolationTests.cs
@@ -52,22 +52,24 @@ namespace MobiFlightUnitTests
 
             Assert.IsTrue(o1.Equals(o2));
 
+            // Verify that Active is used in the equals comparison
+            o1.Active = true;
+            Assert.IsFalse(o1.Equals(o2));
+
+            // Verify that a list of interpolations is used in the equals comparison
             float x1 = 0.1f; float y1 = 0.1f;
             float x3 = 0.5f; float y3 = 2.0f;
             float x2 = 1.0f; float y2 = 1.0f;
-            o1.Active = true;
             o1.Add(x1, y1);
             o1.Add(x2, y2);
             o1.Add(x3, y3);
-
             Assert.IsFalse(o1.Equals(o2));
 
-            o2.Active = true;
             o2.Add(x1, y1);
             o2.Add(x2, y2);
             o2.Add(x3, y3);
+            o2.Active = true;
             Assert.IsTrue(o1.Equals(o2));
-
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixes #607 

The `Equals()` method on `Interpolation` wasn't including `Active` in the list of values that must be the same for two interpolation objects to be equals. Adding the test is sufficient to make the Save button work correctly.