### PR TITLE
Add checks for in-use I2C pins and no I2C pins defined for the board.

### DIFF
--- a/MobiFlight/I2CPinInUseException.cs
+++ b/MobiFlight/I2CPinInUseException.cs
@@ -1,0 +1,20 @@
+﻿using MobiFlight.OutputConfig;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MobiFlight
+{
+    class I2CPinInUseException : Exception
+    {
+        public String DeviceType;
+        public MobiFlightPin Pin;
+        public I2CPinInUseException(String DeviceType, MobiFlightPin Pin)
+            : base(String.Format("{0} requires the use of pin {1} which is already assigned to another module. Remove the pin assignment from the other module then try adding {0} again.", DeviceType, Pin.Pin))
+        {
+            this.DeviceType = DeviceType;
+            this.Pin = Pin;
+        }
+    }
+}

--- a/MobiFlight/I2CPinsNotDefinedException.cs
+++ b/MobiFlight/I2CPinsNotDefinedException.cs
@@ -1,0 +1,18 @@
+﻿using MobiFlight.OutputConfig;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MobiFlight
+{
+    class I2CPinsNotDefinedException : Exception
+    {
+        public String DeviceType;
+        public I2CPinsNotDefinedException(String DeviceType)
+            : base(String.Format("{0} requires I2C pins however none are defined for the selected board.", DeviceType))
+        {
+            this.DeviceType = DeviceType;
+        }
+    }
+}

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -1078,7 +1078,7 @@ namespace MobiFlight
         }
 
         // Returns a List<> of the pins used by the module
-        public List<MobiFlightPin> GetPins(bool FreeOnly = false)
+        public List<MobiFlightPin> GetPins(bool FreeOnly = false, bool ExcludeI2CDevices = false)
         {
             List<MobiFlightPin> ResultPins = new List<MobiFlightPin>();
             ResultPins.AddRange(Board.Pins.Select(x => new MobiFlightPin(x)));
@@ -1127,6 +1127,11 @@ namespace MobiFlight
                         break;
 
                     case DeviceType.LcdDisplay:
+                        if (ExcludeI2CDevices)
+                        {
+                            continue;
+                        }
+
                         // Statically add correct I2C pins
                         foreach (MobiFlightPin pin in Board.Pins.FindAll(x => x.isI2C))
                         {

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -224,6 +224,8 @@
     <Compile Include="MobiFlight\Config\ShiftRegister.cs" />
     <Compile Include="MobiFlight\Config\IConfigRefConfigItem.cs" />
     <Compile Include="MobiFlight\Config\AnalogInput.cs" />
+    <Compile Include="MobiFlight\I2CPinInUseException.cs" />
+    <Compile Include="MobiFlight\I2CPinsNotDefinedException.cs" />
     <Compile Include="MobiFlight\InputConfig\AnalogInputConfig.cs" />
     <Compile Include="MobiFlight\InputConfig\InputMultiplexerConfig.cs" />
     <Compile Include="MobiFlight\InputConfig\InputActionExecutionCache.cs" />

--- a/ProjectMessages/ProjectMessages.Designer.cs
+++ b/ProjectMessages/ProjectMessages.Designer.cs
@@ -340,6 +340,24 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to {0} requires the use of pin {1} which is already assigned to another module. Remove the pin assignment from the other module then try adding {0} again..
+        /// </summary>
+        internal static string uiI2CPinInUse {
+            get {
+                return ResourceManager.GetString("uiI2CPinInUse", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to I2C pin in use.
+        /// </summary>
+        internal static string uiI2CPinInUseHint {
+            get {
+                return ResourceManager.GetString("uiI2CPinInUseHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Double-click row to add new config....
         /// </summary>
         internal static string uiLabelDoubleClickToAddConfig {
@@ -1110,6 +1128,24 @@ namespace MobiFlight.ProjectMessages {
         internal static string uiMessageWasmUpdater {
             get {
                 return ResourceManager.GetString("uiMessageWasmUpdater", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} requires I2C pins however {1} doesn&apos;t have any defined..
+        /// </summary>
+        internal static string uiNoI2CPinsDefined {
+            get {
+                return ResourceManager.GetString("uiNoI2CPinsDefined", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No I2C pins defined.
+        /// </summary>
+        internal static string uiNoI2CPinsDefinedHint {
+            get {
+                return ResourceManager.GetString("uiNoI2CPinsDefinedHint", resourceCulture);
             }
         }
         

--- a/ProjectMessages/ProjectMessages.resx
+++ b/ProjectMessages/ProjectMessages.resx
@@ -497,4 +497,16 @@ Respective input actions won't work until they are connected and you have restar
   <data name="uiSettingsMobiFlightChangeRequiresRestart" xml:space="preserve">
     <value>This change will require a restart of MobiFlight to become effective.</value>
   </data>
+  <data name="uiI2CPinInUse" xml:space="preserve">
+    <value>{0} requires the use of pin {1} which is already assigned to another module. Remove the pin assignment from the other module then try adding {0} again.</value>
+  </data>
+  <data name="uiI2CPinInUseHint" xml:space="preserve">
+    <value>I2C pin in use</value>
+  </data>
+  <data name="uiNoI2CPinsDefined" xml:space="preserve">
+    <value>{0} requires I2C pins however {1} doesn't have any defined.</value>
+  </data>
+  <data name="uiNoI2CPinsDefinedHint" xml:space="preserve">
+    <value>No I2C pins defined</value>
+  </data>
 </root>

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -567,9 +567,9 @@ namespace MobiFlight.UI.Panels.Settings
 
                         // Check and see if any I2CPins exist in the board definition file. If not then there's no way to add an LCD device
                         // so throw an error.
-                        var I2CPins = tempModule.Board.Pins.FindAll(x => x.isI2C);
+                        var availableI2Cpins = tempModule.Board.Pins.FindAll(x => x.isI2C);
 
-                        if (!(I2CPins?.Any() ?? false))
+                        if (!(availableI2Cpins?.Any() ?? false))
                         {
                             throw new I2CPinsNotDefinedException(MobiFlightLcdDisplay.TYPE);
                         }
@@ -582,11 +582,11 @@ namespace MobiFlight.UI.Panels.Settings
                         // in use since that's sufficient to throw an error and tell the user what to do. Trying to
                         // write an error message that works for one or more in use I2C pins is way more trouble
                         // than it's worth.
-                        var inUseI2CPin = I2CPins.Find(x => pinsInUse?.Contains(x) ?? false);
+                        var firstInUseI2CPin = availableI2Cpins.Find(x => pinsInUse?.Contains(x) ?? false);
 
-                        if (inUseI2CPin != null)
+                        if (firstInUseI2CPin != null)
                         {
-                            throw new I2CPinInUseException(MobiFlightLcdDisplay.TYPE, inUseI2CPin);
+                            throw new I2CPinInUseException(MobiFlightLcdDisplay.TYPE, firstInUseI2CPin);
                         }
 
                         cfgItem = new MobiFlight.Config.LcdDisplay();


### PR DESCRIPTION
Fixes #900 

* Before adding an LCD display check for I2C pins being defined in the board definition file. If there aren't any then throw an error.
* When adding an LCD display check to see if any of the I2C pins are already assigned to non-I2C devices. If yes throw an error.