### PR TITLE
ShiftRegister Pins > 8  turn off correctly when stopping test mode

### DIFF
--- a/MobiFlight/MobiFlightShiftRegister.cs
+++ b/MobiFlight/MobiFlightShiftRegister.cs
@@ -71,8 +71,12 @@ namespace MobiFlight
 
         public void Stop()
         {
-            for (int i = 0; i != NumberOfShifters; i++)
-                Display("0|1|2|3|4|5|6|7", "0");
+            List<String> pins = new List<string>();
+            for (int i = 0; i != NumberOfShifters*8; i++)
+                pins.Add(i.ToString());
+
+            String pinString = string.Join("|", pins);
+            Display(pinString, "0");
         }
     }
 }


### PR DESCRIPTION
The way the Stop method was written worked only for 8-bit shift register.
Now it will work for all pins.