### PR TITLE
Check for max number of output shifters

### DIFF
--- a/MobiFlight/Board.cs
+++ b/MobiFlight/Board.cs
@@ -165,6 +165,11 @@ namespace MobiFlight
         public int MaxServos = 0;
 
         /// <summary>
+        /// Maximum number of output shifters supported by the board.
+        /// </summary>
+        public int MaxShifters = 0;
+
+        /// <summary>
         /// Maximum number of steppers supported by the board.
         /// </summary>
         public int MaxSteppers = 0;

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -546,6 +546,10 @@ namespace MobiFlight.UI.Panels.Settings
 
                     case "ShiftRegisterToolStripMenuItem":
                     case "addShiftRegisterToolStripMenuItem":
+                        if (statistics[MobiFlightShiftRegister.TYPE] == tempModule.Board.ModuleLimits.MaxShifters)
+                        {
+                            throw new MaximumDeviceNumberReachedMobiFlightException(MobiFlightLcdDisplay.TYPE, tempModule.Board.ModuleLimits.MaxShifters);
+                        }
                         cfgItem = new MobiFlight.Config.ShiftRegister();
                         (cfgItem as MobiFlight.Config.ShiftRegister).DataPin = freePinList.ElementAt(0).ToString();
                         (cfgItem as MobiFlight.Config.ShiftRegister).ClockPin = freePinList.ElementAt(1).ToString();

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -548,7 +548,7 @@ namespace MobiFlight.UI.Panels.Settings
                     case "addShiftRegisterToolStripMenuItem":
                         if (statistics[MobiFlightShiftRegister.TYPE] == tempModule.Board.ModuleLimits.MaxShifters)
                         {
-                            throw new MaximumDeviceNumberReachedMobiFlightException(MobiFlightLcdDisplay.TYPE, tempModule.Board.ModuleLimits.MaxShifters);
+                            throw new MaximumDeviceNumberReachedMobiFlightException(MobiFlightShiftRegister.TYPE, tempModule.Board.ModuleLimits.MaxShifters);
                         }
                         cfgItem = new MobiFlight.Config.ShiftRegister();
                         (cfgItem as MobiFlight.Config.ShiftRegister).DataPin = freePinList.ElementAt(0).ToString();


### PR DESCRIPTION
Fixes #821 

* Add a check for maximum number of output shifters when one is added.
* Expose the `MaxShifters` board.json property via the `Board` class. Somehow this got missed during original implementation!

<img width="291" alt="image" src="https://user-images.githubusercontent.com/9524118/171033133-40352e77-0601-4fab-baad-a35e47ba3727.png">
