### PR TITLE
Webrequest timeout for update check during startup.

### DIFF
--- a/Base/AutoUpdateChecker.cs
+++ b/Base/AutoUpdateChecker.cs
@@ -10,6 +10,7 @@ namespace MobiFlight.UpdateChecker
     static class AutoUpdateChecker
     {
         static string mobiFlightInstaller = "MobiFlight-Installer.exe";
+        static int UpdateCheckTimeoutInMs = 5000;
         public static void CheckForUpdate(bool force = false, bool silent = false)
         {
             String hash = (Environment.UserName + Environment.MachineName).GetHashCode().ToString();
@@ -45,7 +46,7 @@ namespace MobiFlight.UpdateChecker
             p.Start();
             string output = p.StandardOutput.ReadToEnd();
             string error = p.StandardError.ReadToEnd();
-            p.WaitForExit();
+            p.WaitForExit(UpdateCheckTimeoutInMs);
 
             Console.WriteLine(output + error);
             if (output.Contains("##RESULT##|1"))

--- a/MobiFlight-Installer/MobiFlight-Installer/Properties/AssemblyInfo.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.4.0")]
-[assembly: AssemblyFileVersion("1.4.0")]
+[assembly: AssemblyVersion("1.5.0")]
+[assembly: AssemblyFileVersion("1.5.0")]

--- a/MobiFlight-Installer/MobiFlight-Installer/model/MobiFlightUpdaterModel.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/model/MobiFlightUpdaterModel.cs
@@ -253,10 +253,20 @@ namespace MobiFlightInstaller
             webRequest.Timeout = RequestTimeoutInMilliseconds;
 
             WebResponse webResponse;
-            webResponse = webRequest.GetResponse();
-            Stream ContentStream = webResponse.GetResponseStream();
-            
-            if (ContentStream == null )
+            Stream ContentStream = null;
+
+            try
+            {
+                webResponse = webRequest.GetResponse();
+                ContentStream = webResponse.GetResponseStream();
+            }
+            catch (WebException e)
+            {
+                _handleWebException(e);
+                return;
+            }
+
+            if (ContentStream == null)
             {
                 MessageBox.Show("Error download Mobiflight list failed");
                 return;
@@ -277,7 +287,16 @@ namespace MobiFlightInstaller
                     }
 
                 }
-            }            
+            }   
+        }
+
+        private static void _handleWebException(WebException e)
+        {
+            var reason = "";
+            // e.g. request timed out
+            if (e.Status == WebExceptionStatus.Timeout)
+                reason = " due to timeout";
+            Log.Instance.log($"Download FAILED{reason}, probably a connection error. ({e.Status.ToString()})", LogSeverity.Error);
         }
 
         public static void InstallerCheckForUpgrade(String InstallerUpdateUrl)
@@ -286,9 +305,19 @@ namespace MobiFlightInstaller
             webRequest.CachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.NoCacheNoStore);
             webRequest.Timeout = RequestTimeoutInMilliseconds;
 
-            WebResponse webResponse;
-            webResponse = webRequest.GetResponse();
-            Stream ContentStream = webResponse.GetResponseStream();
+            WebResponse webResponse = null;
+            Stream ContentStream = null;
+
+            try
+            {
+                webResponse = webRequest.GetResponse();
+                ContentStream = webResponse.GetResponseStream();
+            }
+            catch(WebException e)
+            {
+                _handleWebException(e);
+                return;
+            }
 
             string LastFindVersion = "";
             string VersionDownloadURL = "";
@@ -298,7 +327,7 @@ namespace MobiFlightInstaller
 
             SafeDelete(fileTemp);
             SafeDelete(fileOld);
-            
+
             if (ContentStream != null)
             {
                 var ReceivedContent = new XmlDocument();

--- a/MobiFlight-Installer/MobiFlight-Installer/model/MobiFlightUpdaterModel.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/model/MobiFlightUpdaterModel.cs
@@ -26,6 +26,7 @@ namespace MobiFlightInstaller
 
         public static string InstallerUpdateUrl = ""; // URL to check for installer upgrade, Set to empty to avoid installer autoUpgrade
         public static string InstallerActualVersion = "0.0.0";
+        public static int RequestTimeoutInMilliseconds = 5000;
         
         public static string CacheId = null;
 
@@ -249,6 +250,8 @@ namespace MobiFlightInstaller
         {
             WebRequest webRequest = WebRequest.Create(UrlXmlFile);
             webRequest.CachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.NoCacheNoStore);
+            webRequest.Timeout = RequestTimeoutInMilliseconds;
+
             WebResponse webResponse;
             webResponse = webRequest.GetResponse();
             Stream ContentStream = webResponse.GetResponseStream();
@@ -281,6 +284,8 @@ namespace MobiFlightInstaller
         {
             WebRequest webRequest = WebRequest.Create(InstallerUpdateUrl);
             webRequest.CachePolicy = new HttpRequestCachePolicy(HttpRequestCacheLevel.NoCacheNoStore);
+            webRequest.Timeout = RequestTimeoutInMilliseconds;
+
             WebResponse webResponse;
             webResponse = webRequest.GetResponse();
             Stream ContentStream = webResponse.GetResponseStream();


### PR DESCRIPTION
fixes #848 

I added a timeout of 5s (5000ms) to the MobiFlight Connector and the installer. So both should not wait than 5s for the update check.
This will require the release of a new installer. Version 1.5.0

- [x] When using small timeout values for testing, the installer should logs the timeout
- [x] MobiFlight will continue with startup in any case
- [x] No error message will be displayed to the user
- [x] Version number of installer is updated to 1.5.0

