### PR TITLE
Show progress of HubHop event download

### DIFF
--- a/Base/ProgressUpdateEvent.cs
+++ b/Base/ProgressUpdateEvent.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MobiFlight.Base
+{
+    public class ProgressUpdateEvent
+    {
+        public int Total = 100;
+        public int Current = 0;
+        public string ProgressMessage = null;
+    }
+}

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -210,6 +210,7 @@
     <Compile Include="Base\FullCacheInterface.cs" />
     <Compile Include="Base\i18n.cs" />
     <Compile Include="Base\PreconditionList.cs" />
+    <Compile Include="Base\ProgressUpdateEvent.cs" />
     <Compile Include="Base\SerialNumber.cs" />
     <Compile Include="Base\AppTelemetry.cs" />
     <Compile Include="Base\WriteCacheInterface.cs" />
@@ -326,6 +327,12 @@
     </Compile>
     <Compile Include="UI\Forms\ConfigUploadProgress.Designer.cs">
       <DependentUpon>ConfigUploadProgress.cs</DependentUpon>
+    </Compile>
+    <Compile Include="UI\Forms\ProgressForm.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="UI\Forms\ProgressForm.Designer.cs">
+      <DependentUpon>ProgressForm.cs</DependentUpon>
     </Compile>
     <Compile Include="UI\Forms\SimConnectLvarsListForm.cs">
       <SubType>Form</SubType>
@@ -944,6 +951,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UI\Forms\FirmwareUpdateProcess.de.resx">
       <DependentUpon>FirmwareUpdateProcess.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\Forms\ProgressForm.resx">
+      <DependentUpon>ProgressForm.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\Forms\SimConnectLvarsListForm.de.resx">
       <DependentUpon>SimConnectLvarsListForm.cs</DependentUpon>

--- a/SimConnectMSFS/WasmModuleUpdater.cs
+++ b/SimConnectMSFS/WasmModuleUpdater.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MobiFlight.Base;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
@@ -32,6 +33,8 @@ namespace MobiFlight.SimConnectMSFS
 
         public const String WasmModuleName = @"MobiFlightWasmModule.wasm";
         public const String WasmModuleNameOld = @"StandaloneModule.wasm";
+
+        public event EventHandler<ProgressUpdateEvent> DownloadAndInstallProgress;
 
         public String CommunityFolder { get; set; }
 
@@ -227,17 +230,36 @@ namespace MobiFlight.SimConnectMSFS
 
         public bool DownloadWasmEvents()
         {
-            if(!DownloadSingleFile(new Uri(WasmEventsTxtUrl), WasmEventsTxtFile, WasmModuleFolder + @"\modules")) return false;
+            ProgressUpdateEvent progress = new ProgressUpdateEvent();
+
+            progress.ProgressMessage = "Downloading WASM events.txt (legacy)";
+            progress.Current = 5;
+            DownloadAndInstallProgress?.Invoke(this, progress);
+
+            if (!DownloadSingleFile(new Uri(WasmEventsTxtUrl), WasmEventsTxtFile, WasmModuleFolder + @"\modules")) return false;
             Log.Instance.log("WASM events.txt has been downloaded and installed successfully.", LogSeverity.Info);
 
+            progress.ProgressMessage = "Downloading EventIDs (legacy)";
+            progress.Current = 25;
+            DownloadAndInstallProgress?.Invoke(this, progress);
             if (!DownloadSingleFile(new Uri(WasmEventsCipUrl), WasmEventsCipFileName, WasmEventsCipFolder)) return false;
             Log.Instance.log("WASM msfs2020_eventids.cip has been downloaded and installed successfully.", LogSeverity.Info);
-            
+
+            progress.ProgressMessage = "Downloading SimVars (legacy)";
+            progress.Current = 50;
+            DownloadAndInstallProgress?.Invoke(this, progress);
             if (!DownloadSingleFile(new Uri(WasmEventsSimVarsUrl), WasmEventsSimVarsFileName, WasmEventsSimVarsFolder)) return false;
             Log.Instance.log("WASM msfs2020_simvars.cip has been downloaded and installed successfully.", LogSeverity.Info);
 
+            progress.ProgressMessage = "Downloading HubHop Presets";
+            progress.Current = 75;
+            DownloadAndInstallProgress?.Invoke(this, progress);
             if (!DownloadSingleFile(new Uri(WasmEventHubHHopUrl), WasmEventsHubHopFileName, WasmEventsHubHopFolder)) return false;
             Log.Instance.log($"WASM {WasmEventsHubHopFileName} has been downloaded and installed successfully.", LogSeverity.Info);
+
+            progress.ProgressMessage = "Downloading done";
+            progress.Current = 100;
+            DownloadAndInstallProgress?.Invoke(this, progress);
             return true;
         }
 

