### PR TITLE
Fixed output processing

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -466,7 +466,6 @@ namespace MobiFlight
 
                 List<ConfigRefValue> configRefs = GetRefs(cfg.ConfigRefs);
 
-                String strValue = "";
                 try
                 {
                     processedValue = value;
@@ -494,7 +493,8 @@ namespace MobiFlight
                     }
                     else
                     {
-                        strValue = cfg.Preconditions.FalseCaseValue;
+                        processedValue.type = FSUIPCOffsetType.String;
+                        processedValue.String = cfg.Preconditions.FalseCaseValue;
                     }
                 }
                 else
@@ -505,7 +505,7 @@ namespace MobiFlight
 
                 try
                 {
-                    ExecuteDisplay(strValue, cfg);
+                    ExecuteDisplay(processedValue.ToString(), cfg);
                 }
                 catch (Exception exc)
                 {


### PR DESCRIPTION
Hi all,
I think the most recent PR (#909) introduced a bug regarding outputs. The refactoring of the `ExecuteConfig` function did not update the value passed into the `ExecuteDisplay` function. Therefore, this function was always called with an empty string.