### PR TITLE
Make the analog pin dropdown wider

### DIFF
--- a/UI/Panels/Device/MFAnalogPanel.resx
+++ b/UI/Panels/Device/MFAnalogPanel.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="mfPinLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>61, 22</value>
+    <value>76, 22</value>
   </data>
   <data name="mfPinLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 18</value>
@@ -150,7 +150,7 @@
     <value>2</value>
   </data>
   <data name="mfPinComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>37, 21</value>
+    <value>52, 21</value>
   </data>
   <data name="mfPinComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>

--- a/UI/Panels/Device/MFButtonPanel.resx
+++ b/UI/Panels/Device/MFButtonPanel.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="mfPinLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>61, 22</value>
+    <value>76, 22</value>
   </data>
   <data name="mfPinLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 18</value>
@@ -150,7 +150,7 @@
     <value>2</value>
   </data>
   <data name="mfPinComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 21</value>
+    <value>52, 21</value>
   </data>
   <data name="mfPinComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>

--- a/UI/Panels/Device/MFDigInputMuxPanel.resx
+++ b/UI/Panels/Device/MFDigInputMuxPanel.resx
@@ -172,7 +172,7 @@
     <value>1</value>
   </data>
   <data name="mfNumModulesComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>59, 38</value>
+    <value>76, 38</value>
   </data>
   <data name="mfNumModulesComboBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>67, 21</value>
@@ -196,7 +196,7 @@
     <value>NoControl</value>
   </data>
   <data name="numberOfModulesLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>57, 19</value>
+    <value>76, 19</value>
   </data>
   <data name="numberOfModulesLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>103, 17</value>
@@ -250,7 +250,7 @@
     <value>9, 38</value>
   </data>
   <data name="mfPin1ComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>40, 21</value>
+    <value>52, 21</value>
   </data>
   <data name="mfPin1ComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>

--- a/UI/Panels/Device/MFEncoderPanel.resx
+++ b/UI/Panels/Device/MFEncoderPanel.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>61, 46</value>
+    <value>76, 46</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
     <value>57, 18</value>
@@ -150,7 +150,7 @@
     <value>2</value>
   </data>
   <data name="mfRightPinComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 21</value>
+    <value>52, 21</value>
   </data>
   <data name="mfRightPinComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -168,7 +168,7 @@
     <value>1</value>
   </data>
   <data name="mfPinLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>61, 22</value>
+    <value>76, 22</value>
   </data>
   <data name="mfPinLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>47, 18</value>
@@ -198,7 +198,7 @@
     <value>2</value>
   </data>
   <data name="mfLeftPinComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 21</value>
+    <value>52, 21</value>
   </data>
   <data name="mfLeftPinComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>

--- a/UI/Panels/Device/MFOutputPanel.resx
+++ b/UI/Panels/Device/MFOutputPanel.resx
@@ -119,7 +119,7 @@
   </resheader>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="mfPinLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>61, 22</value>
+    <value>76, 22</value>
   </data>
   <data name="mfPinLabel.Size" type="System.Drawing.Size, System.Drawing">
     <value>75, 18</value>
@@ -150,7 +150,7 @@
     <value>2</value>
   </data>
   <data name="mfPinComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>41, 21</value>
+    <value>52, 21</value>
   </data>
   <data name="mfPinComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>

--- a/UI/Panels/Device/MFServoPanel.Designer.cs
+++ b/UI/Panels/Device/MFServoPanel.Designer.cs
@@ -51,7 +51,7 @@
             // 
             // mfPinLabel
             // 
-            this.mfPinLabel.Location = new System.Drawing.Point(61, 22);
+            this.mfPinLabel.Location = new System.Drawing.Point(76, 22);
             this.mfPinLabel.Name = "mfPinLabel";
             this.mfPinLabel.Size = new System.Drawing.Size(75, 18);
             this.mfPinLabel.TabIndex = 14;
@@ -64,7 +64,7 @@
             this.mfPinComboBox.Location = new System.Drawing.Point(18, 19);
             this.mfPinComboBox.MaxLength = 2;
             this.mfPinComboBox.Name = "mfPinComboBox";
-            this.mfPinComboBox.Size = new System.Drawing.Size(41, 21);
+            this.mfPinComboBox.Size = new System.Drawing.Size(52, 21);
             this.mfPinComboBox.TabIndex = 13;
             this.mfPinComboBox.SelectedIndexChanged += new System.EventHandler(this.value_Changed);
             // 

--- a/UI/Panels/Device/MFStepperPanel.Designer.cs
+++ b/UI/Panels/Device/MFStepperPanel.Designer.cs
@@ -68,7 +68,7 @@
             // 
             // mfPin4Label
             // 
-            this.mfPin4Label.Location = new System.Drawing.Point(148, 50);
+            this.mfPin4Label.Location = new System.Drawing.Point(160, 50);
             this.mfPin4Label.Name = "mfPin4Label";
             this.mfPin4Label.Size = new System.Drawing.Size(35, 18);
             this.mfPin4Label.TabIndex = 20;
