### PR TITLE
Add extra debug info when run isn't turned on

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1600,10 +1600,14 @@ namespace MobiFlight
             	}
             }
 
-            Log.Instance.log($"Config found for {e.Type}: {e.DeviceId}{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} ({eventAction})@{e.Serial}{(!IsStarted() ? ". Run isn't enabled so the event wasn't sent to the simulator." : "")}", LogSeverity.Debug);
+            Log.Instance.log($"Config found for {e.Type}: {e.DeviceId}{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} ({eventAction})@{e.Serial}", LogSeverity.Debug);
 
             // Skip execution if not started
-            if (!IsStarted()) return;
+            if (!IsStarted())
+            {
+                Log.Instance.log("Run isn't enabled so the event wasn't sent to the simulator.", LogSeverity.Debug);
+                return;
+            }
 
             ConnectorValue currentValue = new ConnectorValue();
             CacheCollection cacheCollection = new CacheCollection()

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1600,7 +1600,7 @@ namespace MobiFlight
             	}
             }
 
-            Log.Instance.log($"Config found for {e.Type}: {e.DeviceId}{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} ({eventAction})@{e.Serial}", LogSeverity.Debug);
+            Log.Instance.log($"Config found for {e.Type}: {e.DeviceId}{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} ({eventAction})@{e.Serial}{(!IsStarted() ? ". Run isn't enabled so the event wasn't sent to the simulator." : "")}", LogSeverity.Debug);
 
             // Skip execution if not started
             if (!IsStarted()) return;


### PR DESCRIPTION
Fixes #903 

Add a little bit of extra info to the log message when a config is found. Here's what it looks like when run isn't turned on and you trigger an input:

`Debug	9/11/2022 6:02:33 AM	Config found for Encoder: ENC1 (RIGHT)@SN-eaf-59f. Run isn't enabled so the event wasn't sent to the simulator.`

Here's what it looks like when run is active (no change):

`Debug	9/11/2022 6:02:29 AM	Config found for Encoder: ENC1 (RIGHT)@SN-eaf-59f`