### PR TITLE
Handle null config case when updating serials

### DIFF
--- a/UI/Dialogs/OrphanedSerialsDialog.cs
+++ b/UI/Dialogs/OrphanedSerialsDialog.cs
@@ -77,7 +77,7 @@ namespace MobiFlight.UI.Dialogs
             foreach (DataRow row in configDataTable.Rows)
             {
                 OutputConfigItem cfg = row["settings"] as OutputConfigItem;
-                if (cfg.DisplaySerial == oldSerial)
+                if (cfg?.DisplaySerial == oldSerial)
                 {
                     cfg.DisplaySerial = newSerial;
                     row["settings"] = cfg;
@@ -87,7 +87,7 @@ namespace MobiFlight.UI.Dialogs
             foreach (DataRow row in inputDataTable.Rows)
             {
                 InputConfigItem cfg = row["settings"] as InputConfigItem;
-                if (cfg.ModuleSerial == oldSerial)
+                if (cfg?.ModuleSerial == oldSerial)
                 {
                     cfg.ModuleSerial = newSerial;
                     row["settings"] = cfg;


### PR DESCRIPTION
Fixes #670 

Make sure to handle the case where the config row is null.