--- a/UI/Dialogs/TimeoutMessageDialog.cs
+++ b/UI/Dialogs/TimeoutMessageDialog.cs
@@ -51,7 +51,18 @@ namespace MobiFlight.UI.Dialogs
             tmd.HasCancelButton = buttons == MessageBoxButtons.OKCancel;
             tmd.Message = Message;
             tmd.Text = Title;
-            return tmd.ShowDialog();
+            return tmd.ShowDialog(tmd.Parent);
+        }
+
+        new public static DialogResult Show(Control Parent, string Message, String Title, MessageBoxButtons buttons, MessageBoxIcon icon)
+        {
+            TimeoutMessageDialog tmd = new TimeoutMessageDialog();
+            tmd.Parent = Parent;
+            tmd.StartPosition = FormStartPosition.CenterParent;
+            tmd.HasCancelButton = buttons == MessageBoxButtons.OKCancel;
+            tmd.Message = Message;
+            tmd.Text = Title;
+            return tmd.ShowDialog(tmd.Parent);
         }
 
         public TimeoutMessageDialog()

--- a/UI/Forms/ProgressForm.Designer.cs
+++ b/UI/Forms/ProgressForm.Designer.cs
@@ -31,63 +31,55 @@
             this.progressBar1 = new System.Windows.Forms.ProgressBar();
             this.StepDescriptionLabel = new System.Windows.Forms.Label();
             this.ProgressLabel = new System.Windows.Forms.Label();
-            this.button1 = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // progressBar1
             // 
             this.progressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.progressBar1.Location = new System.Drawing.Point(11, 70);
-            this.progressBar1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.progressBar1.Location = new System.Drawing.Point(11, 44);
+            this.progressBar1.Margin = new System.Windows.Forms.Padding(2);
             this.progressBar1.Name = "progressBar1";
-            this.progressBar1.Size = new System.Drawing.Size(398, 44);
+            this.progressBar1.Size = new System.Drawing.Size(373, 44);
             this.progressBar1.TabIndex = 0;
             // 
             // StepDescriptionLabel
             // 
             this.StepDescriptionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.StepDescriptionLabel.Location = new System.Drawing.Point(12, 35);
+            this.StepDescriptionLabel.Location = new System.Drawing.Point(12, 9);
             this.StepDescriptionLabel.Name = "StepDescriptionLabel";
-            this.StepDescriptionLabel.Size = new System.Drawing.Size(398, 33);
+            this.StepDescriptionLabel.Size = new System.Drawing.Size(373, 33);
             this.StepDescriptionLabel.TabIndex = 1;
             this.StepDescriptionLabel.Text = "label1";
             // 
             // ProgressLabel
             // 
-            this.ProgressLabel.Location = new System.Drawing.Point(12, 116);
+            this.ProgressLabel.Location = new System.Drawing.Point(11, 99);
             this.ProgressLabel.Name = "ProgressLabel";
