### PR TITLE
Fixed memory leak with HubHop presets

### DIFF
--- a/HubHop/Msfs2020HubhopPresetList.cs
+++ b/HubHop/Msfs2020HubhopPresetList.cs
@@ -30,18 +30,39 @@ namespace MobiFlight.HubHop
         public int score;
         public String id { get; set; }
     }
+
+    public class Msfs2020HubhopPresetListSingleton
+    {
+        public static Msfs2020HubhopPresetList Instance { get; } = new Msfs2020HubhopPresetList();
+    }
+
     public class Msfs2020HubhopPresetList
     {
         public List<Msfs2020HubhopPreset> Items = new List<Msfs2020HubhopPreset>();
+        String LoadedFile = null;
+
+        public void Clear()
+        {
+            if (Items != null)
+            {
+                for (int i = 0; i != Items.Count; i++)
+                {
+                    Items[i] = null;
+                }
+                Items = null;
+            }
+        }
 
         public void Load(String Msfs2020HubhopPreset)
         {
-            Items.Clear();
+            if (LoadedFile == Msfs2020HubhopPreset) return;
+
+            Clear();
             try
             {
-                var presets = JsonConvert.DeserializeObject<List<Msfs2020HubhopPreset>>
-                                (File.ReadAllText(Msfs2020HubhopPreset), new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });  ;
-                Items.AddRange(presets);
+                Items = JsonConvert.DeserializeObject<List<Msfs2020HubhopPreset>>
+                                (File.ReadAllText(Msfs2020HubhopPreset), new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore });
+                LoadedFile = Msfs2020HubhopPreset;
             }
             catch (Exception ex)
             {

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -408,6 +408,10 @@ namespace MobiFlight.UI.Dialogs
         private void ConfigWizard_FormClosing(object sender, FormClosingEventArgs e)
         {
             _execManager.GetSimConnectCache().LVarListUpdated -= ConfigWizard_LVarListUpdated;
+            // actively trigger dispose
+            // to be able to clean up hubHopPreset Instances
+            // to prevent memory leak.
+            simConnectPanel1.Dispose();
         }
 
         private void _testModeStart()

--- a/UI/Dialogs/InputConfigWizard.Designer.cs
+++ b/UI/Dialogs/InputConfigWizard.Designer.cs
@@ -237,6 +237,7 @@
             this.MaximizeBox = false;
             this.Name = "InputConfigWizard";
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.InputConfigWizard_FormClosing);
             this.Load += new System.EventHandler(this.ConfigWizard_Load);
             this.Shown += new System.EventHandler(this.InputConfigWizard_Shown);
             this.MainPanel.ResumeLayout(false);

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -656,5 +656,10 @@ namespace MobiFlight.UI.Dialogs
         {
             IsShown = true;
         }
+
+        private void InputConfigWizard_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            groupBoxInputSettings.Dispose();
+        }
     }
 }

--- a/UI/Dialogs/InputConfigWizard.resx
+++ b/UI/Dialogs/InputConfigWizard.resx
@@ -123,13 +123,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="preconditionPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 5</value>
   </data>
   <data name="preconditionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="preconditionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>574, 567</value>
+    <value>866, 879</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="preconditionPanel.TabIndex" type="System.Int32, mscorlib">
@@ -139,7 +139,7 @@
     <value>preconditionPanel</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.3.2.1, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
     <value>preconditionTabPage</value>
@@ -148,13 +148,16 @@
     <value>0</value>
   </data>
   <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="preconditionTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>580, 573</value>
+    <value>874, 889</value>
   </data>
   <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -181,13 +184,13 @@
     <value>0, 0</value>
   </data>
   <data name="configRefPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="configRefPanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 5</value>
+    <value>8, 8, 8, 8</value>
   </data>
   <data name="configRefPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>580, 573</value>
+    <value>874, 889</value>
   </data>
   <data name="configRefPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -196,7 +199,7 @@
     <value>configRefPanel</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.3.2.1, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Parent" xml:space="preserve">
     <value>configRefTabPage</value>
@@ -205,10 +208,13 @@
     <value>0</value>
   </data>
   <data name="configRefTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="configRefTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="configRefTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>580, 573</value>
+    <value>874, 889</value>
   </data>
   <data name="configRefTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -238,10 +244,16 @@
     <value>Fill</value>
   </data>
   <data name="groupBoxInputSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 111</value>
+    <value>4, 171</value>
+  </data>
+  <data name="groupBoxInputSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="groupBoxInputSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="groupBoxInputSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>574, 459</value>
+    <value>866, 713</value>
   </data>
   <data name="groupBoxInputSettings.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -262,10 +274,13 @@
     <value>0</value>
   </data>
   <data name="inputPinDropDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>334, 45</value>
