### PR TITLE
Use WMI to detect devices instead of the system registry

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -177,12 +177,14 @@ namespace MobiFlight
         {
             Log.Instance.log("MobiFlightCache.LookupAllConnectedArduinoModulesAsync: Start", LogSeverity.Debug);
             List<MobiFlightModuleInfo> result = new List<MobiFlightModuleInfo>();
+            string[] connectedPorts = SerialPort.GetPortNames();
 
             if (_lookingUpModules) return result;
             _lookingUpModules = true;
             
             List<Task<MobiFlightModuleInfo>> tasks = new List<Task<MobiFlightModuleInfo>>();
             var supportedPorts = getSupportedPorts();
+            List<string> connectingPorts = new List<string>();
             
             for (var i = 0; i != supportedPorts.Count; i++)
             {
@@ -190,6 +192,19 @@ namespace MobiFlight
                 String portName = port.Key;
                 Board board = port.Value;
                 int progressValue = (i * 25) / supportedPorts.Count;
+
+                if (!connectedPorts.Contains(portName))
+                {
+                    Log.Instance.log("MobiFlightCache.LookupAllConnectedArduinoModulesAsync: Port not connected ("+portName+")", LogSeverity.Debug);
+                    continue;
+                }
+                if (connectingPorts.Contains(portName))
+                {
+                    Log.Instance.log("MobiFlightCache.LookupAllConnectedArduinoModulesAsync: Port already connecting (" + portName + ")", LogSeverity.Debug);
+                    continue;
+                }
+
+                connectingPorts.Add(portName);
 
                 tasks.Add(Task.Run(() =>
                 {

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -131,7 +131,7 @@ namespace MobiFlight
                 // is null.
                 if (!rawHardwareID?.StartsWith("USB") ?? false)
                 {
-                    Log.Instance.log($"Incompatible module skipped: VID/PID: {rawHardwareID}", LogSeverity.Debug);
+                    Log.Instance.log($"Incompatible module skipped: {rawHardwareID}", LogSeverity.Debug);
                     continue;
                 }
 
@@ -145,7 +145,7 @@ namespace MobiFlight
                 // If no matching board definition is found at this point then it's an incompatible board and just keep going.
                 if (board == null)
                 {
-                    Log.Instance.log($"Incompatible module skipped: VID/PID: {hardwareId}", LogSeverity.Debug);
+                    Log.Instance.log($"Incompatible module skipped: {hardwareId}", LogSeverity.Debug);
                     continue;
                 }
 

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -177,14 +177,12 @@ namespace MobiFlight
         {
             Log.Instance.log("MobiFlightCache.LookupAllConnectedArduinoModulesAsync: Start", LogSeverity.Debug);
             List<MobiFlightModuleInfo> result = new List<MobiFlightModuleInfo>();
-            string[] connectedPorts = SerialPort.GetPortNames();
 
             if (_lookingUpModules) return result;
             _lookingUpModules = true;
             
             List<Task<MobiFlightModuleInfo>> tasks = new List<Task<MobiFlightModuleInfo>>();
             var supportedPorts = getSupportedPorts();
-            List<string> connectingPorts = new List<string>();
             
             for (var i = 0; i != supportedPorts.Count; i++)
             {
@@ -192,19 +190,6 @@ namespace MobiFlight
                 String portName = port.Key;
                 Board board = port.Value;
                 int progressValue = (i * 25) / supportedPorts.Count;
-
-                if (!connectedPorts.Contains(portName))
-                {
-                    Log.Instance.log("MobiFlightCache.LookupAllConnectedArduinoModulesAsync: Port not connected ("+portName+")", LogSeverity.Debug);
-                    continue;
-                }
-                if (connectingPorts.Contains(portName))
-                {
-                    Log.Instance.log("MobiFlightCache.LookupAllConnectedArduinoModulesAsync: Port already connecting (" + portName + ")", LogSeverity.Debug);
-                    continue;
-                }
-
-                connectingPorts.Add(portName);
 
                 tasks.Add(Task.Run(() =>
                 {

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -7,6 +7,7 @@ using Microsoft.Win32;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Management;
 
 namespace MobiFlight
 {
@@ -106,62 +107,60 @@ namespace MobiFlight
 
         private static Dictionary<string, Board> getSupportedPorts()
         {
+            var portNameRegEx = "\\(.*\\)";
             var result = new Dictionary<string, Board>();
 
-            RegistryKey regLocalMachine = Registry.LocalMachine;
-
-            string[] regPaths = {
-                    @"SYSTEM\CurrentControlSet\Enum\USB",
-                    @"SYSTEM\CurrentControlSet\Enum\FTDIBUS"
-            };
-
-            foreach (var regPath in regPaths)
+            // Code from https://stackoverflow.com/questions/45165299/wmi-get-list-of-all-serial-com-ports-including-virtual-ports
+            ManagementObjectSearcher searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_PnPEntity WHERE ClassGuid=\"{4d36e978-e325-11ce-bfc1-08002be10318}\"");
+            foreach (ManagementObject queryObj in searcher.Get())
             {
+                // At this point we have a list of possibly valid connected devices. Since everything at this point
+                // depends on the VID/PID extract that to start.
+                var rawHardwareID = (queryObj["HardwareID"] as string[])?[0];
 
-                RegistryKey regUSB = regLocalMachine.OpenSubKey(regPath);
-                if (regUSB == null) continue;
-
-                foreach (String regDevice in regUSB.GetSubKeyNames())
+                // Only hardware IDs that start with USB are potentially valid. In testing we've seen other
+                // detected connection types, such as "ACPI".
+                if (!rawHardwareID.StartsWith("USB\\"))
                 {
-                    String message = null;
-                    Log.Instance.log($"Checking for compatible module: {regDevice}", LogSeverity.Debug);
-
-                    foreach (String regSubDevice in regUSB.OpenSubKey(regDevice).GetSubKeyNames())
-                    {
-                        Board board;
-                        String FriendlyName = regUSB.OpenSubKey(regDevice).OpenSubKey(regSubDevice).GetValue("FriendlyName") as String;
-                        if (FriendlyName == null) continue;
-
-                        // Check to see if any board configurations exist
-                        board = BoardDefinitions.GetBoardByFriendlyName(FriendlyName) ?? BoardDefinitions.GetBoardByHardwareId(regDevice);
-
-                        // If no matching board definition is found at this point then it's an incompatible board and just keep going.
-                        if (board == null)
-                        {
-                            Log.Instance.log($"Incompatible module skipped: {FriendlyName} - VID/PID: {regDevice}", LogSeverity.Debug);
-                            continue;
-                        }
-
-                        // The board is a known type so test and see if a COM port is registered for it. If not, skip it.
-                        String portName = regUSB.OpenSubKey(regDevice).OpenSubKey(regSubDevice).OpenSubKey("Device Parameters").GetValue("PortName") as String;
-
-                        if (portName == null)
-                        {
-                            Log.Instance.log($"Arduino device has no port information: {regDevice}", LogSeverity.Debug);
-                            continue;
-                        }
-
-                        // Safety check to ensure duplicate entires in the registry don't result in duplicate entires in the list.
-                        if (result.ContainsKey(portName))
-                        {
-                            Log.Instance.log($"Duplicate entry for port: {board.Info.FriendlyName} {portName}", LogSeverity.Debug);
-                            continue;
-                        }
-
-                        result.Add(portName, board);
-                        Log.Instance.log($"Found potentially compatible module ({FriendlyName}): {regDevice}@{portName}", LogSeverity.Debug);
-                    }
+                    continue;
                 }
+
+                // Historically MobiFlight expects a straight VID/PID string without a leading USB\\ so get
+                // rid of that to ensure other code works as it used to.
+                var hardwareId = rawHardwareID.Remove(0, 4);
+
+                String message = null;
+                Board board;
+
+                Log.Instance.log($"Checking for compatible module: {hardwareId}", LogSeverity.Debug);
+                board = BoardDefinitions.GetBoardByHardwareId(hardwareId);
+
+                // If no matching board definition is found at this point then it's an incompatible board and just keep going.
+                if (board == null)
+                {
+                    Log.Instance.log($"Incompatible module skipped: VID/PID: {hardwareId}", LogSeverity.Debug);
+                    continue;
+                }
+
+                // The board is a known type so grab the COM port for it.
+                var portNameMatch = Regex.Match(queryObj["Caption"].ToString(), portNameRegEx);
+                var portName = portNameMatch?.Value.Trim(new char[]{ '(', ')'});
+
+                if (portName == null)
+                {
+                    Log.Instance.log($"Arduino device has no port information: {hardwareId}", LogSeverity.Debug);
+                    continue;
+                }
+
+                // Safety check to ensure duplicate entires in the registry don't result in duplicate entires in the list.
+                if (result.ContainsKey(portName))
+                {
+                    Log.Instance.log($"Duplicate entry for port: {board.Info.FriendlyName} {portName}", LogSeverity.Debug);
+                    continue;
+                }
+
+                result.Add(portName, board);
+                Log.Instance.log($"Found potentially compatible module ({board.Info.FriendlyName}): {hardwareId}@{portName}", LogSeverity.Debug);
             }
 
             return result;

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -126,18 +126,15 @@ namespace MobiFlight
                 // case where no hardware IDs are available.
                 var rawHardwareID = (queryObj["HardwareID"] as string[])?[0];
 
-                // Only hardware IDs that start with USB are potentially valid. In testing we've seen other
-                // detected connection types, such as "ACPI". Also handle the case where rawHardwareID
-                // is null.
-                if (!rawHardwareID?.StartsWith("USB") ?? false)
+                if (String.IsNullOrEmpty(rawHardwareID))
                 {
-                    Log.Instance.log($"Incompatible module skipped: {rawHardwareID}", LogSeverity.Debug);
+                    Log.Instance.log($"Skipping module with no available VID/PID", LogSeverity.Debug);
                     continue;
                 }
 
-                // Historically MobiFlight expects a straight VID/PID string without a leading USB\ so get
+                // Historically MobiFlight expects a straight VID/PID string without a leading USB\ or FTDI\ so get
                 // rid of that to ensure other code works as it used to.
-                var hardwareId = rawHardwareID.Remove(0, 4);
+                var hardwareId = rawHardwareID.Substring(rawHardwareID.IndexOf('\\') + 1);
 
                 Log.Instance.log($"Checking for compatible module: {hardwareId}", LogSeverity.Debug);
                 var board = BoardDefinitions.GetBoardByHardwareId(hardwareId);

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -164,6 +164,7 @@
     <Reference Include="System.Diagnostics.DiagnosticSource, Version=5.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Diagnostics.DiagnosticSource.5.0.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
+    <Reference Include="System.Management" />
     <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Memory.4.5.4\lib\netstandard1.1\System.Memory.dll</HintPath>
     </Reference>

--- a/packages.config
+++ b/packages.config
@@ -8,6 +8,7 @@
   <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net452" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net452" />
   <package id="System.Diagnostics.DiagnosticSource" version="5.0.0" targetFramework="net452" />
+  <package id="System.Management" version="4.5.0" targetFramework="net452" />
   <package id="System.Memory" version="4.5.4" targetFramework="net452" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Fixes #733 

Initial attempt at using WMI to detect devices instead of using the system registry. This works on my desktop and detects all my connected Arduinos, as well as a few other non-Arduino devices that are correctly skipped.

A few things to note:

1. The "FriendlyName" is no longer used to detect boards, only the VID/PID. In practice I don't believe this changes anything since I've never seen FriendlyName match at this stage of the detection, even using the old registry method.
2. The VID/PID string used to detect is slightly different than in the past but it doesn't matter given how the BoardDefinition class and board definition files were using regex for matching: the current tests are all based on "start of string" so things still work fine.
3. The log messages look slightly different now since the FriendlyName from the registry is no longer used.

Here's debug output example of this in action on my machine. note that it correctly skips the ACPI device.

```
Debug	3/11/2022 8:05:59 AM	Checking for compatible module: VID_1B4F&PID_9206&REV_0100&MI_00
Debug	3/11/2022 8:05:59 AM	Found potentially compatible module (Arduino Micro Pro): VID_1B4F&PID_9206&REV_0100&MI_00@COM22
Debug	3/11/2022 8:05:59 AM	Incompatible module skipped: VID/PID: ACPI\VEN_PNP&DEV_0501
Debug	3/11/2022 8:05:59 AM	Checking for compatible module: VID_2341&PID_0042&REV_0001
Debug	3/11/2022 8:05:59 AM	Found potentially compatible module (Arduino Mega 2560): VID_2341&PID_0042&REV_0001@COM3
Debug	3/11/2022 8:05:59 AM	Checking for compatible module: VID_1B4F&PID_9206&REV_0100&MI_00
Debug	3/11/2022 8:05:59 AM	Found potentially compatible module (Arduino Micro Pro): VID_1B4F&PID_9206&REV_0100&MI_00@COM15
Debug	3/11/2022 8:05:59 AM	Checking for compatible module: VID_1B4F&PID_9206&REV_0100&MI_00
Debug	3/11/2022 8:05:59 AM	Found potentially compatible module (Arduino Micro Pro): VID_1B4F&PID_9206&REV_0100&MI_00@COM17
Debug	3/11/2022 8:05:59 AM	Checking for compatible module: VID_1B4F&PID_9206&REV_0100&MI_00
Debug	3/11/2022 8:05:59 AM	Found potentially compatible module (Arduino Micro Pro): VID_1B4F&PID_9206&REV_0100&MI_00@COM7
```