### PR TITLE
Correct output shifter log message

### DIFF
--- a/MobiFlight/MobiFlightShiftRegister.cs
+++ b/MobiFlight/MobiFlightShiftRegister.cs
@@ -63,7 +63,7 @@ namespace MobiFlight
 
             Log.Instance.log("Command: SetShiftRegisterPin <" + (int)MobiFlightModule.Command.SetShiftRegisterPins + "," +
                                                       this.ModuleNumber + "," +
-                                                      outputPins + "," +
+                                                      pinsOnly + "," +
                                                       value + ";>", LogSeverity.Debug);
             // Send command
             CmdMessenger.SendCommand(command);


### PR DESCRIPTION
Fixes #662 

Replace the variable used for the log message with the correct one.