@@ -81,13 +81,13 @@
             this.mfPin4ComboBox.Location = new System.Drawing.Point(106, 47);
             this.mfPin4ComboBox.MaxLength = 2;
             this.mfPin4ComboBox.Name = "mfPin4ComboBox";
-            this.mfPin4ComboBox.Size = new System.Drawing.Size(41, 21);
+            this.mfPin4ComboBox.Size = new System.Drawing.Size(52, 21);
             this.mfPin4ComboBox.TabIndex = 19;
             this.mfPin4ComboBox.SelectedIndexChanged += new System.EventHandler(this.value_Changed);
             // 
             // mfPin1Label
             // 
-            this.mfPin1Label.Location = new System.Drawing.Point(60, 21);
+            this.mfPin1Label.Location = new System.Drawing.Point(72, 21);
             this.mfPin1Label.Name = "mfPin1Label";
             this.mfPin1Label.Size = new System.Drawing.Size(31, 18);
             this.mfPin1Label.TabIndex = 16;
@@ -100,13 +100,13 @@
             this.mfPin1ComboBox.Location = new System.Drawing.Point(18, 18);
             this.mfPin1ComboBox.MaxLength = 2;
             this.mfPin1ComboBox.Name = "mfPin1ComboBox";
-            this.mfPin1ComboBox.Size = new System.Drawing.Size(41, 21);
+            this.mfPin1ComboBox.Size = new System.Drawing.Size(52, 21);
             this.mfPin1ComboBox.TabIndex = 15;
             this.mfPin1ComboBox.SelectedIndexChanged += new System.EventHandler(this.value_Changed);
             // 
             // mfPin3Label
             // 
-            this.mfPin3Label.Location = new System.Drawing.Point(60, 48);
+            this.mfPin3Label.Location = new System.Drawing.Point(72, 48);
             this.mfPin3Label.Name = "mfPin3Label";
             this.mfPin3Label.Size = new System.Drawing.Size(35, 18);
             this.mfPin3Label.TabIndex = 18;
@@ -119,13 +119,13 @@
             this.mfPin3ComboBox.Location = new System.Drawing.Point(18, 45);
             this.mfPin3ComboBox.MaxLength = 2;
             this.mfPin3ComboBox.Name = "mfPin3ComboBox";
-            this.mfPin3ComboBox.Size = new System.Drawing.Size(41, 21);
+            this.mfPin3ComboBox.Size = new System.Drawing.Size(52, 21);
             this.mfPin3ComboBox.TabIndex = 17;
             this.mfPin3ComboBox.SelectedIndexChanged += new System.EventHandler(this.value_Changed);
             // 
             // mfPin2Label
             // 
-            this.mfPin2Label.Location = new System.Drawing.Point(148, 21);
+            this.mfPin2Label.Location = new System.Drawing.Point(160, 21);
             this.mfPin2Label.Name = "mfPin2Label";
             this.mfPin2Label.Size = new System.Drawing.Size(31, 18);
             this.mfPin2Label.TabIndex = 16;
@@ -138,7 +138,7 @@
             this.mfPin2ComboBox.Location = new System.Drawing.Point(106, 18);
             this.mfPin2ComboBox.MaxLength = 2;
             this.mfPin2ComboBox.Name = "mfPin2ComboBox";
-            this.mfPin2ComboBox.Size = new System.Drawing.Size(41, 21);
+            this.mfPin2ComboBox.Size = new System.Drawing.Size(52, 21);
             this.mfPin2ComboBox.TabIndex = 15;
             this.mfPin2ComboBox.SelectedIndexChanged += new System.EventHandler(this.value_Changed);
             // 
@@ -187,7 +187,7 @@
             // 
             // label2
             // 
-            this.label2.Location = new System.Drawing.Point(148, 16);
+            this.label2.Location = new System.Drawing.Point(160, 16);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(31, 18);
             this.label2.TabIndex = 16;
@@ -200,7 +200,7 @@
             this.mfBtnPinComboBox.Location = new System.Drawing.Point(106, 13);
             this.mfBtnPinComboBox.MaxLength = 2;
             this.mfBtnPinComboBox.Name = "mfBtnPinComboBox";
-            this.mfBtnPinComboBox.Size = new System.Drawing.Size(41, 21);
+            this.mfBtnPinComboBox.Size = new System.Drawing.Size(52, 21);
             this.mfBtnPinComboBox.TabIndex = 15;
             this.mfBtnPinComboBox.SelectedIndexChanged += new System.EventHandler(this.value_Changed);
             // 


### PR DESCRIPTION
Fixes #801 

Make the dropdown wider and move the pin label over a bit to make room for the wider dropdown.

<img width="224" alt="image" src="https://user-images.githubusercontent.com/9524118/167498740-aa7059f6-92ee-477a-b2d1-e2f60b06efd7.png">
