### PR TITLE
Fix bug introduced in #876

### DIFF
--- a/HubHop/Msfs2020HubhopPresetList.cs
+++ b/HubHop/Msfs2020HubhopPresetList.cs
@@ -51,6 +51,7 @@ namespace MobiFlight.HubHop
                 }
                 Items = null;
             }
+            LoadedFile = null;
         }
 
         public void Load(String Msfs2020HubhopPreset)


### PR DESCRIPTION
Set Loaded File to empty right after clearing to make sure that next time the events are loaded again

PresetList was not initialized correctly after updating.
This is now fixed.