### PR TITLE
Joystick Events also show in log when MobiFlight is NOT running.

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -137,6 +137,7 @@ namespace MobiFlight
             mobiFlightCache.OnButtonPressed += new ButtonEventHandler(mobiFlightCache_OnButtonPressed);
 #endif
             joystickManager.OnButtonPressed += new ButtonEventHandler(mobiFlightCache_OnButtonPressed);
+            joystickManager.Connected += (o, e) => { joystickManager.Start(); };
             joystickManager.Connect(handle);
         }
 
@@ -259,7 +260,6 @@ namespace MobiFlight
         {
             simConnectCache.Start();
             xplaneCache.Start();
-            joystickManager.Start();
             timer.Enabled = true;
         }
 
@@ -270,7 +270,6 @@ namespace MobiFlight
             mobiFlightCache.Stop();
             simConnectCache.Stop();
             xplaneCache.Stop();
-            joystickManager.Stop();
             ClearErrorMessages();
         }
 
@@ -388,7 +387,7 @@ namespace MobiFlight
 #if SIMCONNECT
             simConnectCache.Disconnect();
 #endif
-
+            joystickManager.Stop();
             this.OnModulesDisconnected?.Invoke(this, new EventArgs());
         }
 

--- a/MobiFlight/JoystickManager.cs
+++ b/MobiFlight/JoystickManager.cs
@@ -9,6 +9,7 @@ namespace MobiFlight
 {
     public class JoystickManager
     {
+        public event EventHandler Connected;
         public event ButtonEventHandler OnButtonPressed;
         Timer PollTimer = new Timer();
         List<Joystick> joysticks = new List<Joystick>();
@@ -80,6 +81,7 @@ namespace MobiFlight
             }
 
             joysticks.Sort((j1, j2) => j1.Name.CompareTo(j2.Name));
+            Connected?.Invoke(this, null);
         }
 
         private void Js_OnDisconnected(object sender, EventArgs e)


### PR DESCRIPTION
fixes #783 

Joystick events like button press and release are now received and logged even without MF being in RUN mode. This makes it more convenient while setting up and configuring stuff.

- [x] Events show with being in Run Mode
- [x] Unit tests - does not apply
- [x] I18N strings updated - does not apply
- [x] Documentation updated - does not apply