### PR TITLE
Use MobiFlightType instead of Type

### DIFF
--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -565,7 +565,7 @@ namespace MobiFlight.UI.Panels.Settings
             }
             catch (MaximumDeviceNumberReachedMobiFlightException ex)
             {
-                MessageBox.Show(String.Format(i18n._tr("uiMessageMaxNumberOfDevicesReached"), ex.MaxNumber, ex.DeviceType, tempModule.Type),
+                MessageBox.Show(String.Format(i18n._tr("uiMessageMaxNumberOfDevicesReached"), ex.MaxNumber, ex.DeviceType, tempModule.Board.Info.MobiFlightType),
                                 i18n._tr("uiMessageNotEnoughPinsHint"),
                                 MessageBoxButtons.OK, MessageBoxIcon.Error);
             }


### PR DESCRIPTION
Fixes #822 

Replace `Type` with `MobiFlightType` in the max modules error message.

<img width="312" alt="image" src="https://user-images.githubusercontent.com/9524118/171033749-ec9b83a2-414c-4301-919b-10b1859b45d9.png">