-            this.ProgressLabel.Size = new System.Drawing.Size(398, 21);
+            this.ProgressLabel.Size = new System.Drawing.Size(373, 21);
             this.ProgressLabel.TabIndex = 2;
             this.ProgressLabel.Text = "Step {0} / {1}";
-            // 
-            // button1
-            // 
-            this.button1.Location = new System.Drawing.Point(169, 140);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(82, 29);
-            this.button1.TabIndex = 3;
-            this.button1.Text = "Cancel";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
             // ProgressForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(420, 196);
-            this.Controls.Add(this.button1);
+            this.ClientSize = new System.Drawing.Size(395, 133);
+            this.ControlBox = false;
             this.Controls.Add(this.ProgressLabel);
             this.Controls.Add(this.StepDescriptionLabel);
             this.Controls.Add(this.progressBar1);
+            this.DoubleBuffered = true;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.Margin = new System.Windows.Forms.Padding(2);
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
             this.Name = "ProgressForm";
             this.ShowIcon = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "ProgressForm";
+            this.Text = "Download HubHop Events";
             this.ResumeLayout(false);
 
         }
@@ -97,6 +89,5 @@
         private System.Windows.Forms.ProgressBar progressBar1;
         private System.Windows.Forms.Label StepDescriptionLabel;
         private System.Windows.Forms.Label ProgressLabel;
-        private System.Windows.Forms.Button button1;
     }
 }

--- a/UI/Forms/ProgressForm.Designer.cs
+++ b/UI/Forms/ProgressForm.Designer.cs
@@ -1,0 +1,102 @@
+﻿namespace MobiFlight.UI.Forms
+{
+    partial class ProgressForm
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.progressBar1 = new System.Windows.Forms.ProgressBar();
+            this.StepDescriptionLabel = new System.Windows.Forms.Label();
+            this.ProgressLabel = new System.Windows.Forms.Label();
+            this.button1 = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // progressBar1
+            // 
+            this.progressBar1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.progressBar1.Location = new System.Drawing.Point(11, 70);
+            this.progressBar1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.progressBar1.Name = "progressBar1";
+            this.progressBar1.Size = new System.Drawing.Size(398, 44);
+            this.progressBar1.TabIndex = 0;
+            // 
+            // StepDescriptionLabel
+            // 
+            this.StepDescriptionLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.StepDescriptionLabel.Location = new System.Drawing.Point(12, 35);
+            this.StepDescriptionLabel.Name = "StepDescriptionLabel";
+            this.StepDescriptionLabel.Size = new System.Drawing.Size(398, 33);
+            this.StepDescriptionLabel.TabIndex = 1;
+            this.StepDescriptionLabel.Text = "label1";
+            // 
+            // ProgressLabel
+            // 
+            this.ProgressLabel.Location = new System.Drawing.Point(12, 116);
+            this.ProgressLabel.Name = "ProgressLabel";
+            this.ProgressLabel.Size = new System.Drawing.Size(398, 21);
+            this.ProgressLabel.TabIndex = 2;
+            this.ProgressLabel.Text = "Step {0} / {1}";
+            // 
+            // button1
+            // 
+            this.button1.Location = new System.Drawing.Point(169, 140);
+            this.button1.Name = "button1";
+            this.button1.Size = new System.Drawing.Size(82, 29);
+            this.button1.TabIndex = 3;
+            this.button1.Text = "Cancel";
+            this.button1.UseVisualStyleBackColor = true;
+            this.button1.Click += new System.EventHandler(this.button1_Click);
+            // 
+            // ProgressForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(420, 196);
+            this.Controls.Add(this.button1);
+            this.Controls.Add(this.ProgressLabel);
+            this.Controls.Add(this.StepDescriptionLabel);
+            this.Controls.Add(this.progressBar1);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.Name = "ProgressForm";
+            this.ShowIcon = false;
+            this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Text = "ProgressForm";
+            this.ResumeLayout(false);
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.ProgressBar progressBar1;
+        private System.Windows.Forms.Label StepDescriptionLabel;
+        private System.Windows.Forms.Label ProgressLabel;
+        private System.Windows.Forms.Button button1;
+    }
+}