+    <value>501, 69</value>
+  </data>
+  <data name="inputPinDropDown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="inputPinDropDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>45, 21</value>
+    <value>66, 28</value>
   </data>
   <data name="inputPinDropDown.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -286,10 +301,13 @@
     <value>NoControl</value>
   </data>
   <data name="arcazeSerialLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>50, 23</value>
+    <value>75, 35</value>
+  </data>
+  <data name="arcazeSerialLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="arcazeSerialLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>42, 13</value>
+    <value>63, 20</value>
   </data>
   <data name="arcazeSerialLabel.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -319,10 +337,13 @@
     <value>Modul B</value>
   </data>
   <data name="inputModuleNameComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>98, 20</value>
+    <value>147, 31</value>
+  </data>
+  <data name="inputModuleNameComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="inputModuleNameComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 21</value>
+    <value>420, 28</value>
   </data>
   <data name="inputModuleNameComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -343,10 +364,13 @@
     <value>NoControl</value>
   </data>
   <data name="inputTypeComboBoxLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>31, 48</value>
+    <value>46, 74</value>
+  </data>
+  <data name="inputTypeComboBoxLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="inputTypeComboBoxLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 13</value>
+    <value>92, 20</value>
   </data>
   <data name="inputTypeComboBoxLabel.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -379,10 +403,13 @@
     <value>BCD4056</value>
   </data>
   <data name="inputTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>98, 45</value>
+    <value>147, 69</value>
+  </data>
+  <data name="inputTypeComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="inputTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>230, 21</value>
+    <value>343, 28</value>
   </data>
   <data name="inputTypeComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -403,10 +430,16 @@
     <value>Top</value>
   </data>
   <data name="displayTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 36</value>
+    <value>4, 56</value>
+  </data>
+  <data name="displayTypeGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="displayTypeGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="displayTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>574, 75</value>
+    <value>866, 115</value>
   </data>
   <data name="displayTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -430,16 +463,16 @@
     <value>Top</value>
   </data>
   <data name="displayTabTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
+    <value>4, 5</value>
   </data>
   <data name="displayTabTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>12, 12, 12, 12</value>
+    <value>18, 18, 18, 18</value>
   </data>
   <data name="displayTabTextBox.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="displayTabTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>574, 33</value>
+    <value>866, 51</value>
   </data>
   <data name="displayTabTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -460,13 +493,16 @@
     <value>2</value>
   </data>
   <data name="displayTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="displayTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="displayTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="displayTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>580, 573</value>
+    <value>874, 889</value>
   </data>
   <data name="displayTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -492,8 +528,11 @@
   <data name="tabControlFsuipc.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="tabControlFsuipc.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
   <data name="tabControlFsuipc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>588, 599</value>
+    <value>882, 922</value>
   </data>
   <data name="tabControlFsuipc.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -516,8 +555,11 @@
   <data name="MainPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="MainPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
   <data name="MainPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>588, 599</value>
+    <value>882, 922</value>
   </data>
   <data name="MainPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -541,10 +583,13 @@
     <value>NoControl</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>438, 0</value>
+    <value>658, 0</value>
+  </data>
+  <data name="button1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 28</value>
+    <value>112, 43</value>
   </data>
   <data name="button1.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -571,10 +616,13 @@
     <value>NoControl</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>513, 0</value>
+    <value>770, 0</value>
+  </data>
+  <data name="cancelButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 28</value>
+    <value>112, 43</value>
   </data>
   <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -598,10 +646,13 @@
     <value>Bottom</value>
   </data>
   <data name="ButtonPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 599</value>
+    <value>0, 922</value>
+  </data>
+  <data name="ButtonPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ButtonPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>588, 28</value>
+    <value>882, 43</value>
   </data>
   <data name="ButtonPanel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -625,10 +676,10 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>9, 20</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>588, 627</value>
+    <value>882, 965</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -773,6 +824,9 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
 </value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -22,6 +22,7 @@ using MobiFlight.UpdateChecker;
 using MobiFlight.Base;
 using Microsoft.ApplicationInsights.DataContracts;
 using MobiFlight.xplane;
