### PR TITLE
Remove "v" from get_firmware script

### DIFF
--- a/Build/get_firmware.ps1
+++ b/Build/get_firmware.ps1
@@ -11,7 +11,7 @@ if ($version -eq "latest") {
 }
 else {
   Write-Output "Downloading firmware version $($version)"
-  $releaseDetails = Invoke-RestMethod -Uri "https://api.github.com/repos/MobiFlight/MobiFlight-FirmwareSource/releases/tags/v${version}"
+  $releaseDetails = Invoke-RestMethod -Uri "https://api.github.com/repos/MobiFlight/MobiFlight-FirmwareSource/releases/tags/${version}"
 }
 
 # The list of assets also includes the zipped source code so filter it to just the

--- a/Build/get_firmware.ps1
+++ b/Build/get_firmware.ps1
@@ -1,17 +1,17 @@
-param ($version = "latest", $outDir = "../firmware")
+param ($tag = "latest", $outDir = "../firmware")
 
 # Create the output folder if it doesn't exist
 if (!(Test-Path $outDir)) {
   New-Item -ItemType Directory -Force -Path $outDir | Out-Null
 }
 
-if ($version -eq "latest") {
+if ($tag -eq "latest") {
   Write-Output "Downloading latest release"
   $releaseDetails = Invoke-RestMethod -Uri "https://api.github.com/repos/MobiFlight/MobiFlight-FirmwareSource/releases/latest"
 }
 else {
-  Write-Output "Downloading firmware version $($version)"
-  $releaseDetails = Invoke-RestMethod -Uri "https://api.github.com/repos/MobiFlight/MobiFlight-FirmwareSource/releases/tags/${version}"
+  Write-Output "Downloading firmware tag $($tag)"
+  $releaseDetails = Invoke-RestMethod -Uri "https://api.github.com/repos/MobiFlight/MobiFlight-FirmwareSource/releases/tags/${tag}"
 }
 
 # The list of assets also includes the zipped source code so filter it to just the


### PR DESCRIPTION
Fixes #621

Instead of assuming all tags start with "v" in the firmware source repo require the script get called with the actual version tag.

Change the command line parameter from "version" to "tag" to accurately reflect what it is.