### PR TITLE
Add assigned pin display to output shifter

### DIFF
--- a/MobiFlight/OutputConfig/ShiftRegister.cs
+++ b/MobiFlight/OutputConfig/ShiftRegister.cs
@@ -48,6 +48,17 @@ namespace MobiFlight.OutputConfig
             writer.WriteAttributeString("registerOutputPin", Pin);
         }
 
+        public override string ToString()
+        {
+            // The list of selected pins is stored as a string in this format: Output 1|Output 2|Output 10
+            // That's too wordy to display in UI so strip out the "Output " and "|", then separate
+            // the pin assignments with a comma. The resulting display string is: ShiftRegister:1,2,10.
+            //
+            // The UI forces at least one pin assignment so there is no case where the resulting string
+            // would be ShiftRegister: (with no pins listed and a trailing colon).
+            return $"{Address}:{Pin.Replace("Output ", ",").Replace("|", "").TrimStart(',')}";
+        }
+
         public object Clone()
         {
             ShiftRegister clone = new ShiftRegister();

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -576,7 +576,7 @@ namespace MobiFlight.UI.Panels
                                 row["OutputName"] = cfgItem.Stepper.Address;
                                 break;
                             case MobiFlightShiftRegister.TYPE:
-                                row["OutputName"] = cfgItem.ShiftRegister.Address;
+                                row["OutputName"] = cfgItem.ShiftRegister.ToString();
                                 break;
 
                         }


### PR DESCRIPTION
Fixes #868 

Switch to using `ToString()` to get the display string for an output shifter, then put the logic for constructing the pin assignment display string in that method.

<img width="590" alt="image" src="https://user-images.githubusercontent.com/9524118/179003377-75aaa11b-680e-4433-90c4-f76d6628d9ec.png">

This is what it looks like with a single pin assignment and multiple pin assignments. It's not possible to have no pin assignments given how the UI is built, so no need to handle that special case.