--- a/UI/Forms/ProgressForm.cs
+++ b/UI/Forms/ProgressForm.cs
@@ -14,9 +14,23 @@ namespace MobiFlight.UI.Forms
     public partial class ProgressForm : Form
     {
         delegate void VoidDelegate(); 
+        Timer timer = new Timer();
+
         public ProgressForm()
         {
             InitializeComponent();
+            //FormClosing += (sender, e) => { timer.Stop(); timer.Dispose(); };
+            timer.Interval = 200;
+            timer.Tick += Timer_Tick;
+        }
+
+        private void Timer_Tick(object sender, EventArgs e)
+        {
+            if (progressBar1.Value >= progressBar1.Maximum - 2)
+                return;
+            
+            progressBar1.Value += 1;
+            ProgressLabel.Text = String.Format("Completed {0}%", Math.Round((decimal) progressBar1.Value * 100 / progressBar1.Maximum, 0));
         }
 
         public void OnProgressUpdated(object sender, ProgressUpdateEvent e)
@@ -24,18 +38,27 @@ namespace MobiFlight.UI.Forms
             if (this.InvokeRequired)
                 this.Invoke(new EventHandler<ProgressUpdateEvent>(OnProgressUpdated), new object[] { sender, e });
 
+            timer.Start();  
             progressBar1.Value = e.Current;
             progressBar1.Maximum = e.Total;
-            ProgressLabel.Text = String.Format("Step {0} / {1}", e.Current, e.Total);
+            ProgressLabel.Text = String.Format("Completed {0}%", Math.Round((decimal)e.Current * 100 / e.Total, 0));
             StepDescriptionLabel.Text = e.ProgressMessage;
 
             if (e.Current == e.Total)
             {
                 if (this.InvokeRequired)
-                    this.Invoke(new VoidDelegate(Close), new object[] { });
-                else 
-                    this.Close();
+                    this.Invoke(new EventHandler<ProgressUpdateEvent>(OnProgressCompleted), new object[] { sender, e });
             }
+        }
+
+        public void OnProgressCompleted(object sender, ProgressUpdateEvent e)
+        {
+            timer.Stop();
+            progressBar1.Value = e.Current;
+            progressBar1.Maximum = e.Total;
+            ProgressLabel.Text = String.Format("Completed {0}%", Math.Round((decimal)e.Current * 100 / e.Total, 0));
+            StepDescriptionLabel.Text = e.ProgressMessage;
+            button1.Text = "OK";
         }
 
         private void button1_Click(object sender, EventArgs e)

--- a/UI/Forms/ProgressForm.cs
+++ b/UI/Forms/ProgressForm.cs
@@ -1,0 +1,46 @@
+﻿using MobiFlight.Base;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace MobiFlight.UI.Forms
+{
+    public partial class ProgressForm : Form
+    {
+        delegate void VoidDelegate(); 
+        public ProgressForm()
+        {
+            InitializeComponent();
+        }
+
+        public void OnProgressUpdated(object sender, ProgressUpdateEvent e)
+        {
+            if (this.InvokeRequired)
+                this.Invoke(new EventHandler<ProgressUpdateEvent>(OnProgressUpdated), new object[] { sender, e });
+
+            progressBar1.Value = e.Current;
+            progressBar1.Maximum = e.Total;
+            ProgressLabel.Text = String.Format("Step {0} / {1}", e.Current, e.Total);
+            StepDescriptionLabel.Text = e.ProgressMessage;
+
+            if (e.Current == e.Total)
+            {
+                if (this.InvokeRequired)
+                    this.Invoke(new VoidDelegate(Close), new object[] { });
+                else 
+                    this.Close();
+            }
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+    }
+}

--- a/UI/Forms/ProgressForm.cs
+++ b/UI/Forms/ProgressForm.cs
@@ -58,7 +58,7 @@ namespace MobiFlight.UI.Forms
             progressBar1.Maximum = e.Total;
             ProgressLabel.Text = String.Format("Completed {0}%", Math.Round((decimal)e.Current * 100 / e.Total, 0));
             StepDescriptionLabel.Text = e.ProgressMessage;
-            button1.Text = "OK";
+            this.Close();
         }
 
         private void button1_Click(object sender, EventArgs e)

