### PR TITLE
Input Device change correctly handled

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1572,12 +1572,12 @@ namespace MobiFlight
                             	// assigned to the row. If not just skip this row. Without this every row that uses the input shift register
                             	// would get added to the input cache and fired even though the pins don't match.
 //GCC CHECK
-                            	if (cfg.inputShiftRegister != null && cfg.inputShiftRegister.ExtPin != e.ExtPin)
+                            	if (e.Type == DeviceType.InputShiftRegister && cfg.inputShiftRegister != null && cfg.inputShiftRegister.ExtPin != e.ExtPin)
                             	{
                                 	continue;
                             	}
                             	// similarly also for digital input Muxes
-                            	if (cfg.digInputMux != null && cfg.digInputMux.ExtPin != e.ExtPin)
+                            	if (e.Type == DeviceType.DigInputMux && cfg.digInputMux != null && cfg.digInputMux.ExtPin != e.ExtPin)
                             	{
                                 	continue;
                             	}

--- a/MobiFlight/InputConfigItem.cs
+++ b/MobiFlight/InputConfigItem.cs
@@ -178,35 +178,35 @@ namespace MobiFlight
             writer.WriteAttributeString("name", this.Name);
             writer.WriteAttributeString("type", this.Type);
 
-            if (button != null)
+            if (this.Type == MobiFlightButton.TYPE && button != null)
             {
                 writer.WriteStartElement("button");
                 button.WriteXml(writer);
                 writer.WriteEndElement();
             }
 
-            if (encoder != null)
+            if (this.Type == MobiFlightEncoder.TYPE && encoder != null)
             {
                 writer.WriteStartElement("encoder");
                 encoder.WriteXml(writer);
                 writer.WriteEndElement();
             }
 
-            if (inputShiftRegister != null)
+            if (this.Type == MobiFlightInputShiftRegister.TYPE && inputShiftRegister != null)
             {
                 writer.WriteStartElement("inputShiftRegister");
                 inputShiftRegister.WriteXml(writer);
                 writer.WriteEndElement();
             }
 
-            if (digInputMux != null)
+            if (this.Type == MobiFlightDigInputMux.TYPE && digInputMux != null)
             {
                 writer.WriteStartElement("inputMultiplexer");
                 digInputMux.WriteXml(writer);
                 writer.WriteEndElement();
             }
 
-            if (analog != null)
+            if (this.Type == MobiFlightAnalogInput.TYPE && analog != null)
             {
                 writer.WriteStartElement("analog");
                 analog.WriteXml(writer);


### PR DESCRIPTION
fixes #782 

- Only the currently active input device is really stored in the configuration file on saving.
- During the session, the information about alternative input device action assignments is maintained in the config object.
  This means, that you can switch between, e.g. a button and an encoder, without loosing their individual settings as long as it is the same session in MobiFlight connector.
- Even though the config item still contains more than on input action configuration, during execution only the currently selected input action type is used. That means if the config shows the "button" input action in the grid view or in the input config wizard, the button input action will be executed. 