### PR TITLE
Increase device limits on Uno

### DIFF
--- a/Boards/arduino_uno.board.json
+++ b/Boards/arduino_uno.board.json
@@ -24,13 +24,13 @@
     "MobiFlightType": "MobiFlight Uno"
   },
   "ModuleLimits": {
-    "MaxAnalogInputs": 3,
-    "MaxButtons": 8,
+    "MaxAnalogInputs": 6,
+    "MaxButtons": 18,
     "MaxEncoders": 3,
     "MaxInputShifters":  2,
     "MaxLcdI2C": 2,
     "MaxLedSegments": 1,
-    "MaxOutputs": 8,
+    "MaxOutputs": 18,
     "MaxServos": 2,
     "MaxShifters": 2,
     "MaxSteppers": 2


### PR DESCRIPTION
Fixes #715

* Increase buttons to 18
* Increase outputs to 18
* Increase analog inputs to 6