### PR TITLE
Add device name in input event log entry

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1356,12 +1356,12 @@ namespace MobiFlight
             	if (inputCache[inputKey].Count == 0)
             	{
                 	if (LogIfNotJoystickOrJoystickAxisEnabled(e.Serial, e.Type))
-                    	    Log.Instance.log($"No config found for {e.Type}: {e.DeviceId}{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} ({eventAction})@{e.Serial}", LogSeverity.Debug);
+                    	    Log.Instance.log($"No config found for {e.Type}: [{e.Name}] > [{e.DeviceId}]{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} > {eventAction}", LogSeverity.Debug);
                 	return;
             	}
             }
 
-            Log.Instance.log($"Config found for {e.Type}: {e.DeviceId}{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} ({eventAction})@{e.Serial}", LogSeverity.Debug);
+            Log.Instance.log($"Config found for {e.Type}: [{e.Name}] > [{e.DeviceId}]{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} > {eventAction}", LogSeverity.Debug);
 
             // Skip execution if not started
             if (!IsStarted())

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1356,12 +1356,12 @@ namespace MobiFlight
             	if (inputCache[inputKey].Count == 0)
             	{
                 	if (LogIfNotJoystickOrJoystickAxisEnabled(e.Serial, e.Type))
-                    	    Log.Instance.log($"No config found for {e.Type}: [{e.Name}] > [{e.DeviceId}]{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} > {eventAction}", LogSeverity.Debug);
+                    	    Log.Instance.log($"No config found for {e.Type}: [{e.Name}] > [{e.DeviceId}] {(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} > {eventAction}", LogSeverity.Debug);
                 	return;
             	}
             }
 
-            Log.Instance.log($"Config found for {e.Type}: [{e.Name}] > [{e.DeviceId}]{(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} > {eventAction}", LogSeverity.Debug);
+            Log.Instance.log($"Config found for {e.Type}: [{e.Name}] > [{e.DeviceId}] {(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} > {eventAction}", LogSeverity.Debug);
 
             // Skip execution if not started
             if (!IsStarted())

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -203,6 +203,7 @@ namespace MobiFlight
 
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
+                        Name = Name,
                         DeviceId = POV[index].Label,
                         Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                         Type = DeviceType.Button,
@@ -217,6 +218,7 @@ namespace MobiFlight
 
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
+                        Name = Name,
                         DeviceId = POV[index].Label,
                         Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                         Type = DeviceType.Button,
@@ -244,6 +246,7 @@ namespace MobiFlight
                     if (!StateExists() || oldValue != newValue)
                         OnButtonPressed?.Invoke(this, new InputEventArgs()
                         {
+                            Name = Name,
                             DeviceId = Axes[CurrentAxis].Label,
                             Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                             Type = DeviceType.AnalogInput,
@@ -263,6 +266,7 @@ namespace MobiFlight
                     if (newState.Buttons[i] || (state != null))
                         OnButtonPressed?.Invoke(this, new InputEventArgs()
                         {
+                            Name = Name,
                             DeviceId = Buttons[i].Label,
                             Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                             Type = DeviceType.Button,

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -21,6 +21,8 @@ namespace MobiFlight
     {
         public string Serial { get; set; }
         public string DeviceId { get; set; }
+
+        public string Name { get; set; }
         public DeviceType Type { get; set; }
         public int? ExtPin { get; set; }
         public int Value { get; set; }
@@ -511,7 +513,7 @@ namespace MobiFlight
             if (!int.TryParse(pos, out value)) return;
 
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, DeviceId = enc, Type = DeviceType.Encoder, Value = value });
+                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = enc, Type = DeviceType.Encoder, Value = value });
             //addLog("Enc: " + enc + ":" + pos);
         }
 
@@ -521,7 +523,7 @@ namespace MobiFlight
             String channel = arguments.ReadStringArg();
             String state = arguments.ReadStringArg();
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, DeviceId = deviceId, Type = DeviceType.InputShiftRegister, ExtPin = int.Parse(channel), Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = deviceId, Type = DeviceType.InputShiftRegister, ExtPin = int.Parse(channel), Value = int.Parse(state) });
         }
 
         void OnInputMultiplexerChange(ReceivedCommand arguments)
@@ -530,7 +532,7 @@ namespace MobiFlight
             String channel = arguments.ReadStringArg();
             String state = arguments.ReadStringArg();
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, DeviceId = deviceId, Type = DeviceType.InputMultiplexer, ExtPin = int.Parse(channel), Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = deviceId, Type = DeviceType.InputMultiplexer, ExtPin = int.Parse(channel), Value = int.Parse(state) });
         }
 
         // Callback function that prints the Arduino status to the console
@@ -540,7 +542,7 @@ namespace MobiFlight
             String state = arguments.ReadStringArg();
             //addLog("Button: " + button + ":" + state);
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, DeviceId = button, Type = DeviceType.Button, Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = button, Type = DeviceType.Button, Value = int.Parse(state) });
         }
 
         // Callback function that prints the Arduino status to the console
@@ -550,7 +552,7 @@ namespace MobiFlight
             String value = arguments.ReadStringArg();
             //addLog("Button: " + button + ":" + state);
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, DeviceId = name, Type = DeviceType.AnalogInput, Value = int.Parse(value) });
+                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = name, Type = DeviceType.AnalogInput, Value = int.Parse(value) });
         }
 
         // Callback function that prints the Arduino Debug Print to the console


### PR DESCRIPTION
relates to #903 

Improved logging output, now uses clear name instead of serial number.
Following @neilenns original idea to have "Not sent, no sim running" in one line.

