### PR TITLE
All devices have a Stop() method now.

### DIFF
--- a/MobiFlight/IConnectedDevice.cs
+++ b/MobiFlight/IConnectedDevice.cs
@@ -9,5 +9,7 @@ namespace MobiFlight
     {
         String Name { get; }
         DeviceType Type { get; }
+
+        void Stop();
     }
 }

--- a/MobiFlight/MobiFlightAnalogInput.cs
+++ b/MobiFlight/MobiFlightAnalogInput.cs
@@ -29,5 +29,11 @@ namespace MobiFlight
 
             return eventAction;
         }
+
+        public void Stop()
+        {
+            // do nothing
+            return;
+        }
     }
 }

--- a/MobiFlight/MobiFlightButton.cs
+++ b/MobiFlight/MobiFlightButton.cs
@@ -39,5 +39,10 @@ namespace MobiFlight
 
             return eventAction;
         }
+        public void Stop()
+        {
+            // do nothing
+            return;
+        }
     }
 }

--- a/MobiFlight/MobiFlightEncoder.cs
+++ b/MobiFlight/MobiFlightEncoder.cs
@@ -46,5 +46,11 @@ namespace MobiFlight
 
             return eventAction;
         }
+
+        public void Stop()
+        {
+            // do nothing
+            return;
+        }
     }
 }

--- a/MobiFlight/MobiFlightInputShiftRegister.cs
+++ b/MobiFlight/MobiFlightInputShiftRegister.cs
@@ -67,5 +67,11 @@ namespace MobiFlight
             if (_initialized) return;
             _initialized = true;
         }
+
+        public void Stop()
+        {
+            // do nothing
+            return;
+        }
     }
 }

--- a/MobiFlight/MobiFlightLcdDisplay.cs
+++ b/MobiFlight/MobiFlightLcdDisplay.cs
@@ -57,7 +57,7 @@ namespace MobiFlight
             _initialized = true;
         }
 
-        public void Display(string address, String value)
+        public void Display(String value)
         {
             if (!_initialized) Initialize();
 
@@ -127,6 +127,12 @@ namespace MobiFlight
             result += String.Join("", lineArray);
 
             return result;
+        }
+
+        public void Stop()
+        {
+            Display(new string(' ', Cols * Lines));
+            return;
         }
     }
 }

--- a/MobiFlight/MobiFlightLedModule.cs
+++ b/MobiFlight/MobiFlightLedModule.cs
@@ -99,5 +99,12 @@ namespace MobiFlight
             // Send command
             CmdMessenger.SendCommand(command);
         }
+
+        // Blank the display when stopped
+        public void Stop()
+        {
+            for (int i = 0; i != SubModules; i++)
+                Display(i, "        ", 0, 0xff);
+        }
     }
 }

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -642,7 +642,7 @@ namespace MobiFlight
 
             lastValue[key] = cachedValue;
 
-            lcdDisplays[address].Display(address, value);
+            lcdDisplays[address].Display(value);
             return true;
         }
 
@@ -1016,23 +1016,17 @@ namespace MobiFlight
 
         public void Stop()
         {
-            foreach (MobiFlightOutput output in outputs.Values)
-            {
-                SetPin("base", output.Name, 0);
-            }
-            
-            foreach (MobiFlightLedModule module in ledModules.Values)
-            {
-                for(int i = 0; i!=module.SubModules;i++)
-                    SetDisplay(module.Name, i, 0, 0xff, "        ");
-            }
-            
-            foreach (MobiFlightStepper stepper in stepperModules.Values)
-            {
-                SetStepper(stepper.Name, 0);
-            }
-
+            // Always clear the cache 
+            // also in case maybe later something goes wrong
+            // we will simply resend the value in that case
+            // when we start again
             lastValue.Clear();
+
+            // we have to make sure to not send messages
+            // when we are not connected
+            if (!this.connected) return;
+            
+            GetConnectedDevices().ForEach(device => device.Stop());                      
         }
 
         public List<MobiFlightPin> GetFreePins()

--- a/MobiFlight/MobiFlightOutput.cs
+++ b/MobiFlight/MobiFlightOutput.cs
@@ -42,5 +42,10 @@ namespace MobiFlight
 
             CmdMessenger.SendCommand(command);
         }
+
+        public void Stop()
+        {
+            Set(0);
+        }
     }
 }

--- a/MobiFlight/MobiFlightServo.cs
+++ b/MobiFlight/MobiFlightServo.cs
@@ -60,5 +60,10 @@ namespace MobiFlight
             // Send command
             CmdMessenger.SendCommand(command);
         }
+
+        public void Stop()
+        {
+            MoveToPosition(0);
+        }
     }
 }

--- a/MobiFlight/MobiFlightShiftRegister.cs
+++ b/MobiFlight/MobiFlightShiftRegister.cs
@@ -68,5 +68,11 @@ namespace MobiFlight
             // Send command
             CmdMessenger.SendCommand(command);
         }
+
+        public void Stop()
+        {
+            for (int i = 0; i != NumberOfShifters; i++)
+                Display("0|1|2|3|4|5|6|7", "255");
+        }
     }
 }

--- a/MobiFlight/MobiFlightStepper.cs
+++ b/MobiFlight/MobiFlightStepper.cs
@@ -119,5 +119,10 @@ namespace MobiFlight
             // Send command
             CmdMessenger.SendCommand(command);
         }
+
+        public void Stop()
+        {
+            MoveToPosition(0, true);
+        }
     }
 }


### PR DESCRIPTION
All devices are stopped when the MobiFlightCache is stopped.

Open issues: The Test Mode Stop uses a different way to stop the device.

fixes #657 