### PR TITLE
Add missing catch when writing log files

### DIFF
--- a/Base/Log.cs
+++ b/Base/Log.cs
@@ -165,6 +165,12 @@ namespace MobiFlight
                         sw.Close();
                     }
                 }
+                catch
+                {
+                    // Fix for https://github.com/MobiFlight/MobiFlight-Connector/issues/757
+                    // If something goes wrong writing to the log file it's just the log file, no need to crash
+                    // or do anything special. Just ignore the exception and keep going.
+                }
                 finally
                 {
                     // Release lock


### PR DESCRIPTION
Fixes #757 

Add a `catch` block to handle exceptions when writing to the log file.