+using MobiFlight.HubHop;
 
 namespace MobiFlight.UI
 {
@@ -1695,6 +1696,8 @@ namespace MobiFlight.UI
 
             if (updater.InstallWasmEvents())
             {
+                Msfs2020HubhopPresetListSingleton.Instance.Clear();
+
                 TimeoutMessageDialog.Show(
                    i18n._tr("uiMessageWasmEventsInstallationSuccessful"),
                    i18n._tr("uiMessageWasmUpdater"),

--- a/UI/Panels/Action/MSFS2020CustomInputPanel.cs
+++ b/UI/Panels/Action/MSFS2020CustomInputPanel.cs
@@ -20,6 +20,7 @@ namespace MobiFlight.UI.Panels.Action
             InitializeComponent();
             hubHopPresetPanel1.Mode = Config.HubHopPanelMode.Input;
             hubHopPresetPanel1.LoadPresets();
+            Disposed += (sender, args) => { hubHopPresetPanel1.Dispose(); };
         }       
 
         internal void syncFromConfig(InputConfig.MSFS2020CustomInputAction inputAction)

--- a/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.cs
@@ -80,6 +80,8 @@ namespace MobiFlight.UI.Panels.Config
         {
             InitializeComponent();
 
+            Disposed += HubHopPresetPanel_Disposed;
+
             linkLabel1.LinkClicked += this.linkLabel1_LinkClicked;
             ExpandButton.Click += this.ExpandButton_Click;
             ShowExpertSettingsCheckBox.CheckedChanged += this.ShowExpertSerttingsCheckBox_CheckedChanged;            
@@ -102,6 +104,24 @@ namespace MobiFlight.UI.Panels.Config
 
             SimVarNameTextBox.TextChanged += SimVarNameTextBox_TextChanged;
             FilterTextBox.TextChanged += textBox1_TextChanged;
+        }
+
+        private void HubHopPresetPanel_Disposed(object sender, EventArgs e)
+        {
+            // Explicitly setting the HubHopPresets to null actually 
+            // helps with the Garbage Collection    
+            for(int i=0; i!=PresetList.Items.Count;i++)
+            {
+                PresetList.Items[i] = null;
+            }
+            PresetList = null;
+
+            for (int i = 0; i != FilteredPresetList.Items.Count; i++)
+            {
+                FilteredPresetList.Items[i] = null;
+            }
+            FilteredPresetList = null;
+            GC.Collect();
         }
 
         public void LoadPresets()

--- a/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.cs
@@ -60,7 +60,7 @@ namespace MobiFlight.UI.Panels.Config
 
         SimConnectLvarsListForm LVarsListForm = new SimConnectLvarsListForm();
 
-        Msfs2020HubhopPresetList PresetList = new Msfs2020HubhopPresetList();
+        Msfs2020HubhopPresetList PresetList = null;
         Msfs2020HubhopPresetList FilteredPresetList = new Msfs2020HubhopPresetList();
 
         public List<String> LVars
@@ -79,6 +79,7 @@ namespace MobiFlight.UI.Panels.Config
         public HubHopPresetPanel()
         {
             InitializeComponent();
+            PresetList = Msfs2020HubhopPresetListSingleton.Instance;
 
             Disposed += HubHopPresetPanel_Disposed;
 
@@ -88,9 +89,11 @@ namespace MobiFlight.UI.Panels.Config
             ResetButton.Click += this.ResetFilterButton_Click;
             OnLVarsSet += SimConnectPanel_OnLVarsSet;
             ExpertSettingsPanel.Visible = false;
+
             PresetFile = Properties.Settings.Default.PresetFileMSFS2020SimVars;
             // New Json File
             PresetFile = @"Presets\msfs2020_hubhop_presets.json";
+            
             // Not sure if we want to keep the user file?
             // Would have to be JSON too...
             PresetFileUser = Properties.Settings.Default.PresetFileMSFS2020SimVarsUser;
@@ -110,18 +113,7 @@ namespace MobiFlight.UI.Panels.Config
         {
             // Explicitly setting the HubHopPresets to null actually 
             // helps with the Garbage Collection    
-            for(int i=0; i!=PresetList.Items.Count;i++)
-            {
-                PresetList.Items[i] = null;
-            }
-            PresetList = null;
-
-            for (int i = 0; i != FilteredPresetList.Items.Count; i++)
-            {
-                FilteredPresetList.Items[i] = null;
-            }
-            FilteredPresetList = null;
-            GC.Collect();
+            FilteredPresetList.Clear();
         }
 
         public void LoadPresets()


### PR DESCRIPTION
fixes #863 

This fixes prevents the memory leak by using one instance of the HubHop preset list.
It also increases speed of opening the Config Wizards because we are not loading the Presets every time.

- [x] Config Wizard uses central preset list
- [x] Input Config Wizard uses central preset list
- [x] Memory usage doesn't increase by 12MB anymore
- [x] Updating HubHop events will also update the central instance of the preset list

Notes:
- Added a Disposed-Handler to make sure that the FilteredPreset List is freed when closing the Wizard.
- Dispose method of a parent control had to be triggered explicitly in the Wizards