### PR TITLE
Add Genuino UNO

### DIFF
--- a/Boards/arduino_uno.board.json
+++ b/Boards/arduino_uno.board.json
@@ -16,7 +16,7 @@
     "ForceResetOnFirmwareUpdate": false,
     "MessageSize": 32
   },
-  "HardwareIds": ["^VID_2341&PID_0043", "^VID_2A03&PID_0043"],
+  "HardwareIds": [ "^VID_2341&PID_0043", "^VID_2A03&PID_0043", "^VID_2341&PID_0243" ],
   "Info": {
     "CanInstallFirmware": true,
     "FriendlyName": "Arduino Uno",


### PR DESCRIPTION
The Genuino UNO is an official (but older) Arduino UNO. I have one, and I managed to get it working by adding the proper PID value.
I tested this by rebuilding mobiflight and connecting it to MSFS 2020. I added a dual button setup for HDG inc and dec and it worked fine.
The test suite is unaffected by the change.