### PR TITLE
7 Segments update correctly when using preconditions

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -519,11 +519,7 @@ namespace MobiFlight
                 }
                 else
                 {
-                    // the error text is coming from
-                    // the missing connection to FSUIPC/SimConnect
-                    // so if we are in Offline Mode then we want to keep it.
-                    if(!OfflineMode)
-                        row.ErrorText = "";
+                    row.ErrorText = "";
                 }
 
                 try

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -590,13 +590,6 @@ namespace MobiFlight
 
         public bool SetDisplay(string name, int module, byte points, byte mask, string value)
         {
-            String key = "LED_" + name + "_" + module + "_" + mask;
-            String cachedValue = value + "_" + points;
-
-            if (!KeepAliveNeeded() && lastValue.ContainsKey(key) &&
-                lastValue[key] == cachedValue) return false;
-
-            lastValue[key] = cachedValue;
             ledModules[name].Display(module, value, points, mask);
             return true;
         }

--- a/MobiFlightUnitTests/MobiFlight/LedModuleStateTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/LedModuleStateTests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MobiFlight.Tests
+{
+    [TestClass()]
+    public class LedModuleStateTests
+    {
+        [TestMethod()]
+        public void SetRequiresUpdateTest()
+        {
+            LedModuleState state = new LedModuleState();
+            Assert.IsTrue(state.SetRequiresUpdate("12345678", 0, 255));
+            Assert.IsFalse(state.SetRequiresUpdate("12345678", 0, 255));
+            Assert.IsTrue(state.SetRequiresUpdate("87654321", 0, 255));
+            Assert.IsTrue(state.SetRequiresUpdate("11111111", 0, 255));
+            Assert.IsTrue(state.SetRequiresUpdate("2", 0, 2));
+            Assert.IsFalse(state.SetRequiresUpdate("2", 0, 2));
+            Assert.IsTrue(state.SetRequiresUpdate("12121212", 0, 255));
+            Assert.IsFalse(state.SetRequiresUpdate("2222", 0, 2^1+2^3+2^5+2^7));
+            Assert.IsTrue(state.SetRequiresUpdate("3333", 0, 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7));
+
+            // check the decimal points
+            Assert.IsTrue(state.SetRequiresUpdate("12121212", 1, 255));
+            Assert.IsFalse(state.SetRequiresUpdate("12121212", 1, 255));
+            Assert.IsTrue(state.SetRequiresUpdate("12121212", 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7, 255));
+            Assert.IsFalse (state.SetRequiresUpdate("12121212", 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7, 255));
+        }
+    }
+}

--- a/MobiFlightUnitTests/MobiFlight/LedModuleStateTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/LedModuleStateTests.cs
@@ -12,24 +12,35 @@ namespace MobiFlight.Tests
     public class LedModuleStateTests
     {
         [TestMethod()]
-        public void SetRequiresUpdateTest()
+        public void DisplayRequiresUpdateTest()
         {
             LedModuleState state = new LedModuleState();
-            Assert.IsTrue(state.SetRequiresUpdate("12345678", 0, 255));
-            Assert.IsFalse(state.SetRequiresUpdate("12345678", 0, 255));
-            Assert.IsTrue(state.SetRequiresUpdate("87654321", 0, 255));
-            Assert.IsTrue(state.SetRequiresUpdate("11111111", 0, 255));
-            Assert.IsTrue(state.SetRequiresUpdate("2", 0, 2));
-            Assert.IsFalse(state.SetRequiresUpdate("2", 0, 2));
-            Assert.IsTrue(state.SetRequiresUpdate("12121212", 0, 255));
-            Assert.IsFalse(state.SetRequiresUpdate("2222", 0, 2^1+2^3+2^5+2^7));
-            Assert.IsTrue(state.SetRequiresUpdate("3333", 0, 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7));
+            Assert.IsTrue(state.DisplayRequiresUpdate("12345678", 0, 255));
+            Assert.IsFalse(state.DisplayRequiresUpdate("12345678", 0, 255));
+            Assert.IsTrue(state.DisplayRequiresUpdate("87654321", 0, 255));
+            Assert.IsTrue(state.DisplayRequiresUpdate("11111111", 0, 255));
+            Assert.IsTrue(state.DisplayRequiresUpdate("2", 0, 2));
+            Assert.IsFalse(state.DisplayRequiresUpdate("2", 0, 2));
+            Assert.IsTrue(state.DisplayRequiresUpdate("12121212", 0, 255));
+            Assert.IsFalse(state.DisplayRequiresUpdate("2222", 0, 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7));
+            Assert.IsTrue(state.DisplayRequiresUpdate("3333", 0, 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7));
 
             // check the decimal points
-            Assert.IsTrue(state.SetRequiresUpdate("12121212", 1, 255));
-            Assert.IsFalse(state.SetRequiresUpdate("12121212", 1, 255));
-            Assert.IsTrue(state.SetRequiresUpdate("12121212", 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7, 255));
-            Assert.IsFalse (state.SetRequiresUpdate("12121212", 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7, 255));
+            Assert.IsTrue(state.DisplayRequiresUpdate("12121212", 1, 255));
+            Assert.IsFalse(state.DisplayRequiresUpdate("12121212", 1, 255));
+            Assert.IsTrue(state.DisplayRequiresUpdate("12121212", 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7, 255));
+            Assert.IsFalse(state.DisplayRequiresUpdate("12121212", 2 ^ 1 + 2 ^ 3 + 2 ^ 5 + 2 ^ 7, 255));
+            Assert.IsTrue(state.DisplayRequiresUpdate("12121212", 2 ^ 1 + 2 ^ 3 + 2 ^ 5, 255));
+        }
+
+        [TestMethod()]
+        public void SetBrightnessRequiresUpdateTest()
+        {
+            LedModuleState state = new LedModuleState();
+            Assert.IsTrue(state.SetBrightnessRequiresUpdate("15"));
+            Assert.IsFalse(state.SetBrightnessRequiresUpdate("15"));
+            Assert.IsTrue(state.SetBrightnessRequiresUpdate("0"));
+            Assert.IsFalse(state.SetBrightnessRequiresUpdate("0"));
         }
     }
 }

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="MobiFlight\InputConfig\KeyInputActionTests.cs" />
     <Compile Include="MobiFlight\InputConfig\MSFS2020EventIdInputActionTests.cs" />
     <Compile Include="MobiFlight\InputConfig\VJoyInputActionTests.cs" />
+    <Compile Include="MobiFlight\LedModuleStateTests.cs" />
     <Compile Include="MobiFlight\MobiFlightLcdDisplayTests.cs" />
     <Compile Include="MobiFlight\MobiFlightModuleTests.cs" />
     <Compile Include="MobiFlight\OutputConfigItemTests.cs" />


### PR DESCRIPTION
7 Segment modules now cache their state locally, and can compare more precisely whether an update is needed.
This will make precondition related updates work as expected every time.

You still have to make sure that if only parts are updated by a config, then these parts have to be same amount of digits. Otherwise you might still see parts of the value that was displayed before. This is not a flaw, this is expected behavior.

fixes #874 

- [x] Move the cache to the LedModule
- [x] Cache the value, mask and decimal point state
- [x] Cache the brightness state
- [x] Cache is cleared when MobiFlight is stopped.
- [x] Works with daisy-chained modules
- [x] Write unit tests
- [x] Fix the problem with the precondition message when in Offline Mode
- [x] Documentation - doesn't require update
- [x] UI translation - doesn't apply