### PR TITLE
Move vid/pid from mega to uno board file

### DIFF
--- a/Boards/arduino_mega.board.json
+++ b/Boards/arduino_mega.board.json
@@ -19,7 +19,6 @@
   "HardwareIds": [
     "^VID_2341&PID_0010",
     "^VID_2341&PID_0042",
-    "^VID_2341&PID_0001",
     "^VID_8087&PID_0024",
     "^VID_1A86&PID_7523",
     "^VID_2A03&PID_0042",

--- a/Boards/arduino_uno.board.json
+++ b/Boards/arduino_uno.board.json
@@ -16,7 +16,12 @@
     "ForceResetOnFirmwareUpdate": false,
     "MessageSize": 32
   },
-  "HardwareIds": [ "^VID_2341&PID_0043", "^VID_2A03&PID_0043", "^VID_2341&PID_0243" ],
+  "HardwareIds": [
+    "^VID_2341&PID_0043",
+    "^VID_2A03&PID_0043",
+    "^VID_2341&PID_0243",
+    "^VID_2341&PID_0001"
+  ],
   "Info": {
     "CanInstallFirmware": true,
     "FriendlyName": "Arduino Uno",
@@ -27,7 +32,7 @@
     "MaxAnalogInputs": 6,
     "MaxButtons": 18,
     "MaxEncoders": 9,
-    "MaxInputShifters":  2,
+    "MaxInputShifters": 2,
     "MaxLcdI2C": 2,
     "MaxLedSegments": 1,
     "MaxOutputs": 18,


### PR DESCRIPTION
Fixes #865

Move `"^VID_2341&PID_0001"` from the Mega to the Uno board.json file.