### PR TITLE
Added the missing 7 option from "Number of Digits" dropdown

### DIFF
--- a/UI/Panels/Output/DisplayLedDisplayPanel.Designer.cs
+++ b/UI/Panels/Output/DisplayLedDisplayPanel.Designer.cs
@@ -217,7 +217,8 @@
             resources.GetString("displayLedModuleSizeComboBox.Items1"),
             resources.GetString("displayLedModuleSizeComboBox.Items2"),
             resources.GetString("displayLedModuleSizeComboBox.Items3"),
-            resources.GetString("displayLedModuleSizeComboBox.Items4")});
+            resources.GetString("displayLedModuleSizeComboBox.Items4"),
+            resources.GetString("displayLedModuleSizeComboBox.Items5")});
             resources.ApplyResources(this.displayLedModuleSizeComboBox, "displayLedModuleSizeComboBox");
             this.displayLedModuleSizeComboBox.Name = "displayLedModuleSizeComboBox";
             this.displayLedModuleSizeComboBox.SelectedIndexChanged += new System.EventHandler(this.comboBox1_SelectedIndexChanged);

--- a/UI/Panels/Output/DisplayLedDisplayPanel.resx
+++ b/UI/Panels/Output/DisplayLedDisplayPanel.resx
@@ -664,6 +664,9 @@
     <value>6</value>
   </data>
   <data name="displayLedModuleSizeComboBox.Items4" xml:space="preserve">
+    <value>7</value>
+  </data>
+  <data name="displayLedModuleSizeComboBox.Items5" xml:space="preserve">
     <value>8</value>
   </data>
   <data name="displayLedModuleSizeComboBox.Location" type="System.Drawing.Point, System.Drawing">


### PR DESCRIPTION
The "Number of digits dropdown for LED display modules was missing the 7 option.