--- a/UI/Forms/ProgressForm.resx
+++ b/UI/Forms/ProgressForm.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1676,10 +1676,10 @@ namespace MobiFlight.UI
             var t = new Task(() => {
                     if (!updater.AutoDetectCommunityFolder())
                     {
-                        TimeoutMessageDialog.Show(
+                        /*TimeoutMessageDialog.Show(
                            i18n._tr("uiMessageWasmUpdateCommunityFolderNotFound"),
                            i18n._tr("uiMessageWasmUpdater"),
-                           MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                           MessageBoxButtons.OK, MessageBoxIcon.Warning);*/
                         return;
                     }
 
@@ -1694,15 +1694,16 @@ namespace MobiFlight.UI
                     }
                     else
                     {
-                        TimeoutMessageDialog.Show(
+                        /*TimeoutMessageDialog.Show(
                            i18n._tr("uiMessageWasmEventsInstallationError"),
                            i18n._tr("uiMessageWasmUpdater"),
-                           MessageBoxButtons.OK, MessageBoxIcon.Error);
+                           MessageBoxButtons.OK, MessageBoxIcon.Error);*/
                     }
                 }
             );
             t.Start();
-            progressForm.ShowDialog(Owner); 
+            progressForm.ShowDialog();
+            progressForm.Dispose();
         }
 
         private void openDiscordServer_Click(object sender, EventArgs e)

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1671,38 +1671,50 @@ namespace MobiFlight.UI
         {
             WasmModuleUpdater updater = new WasmModuleUpdater();
             ProgressForm progressForm = new ProgressForm();
+            Control MainForm = this;
 
             updater.DownloadAndInstallProgress += progressForm.OnProgressUpdated;
             var t = new Task(() => {
                     if (!updater.AutoDetectCommunityFolder())
                     {
-                        /*TimeoutMessageDialog.Show(
-                           i18n._tr("uiMessageWasmUpdateCommunityFolderNotFound"),
-                           i18n._tr("uiMessageWasmUpdater"),
-                           MessageBoxButtons.OK, MessageBoxIcon.Warning);*/
+                        Log.Instance.log(
+                            i18n._tr("uiMessageWasmUpdateCommunityFolderNotFound"),
+                            LogSeverity.Error
+                        );
                         return;
                     }
 
                     if (updater.InstallWasmEvents())
                     {
                         Msfs2020HubhopPresetListSingleton.Instance.Clear();
-
-                        TimeoutMessageDialog.Show(
-                           i18n._tr("uiMessageWasmEventsInstallationSuccessful"),
-                           i18n._tr("uiMessageWasmUpdater"),
-                           MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        progressForm.DialogResult = DialogResult.OK;
                     }
                     else
                     {
-                        /*TimeoutMessageDialog.Show(
-                           i18n._tr("uiMessageWasmEventsInstallationError"),
-                           i18n._tr("uiMessageWasmUpdater"),
-                           MessageBoxButtons.OK, MessageBoxIcon.Error);*/
+                        progressForm.DialogResult = DialogResult.No;
+                        Log.Instance.log(
+                            i18n._tr("uiMessageWasmEventsInstallationError"),
+                            LogSeverity.Error
+                        );
                     }
                 }
             );
+
             t.Start();
-            progressForm.ShowDialog();
+            if (progressForm.ShowDialog() == DialogResult.OK)
+            {
+                TimeoutMessageDialog.Show(
+                   i18n._tr("uiMessageWasmEventsInstallationSuccessful"),
+                   i18n._tr("uiMessageWasmUpdater"),
+                   MessageBoxButtons.OK, MessageBoxIcon.Information);
+            } else
+            {
+                TimeoutMessageDialog.Show(
+                    i18n._tr("uiMessageWasmEventsInstallationError"),
+                    i18n._tr("uiMessageWasmUpdater"),
+                    MessageBoxButtons.OK, MessageBoxIcon.Error);
+            };
+
             progressForm.Dispose();
         }
 

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -23,6 +23,7 @@ using MobiFlight.Base;
 using Microsoft.ApplicationInsights.DataContracts;
 using MobiFlight.xplane;
 using MobiFlight.HubHop;
+using System.Threading.Tasks;
 
 namespace MobiFlight.UI
 {
@@ -1669,32 +1670,39 @@ namespace MobiFlight.UI
         private void downloadLatestEventsToolStripMenuItem_Click(object sender, EventArgs e)
         {
             WasmModuleUpdater updater = new WasmModuleUpdater();
+            ProgressForm progressForm = new ProgressForm();
 
-            if (!updater.AutoDetectCommunityFolder())
-            {
-                TimeoutMessageDialog.Show(
-                   i18n._tr("uiMessageWasmUpdateCommunityFolderNotFound"),
-                   i18n._tr("uiMessageWasmUpdater"),
-                   MessageBoxButtons.OK, MessageBoxIcon.Warning);
-                return;
-            }
+            updater.DownloadAndInstallProgress += progressForm.OnProgressUpdated;
+            var t = new Task(() => {
+                    if (!updater.AutoDetectCommunityFolder())
+                    {
+                        TimeoutMessageDialog.Show(
+                           i18n._tr("uiMessageWasmUpdateCommunityFolderNotFound"),
+                           i18n._tr("uiMessageWasmUpdater"),
+                           MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                        return;
+                    }
 
-            if (updater.InstallWasmEvents())
-            {
-                Msfs2020HubhopPresetListSingleton.Instance.Clear();
+                    if (updater.InstallWasmEvents())
+                    {
+                        Msfs2020HubhopPresetListSingleton.Instance.Clear();
 
-                TimeoutMessageDialog.Show(
-                   i18n._tr("uiMessageWasmEventsInstallationSuccessful"),
-                   i18n._tr("uiMessageWasmUpdater"),
-                   MessageBoxButtons.OK, MessageBoxIcon.Information);
-            }
-            else
-            {
-                TimeoutMessageDialog.Show(
-                   i18n._tr("uiMessageWasmEventsInstallationError"),
-                   i18n._tr("uiMessageWasmUpdater"),
-                   MessageBoxButtons.OK, MessageBoxIcon.Error);
-            }
+                        TimeoutMessageDialog.Show(
+                           i18n._tr("uiMessageWasmEventsInstallationSuccessful"),
+                           i18n._tr("uiMessageWasmUpdater"),
+                           MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    }
+                    else
+                    {
+                        TimeoutMessageDialog.Show(
+                           i18n._tr("uiMessageWasmEventsInstallationError"),
+                           i18n._tr("uiMessageWasmUpdater"),
+                           MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                }
+            );
+            t.Start();
+            progressForm.ShowDialog(Owner); 
         }
 
         private void openDiscordServer_Click(object sender, EventArgs e)


### PR DESCRIPTION
It is now possible to see the progress of the hubhop event file downloads instead of simply having a blocking UI.
fixes #720 

- [x] Dialog shows progress
- [x] Existing success message still shown after successful download
- [x] Existing error message is shown when something goes wrong
- [x] More details about errors are available in the log file as error

Notes:

This is the new progress bar when downloading the events.
<img width="302" alt="image" src="https://user-images.githubusercontent.com/86157512/189542597-da9f850e-f5a1-46bb-a8ed-af8570ce432e.png">
