### PR TITLE
Feature Proposal: REST/WebSocket API

### DIFF
--- a/MobiFlight/RestWebSocketApi/MessageProcessor.cs
+++ b/MobiFlight/RestWebSocketApi/MessageProcessor.cs
@@ -1,0 +1,88 @@
+﻿using MobiFlight.RestWebSocketApi.Messages;
+using Swan;
+using System;
+using System.Collections.Generic;
+
+namespace MobiFlight.RestWebSocketApi
+{
+
+    internal class MessageProcessor
+    {
+        public event ButtonEventHandler TriggerInputEvent;
+        public List<string> InputEndpoints { get; set; }
+        public Dictionary<string, string> OutputCache { get; set; }
+
+        public MessageProcessor(Dictionary<string, string> outputCache)
+        {
+            OutputCache = outputCache;
+        }
+
+        public string ProcessJsonMessage(string msg)
+        {
+            try
+            {
+                IMessage jsonMsg = BaseMessage.Deserialize(msg);
+                return ProcessMessage(jsonMsg);
+            } catch(Exception e)
+            {
+                return new ErrorMessage($"Could not deserialize message ({e.Message})").Serialize();
+            }
+        }
+
+        public string ProcessMessage(IMessage msg)
+        {
+            switch(msg.msgType)
+            {
+                case MessageTypeEnum.TRIGGER_INPUT:
+                    return triggerInput((TriggerInputMessage)msg);
+                case MessageTypeEnum.GET_OUTPUT:
+                    return getOutput((GetOutputMessage)msg);
+                case MessageTypeEnum.GET_ALL_OUTPUTS:
+                    return getAllOutputs((GetAllOutputsMessage)msg);
+            }
+
+            return new ErrorMessage("Message could not be processed.").Serialize();
+        }
+
+        private string triggerInput(TriggerInputMessage msg)
+        {
+            if (!InputEndpoints.Contains(msg.Input))
+            {
+                return new ErrorMessage("Input not found").Serialize();
+            }
+
+            var inpEv = new InputEventArgs()
+            {
+                Serial = RestApiManager.serial,
+                Type = DeviceType.AnalogInput,
+                DeviceId = msg.Input,
+                StrValue = msg.Value,
+            };
+
+
+            try
+            {
+                inpEv.Value = int.Parse(msg.Value);
+            }
+            catch (FormatException e) { }
+
+            TriggerInputEvent.Invoke(null, inpEv);
+            return new SuccessMessage().Serialize();
+        }
+
+        private string getOutput(GetOutputMessage msg)
+        {
+            if (!OutputCache.ContainsKey(msg.Output))
+            {
+                return new ErrorMessage("Output not found").Serialize();
+            }
+
+            return new GetOutputMessage(msg.Output, OutputCache.GetValueOrDefault(msg.Output)).Serialize();
+        }
+
+        private string getAllOutputs(GetAllOutputsMessage msg)
+        {
+            return new GetAllOutputsMessage(OutputCache).Serialize();
+        }
+    }
+}

--- a/MobiFlight/RestWebSocketApi/Messages/BaseMessage.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/BaseMessage.cs
@@ -1,0 +1,55 @@
+﻿using Newtonsoft.Json;
+using Swan.Formatters;
+using System;
+
+namespace MobiFlight.RestWebSocketApi.Messages
+{
+    internal abstract class BaseMessage: IMessage
+    {
+        public string MessageType { get; set; }
+        public MessageTypeEnum msgType { 
+            get { 
+                return (MessageTypeEnum)Enum.Parse(typeof(MessageTypeEnum), MessageType, true); 
+            } 
+        }
+
+        public BaseMessage(MessageTypeEnum messageType)
+        {
+            switch(messageType)
+            {
+                case MessageTypeEnum.ERROR:
+                    MessageType = "ERROR";
+                    break;
+                case MessageTypeEnum.OUTPUT_CHANGED:
+                    MessageType = "OUTPUT_CHANGED";
+                    break;
+                case MessageTypeEnum.TRIGGER_INPUT:
+                    MessageType = "TRIGGER_INPUT";
+                    break;
+                case MessageTypeEnum.GET_OUTPUT:
+                    MessageType = "GET_OUTPUT";
+                    break;
+                case MessageTypeEnum.GET_ALL_OUTPUTS:
+                    MessageType = "GET_ALL_OUTPUTS";
+                    break;
+                case MessageTypeEnum.SUCCESS:
+                    MessageType = "SUCCESS";
+                    break;
+            }
+        }
+
+
+        public string Serialize()
+        {
+            return Json.Serialize(this, excludedNames: new[] {"msgType"});
+        }
+
+        public static IMessage Deserialize(string json)
+        {
+            return JsonConvert.DeserializeObject<IMessage>(json, new MessageConverter());
+        }
+
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/ErrorMessage.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/ErrorMessage.cs
@@ -1,0 +1,15 @@
+﻿namespace MobiFlight.RestWebSocketApi.Messages
+{
+    internal class ErrorMessage: BaseMessage
+    {
+        public string ErrorMsg { get; set; }
+        public ErrorMessage(string msg) : base(MessageTypeEnum.ERROR)
+        {
+            this.ErrorMsg = msg;
+        }
+
+        public ErrorMessage(): base(MessageTypeEnum.ERROR) { }
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/GetAllOutputsMessage.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/GetAllOutputsMessage.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+
+namespace MobiFlight.RestWebSocketApi.Messages
+{
+    internal class GetAllOutputsMessage: BaseMessage
+    {
+        public Dictionary<string, string> OutputValues { get; set; }
+        public GetAllOutputsMessage(Dictionary<string, string> outputValues) : base(MessageTypeEnum.GET_ALL_OUTPUTS) {
+            OutputValues = outputValues;
+        }
+        public GetAllOutputsMessage(): base(MessageTypeEnum.GET_ALL_OUTPUTS) { }
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/GetOutputMessage.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/GetOutputMessage.cs
@@ -1,0 +1,23 @@
+﻿namespace MobiFlight.RestWebSocketApi.Messages
+{
+    internal class GetOutputMessage: BaseMessage
+    {
+        public string Output { get; set; }
+        public string Value { get; set; }
+
+        public GetOutputMessage(string output, string value) : base(MessageTypeEnum.GET_OUTPUT)
+        {
+            Output = output;
+            Value = value;
+        }
+
+        public GetOutputMessage(string output) : base(MessageTypeEnum.GET_OUTPUT)
+        {
+            Output = output;
+        }
+
+        public GetOutputMessage(): base(MessageTypeEnum.GET_OUTPUT) { }
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/IMessage.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/IMessage.cs
@@ -1,0 +1,10 @@
+﻿namespace MobiFlight.RestWebSocketApi.Messages
+{
+    internal interface IMessage
+    {
+        string MessageType { get; set; }
+        MessageTypeEnum msgType { get; }
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/MessageConverter.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/MessageConverter.cs
@@ -1,0 +1,51 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Newtonsoft.Json.Linq;
+using System;
+
+namespace MobiFlight.RestWebSocketApi.Messages
+{
+
+    class MessageConverter : CustomCreationConverter<IMessage>
+    {
+        public override IMessage Create(Type objectType)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IMessage Create(Type objectType, JObject jobject)
+        {
+            string type = (string)jobject.Property("MessageType");
+            MessageTypeEnum msgType = (MessageTypeEnum)Enum.Parse(typeof(MessageTypeEnum), type, true);
+
+            switch (msgType)
+            {
+                case MessageTypeEnum.OUTPUT_CHANGED:
+                    return new OutputChangedMessage();
+                case MessageTypeEnum.TRIGGER_INPUT:
+                    return new TriggerInputMessage();
+                case MessageTypeEnum.GET_ALL_OUTPUTS:
+                    return new GetAllOutputsMessage();
+                case MessageTypeEnum.ERROR:
+                    return new ErrorMessage();
+                case MessageTypeEnum.GET_OUTPUT:
+                    return new GetOutputMessage();
+                case MessageTypeEnum.SUCCESS:
+                    return new SuccessMessage();
+            }
+
+            throw new ApplicationException($"Unknown message type! ${type}");
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject job = JObject.Load(reader);
+            var target = Create(objectType, job);
+            serializer.Populate(job.CreateReader(), target);
+            return target;
+        }
+
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/MessageTypeEnum.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/MessageTypeEnum.cs
@@ -1,0 +1,14 @@
+﻿namespace MobiFlight.RestWebSocketApi.Messages
+{
+    public enum MessageTypeEnum
+    {
+        ERROR,
+        SUCCESS,
+        OUTPUT_CHANGED,
+        TRIGGER_INPUT,
+        GET_OUTPUT,
+        GET_ALL_OUTPUTS
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/OutputChangedMessage.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/OutputChangedMessage.cs
@@ -1,0 +1,18 @@
+﻿namespace MobiFlight.RestWebSocketApi.Messages
+{
+    internal class OutputChangedMessage: BaseMessage
+    {
+        public string Output { get; set; }
+        public string Value { get; set; }
+
+        public OutputChangedMessage(string output, string value): base(MessageTypeEnum.OUTPUT_CHANGED)
+        {
+            this.Output = output;
+            this.Value = value;
+        }
+
+        public OutputChangedMessage(): base(MessageTypeEnum.OUTPUT_CHANGED) { }
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/SuccessMessage.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/SuccessMessage.cs
@@ -1,0 +1,12 @@
+﻿namespace MobiFlight.RestWebSocketApi.Messages
+{
+    internal class SuccessMessage: BaseMessage
+    {
+        public string Message { get; set; }
+        public SuccessMessage(): base(MessageTypeEnum.SUCCESS) {
+            Message = "ok";
+        }
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/Messages/TriggerInputMessage.cs
+++ b/MobiFlight/RestWebSocketApi/Messages/TriggerInputMessage.cs
@@ -1,0 +1,18 @@
+﻿namespace MobiFlight.RestWebSocketApi.Messages
+{
+    internal class TriggerInputMessage: BaseMessage
+    {
+        public string Input { get; set; }
+        public string Value { get; set; }
+
+        public TriggerInputMessage(string input, string value): base(MessageTypeEnum.TRIGGER_INPUT)
+        {
+            Input = input;
+            Value = value;
+        }
+
+        public TriggerInputMessage(): base(MessageTypeEnum.TRIGGER_INPUT) { }
+    }
+
+
+}

--- a/MobiFlight/RestWebSocketApi/RestApiManger.cs
+++ b/MobiFlight/RestWebSocketApi/RestApiManger.cs
@@ -1,0 +1,87 @@
+﻿using EmbedIO;
+using EmbedIO.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace MobiFlight.RestWebSocketApi
+{
+    internal class RestApiManager
+    {
+        public static string serial = "RestAPI";
+        public List<string> apiInputEndpoints = new List<string>();
+        private readonly Dictionary<string, string> outputCache = new Dictionary<string, string>();
+
+        public readonly RestApiServer restApiServer;
+        public readonly WebSocketApiServer webSocketApiServer;
+
+        private WebServer restServer;
+        private WebServer websocketServer;
+        private CancellationTokenSource cancellationToken;
+        public event ButtonEventHandler OnButtonPressed;
+
+        private bool isRunning = false;
+        
+
+        private readonly MessageProcessor messageProcessor;
+
+        public RestApiManager()
+        {
+            messageProcessor = new MessageProcessor(outputCache);
+
+            restApiServer = new RestApiServer(messageProcessor);
+            webSocketApiServer = new WebSocketApiServer("/", true, messageProcessor);
+        }
+
+        public void Start(List<string> apiInputEndpoints)
+        {
+            if (apiInputEndpoints.Count == 0) { return; }
+            if (isRunning) {
+                cancellationToken.Cancel();
+            }
+
+
+            RestApiServerSettings settings = RestApiServerSettings.Load();
+
+            restServer = new WebServer(o => o.WithUrlPrefix($"http://{settings.restServerInterface}:{settings.restPort}/").WithMode(HttpListenerMode.EmbedIO))
+            .WithWebApi("/", m => m.WithController<RestApiServer>(() =>
+            {
+                return restApiServer;
+            }));
+
+            websocketServer = new WebServer(o => o.WithUrlPrefix($"http://{settings.websocketServerInterface}:{settings.websocketPort}/"))
+                .WithModule(webSocketApiServer);
+
+
+            isRunning = true;
+            messageProcessor.TriggerInputEvent += OnButtonPressed;
+
+            cancellationToken = new CancellationTokenSource();
+            restServer.Start(cancellationToken.Token);
+            websocketServer.Start(cancellationToken.Token);
+        }
+
+        public void UpdateRestApiEndpoints(List<string> apiInputEndpoints)
+        {
+            messageProcessor.InputEndpoints = apiInputEndpoints;
+        }
+
+        public void Stop()
+        {
+            if (cancellationToken != null)
+            {
+                cancellationToken.Cancel();
+            }
+        }
+
+        public void PublishOutput(string endpoint, string value)
+        {
+            if (!outputCache.ContainsKey(endpoint) || value != outputCache[endpoint])
+            {
+                outputCache[endpoint] = value;
+                webSocketApiServer.OutputChanged(endpoint, value);
+            }
+        }
+
+    }
+}

--- a/MobiFlight/RestWebSocketApi/RestApiServer.cs
+++ b/MobiFlight/RestWebSocketApi/RestApiServer.cs
@@ -1,0 +1,55 @@
+﻿using EmbedIO.Routing;
+using EmbedIO;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using Swan;
+using MobiFlight.RestWebSocketApi.Messages;
+
+namespace MobiFlight.RestWebSocketApi
+{
+    internal class RestApiServer: EmbedIO.WebApi.WebApiController
+    {
+        private readonly MessageProcessor messageProcessor;
+
+        public RestApiServer(MessageProcessor aMessageProcessor)
+        {
+            messageProcessor = aMessageProcessor;
+        }
+
+
+        [Route(HttpVerbs.Post, "/")]
+        public async Task<Task> generalEndpoint()
+        {
+            string data = await HttpContext.GetRequestBodyAsStringAsync();
+            return jsonResp(messageProcessor.ProcessJsonMessage(data));
+        }
+
+        [Route(HttpVerbs.Post, "/input/{name}")]
+        public async Task<Task> inputEndpoint(string name)
+        {
+            string data = await HttpContext.GetRequestBodyAsStringAsync();
+            return jsonResp(messageProcessor.ProcessMessage(new TriggerInputMessage(name, data)));
+        }
+
+        [Route(HttpVerbs.Get, "/output/{name}")]
+        public Task outputEndpoint(string name)
+        {
+            return jsonResp(messageProcessor.ProcessMessage(new GetOutputMessage(name)));
+        }
+
+        [Route(HttpVerbs.Get, "/output/")]
+        public Task getAllOutputs(string name)
+        {
+            return jsonResp(messageProcessor.ProcessMessage(new GetAllOutputsMessage()));
+        }
+
+        private Task jsonResp(string name)
+        {
+            return HttpContext.SendStringAsync(name, "application/json", Encoding.UTF8);
+        }
+    }
+}

--- a/MobiFlight/RestWebSocketApi/RestApiServerSettings.cs
+++ b/MobiFlight/RestWebSocketApi/RestApiServerSettings.cs
@@ -1,0 +1,120 @@
+﻿using MobiFlight.Config;
+using MobiFlight.Properties;
+using System.IO;
+using System.Text;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace MobiFlight.RestWebSocketApi
+{
+    public class RestApiServerSettings : IXmlSerializable
+    {
+
+
+        private bool _hasChanged = false;
+        public bool HasChanged { get { return _hasChanged; } }
+
+
+        public static RestApiServerSettings Load()
+        {
+            string config = Settings.Default.RestWebsocketServerConfig;
+            if (config == "")
+            {
+                RestApiServerSettings r = new RestApiServerSettings();
+                r.restPort = "9998";
+                r.websocketPort = "9999";
+                r.websocketServerInterface = "127.0.0.1";
+                r.restServerInterface = "127.0.0.1";
+                return r;
+            }
+
+            XmlSerializer serializer = new XmlSerializer(typeof(RestApiServerSettings));
+            StringReader w = new StringReader(config);
+            return (RestApiServerSettings)serializer.Deserialize(w);
+        }
+
+        public void Save()
+        {
+            XmlSerializer serializer = new XmlSerializer(typeof(RestApiServerSettings));
+            StringBuilder builder = new StringBuilder();
+            StringWriter w = new StringWriter(builder);
+            serializer.Serialize(w, this);
+            string s = w.ToString();
+            Settings.Default.RestWebsocketServerConfig = s;
+        }
+
+
+        string _restPort;
+        public string restPort
+        {
+            get { return _restPort; }
+            set
+            {
+                if (_restPort == value) return;
+                _restPort = value;
+                _hasChanged = true;
+            }
+        }
+
+        string _restServerInterface;
+        public string restServerInterface
+        {
+            get { return _restServerInterface; }
+            set
+            {
+                if (_restServerInterface == value) return;
+                _restServerInterface = value;
+                _hasChanged = true;
+            }
+        }
+
+        string _websocketPort;
+        public string websocketPort
+        {
+            get { return _websocketPort; }
+            set
+            {
+                if (_websocketPort == value) return;
+                _websocketPort = value;
+                _hasChanged = true;
+            }
+        }
+
+        string _websocketServerInterface;
+        public string websocketServerInterface
+        {
+            get { return _websocketServerInterface; }
+            set
+            {
+                if (_websocketServerInterface == value) return;
+                _websocketServerInterface = value;
+                _hasChanged = true;
+            }
+        }
+
+
+        public XmlSchema GetSchema()
+        {
+            return null;
+        }
+
+        public void ReadXml(XmlReader reader)
+        {
+            websocketServerInterface = reader["websocketServerInterface"];
+            websocketPort = reader["websocketPort"];
+            restServerInterface = reader["restServerInterface"];
+            restPort = reader["restPort"];
+            _hasChanged = false;
+            reader.Read();
+        }
+
+        public void WriteXml(XmlWriter writer)
+        {
+            writer.WriteAttributeString("websocketServerInterface", websocketServerInterface);
+            writer.WriteAttributeString("restServerInterface", restServerInterface);
+            writer.WriteAttributeString("websocketPort", websocketPort);
+            writer.WriteAttributeString("restPort", restPort);
+        }
+    }
+}

--- a/MobiFlight/RestWebSocketApi/WebSocketApiServer.cs
+++ b/MobiFlight/RestWebSocketApi/WebSocketApiServer.cs
@@ -1,0 +1,35 @@
+﻿using EmbedIO.WebSockets;
+using MobiFlight.RestWebSocketApi.Messages;
+using Newtonsoft.Json;
+using Swan;
+using Swan.Formatters;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MobiFlight.RestWebSocketApi
+{
+
+    internal class WebSocketApiServer : EmbedIO.WebSockets.WebSocketModule
+    {
+
+        private readonly MessageProcessor messageProcessor;
+
+        public WebSocketApiServer(string urlPath, bool enableConnectionWatchdog, MessageProcessor aMessageProcessor): base(urlPath, enableConnectionWatchdog)
+        {
+            messageProcessor = aMessageProcessor;
+        }
+
+        protected override Task OnMessageReceivedAsync(IWebSocketContext context, byte[] buffer, IWebSocketReceiveResult result)
+        {
+            string msg = Encoding.GetString(buffer);
+            return SendAsync(context, messageProcessor.ProcessJsonMessage(msg));
+        }
+
+        public void OutputChanged(string name, string value)
+        {
+            BroadcastAsync(new OutputChangedMessage(name, value).Serialize());
+        }
+    }    
+}

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -131,6 +131,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\ArcazeHid.dll</HintPath>
     </Reference>
+    <Reference Include="EmbedIO, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\EmbedIO.3.5.0\lib\netstandard2.0\EmbedIO.dll</HintPath>
+    </Reference>
     <Reference Include="fsuipcClient, Version=3.2.19.388, Culture=neutral, PublicKeyToken=7e7559b53e380b17, processorArchitecture=MSIL">
       <HintPath>packages\FSUIPCClientDLL.3.2.19\lib\net40\fsuipcClient.dll</HintPath>
     </Reference>
@@ -154,6 +157,9 @@
     </Reference>
     <Reference Include="SharpDX.DirectInput, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>packages\SharpDX.DirectInput.4.2.0\lib\net45\SharpDX.DirectInput.dll</HintPath>
+    </Reference>
+    <Reference Include="Swan.Lite, Version=3.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Unosquare.Swan.Lite.3.1.0\lib\net461\Swan.Lite.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -182,6 +188,9 @@
       <HintPath>packages\System.Runtime.CompilerServices.Unsafe.6.0.0\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Windows.Forms.DataVisualization" />
@@ -257,6 +266,21 @@
     <Compile Include="MobiFlight\OutputConfig\VariableOutput.cs" />
     <Compile Include="MobiFlight\OutputConfig\SimConnectValue.cs" />
     <Compile Include="HubHop\Msfs2020HubhopPresetList.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\MessageProcessor.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\BaseMessage.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\ErrorMessage.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\GetAllOutputsMessage.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\GetOutputMessage.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\IMessage.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\MessageTypeEnum.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\OutputChangedMessage.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\SuccessMessage.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\TriggerInputMessage.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\RestApiManger.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\RestApiServer.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\RestApiServerSettings.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\Messages\MessageConverter.cs" />
+    <Compile Include="MobiFlight\RestWebSocketApi\WebSocketApiServer.cs" />
     <Compile Include="SimConnectMSFS\SimConnectCacheInterface.cs" />
     <Compile Include="SimConnectMSFS\WasmModuleClient.cs" />
     <Compile Include="SimConnectMSFS\SimConnectDefinitions.cs" />
@@ -516,6 +540,12 @@
     </Compile>
     <Compile Include="UI\Panels\Settings\MobiFlightPanel.Designer.cs">
       <DependentUpon>MobiFlightPanel.cs</DependentUpon>
+    </Compile>
+    <Compile Include="UI\Panels\Settings\RestApiPanel.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UI\Panels\Settings\RestApiPanel.Designer.cs">
+      <DependentUpon>RestApiPanel.cs</DependentUpon>
     </Compile>
     <Compile Include="UI\Panels\StartupPanel.cs">
       <SubType>UserControl</SubType>
@@ -1145,6 +1175,9 @@
     <EmbeddedResource Include="UI\Panels\Settings\MobiFlightPanel.resx">
       <DependentUpon>MobiFlightPanel.cs</DependentUpon>
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="UI\Panels\Settings\RestApiPanel.resx">
+      <DependentUpon>RestApiPanel.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\Panels\StartupPanel.resx">
       <DependentUpon>StartupPanel.cs</DependentUpon>

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -443,5 +443,17 @@ namespace MobiFlight.Properties {
                 this["IgnoredComPortsList"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string RestWebsocketServerConfig {
+            get {
+                return ((string)(this["RestWebsocketServerConfig"]));
+            }
+            set {
+                this["RestWebsocketServerConfig"] = value;
+            }
+        }
     }
 }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -108,5 +108,8 @@
     <Setting Name="IgnoredComPortsList" Type="System.String" Scope="User">
       <Value Profile="(Default)" />
     </Setting>
+    <Setting Name="RestWebsocketServerConfig" Type="System.String" Scope="User">
+      <Value Profile="(Default)" />
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/UI/Dialogs/InputConfigWizard.Designer.cs
+++ b/UI/Dialogs/InputConfigWizard.Designer.cs
@@ -50,6 +50,7 @@
             this.presetsDataSet = new System.Data.DataSet();
             this.presetDataTable = new System.Data.DataTable();
             this.description = new System.Data.DataColumn();
+            this.restApiEndpointComboBox = new System.Windows.Forms.ComboBox();
             this.settingsColumn = new System.Data.DataColumn();
             this.MainPanel.SuspendLayout();
             this.tabControlFsuipc.SuspendLayout();
@@ -124,6 +125,7 @@
             this.displayTypeGroupBox.Controls.Add(this.inputModuleNameComboBox);
             this.displayTypeGroupBox.Controls.Add(this.inputTypeComboBoxLabel);
             this.displayTypeGroupBox.Controls.Add(this.inputTypeComboBox);
+            this.displayTypeGroupBox.Controls.Add(this.restApiEndpointComboBox);
             resources.ApplyResources(this.displayTypeGroupBox, "displayTypeGroupBox");
             this.displayTypeGroupBox.Name = "displayTypeGroupBox";
             this.displayTypeGroupBox.TabStop = false;
@@ -220,6 +222,10 @@
             // 
             this.description.ColumnName = "description";
             // 
+            // restApiEndpointComboBox
+            // 
+            resources.ApplyResources(this.restApiEndpointComboBox, "restApiEndpointComboBox");
+            this.restApiEndpointComboBox.Name = "restApiEndpointComboBox";
             // settingsColumn
             // 
             this.settingsColumn.Caption = "settings";
@@ -278,5 +284,6 @@
         private Panels.Config.ConfigRefPanel configRefPanel;
         private System.Windows.Forms.ComboBox inputPinDropDown;
         private Panels.Config.PreconditionPanel preconditionPanel;
+        private System.Windows.Forms.ComboBox restApiEndpointComboBox;
     }
 }

--- a/UI/Dialogs/InputConfigWizard.resx
+++ b/UI/Dialogs/InputConfigWizard.resx
@@ -123,13 +123,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="preconditionPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
+    <value>3, 3</value>
   </data>
   <data name="preconditionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 8, 6, 8</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>866, 879</value>
+    <value>574, 567</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="preconditionPanel.TabIndex" type="System.Int32, mscorlib">
@@ -148,16 +148,13 @@
     <value>0</value>
   </data>
   <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 29</value>
-  </data>
-  <data name="preconditionTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 22</value>
   </data>
   <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>874, 889</value>
+    <value>580, 573</value>
   </data>
   <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -184,13 +181,13 @@
     <value>0, 0</value>
   </data>
   <data name="configRefPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 8, 6, 8</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="configRefPanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
+    <value>5, 5, 5, 5</value>
   </data>
   <data name="configRefPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>874, 889</value>
+    <value>580, 573</value>
   </data>
   <data name="configRefPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -208,13 +205,10 @@
     <value>0</value>
   </data>
   <data name="configRefTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 29</value>
-  </data>
-  <data name="configRefTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 22</value>
   </data>
   <data name="configRefTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>874, 889</value>
+    <value>580, 573</value>
   </data>
   <data name="configRefTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -244,16 +238,10 @@
     <value>Fill</value>
   </data>
   <data name="groupBoxInputSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 171</value>
-  </data>
-  <data name="groupBoxInputSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="groupBoxInputSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 111</value>
   </data>
   <data name="groupBoxInputSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>866, 713</value>
+    <value>574, 459</value>
   </data>
   <data name="groupBoxInputSettings.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -274,13 +262,10 @@
     <value>0</value>
   </data>
   <data name="inputPinDropDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>501, 69</value>
-  </data>
-  <data name="inputPinDropDown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>334, 45</value>
   </data>
   <data name="inputPinDropDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 28</value>
+    <value>45, 21</value>
   </data>
   <data name="inputPinDropDown.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -301,13 +286,10 @@
     <value>NoControl</value>
   </data>
   <data name="arcazeSerialLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>75, 35</value>
-  </data>
-  <data name="arcazeSerialLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>50, 23</value>
   </data>
   <data name="arcazeSerialLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 20</value>
+    <value>42, 13</value>
   </data>
   <data name="arcazeSerialLabel.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -337,13 +319,10 @@
     <value>Modul B</value>
   </data>
   <data name="inputModuleNameComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 31</value>
-  </data>
-  <data name="inputModuleNameComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>98, 20</value>
   </data>
   <data name="inputModuleNameComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>420, 28</value>
+    <value>281, 21</value>
   </data>
   <data name="inputModuleNameComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -364,13 +343,10 @@
     <value>NoControl</value>
   </data>
   <data name="inputTypeComboBoxLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>46, 74</value>
-  </data>
-  <data name="inputTypeComboBoxLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>31, 48</value>
   </data>
   <data name="inputTypeComboBoxLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 20</value>
+    <value>61, 13</value>
   </data>
   <data name="inputTypeComboBoxLabel.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -403,13 +379,10 @@
     <value>BCD4056</value>
   </data>
   <data name="inputTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 69</value>
-  </data>
-  <data name="inputTypeComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>98, 45</value>
   </data>
   <data name="inputTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>343, 28</value>
+    <value>230, 21</value>
   </data>
   <data name="inputTypeComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -426,20 +399,41 @@
   <data name="&gt;&gt;inputTypeComboBox.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="restApiEndpointComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>98, 45</value>
+  </data>
+  <data name="restApiEndpointComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
+  </data>
+  <data name="restApiEndpointComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>281, 21</value>
+  </data>
+  <data name="restApiEndpointComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="restApiEndpointComboBox.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;restApiEndpointComboBox.Name" xml:space="preserve">
+    <value>restApiEndpointComboBox</value>
+  </data>
+  <data name="&gt;&gt;restApiEndpointComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;restApiEndpointComboBox.Parent" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;restApiEndpointComboBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
   <data name="displayTypeGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="displayTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 56</value>
-  </data>
-  <data name="displayTypeGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="displayTypeGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 36</value>
   </data>
   <data name="displayTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>866, 115</value>
+    <value>574, 75</value>
   </data>
   <data name="displayTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -463,16 +457,16 @@
     <value>Top</value>
   </data>
   <data name="displayTabTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
+    <value>3, 3</value>
   </data>
   <data name="displayTabTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>18, 18, 18, 18</value>
+    <value>12, 12, 12, 12</value>
   </data>
   <data name="displayTabTextBox.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="displayTabTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>866, 51</value>
+    <value>574, 33</value>
   </data>
   <data name="displayTabTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -493,16 +487,13 @@
     <value>2</value>
   </data>
   <data name="displayTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 29</value>
-  </data>
-  <data name="displayTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 22</value>
   </data>
   <data name="displayTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="displayTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>874, 889</value>
+    <value>580, 573</value>
   </data>
   <data name="displayTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -528,11 +519,8 @@
   <data name="tabControlFsuipc.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="tabControlFsuipc.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="tabControlFsuipc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>882, 922</value>
+    <value>588, 599</value>
   </data>
   <data name="tabControlFsuipc.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -555,11 +543,8 @@
   <data name="MainPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="MainPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="MainPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>882, 922</value>
+    <value>588, 599</value>
   </data>
   <data name="MainPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -583,13 +568,10 @@
     <value>NoControl</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>658, 0</value>
-  </data>
-  <data name="button1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>438, 0</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 43</value>
+    <value>75, 28</value>
   </data>
   <data name="button1.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -616,13 +598,10 @@
     <value>NoControl</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>770, 0</value>
-  </data>
-  <data name="cancelButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>513, 0</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 43</value>
+    <value>75, 28</value>
   </data>
   <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -646,13 +625,10 @@
     <value>Bottom</value>
   </data>
   <data name="ButtonPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 922</value>
-  </data>
-  <data name="ButtonPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>0, 599</value>
   </data>
   <data name="ButtonPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>882, 43</value>
+    <value>588, 28</value>
   </data>
   <data name="ButtonPanel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -676,10 +652,10 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 20</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>882, 965</value>
+    <value>588, 627</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -824,9 +800,6 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
 </value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>

--- a/UI/Dialogs/OrphanedSerialsDialog.cs
+++ b/UI/Dialogs/OrphanedSerialsDialog.cs
@@ -7,6 +7,8 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using MobiFlight;
+using MobiFlight.Base;
+using MobiFlight.RestWebSocketApi;
 
 namespace MobiFlight.UI.Dialogs
 {
@@ -46,6 +48,7 @@ namespace MobiFlight.UI.Dialogs
                 OutputConfigItem cfg = row["settings"] as OutputConfigItem;
                 if (cfg.DisplaySerial != "" && 
                     cfg.DisplaySerial  != "-" && 
+                    SerialNumber.ExtractSerial(cfg.DisplaySerial) != RestApiManager.serial &&
                     !configSerials.Contains(cfg.DisplaySerial) && 
                     !moduleSerials.Contains(cfg.DisplaySerial))
                 {
@@ -60,6 +63,7 @@ namespace MobiFlight.UI.Dialogs
                 if (cfg != null &&
                     cfg.ModuleSerial != "" &&
                     cfg.ModuleSerial != "-" &&
+                    SerialNumber.ExtractSerial(cfg.ModuleSerial) != RestApiManager.serial &&
                     !Joystick.IsJoystickSerial(cfg.ModuleSerial) &&
                     !configSerials.Contains(cfg.ModuleSerial) &&
                     !moduleSerials.Contains(cfg.ModuleSerial))

--- a/UI/Dialogs/SettingsDialog.Designer.cs
+++ b/UI/Dialogs/SettingsDialog.Designer.cs
@@ -63,6 +63,8 @@
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.mobiFlightTabPage = new System.Windows.Forms.TabPage();
             this.mobiFlightPanel = new MobiFlight.UI.Panels.Settings.MobiFlightPanel();
+            this.RestApiTabPage = new System.Windows.Forms.TabPage();
+            this.restApiPanel = new MobiFlight.UI.Panels.Settings.RestApiPanel();
             this.firmwareSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
             this.firmwareUpdateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -74,6 +76,7 @@
             this.generalTabPage.SuspendLayout();
             this.tabControl1.SuspendLayout();
             this.mobiFlightTabPage.SuspendLayout();
+            this.RestApiTabPage.SuspendLayout();
             this.SuspendLayout();
             // 
             // panel1
@@ -270,6 +273,7 @@
             this.tabControl1.Controls.Add(this.generalTabPage);
             this.tabControl1.Controls.Add(this.mobiFlightTabPage);
             this.tabControl1.Controls.Add(this.ArcazeTabPage);
+            this.tabControl1.Controls.Add(this.RestApiTabPage);
             resources.ApplyResources(this.tabControl1, "tabControl1");
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
@@ -285,6 +289,18 @@
             // 
             resources.ApplyResources(this.mobiFlightPanel, "mobiFlightPanel");
             this.mobiFlightPanel.Name = "mobiFlightPanel";
+            // 
+            // RestApiTabPage
+            // 
+            this.RestApiTabPage.Controls.Add(this.restApiPanel);
+            resources.ApplyResources(this.RestApiTabPage, "RestApiTabPage");
+            this.RestApiTabPage.Name = "RestApiTabPage";
+            this.RestApiTabPage.UseVisualStyleBackColor = true;
+            // 
+            // restApiPanel
+            // 
+            resources.ApplyResources(this.restApiPanel, "restApiPanel");
+            this.restApiPanel.Name = "restApiPanel";
             // 
             // firmwareSettingsToolStripMenuItem
             // 
@@ -323,6 +339,7 @@
             this.generalTabPage.ResumeLayout(false);
             this.tabControl1.ResumeLayout(false);
             this.mobiFlightTabPage.ResumeLayout(false);
+            this.RestApiTabPage.ResumeLayout(false);
             this.ResumeLayout(false);
 
         }
@@ -368,5 +385,7 @@
         private Panels.Settings.ArcazePanel arcazePanel;
         private Panels.Settings.MobiFlightPanel mobiFlightPanel;
         private System.Windows.Forms.ToolStripMenuItem analogDeviceToolStripMenuItem;
+        private System.Windows.Forms.TabPage RestApiTabPage;
+        private Panels.Settings.RestApiPanel restApiPanel;
     }
 }

--- a/UI/Dialogs/SettingsDialog.cs
+++ b/UI/Dialogs/SettingsDialog.cs
@@ -96,6 +96,11 @@ namespace MobiFlight.UI.Dialogs
             // TAB MobiFlight
             //
             mobiFlightPanel.LoadSettings();
+
+            //
+            // TAB RestApiPanel
+            //
+            restApiPanel.LoadSettings();
         }
 
         /// <summary>
@@ -112,6 +117,9 @@ namespace MobiFlight.UI.Dialogs
 #endif
             // MobiFlight Tab
             mobiFlightPanel.SaveSettings();
+
+            // REST/Websocket Config
+            restApiPanel.SaveSettings();
 
             // Save all Settings
             Properties.Settings.Default.Save();

--- a/UI/Dialogs/SettingsDialog.resx
+++ b/UI/Dialogs/SettingsDialog.resx
@@ -519,6 +519,51 @@
   <data name="&gt;&gt;mobiFlightTabPage.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
+  <data name="restApiPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="restApiPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>557, 508</value>
+  </data>
+  <data name="restApiPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;restApiPanel.Name" xml:space="preserve">
+    <value>restApiPanel</value>
+  </data>
+  <data name="&gt;&gt;restApiPanel.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Settings.RestApiPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;restApiPanel.Parent" xml:space="preserve">
+    <value>RestApiTabPage</value>
+  </data>
+  <data name="&gt;&gt;restApiPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="RestApiTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="RestApiTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>563, 514</value>
+  </data>
+  <data name="RestApiTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="RestApiTabPage.Text" xml:space="preserve">
+    <value>REST/WebSocket API</value>
+  </data>
+  <data name="&gt;&gt;RestApiTabPage.Name" xml:space="preserve">
+    <value>RestApiTabPage</value>
+  </data>
+  <data name="&gt;&gt;RestApiTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;RestApiTabPage.Parent" xml:space="preserve">
+    <value>tabControl1</value>
+  </data>
+  <data name="&gt;&gt;RestApiTabPage.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
   <data name="tabControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>

--- a/UI/Panels/OutputWizard/DisplayPanel.Designer.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.Designer.cs
@@ -52,6 +52,11 @@
             this.ButtonInputActionLabel = new System.Windows.Forms.Label();
             this.OutputDevicePanel = new System.Windows.Forms.Panel();
             this.DisplayPanelTextLabel = new System.Windows.Forms.Label();
+            this.restApiBox = new System.Windows.Forms.GroupBox();
+            this.endpointNameLabel = new System.Windows.Forms.Label();
+            this.restApiEndpointTextBox = new System.Windows.Forms.TextBox();
+            this.duplicateLabel = new System.Windows.Forms.Label();
+            this.restWebsocketDescriptionLabel = new System.Windows.Forms.Label();
             this.displayTypeGroupBox.SuspendLayout();
             this.InputActionTypePanel.SuspendLayout();
             this.DisplayTypePanel.SuspendLayout();
@@ -59,6 +64,7 @@
             this.testSettingsGroupBox.SuspendLayout();
             this.inputActionGroupBox.SuspendLayout();
             this.OutputDevicePanel.SuspendLayout();
+            this.restApiBox.SuspendLayout();
             this.SuspendLayout();
             // 
             // displayTypeGroupBox
@@ -149,7 +155,8 @@
             this.OutputTypeComboBox.FormattingEnabled = true;
             this.OutputTypeComboBox.Items.AddRange(new object[] {
             resources.GetString("OutputTypeComboBox.Items"),
-            resources.GetString("OutputTypeComboBox.Items1")});
+            resources.GetString("OutputTypeComboBox.Items1"),
+            resources.GetString("OutputTypeComboBox.Items2")});
             this.OutputTypeComboBox.Name = "OutputTypeComboBox";
             this.OutputTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.OutputTypeComboBox_SelectedIndexChanged);
             // 
@@ -231,10 +238,43 @@
             resources.ApplyResources(this.DisplayPanelTextLabel, "DisplayPanelTextLabel");
             this.DisplayPanelTextLabel.Name = "DisplayPanelTextLabel";
             // 
+            // restApiBox
+            // 
+            resources.ApplyResources(this.restApiBox, "restApiBox");
+            this.restApiBox.Controls.Add(this.endpointNameLabel);
+            this.restApiBox.Controls.Add(this.restApiEndpointTextBox);
+            this.restApiBox.Controls.Add(this.duplicateLabel);
+            this.restApiBox.Controls.Add(this.restWebsocketDescriptionLabel);
+            this.restApiBox.Name = "restApiBox";
+            this.restApiBox.TabStop = false;
+            // 
+            // endpointNameLabel
+            // 
+            resources.ApplyResources(this.endpointNameLabel, "endpointNameLabel");
+            this.endpointNameLabel.Name = "endpointNameLabel";
+            // 
+            // restApiEndpointTextBox
+            // 
+            resources.ApplyResources(this.restApiEndpointTextBox, "restApiEndpointTextBox");
+            this.restApiEndpointTextBox.Name = "restApiEndpointTextBox";
+            this.restApiEndpointTextBox.TextChanged += new System.EventHandler(this.restApiEndpointTextBox_TextChanged);
+            // 
+            // duplicateLabel
+            // 
+            resources.ApplyResources(this.duplicateLabel, "duplicateLabel");
+            this.duplicateLabel.ForeColor = System.Drawing.Color.Red;
+            this.duplicateLabel.Name = "duplicateLabel";
+            // 
+            // restWebsocketDescriptionLabel
+            // 
+            resources.ApplyResources(this.restWebsocketDescriptionLabel, "restWebsocketDescriptionLabel");
+            this.restWebsocketDescriptionLabel.Name = "restWebsocketDescriptionLabel";
+            // 
             // DisplayPanel
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.restApiBox);
             this.Controls.Add(this.inputActionGroupBox);
             this.Controls.Add(this.OutputDevicePanel);
             this.Controls.Add(this.DisplayPanelTextLabel);
@@ -249,6 +289,8 @@
             this.inputActionGroupBox.PerformLayout();
             this.OutputDevicePanel.ResumeLayout(false);
             this.OutputDevicePanel.PerformLayout();
+            this.restApiBox.ResumeLayout(false);
+            this.restApiBox.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -279,5 +321,10 @@
         private Input.ButtonPanel buttonPanel1;
         private System.Windows.Forms.Label AnalogInputActionLabel;
         private System.Windows.Forms.Label ButtonInputActionLabel;
+        private System.Windows.Forms.GroupBox restApiBox;
+        private System.Windows.Forms.Label restWebsocketDescriptionLabel;
+        private System.Windows.Forms.Label duplicateLabel;
+        private System.Windows.Forms.TextBox restApiEndpointTextBox;
+        private System.Windows.Forms.Label endpointNameLabel;
     }
 }

--- a/UI/Panels/OutputWizard/DisplayPanel.resx
+++ b/UI/Panels/OutputWizard/DisplayPanel.resx
@@ -117,492 +117,545 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&gt;&gt;displayPinTestStopButton.Name" xml:space="preserve">
-    <value>displayPinTestStopButton</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Text" xml:space="preserve">
-    <value>Choose your display type which is used for output from the list below.</value>
-  </data>
-  <data name="&gt;&gt;groupBoxDisplaySettings.Parent" xml:space="preserve">
-    <value>OutputDevicePanel</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="DisplayPanelTextLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="analogPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="arcazeSerialLabel.Text" xml:space="preserve">
-    <value>Module</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="displayTypeComboBoxLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;displayModuleNameComboBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="displayPinTestStopButton.Text" xml:space="preserve">
-    <value>Stop</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="testSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 151</value>
-  </data>
-  <data name="ButtonInputActionLabel.Text" xml:space="preserve">
-    <value>Define an action that will be executed when your config value changes.
-Value can be "1" or "0" to trigger "OnPress" and "OnRelease" respectively. </value>
-  </data>
-  <data name="&gt;&gt;AnalogInputActionLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="InputActionTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="OutputDevicePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 36</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialLabel.Parent" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="&gt;&gt;inputActionGroupBox.Name" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="DisplayTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="&gt;&gt;analogPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Input.AnalogPanel, MFConnector, Version=9.2.0.2, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="displayTypeGroupBox.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 200</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 21</value>
-  </data>
-  <data name="OutputTypeComboBox.Items1" xml:space="preserve">
-    <value>Input Action</value>
-  </data>
-  <data name="&gt;&gt;displayTypeGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;inputActionGroupBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="AnalogInputActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Input.ButtonPanel, MFConnector, Version=9.2.0.2, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="displayModuleNameComboBox.Items1" xml:space="preserve">
-    <value>Modul B</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;InputTypeAnalogRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="displayTypeComboBox.Items1" xml:space="preserve">
-    <value>Display Module</value>
-  </data>
-  <data name="OutputTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 6</value>
-  </data>
-  <data name="analogPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>300, 0</value>
-  </data>
-  <data name="AnalogInputActionLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="displayModuleNameComboBox.Items" xml:space="preserve">
-    <value>Modul A</value>
-  </data>
   <data name="displayTypeGroupBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;displayModuleNameComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="displayTypeGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
-  <data name="&gt;&gt;groupBoxDisplaySettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="InputTypeAnalogRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="ButtonInputActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="InputTypeAnalogRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="displayTypeGroupBox.Text" xml:space="preserve">
-    <value>Display type</value>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="InputTypeAnalogRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>263, 6</value>
   </data>
-  <data name="OutputTypeLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
+  <data name="InputTypeAnalogRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 17</value>
   </data>
   <data name="InputTypeAnalogRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;ButtonInputActionLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
+  <data name="InputTypeAnalogRadioButton.Text" xml:space="preserve">
+    <value>OnChange</value>
+  </data>
+  <data name="&gt;&gt;InputTypeAnalogRadioButton.Name" xml:space="preserve">
+    <value>InputTypeAnalogRadioButton</value>
+  </data>
+  <data name="&gt;&gt;InputTypeAnalogRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InputTypeAnalogRadioButton.Parent" xml:space="preserve">
+    <value>InputActionTypePanel</value>
+  </data>
+  <data name="&gt;&gt;InputTypeAnalogRadioButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 6</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 17</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.Text" xml:space="preserve">
+    <value>OnPress / OnRelease</value>
+  </data>
+  <data name="&gt;&gt;InputTypeButtonRadioButton.Name" xml:space="preserve">
+    <value>InputTypeButtonRadioButton</value>
+  </data>
+  <data name="&gt;&gt;InputTypeButtonRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InputTypeButtonRadioButton.Parent" xml:space="preserve">
+    <value>InputActionTypePanel</value>
+  </data>
+  <data name="&gt;&gt;InputTypeButtonRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="InputActionTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="InputActionTypePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 100</value>
+  </data>
+  <data name="InputActionTypePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 29</value>
+  </data>
+  <data name="InputActionTypePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;InputActionTypePanel.Name" xml:space="preserve">
+    <value>InputActionTypePanel</value>
+  </data>
+  <data name="&gt;&gt;InputActionTypePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InputActionTypePanel.Parent" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;InputActionTypePanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="arcazeSerialLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
   <data name="arcazeSerialLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>16, 5</value>
   </data>
-  <data name="&gt;&gt;inputActionGroupBox.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="arcazeSerialLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 21</value>
   </data>
-  <data name="inputActionGroupBox.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 80</value>
+  <data name="arcazeSerialLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
   </data>
-  <data name="&gt;&gt;AnalogInputActionLabel.Name" xml:space="preserve">
-    <value>AnalogInputActionLabel</value>
+  <data name="arcazeSerialLabel.Text" xml:space="preserve">
+    <value>Module</value>
   </data>
-  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 500</value>
+  <data name="arcazeSerialLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
   </data>
-  <data name="groupBoxDisplaySettings.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+  <data name="&gt;&gt;arcazeSerialLabel.Name" xml:space="preserve">
+    <value>arcazeSerialLabel</value>
   </data>
-  <data name="AnalogInputActionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 53</value>
+  <data name="&gt;&gt;arcazeSerialLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="displayTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;arcazeSerialLabel.Parent" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;arcazeSerialLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="displayModuleNameComboBox.Items" xml:space="preserve">
+    <value>Modul A</value>
+  </data>
+  <data name="displayModuleNameComboBox.Items1" xml:space="preserve">
+    <value>Modul B</value>
+  </data>
+  <data name="displayModuleNameComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 4</value>
+  </data>
+  <data name="displayModuleNameComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>281, 21</value>
+  </data>
+  <data name="displayModuleNameComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
-  <data name="displayPinTestButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="&gt;&gt;displayModuleNameComboBox.Name" xml:space="preserve">
+    <value>displayModuleNameComboBox</value>
   </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>DisplayPanel</value>
+  <data name="&gt;&gt;displayModuleNameComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;DisplayTypePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;displayModuleNameComboBox.Parent" xml:space="preserve">
+    <value>DisplayTypePanel</value>
   </data>
-  <data name="&gt;&gt;groupBoxDisplaySettings.Name" xml:space="preserve">
-    <value>groupBoxDisplaySettings</value>
+  <data name="&gt;&gt;displayModuleNameComboBox.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;analogPanel1.Name" xml:space="preserve">
-    <value>analogPanel1</value>
+  <data name="displayTypeComboBoxLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="displayPinTestButton.Text" xml:space="preserve">
-    <value>Test</value>
+  <data name="displayTypeComboBoxLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 31</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 21</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.Text" xml:space="preserve">
+    <value>Use type of</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBoxLabel.Name" xml:space="preserve">
+    <value>displayTypeComboBoxLabel</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBoxLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBoxLabel.Parent" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBoxLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="displayTypeComboBox.Items" xml:space="preserve">
     <value>Pin</value>
   </data>
+  <data name="displayTypeComboBox.Items1" xml:space="preserve">
+    <value>Display Module</value>
+  </data>
+  <data name="displayTypeComboBox.Items2" xml:space="preserve">
+    <value>BCD4056</value>
+  </data>
+  <data name="displayTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 31</value>
+  </data>
+  <data name="displayTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>281, 21</value>
+  </data>
+  <data name="displayTypeComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBox.Name" xml:space="preserve">
+    <value>displayTypeComboBox</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBox.Parent" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="DisplayTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="DisplayTypePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 43</value>
+  </data>
+  <data name="DisplayTypePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 57</value>
+  </data>
+  <data name="DisplayTypePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;DisplayTypePanel.Name" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;DisplayTypePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DisplayTypePanel.Parent" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;DisplayTypePanel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="OutputTypeComboBox.Items" xml:space="preserve">
+    <value>Output Device</value>
+  </data>
+  <data name="OutputTypeComboBox.Items1" xml:space="preserve">
+    <value>Input Action</value>
+  </data>
+  <data name="OutputTypeComboBox.Items2" xml:space="preserve">
+    <value>REST/WebSocket API</value>
+  </data>
+  <data name="OutputTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 4</value>
+  </data>
+  <data name="OutputTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="OutputTypeComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeComboBox.Name" xml:space="preserve">
+    <value>OutputTypeComboBox</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeComboBox.Parent" xml:space="preserve">
+    <value>OutputTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeComboBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="OutputTypeLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="OutputTypeLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 5</value>
+  </data>
+  <data name="OutputTypeLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 17</value>
+  </data>
+  <data name="OutputTypeLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="OutputTypeLabel.Text" xml:space="preserve">
+    <value>Choose</value>
+  </data>
+  <data name="OutputTypeLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeLabel.Name" xml:space="preserve">
+    <value>OutputTypeLabel</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
   <data name="&gt;&gt;OutputTypeLabel.Parent" xml:space="preserve">
     <value>OutputTypePanel</value>
   </data>
-  <data name="displayPinTestStopButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 23</value>
-  </data>
-  <data name="OutputDevicePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="inputActionGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 111</value>
-  </data>
-  <data name="displayPinTestStopButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;InputTypeButtonRadioButton.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;OutputTypeLabel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="OutputTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="&gt;&gt;inputActionGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="OutputTypePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
   </data>
-  <data name="InputActionTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 100</value>
-  </data>
-  <data name="&gt;&gt;InputTypeButtonRadioButton.Parent" xml:space="preserve">
-    <value>InputActionTypePanel</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestStopButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="&gt;&gt;DisplayPanelTextLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="buttonPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="displayModuleNameComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 4</value>
-  </data>
-  <data name="&gt;&gt;analogPanel1.Parent" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;groupBoxDisplaySettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="buttonPanel1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="AnalogInputActionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 37</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 17</value>
-  </data>
-  <data name="&gt;&gt;OutputDevicePanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 31</value>
-  </data>
-  <data name="&gt;&gt;displayTypeGroupBox.Parent" xml:space="preserve">
-    <value>OutputDevicePanel</value>
-  </data>
-  <data name="ButtonInputActionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 37</value>
-  </data>
-  <data name="&gt;&gt;displayTypeGroupBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestButton.Parent" xml:space="preserve">
-    <value>testSettingsGroupBox</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="&gt;&gt;ButtonInputActionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="displayTypeComboBox.Items2" xml:space="preserve">
-    <value>BCD4056</value>
-  </data>
-  <data name="displayTypeGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="inputActionGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="DisplayTypePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 36</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.Text" xml:space="preserve">
-    <value>OnChange</value>
-  </data>
-  <data name="&gt;&gt;OutputTypePanel.Name" xml:space="preserve">
-    <value>OutputTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OutputDevicePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel1.Name" xml:space="preserve">
-    <value>buttonPanel1</value>
-  </data>
-  <data name="OutputDevicePanel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="analogPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 90</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="OutputTypePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 27</value>
   </data>
   <data name="OutputTypePanel.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
   </data>
-  <data name="&gt;&gt;InputActionTypePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeComboBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="displayModuleNameComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 21</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="arcazeSerialLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="displayTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 21</value>
-  </data>
-  <data name="ButtonInputActionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 5</value>
-  </data>
-  <data name="&gt;&gt;analogPanel1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBoxLabel.Parent" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="testSettingsGroupBox.Text" xml:space="preserve">
-    <value>Test current settings</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputTypeButtonRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;OutputTypePanel.Name" xml:space="preserve">
+    <value>OutputTypePanel</value>
   </data>
   <data name="&gt;&gt;OutputTypePanel.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;testSettingsGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;OutputTypePanel.Parent" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;OutputTypePanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="displayTypeGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="displayTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="displayTypeGroupBox.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 200</value>
+  </data>
+  <data name="displayTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 132</value>
+  </data>
+  <data name="displayTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="displayTypeGroupBox.Text" xml:space="preserve">
+    <value>Display type</value>
+  </data>
+  <data name="&gt;&gt;displayTypeGroupBox.Name" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;displayTypeGroupBox.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="analogPanel1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="displayPinTestStopButton.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestStopButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="displayPinTestButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
-    <value>ImageBeforeText</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="AnalogInputActionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="&gt;&gt;testSettingsGroupBox.Name" xml:space="preserve">
-    <value>testSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ButtonInputActionLabel.Parent" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;displayModuleNameComboBox.Parent" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeLabel.Name" xml:space="preserve">
-    <value>OutputTypeLabel</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeComboBox.Name" xml:space="preserve">
-    <value>OutputTypeComboBox</value>
-  </data>
-  <data name="groupBoxDisplaySettings.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="OutputTypeLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="displayPinTestButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>241, 12</value>
-  </data>
-  <data name="&gt;&gt;InputTypeAnalogRadioButton.Parent" xml:space="preserve">
-    <value>InputActionTypePanel</value>
-  </data>
-  <data name="buttonPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="&gt;&gt;AnalogInputActionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputActionTypePanel.Name" xml:space="preserve">
-    <value>InputActionTypePanel</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBoxLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;testSettingsGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;displayTypeGroupBox.Parent" xml:space="preserve">
     <value>OutputDevicePanel</value>
   </data>
-  <data name="&gt;&gt;AnalogInputActionLabel.Parent" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="displayPinTestButton.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="displayPinTestButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 23</value>
-  </data>
-  <data name="testSettingsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel1.Parent" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="displayPinTestStopButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>305, 12</value>
-  </data>
-  <data name="&gt;&gt;DisplayPanelTextLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="displayModuleNameComboBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="&gt;&gt;displayTypeGroupBox.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
-  <data name="inputActionGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
+  <data name="displayPinTestStopButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
-  <data name="displayPinTestButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="InputActionTypePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>263, 6</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBoxLabel.Name" xml:space="preserve">
-    <value>displayTypeComboBoxLabel</value>
-  </data>
-  <data name="arcazeSerialLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
+  <data name="displayPinTestStopButton.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <data name="displayPinTestStopButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>MiddleLeft</value>
   </data>
-  <data name="ButtonInputActionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
+  <data name="displayPinTestStopButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;displayTypeComboBox.Parent" xml:space="preserve">
-    <value>DisplayTypePanel</value>
+  <data name="displayPinTestStopButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>305, 12</value>
+  </data>
+  <data name="displayPinTestStopButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 23</value>
+  </data>
+  <data name="displayPinTestStopButton.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="displayPinTestStopButton.Text" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="displayPinTestStopButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="displayPinTestStopButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
+    <value>ImageBeforeText</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestStopButton.Name" xml:space="preserve">
+    <value>displayPinTestStopButton</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestStopButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestStopButton.Parent" xml:space="preserve">
+    <value>testSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestStopButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="displayPinTestButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="displayPinTestButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="displayPinTestButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="displayPinTestButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>241, 12</value>
+  </data>
+  <data name="displayPinTestButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 23</value>
+  </data>
+  <data name="displayPinTestButton.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="displayPinTestButton.Text" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="displayPinTestButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="displayPinTestButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
+    <value>ImageBeforeText</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestButton.Name" xml:space="preserve">
+    <value>displayPinTestButton</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestButton.Parent" xml:space="preserve">
+    <value>testSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="testSettingsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="testSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 137</value>
+  </data>
+  <data name="testSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 40</value>
+  </data>
+  <data name="testSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="testSettingsGroupBox.Text" xml:space="preserve">
+    <value>Test current settings</value>
+  </data>
+  <data name="&gt;&gt;testSettingsGroupBox.Name" xml:space="preserve">
+    <value>testSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;testSettingsGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;testSettingsGroupBox.Parent" xml:space="preserve">
+    <value>OutputDevicePanel</value>
+  </data>
+  <data name="&gt;&gt;testSettingsGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="groupBoxDisplaySettings.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="groupBoxDisplaySettings.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="groupBoxDisplaySettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="groupBoxDisplaySettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 132</value>
+  </data>
+  <data name="groupBoxDisplaySettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 5</value>
+  </data>
+  <data name="groupBoxDisplaySettings.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="groupBoxDisplaySettings.Text" xml:space="preserve">
+    <value>Display settings</value>
+  </data>
+  <data name="&gt;&gt;groupBoxDisplaySettings.Name" xml:space="preserve">
+    <value>groupBoxDisplaySettings</value>
+  </data>
+  <data name="&gt;&gt;groupBoxDisplaySettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxDisplaySettings.Parent" xml:space="preserve">
+    <value>OutputDevicePanel</value>
+  </data>
+  <data name="&gt;&gt;groupBoxDisplaySettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="inputActionGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="buttonPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="buttonPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
   </data>
   <data name="buttonPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="&gt;&gt;displayModuleNameComboBox.Name" xml:space="preserve">
-    <value>displayModuleNameComboBox</value>
+  <data name="buttonPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 90</value>
   </data>
-  <data name="displayPinTestStopButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
+  <data name="buttonPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>300, 0</value>
+  </data>
+  <data name="buttonPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 18</value>
+  </data>
+  <data name="buttonPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;buttonPanel1.Name" xml:space="preserve">
+    <value>buttonPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonPanel1.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Input.ButtonPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;buttonPanel1.Parent" xml:space="preserve">
+    <value>inputActionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;buttonPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="analogPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="analogPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="analogPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="analogPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 90</value>
+  </data>
+  <data name="analogPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>300, 0</value>
   </data>
   <data name="analogPanel1.Size" type="System.Drawing.Size, System.Drawing">
     <value>451, 18</value>
@@ -610,239 +663,339 @@ Value can be "1" or "0" to trigger "OnPress" and "OnRelease" respectively. </val
   <data name="analogPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
   </data>
-  <data name="&gt;&gt;ButtonInputActionLabel.Name" xml:space="preserve">
-    <value>ButtonInputActionLabel</value>
+  <data name="&gt;&gt;analogPanel1.Name" xml:space="preserve">
+    <value>analogPanel1</value>
   </data>
-  <data name="OutputTypeLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
+  <data name="&gt;&gt;analogPanel1.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Input.AnalogPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="groupBoxDisplaySettings.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
+  <data name="&gt;&gt;analogPanel1.Parent" xml:space="preserve">
+    <value>inputActionGroupBox</value>
   </data>
-  <data name="&gt;&gt;OutputTypePanel.Parent" xml:space="preserve">
-    <value>displayTypeGroupBox</value>
-  </data>
-  <data name="displayTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="groupBoxDisplaySettings.Text" xml:space="preserve">
-    <value>Display settings</value>
-  </data>
-  <data name="&gt;&gt;DisplayTypePanel.Name" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="displayTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 31</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.Text" xml:space="preserve">
-    <value>Use type of</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialLabel.Name" xml:space="preserve">
-    <value>arcazeSerialLabel</value>
-  </data>
-  <data name="DisplayTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 57</value>
-  </data>
-  <data name="inputActionGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 227</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="displayPinTestStopButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
-    <value>ImageBeforeText</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="arcazeSerialLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 21</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeComboBox.Parent" xml:space="preserve">
-    <value>OutputTypePanel</value>
-  </data>
-  <data name="groupBoxDisplaySettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 132</value>
-  </data>
-  <data name="OutputTypeLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="arcazeSerialLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="testSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 40</value>
-  </data>
-  <data name="buttonPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>300, 0</value>
-  </data>
-  <data name="&gt;&gt;OutputDevicePanel.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;analogPanel1.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;InputActionTypePanel.Parent" xml:space="preserve">
-    <value>displayTypeGroupBox</value>
+  <data name="AnalogInputActionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="AnalogInputActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="AnalogInputActionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 53</value>
   </data>
   <data name="AnalogInputActionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>5, 5, 5, 5</value>
   </data>
-  <data name="OutputTypeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 5</value>
+  <data name="AnalogInputActionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 37</value>
   </data>
-  <data name="&gt;&gt;displayTypeComboBoxLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.Text" xml:space="preserve">
-    <value>OnPress / OnRelease</value>
-  </data>
-  <data name="OutputTypeComboBox.Items" xml:space="preserve">
-    <value>Output Device</value>
-  </data>
-  <data name="&gt;&gt;displayTypeGroupBox.Name" xml:space="preserve">
-    <value>displayTypeGroupBox</value>
-  </data>
-  <data name="OutputTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
-  </data>
-  <data name="&gt;&gt;InputTypeAnalogRadioButton.Name" xml:space="preserve">
-    <value>InputTypeAnalogRadioButton</value>
-  </data>
-  <data name="&gt;&gt;testSettingsGroupBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestButton.Name" xml:space="preserve">
-    <value>displayPinTestButton</value>
-  </data>
-  <data name="groupBoxDisplaySettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 19</value>
-  </data>
-  <data name="buttonPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 18</value>
-  </data>
-  <data name="inputActionGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="displayTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 132</value>
-  </data>
-  <data name="OutputDevicePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 191</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBox.Name" xml:space="preserve">
-    <value>displayTypeComboBox</value>
-  </data>
-  <data name="&gt;&gt;DisplayPanelTextLabel.Name" xml:space="preserve">
-    <value>DisplayPanelTextLabel</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="OutputDevicePanel.TabIndex" type="System.Int32, mscorlib">
+  <data name="AnalogInputActionLabel.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
-  </data>
-  <data name="&gt;&gt;InputTypeAnalogRadioButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="displayPinTestStopButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;DisplayPanelTextLabel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;OutputDevicePanel.Name" xml:space="preserve">
-    <value>OutputDevicePanel</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="inputActionGroupBox.Text" xml:space="preserve">
-    <value>Input Action</value>
-  </data>
-  <data name="OutputTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 4</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 17</value>
-  </data>
-  <data name="&gt;&gt;InputActionTypePanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;InputTypeButtonRadioButton.Name" xml:space="preserve">
-    <value>InputTypeButtonRadioButton</value>
-  </data>
-  <data name="OutputTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 27</value>
-  </data>
-  <data name="analogPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="displayPinTestButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="OutputTypeLabel.Text" xml:space="preserve">
-    <value>Choose</value>
-  </data>
-  <data name="displayPinTestStopButton.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
   </data>
   <data name="AnalogInputActionLabel.Text" xml:space="preserve">
     <value>Define an action that will be executed when your config value changes.
 You can reference the current config value with @ (not $).</value>
   </data>
-  <data name="displayTypeGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
+  <data name="&gt;&gt;AnalogInputActionLabel.Name" xml:space="preserve">
+    <value>AnalogInputActionLabel</value>
   </data>
-  <data name="DisplayTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 43</value>
+  <data name="&gt;&gt;AnalogInputActionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ButtonInputActionLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+  <data name="&gt;&gt;AnalogInputActionLabel.Parent" xml:space="preserve">
+    <value>inputActionGroupBox</value>
   </data>
-  <data name="&gt;&gt;DisplayTypePanel.Parent" xml:space="preserve">
-    <value>displayTypeGroupBox</value>
-  </data>
-  <data name="groupBoxDisplaySettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="DisplayPanelTextLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
+  <data name="&gt;&gt;AnalogInputActionLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="ButtonInputActionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="InputActionTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 29</value>
-  </data>
-  <data name="displayPinTestButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="ButtonInputActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="OutputTypeComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
+  <data name="ButtonInputActionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
   </data>
-  <data name="&gt;&gt;DisplayTypePanel.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="ButtonInputActionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 5, 5, 5</value>
   </data>
-  <data name="testSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+  <data name="ButtonInputActionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 37</value>
   </data>
-  <data name="&gt;&gt;OutputTypePanel.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="ButtonInputActionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
-  <data name="displayTypeComboBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="ButtonInputActionLabel.Text" xml:space="preserve">
+    <value>Define an action that will be executed when your config value changes.
+Value can be "1" or "0" to trigger "OnPress" and "OnRelease" respectively. </value>
+  </data>
+  <data name="&gt;&gt;ButtonInputActionLabel.Name" xml:space="preserve">
+    <value>ButtonInputActionLabel</value>
+  </data>
+  <data name="&gt;&gt;ButtonInputActionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ButtonInputActionLabel.Parent" xml:space="preserve">
+    <value>inputActionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;ButtonInputActionLabel.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="buttonPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 90</value>
+  <data name="inputActionGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
   </data>
-  <data name="&gt;&gt;displayPinTestStopButton.Parent" xml:space="preserve">
-    <value>testSettingsGroupBox</value>
+  <data name="inputActionGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 213</value>
+  </data>
+  <data name="inputActionGroupBox.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 80</value>
+  </data>
+  <data name="inputActionGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 111</value>
+  </data>
+  <data name="inputActionGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="inputActionGroupBox.Text" xml:space="preserve">
+    <value>Input Action</value>
+  </data>
+  <data name="&gt;&gt;inputActionGroupBox.Name" xml:space="preserve">
+    <value>inputActionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;inputActionGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputActionGroupBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;inputActionGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="OutputDevicePanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="OutputDevicePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="OutputDevicePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 36</value>
+  </data>
+  <data name="OutputDevicePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 177</value>
+  </data>
+  <data name="OutputDevicePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;OutputDevicePanel.Name" xml:space="preserve">
+    <value>OutputDevicePanel</value>
+  </data>
+  <data name="&gt;&gt;OutputDevicePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OutputDevicePanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;OutputDevicePanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="DisplayPanelTextLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 0</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 36</value>
+  </data>
+  <data name="DisplayPanelTextLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Text" xml:space="preserve">
+    <value>Choose your display type which is used for output from the list below.</value>
+  </data>
+  <data name="&gt;&gt;DisplayPanelTextLabel.Name" xml:space="preserve">
+    <value>DisplayPanelTextLabel</value>
+  </data>
+  <data name="&gt;&gt;DisplayPanelTextLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DisplayPanelTextLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;DisplayPanelTextLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="restApiBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="endpointNameLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="endpointNameLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 104</value>
+  </data>
+  <data name="endpointNameLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>80, 13</value>
+  </data>
+  <data name="endpointNameLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>24</value>
+  </data>
+  <data name="endpointNameLabel.Text" xml:space="preserve">
+    <value>Endpoint Name</value>
+  </data>
+  <data name="&gt;&gt;endpointNameLabel.Name" xml:space="preserve">
+    <value>endpointNameLabel</value>
+  </data>
+  <data name="&gt;&gt;endpointNameLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;endpointNameLabel.Parent" xml:space="preserve">
+    <value>restApiBox</value>
+  </data>
+  <data name="&gt;&gt;endpointNameLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="restApiEndpointTextBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>95, 101</value>
+  </data>
+  <data name="restApiEndpointTextBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 20</value>
+  </data>
+  <data name="restApiEndpointTextBox.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="&gt;&gt;restApiEndpointTextBox.Name" xml:space="preserve">
+    <value>restApiEndpointTextBox</value>
+  </data>
+  <data name="&gt;&gt;restApiEndpointTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;restApiEndpointTextBox.Parent" xml:space="preserve">
+    <value>restApiBox</value>
+  </data>
+  <data name="&gt;&gt;restApiEndpointTextBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="duplicateLabel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="duplicateLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>92, 124</value>
+  </data>
+  <data name="duplicateLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>104, 13</value>
+  </data>
+  <data name="duplicateLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="duplicateLabel.Text" xml:space="preserve">
+    <value>Name already exists!</value>
+  </data>
+  <data name="duplicateLabel.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;duplicateLabel.Name" xml:space="preserve">
+    <value>duplicateLabel</value>
+  </data>
+  <data name="&gt;&gt;duplicateLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;duplicateLabel.Parent" xml:space="preserve">
+    <value>restApiBox</value>
+  </data>
+  <data name="&gt;&gt;duplicateLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="restWebsocketDescriptionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="restWebsocketDescriptionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="restWebsocketDescriptionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="restWebsocketDescriptionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 5, 5, 5</value>
+  </data>
+  <data name="restWebsocketDescriptionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 82</value>
+  </data>
+  <data name="restWebsocketDescriptionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="restWebsocketDescriptionLabel.Text" xml:space="preserve">
+    <value>The value entered into the textfield below is used to identify the output via the API.
+REST API: The current value with a GET request to /output/[Endpoint Name]
+
+WebSocket API: When the value changes the new value is pushed to the connected clients.</value>
+  </data>
+  <data name="&gt;&gt;restWebsocketDescriptionLabel.Name" xml:space="preserve">
+    <value>restWebsocketDescriptionLabel</value>
+  </data>
+  <data name="&gt;&gt;restWebsocketDescriptionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;restWebsocketDescriptionLabel.Parent" xml:space="preserve">
+    <value>restApiBox</value>
+  </data>
+  <data name="&gt;&gt;restWebsocketDescriptionLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="restApiBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="restApiBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 324</value>
+  </data>
+  <data name="restApiBox.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 80</value>
+  </data>
+  <data name="restApiBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 151</value>
+  </data>
+  <data name="restApiBox.TabIndex" type="System.Int32, mscorlib">
+    <value>23</value>
+  </data>
+  <data name="restApiBox.Text" xml:space="preserve">
+    <value>REST/WebSocket API Config</value>
+  </data>
+  <data name="restApiBox.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="&gt;&gt;restApiBox.Name" xml:space="preserve">
+    <value>restApiBox</value>
+  </data>
+  <data name="&gt;&gt;restApiBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;restApiBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;restApiBox.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 500</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>DisplayPanel</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/UI/Panels/Settings/RestApiPanel.Designer.cs
+++ b/UI/Panels/Settings/RestApiPanel.Designer.cs
@@ -1,0 +1,185 @@
+﻿namespace MobiFlight.UI.Panels.Settings
+{
+    partial class RestApiPanel
+    {
+        /// <summary> 
+        /// Erforderliche Designervariable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Verwendete Ressourcen bereinigen.
+        /// </summary>
+        /// <param name="disposing">True, wenn verwaltete Ressourcen gelöscht werden sollen; andernfalls False.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Vom Komponenten-Designer generierter Code
+
+        /// <summary> 
+        /// Erforderliche Methode für die Designerunterstützung. 
+        /// Der Inhalt der Methode darf nicht mit dem Code-Editor geändert werden.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.label1 = new System.Windows.Forms.Label();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.label2 = new System.Windows.Forms.Label();
+            this.RestServerPort = new System.Windows.Forms.TextBox();
+            this.RestServerInterfaces = new System.Windows.Forms.ComboBox();
+            this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.label5 = new System.Windows.Forms.Label();
+            this.WebsocketServerPort = new System.Windows.Forms.TextBox();
+            this.WebsocketServerInterfaces = new System.Windows.Forms.ComboBox();
+            this.groupBox1.SuspendLayout();
+            this.groupBox2.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(3, 14);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(258, 13);
+            this.label1.TabIndex = 0;
+            this.label1.Text = "Configuration for the REST/WebSocket API Servers.";
+            // 
+            // groupBox1
+            // 
+            this.groupBox1.Controls.Add(this.label3);
+            this.groupBox1.Controls.Add(this.label2);
+            this.groupBox1.Controls.Add(this.RestServerPort);
+            this.groupBox1.Controls.Add(this.RestServerInterfaces);
+            this.groupBox1.Location = new System.Drawing.Point(6, 41);
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.Size = new System.Drawing.Size(528, 90);
+            this.groupBox1.TabIndex = 1;
+            this.groupBox1.TabStop = false;
+            this.groupBox1.Text = "REST Server";
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(39, 58);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(71, 13);
+            this.label3.TabIndex = 3;
+            this.label3.Text = "Listening Port";
+            this.label3.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(16, 22);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(94, 13);
+            this.label2.TabIndex = 2;
+            this.label2.Text = "Listening Interface";
+            this.label2.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // RestServerPort
+            // 
+            this.RestServerPort.Location = new System.Drawing.Point(116, 55);
+            this.RestServerPort.Name = "RestServerPort";
+            this.RestServerPort.Size = new System.Drawing.Size(69, 20);
+            this.RestServerPort.TabIndex = 1;
+            // 
+            // RestServerInterfaces
+            // 
+            this.RestServerInterfaces.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.RestServerInterfaces.FormattingEnabled = true;
+            this.RestServerInterfaces.Location = new System.Drawing.Point(116, 19);
+            this.RestServerInterfaces.Name = "RestServerInterfaces";
+            this.RestServerInterfaces.Size = new System.Drawing.Size(162, 21);
+            this.RestServerInterfaces.TabIndex = 0;
+            // 
+            // groupBox2
+            // 
+            this.groupBox2.Controls.Add(this.label4);
+            this.groupBox2.Controls.Add(this.label5);
+            this.groupBox2.Controls.Add(this.WebsocketServerPort);
+            this.groupBox2.Controls.Add(this.WebsocketServerInterfaces);
+            this.groupBox2.Location = new System.Drawing.Point(6, 137);
+            this.groupBox2.Name = "groupBox2";
+            this.groupBox2.Size = new System.Drawing.Size(528, 90);
+            this.groupBox2.TabIndex = 2;
+            this.groupBox2.TabStop = false;
+            this.groupBox2.Text = "Websocket Server";
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(39, 58);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(71, 13);
+            this.label4.TabIndex = 3;
+            this.label4.Text = "Listening Port";
+            this.label4.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // label5
+            // 
+            this.label5.AutoSize = true;
+            this.label5.Location = new System.Drawing.Point(16, 22);
+            this.label5.Name = "label5";
+            this.label5.Size = new System.Drawing.Size(94, 13);
+            this.label5.TabIndex = 2;
+            this.label5.Text = "Listening Interface";
+            this.label5.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // WebsocketServerPort
+            // 
+            this.WebsocketServerPort.Location = new System.Drawing.Point(116, 55);
+            this.WebsocketServerPort.Name = "WebsocketServerPort";
+            this.WebsocketServerPort.Size = new System.Drawing.Size(69, 20);
+            this.WebsocketServerPort.TabIndex = 1;
+            // 
+            // WebsocketServerInterfaces
+            // 
+            this.WebsocketServerInterfaces.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.WebsocketServerInterfaces.FormattingEnabled = true;
+            this.WebsocketServerInterfaces.Location = new System.Drawing.Point(116, 19);
+            this.WebsocketServerInterfaces.Name = "WebsocketServerInterfaces";
+            this.WebsocketServerInterfaces.Size = new System.Drawing.Size(162, 21);
+            this.WebsocketServerInterfaces.TabIndex = 0;
+            // 
+            // RestApiPanel
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.groupBox2);
+            this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.label1);
+            this.Name = "RestApiPanel";
+            this.Size = new System.Drawing.Size(537, 489);
+            this.groupBox1.ResumeLayout(false);
+            this.groupBox1.PerformLayout();
+            this.groupBox2.ResumeLayout(false);
+            this.groupBox2.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.ComboBox RestServerInterfaces;
+        private System.Windows.Forms.TextBox RestServerPort;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.Label label5;
+        private System.Windows.Forms.TextBox WebsocketServerPort;
+        private System.Windows.Forms.ComboBox WebsocketServerInterfaces;
+    }
+}

--- a/UI/Panels/Settings/RestApiPanel.cs
+++ b/UI/Panels/Settings/RestApiPanel.cs
@@ -1,0 +1,71 @@
+﻿using MobiFlight.RestWebSocketApi;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using System.Xml.Serialization;
+
+namespace MobiFlight.UI.Panels.Settings
+{
+    public partial class RestApiPanel : UserControl
+    {
+
+        private RestApiServerSettings settings;
+
+        public RestApiPanel()
+        {
+            InitializeComponent();
+        }
+
+        public void LoadSettings()
+        {
+            settings = RestApiServerSettings.Load();
+            RestServerPort.Text = settings.restPort;
+            WebsocketServerPort.Text = settings.websocketPort;
+
+            RestServerInterfaces.Items.Add("127.0.0.1");
+            RestServerInterfaces.Items.Add("All Interfaces");
+
+            WebsocketServerInterfaces.Items.Add("127.0.0.1");
+            WebsocketServerInterfaces.Items.Add("All Interfaces");
+
+
+            if (settings.websocketServerInterface == "127.0.0.1")
+            {
+                WebsocketServerInterfaces.SelectedIndex = 0;
+            } else
+            {
+                WebsocketServerInterfaces.SelectedIndex = 1;
+            }
+
+
+            if (settings.restServerInterface == "127.0.0.1")
+            {
+                RestServerInterfaces.SelectedIndex = 0;
+            }
+            else
+            {
+                RestServerInterfaces.SelectedIndex = 1;
+            }
+        }
+
+
+        public void SaveSettings()
+        {
+            settings.restPort = RestServerPort.Text;
+            settings.websocketPort = WebsocketServerPort.Text;
+            settings.websocketServerInterface = WebsocketServerInterfaces.SelectedIndex == 0 ? "127.0.0.1" : "0.0.0.0";
+            settings.restServerInterface = RestServerInterfaces.SelectedIndex == 0 ? "127.0.0.1" : "0.0.0.0";
+
+            if (settings.HasChanged)
+            {
+                settings.Save();
+            }
+        }
+    }
+}

--- a/UI/Panels/Settings/RestApiPanel.resx
+++ b/UI/Panels/Settings/RestApiPanel.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/app.config
+++ b/app.config
@@ -133,6 +133,9 @@
       <setting name="IgnoredComPortsList" serializeAs="String">
         <value />
       </setting>
+      <setting name="RestWebsocketServerConfig" serializeAs="String">
+        <value />
+      </setting>
     </MobiFlight.Properties.Settings>
     <ArcazeUSB.Properties.Settings>
       <setting name="RecentFiles" serializeAs="Xml">

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="EmbedIO" version="3.5.0" targetFramework="net48" />
   <package id="FSUIPCClientDLL" version="3.2.19" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights" version="2.20.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.20.0" targetFramework="net48" />
@@ -13,5 +14,7 @@
   <package id="System.Memory" version="4.5.5" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.0.0" targetFramework="net48" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net48" />
+  <package id="Unosquare.Swan.Lite" version="3.1.0" targetFramework="net48" />
   <package id="XPlaneConnector" version="1.3.0" targetFramework="net48" />
 </packages>


### PR DESCRIPTION
Hi,

I would like to propose a new "major" feature for MobiFlight, a REST/WebSocket API that can be used to trigger inputs and receive output values.

# Motivation
I started to play around with a minimal Arduino setup and a single encoder. Instead of having multiple encoders, I want to use this single encoder to control multiple functions in the cockpit. For this I utilized the MobiFlight preconditions, variables and joystick inputs to switch between different encoder modes. So pressing a button on a Joystick sets a MobiFlight variable and multiple encoder input configs with preconditions control which FlightSim variable updates. So far, so good.

The main problem with this approach is that this is only one way. It is not possible to get any information out of MobiFlight in which mode the encoder currently operates. This is where the REST/WebSocket API comes into play.

In the bigger picture, I think this would enable a completely new kind of applications to interact with MobiFlight and profit from the existing features, like the super nice Huphop integration. Stream Deck Plugins that can visualize output variables, iPad/Web Apps to build dashboards and probably many more.

# REST/WebSocket API
The idea is to have a new device category (REST/WebSocket API) that can be used as input and output device.

## UI Overview
### Input
`REST/WebSocket API` can be selected as an Input module. The value entered into the `Device` text field is basically the device identifier used with the API. For example, an HTTP POST request to `/input/[device identifier]` would trigger the input using the value from the body of the POST request. 

Internally, this is handled as an `AnalogInput`. This might not be the cleanest solution, let me know what you think about it. It just was the easiest way to reuse the existing architecture.

![image](https://user-images.githubusercontent.com/7912480/192151508-8b0ab9ee-6fa7-4452-9758-82f1e8db6a6f.png)


### Output
Similar to the inputs, I added a new display type for the outputs as well. In contrast to the inputs, each output must have a unique device/endpoint name. The current value of an output can be received by sending an HTTP GET Request to `/output/[device name]`.

The downside of only using a REST API is that it would be necessary to poll for new output values. Because of that, I also decided to implement a WebSocket API, so that messages could be pushed to clients when an output value changes.

![image](https://user-images.githubusercontent.com/7912480/192151518-35282603-ac56-477b-89c8-66a1d1377541.png)


### Settings
The settings UI is pretty straight forward. The interface where the REST and WebSocket Server is listening can be configured (either `127.0.0.1` or `All Interfaces`) as well as a TCP port.

![image](https://user-images.githubusercontent.com/7912480/192151527-223eaf1e-f9d2-4204-ab62-820e640df8d7.png)

## Supported API Operations
* Trigger input
    * REST API `POST /input/[device name]`, value inside POST body. Response, see WebSocket response below.
    * WebSocket API  
        * Request
        ```json
        {
            "MessageType": "TRIGGER_INPUT",
            "Input": "[device name]",
            "Value": "[value]"
        }
        ```
        * Response
        ```json
        {
            "Message": "ok",
            "MessageType": "SUCCESS"
        }
        ```
* Get value of REST/WebSocket API output device
    * REST API `GET /output/[device name]`, see WebSocket response below.
    * WebSocket API
        * Request
        ```json
        {
            "MessageType": "GET_OUTPUT",
            "Output": "[device name]"
        }
        ```
        * Response
        ```json
        {
            "Output": "[device name]",
            "Value": "[value]",
            "MessageType": "GET_OUTPUT"
        }
        ```
* Get value of all REST/WebSocket API output devices
    * REST API `GET /output/`, see WebSocket response below.
    * WebSocket API
        * Request
        ```json
        {
            "MessageType": "GET_ALL_OUTPUTS"
        }
        ```
        * Response
        ```json
        {
            "OutputValues": {
                "[device name]": "[value]"
            },
            "MessageType": "GET_ALL_OUTPUTS"
        }
        ```

* When an output value changed (WebSocket only)
    ```json
    {
        "Output": "[device name]",
        "Value": "[value]",
        "MessageType": "OUTPUT_CHANGED"
    }
    ```

* Error message (response only)
    ```json
    {
        "ErrorMsg": "[reason]",
        "MessageType": "ERROR"
    }
    ```

## Architecture Details
* As REST/WebSocket server, I added [EmbedIO](https://github.com/unosquare/embedio) as dependency (MIT License).

* The `RestApiManager` class is the entry point that starts both servers and is part of the `ExecutionManager` class.
* `RestApiServer` and `WebSocketApiServer` include the server methods that are called, when a new message is received. Those classes are pretty small.
* The whole message processing is done in the `MessageProcessor` class.
    * The incoming message is deserialized into one of the message classes (`namespace MobiFlight.RestWebSocketApi.Messages`), depending on the `MessageType` field of the request.
    * Depending on the message type, the appropriate action is triggered, and a response sent to the client.
* Supported messages are defined in the `MessageTypeEnum`. Adding new messages should be straight-forward. 

# What needs to be done (at least)
- [ ] Unit Tests (didn't look into the test architecture yet)
- [ ] UI Localization

# Feedback
Please let me know what you think about this proposal. I am open to discuss any changes, maybe you have some additional/other ideas/wishes for the API. Even if you see no future in this feature, that's fine as well. Just let me know.

Best regards,
Philipp