### PR TITLE
Integrated support for Honeycomb Bravo Lights

### DIFF
--- a/Base/SerialNumber.cs
+++ b/Base/SerialNumber.cs
@@ -16,5 +16,14 @@ namespace MobiFlight.Base
 
             return s.Split('/')[1].Trim();
         }
+
+        public static string ExtractDeviceName(String s)
+        {
+            if (s == null) return "";
+
+            if (!s.Contains("/")) return "";
+
+            return s.Split('/')[0].Trim();
+        }
     }
 }

--- a/Build/setup.nsi
+++ b/Build/setup.nsi
@@ -1,0 +1,35 @@
+# define name of installer
+OutFile "mobiflight-setup.exe"
+ 
+# define installation directory
+InstallDir $DESKTOP
+ 
+# For removing Start Menu shortcut in Windows 7
+RequestExecutionLevel user
+ 
+# start default section
+Section
+ 
+    # set the installation directory as the destination for the following actions
+    SetOutPath $INSTDIR
+ 
+    # create the uninstaller
+    WriteUninstaller "$INSTDIR\uninstall.exe"
+ 
+    # create a shortcut named "new shortcut" in the start menu programs directory
+    # point the new shortcut at the program uninstaller
+    CreateShortcut "$SMPROGRAMS\new shortcut.lnk" "$INSTDIR\uninstall.exe"
+SectionEnd
+ 
+# uninstaller section start
+Section "uninstall"
+ 
+    # Remove the link from the start menu
+    Delete "$SMPROGRAMS\new shortcut.lnk"
+ 
+    # Delete the uninstaller
+    Delete $INSTDIR\uninstaller.exe
+ 
+    RMDir $INSTDIR
+# uninstaller section end
+SectionEnd

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -507,10 +507,15 @@ namespace MobiFlight
                 {
                     ExecuteDisplay(processedValue.ToString(), cfg);
                 }
+                catch(JoystickNotConnectedException jEx)
+                {
+                    row.ErrorText = jEx.Message;
+                }
                 catch (Exception exc)
                 {
                     String RowDescription = ((row.Cells["description"]).Value as String);
                     Exception resultExc = new ConfigErrorException(RowDescription + ". " + exc.Message, exc);
+                    row.ErrorText = exc.Message;
                     throw resultExc;
                 }
             }
@@ -708,9 +713,16 @@ namespace MobiFlight
             if (serial.IndexOf(Joystick.SerialPrefix)==0)
             {
                 Joystick joystick = joystickManager.GetJoystickBySerial(serial);
-                joystick.SetOutputDeviceState(cfg.Pin.DisplayPin, value);
-                joystick.UpdateOutputDeviceStates();
-                joystick.Update();
+                if(joystick != null)
+                {
+                    joystick.SetOutputDeviceState(cfg.Pin.DisplayPin, value);
+                    joystick.UpdateOutputDeviceStates();
+                    joystick.Update();
+                } else
+                {
+                    var joystickName = SerialNumber.ExtractDeviceName(cfg.DisplaySerial);
+                    throw new JoystickNotConnectedException(i18n._tr($"{joystickName} not connected"));
+                }
             }
             else if (serial.IndexOf("SN") != 0 && cfg.DisplayType != "InputAction")
             {

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -705,7 +705,14 @@ namespace MobiFlight
                 cfg.DisplayType!="InputAction") 
                 return value.ToString();
 
-            if (serial.IndexOf("SN") != 0 && cfg.DisplayType != "InputAction")
+            if (serial.IndexOf(Joystick.SerialPrefix)==0)
+            {
+                Joystick joystick = joystickManager.GetJoystickBySerial(serial);
+                joystick.SetOutputDeviceState(cfg.Pin.DisplayPin, value);
+                joystick.UpdateOutputDeviceStates();
+                joystick.Update();
+            }
+            else if (serial.IndexOf("SN") != 0 && cfg.DisplayType != "InputAction")
             {
 #if ARCAZE
                 switch (cfg.DisplayType)

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -269,6 +269,7 @@ namespace MobiFlight
             mobiFlightCache.Stop();
             simConnectCache.Stop();
             xplaneCache.Stop();
+            joystickManager.Stop();
             ClearErrorMessages();
         }
 
@@ -373,7 +374,7 @@ namespace MobiFlight
 #if SIMCONNECT
             simConnectCache.Disconnect();
 #endif
-            joystickManager.Stop();
+            joystickManager.Shutdown();
             this.OnModulesDisconnected?.Invoke(this, new EventArgs());
         }
 

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -10,6 +10,11 @@ using SharpDX.DirectInput;
 
 namespace MobiFlight
 {
+    public class JoystickNotConnectedException : Exception
+    {
+        public JoystickNotConnectedException(string Message) : base(Message) { }
+    }
+
     public enum JoystickDeviceType
     {
         Button,

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -381,5 +381,15 @@ namespace MobiFlight
 
             SendData(data);
         }
+
+        virtual public void Stop()
+        {
+            foreach(var light in Lights)
+            {
+                light.State = 0;
+            }
+            RequiresOutputUpdate = true;
+            UpdateOutputDeviceStates();
+        }
     }
 }

--- a/MobiFlight/JoystickManager.cs
+++ b/MobiFlight/JoystickManager.cs
@@ -68,8 +68,13 @@ namespace MobiFlight
 
                 if (!IsSupportedDeviceType(d)) continue;
 
-                MobiFlight.Joystick js = new MobiFlight.Joystick(new SharpDX.DirectInput.Joystick(di, d.InstanceGuid));
-                
+                MobiFlight.Joystick js;
+                if (d.InstanceName == "Bravo Throttle Quadrant")
+                {
+                    js = new Joysticks.HoneycombBravo(new SharpDX.DirectInput.Joystick(di, d.InstanceGuid));
+                } else
+                    js = new Joystick(new SharpDX.DirectInput.Joystick(di, d.InstanceGuid));
+
                 if (!HasAxisOrButtons(js)) continue;
 
                 Log.Instance.log("Adding attached Joystick Device: " + d.InstanceName + " Buttons " + js.Capabilities.ButtonCount + ", Axis: " + js.Capabilities.AxeCount, LogSeverity.Debug);

--- a/MobiFlight/JoystickManager.cs
+++ b/MobiFlight/JoystickManager.cs
@@ -45,9 +45,17 @@ namespace MobiFlight
             PollTimer.Start();
         }
 
-        public void Stop()
+        public void Shutdown()
         {
             PollTimer.Stop();
+        }
+
+        public void Stop()
+        {
+            foreach (var j in joysticks)
+            {
+                j.Stop();
+            }
         }
 
         public List<MobiFlight.Joystick> GetJoysticks()

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HidSharp;
+
+namespace MobiFlight.Joysticks
+{
+    internal class HoneycombBravo : Joystick
+    {
+        int VendorId = 0x294B;
+        int ProductId = 0x1901;
+        HidStream Stream { get; set; }
+        HidDevice Device { get; set; }
+        public HoneycombBravo(SharpDX.DirectInput.Joystick joystick) : base(joystick)
+        {
+
+        }
+
+        public void Connect()
+        {
+            if (Device == null)
+            {
+                Device = DeviceList.Local.GetHidDeviceOrNull(vendorID: VendorId, productID: ProductId);
+                if (Device == null) return;
+            }
+
+            Stream = Device.Open();
+        }
+
+        protected override void SendData(byte[] data)
+        {
+            if (!RequiresOutputUpdate) return;
+            if (Stream == null)
+            {
+                Connect();
+            };
+            Stream.SetFeature(data);
+            base.SendData(data);
+        }
+
+        protected override void EnumerateOutputDevices()
+        {
+            base.EnumerateOutputDevices();
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - HDG",                Name = "AP.hdg",                Byte = 1, Bit = 0 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - NAV",                Name = "AP.nav",                Byte = 1, Bit = 1 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - APR",                Name = "AP.apr",                Byte = 1, Bit = 2 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - REV",                Name = "AP.rev",                Byte = 1, Bit = 3 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - ALT",                Name = "AP.alt",                Byte = 1, Bit = 4 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - VS",                 Name = "AP.vs",                 Byte = 1, Bit = 5 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - IAS",                Name = "AP.ias",                Byte = 1, Bit = 6 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - On/Off",             Name = "AP.autopilot",          Byte = 1, Bit = 7 });
+            // -- Byte 2
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Left Green",            Name = "Gear.LeftGreen",        Byte = 2, Bit = 0 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Left Red",              Name = "Gear.LeftRed",          Byte = 2, Bit = 1 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Center Green",          Name = "Gear.CenterGreen",      Byte = 2, Bit = 2 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Center Red",            Name = "Gear.CenterRed",        Byte = 2, Bit = 3 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Green",           Name = "Gear.RightGreen",       Byte = 2, Bit = 4 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Right",           Name = "Gear.RightRed",         Byte = 2, Bit = 5 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Master Warning",      Name = "Light.MasterWarn",      Byte = 2, Bit = 6 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Engine Fire",         Name = "Light.EngineFire",      Byte = 2, Bit = 7 });
+            // -- Byte 3
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Oil Pressure",    Name = "Light.LowOil",          Byte = 3, Bit = 0 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Fuel Pressure",   Name = "Light.LowFuel",         Byte = 3, Bit = 1 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Anti Ice",            Name = "Light.Antiice",         Byte = 3, Bit = 2 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Starter Engaged",     Name = "Light.Starter",         Byte = 3, Bit = 3 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - APU",                 Name = "Light.APU",             Byte = 3, Bit = 4 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Master Caution",      Name = "Light.MasterCaution",   Byte = 3, Bit = 5 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Vacuum",              Name = "Light.Vacuum",          Byte = 3, Bit = 6 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Hyd Pressure",    Name = "Light.LowHydPressURE",  Byte = 3, Bit = 7 });
+            // -- Byte 4
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Aux Fuel Pump",       Name = "Lights.AuxFuelPump",    Byte = 4, Bit = 0 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Parking Brake",       Name = "Lights.ParkingBrake",   Byte = 4, Bit = 1 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Volts",           Name = "Lights.LowVolts",       Byte = 4, Bit = 2 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Door",                Name = "Lights.door",           Byte = 4, Bit = 3 });
+
+
+        }
+    }
+}

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -57,7 +57,7 @@ namespace MobiFlight.Joysticks
             Lights.Add(new JoystickOutputDevice() { Label = "Gear - Center Green",          Name = "Gear.CenterGreen",      Byte = 2, Bit = 2 });
             Lights.Add(new JoystickOutputDevice() { Label = "Gear - Center Red",            Name = "Gear.CenterRed",        Byte = 2, Bit = 3 });
             Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Green",           Name = "Gear.RightGreen",       Byte = 2, Bit = 4 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Right",           Name = "Gear.RightRed",         Byte = 2, Bit = 5 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Red",             Name = "Gear.RightRed",         Byte = 2, Bit = 5 });
             Lights.Add(new JoystickOutputDevice() { Label = "Lights - Master Warning",      Name = "Light.MasterWarn",      Byte = 2, Bit = 6 });
             Lights.Add(new JoystickOutputDevice() { Label = "Lights - Engine Fire",         Name = "Light.EngineFire",      Byte = 2, Bit = 7 });
             // -- Byte 3

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -134,6 +134,9 @@
     <Reference Include="fsuipcClient, Version=3.2.19.388, Culture=neutral, PublicKeyToken=7e7559b53e380b17, processorArchitecture=MSIL">
       <HintPath>packages\FSUIPCClientDLL.3.2.19\lib\net40\fsuipcClient.dll</HintPath>
     </Reference>
+    <Reference Include="HidSharp, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\HidSharp.2.1.0\lib\net35\HidSharp.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.20.0.103, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.20.0\lib\net452\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
     </Reference>
@@ -238,6 +241,7 @@
     <Compile Include="MobiFlight\Joystick.cs" />
     <Compile Include="MobiFlight\JoystickManager.cs" />
     <Compile Include="MobiFlight\InputConfig\MSFS2020EventIdInputAction.cs" />
+    <Compile Include="MobiFlight\Joysticks\HoneycombBravo.cs" />
     <Compile Include="MobiFlight\MaximumDeviceNumberReachedMobiFlightException.cs" />
     <Compile Include="MobiFlight\MobiFlightAnalogInput.cs" />
     <Compile Include="MobiFlight\MobiFlightInputMultiplexer.cs" />

--- a/ProjectMessages/ProjectMessages.Designer.cs
+++ b/ProjectMessages/ProjectMessages.Designer.cs
@@ -796,7 +796,7 @@ namespace MobiFlight.ProjectMessages {
         ///
         ///{0}
         ///
-        ///Respective input actions won&apos;t work until they are connected and you have restarted MobiFlight..
+        ///Respective configs won&apos;t work until joysticks are connected and you have restarted MobiFlight..
         /// </summary>
         internal static string uiMessageNotConnectedJoysticksInConfigFound {
             get {

--- a/ProjectMessages/ProjectMessages.de.resx
+++ b/ProjectMessages/ProjectMessages.de.resx
@@ -459,7 +459,7 @@ Du kannst es jederzeit wieder in den Einstellungen aktivieren </value>
 
 {0}
 
-Die entsprechenden Input Actions funktionieren nicht bis der Joystick wieder angeschlossen und MobiFlight neu gestartet ist.</value>
+Die entsprechenden Konfigurationen funktionieren nicht bis der Joystick wieder angeschlossen und MobiFlight neu gestartet ist.</value>
     <comment>The following joysticks are currently not connected but referenced in the config:
 
 {0}

--- a/ProjectMessages/ProjectMessages.resx
+++ b/ProjectMessages/ProjectMessages.resx
@@ -471,7 +471,7 @@ Check log for more details.</value>
 
 {0}
 
-Respective input actions won't work until they are connected and you have restarted MobiFlight.</value>
+Respective configs won't work until joysticks are connected and you have restarted MobiFlight.</value>
   </data>
   <data name="uiMessageFirmwareUpdateStatus" xml:space="preserve">
     <value>Updating {0} on {1} (Module {2}/{3})</value>

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -177,6 +177,21 @@ namespace MobiFlight.UI.Dialogs
                 // preconditionPinSerialComboBox.Items.Add(module.Name + "/ " + module.Serial);
             }
 
+
+            foreach (Joystick joystick in _execManager.GetJoystickManager().GetJoysticks())
+            {
+                if (joystick.GetAvailableOutputDevices().Count == 0) continue;
+
+                DisplayModuleList.Add(new ListItem()
+                {
+                    Value = joystick.Name + "/ " + joystick.Serial,
+                    Label = $"{joystick.Name}"
+                });
+
+                // Not yet supported for pins
+                // preconditionPinSerialComboBox.Items.Add(module.Name + "/ " + module.Serial);
+            }
+
             displayPanel1.SetArcazeSettings(arcazeFirmware, moduleSettings);
             displayPanel1.SetModules(DisplayModuleList);
             preconditionPanel.SetModules(PreconditionModuleList);

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -164,33 +164,8 @@ namespace MobiFlight.UI.Dialogs
                 });
             }
 
-
-            foreach (IModuleInfo module in _execManager.getMobiFlightModuleCache().getModuleInfo())
-            {
-                DisplayModuleList.Add(new ListItem()
-                {
-                    Value = module.Name + "/ " + module.Serial,
-                    Label = $"{module.Name} ({module.Port})"
-                });
-
-                // Not yet supported for pins
-                // preconditionPinSerialComboBox.Items.Add(module.Name + "/ " + module.Serial);
-            }
-
-
-            foreach (Joystick joystick in _execManager.GetJoystickManager().GetJoysticks())
-            {
-                if (joystick.GetAvailableOutputDevices().Count == 0) continue;
-
-                DisplayModuleList.Add(new ListItem()
-                {
-                    Value = joystick.Name + "/ " + joystick.Serial,
-                    Label = $"{joystick.Name}"
-                });
-
-                // Not yet supported for pins
-                // preconditionPinSerialComboBox.Items.Add(module.Name + "/ " + module.Serial);
-            }
+            _AddMobiFlightModules(DisplayModuleList);
+            _AddJoysticks(DisplayModuleList);
 
             displayPanel1.SetArcazeSettings(arcazeFirmware, moduleSettings);
             displayPanel1.SetModules(DisplayModuleList);
@@ -203,8 +178,17 @@ namespace MobiFlight.UI.Dialogs
         /// </summary>
         public void initWithoutArcazeCache()
         {
-            List<ListItem> DisplayModuleList = new List<ListItem>();
+            var DisplayModuleList = new List<ListItem>();
             
+            _AddMobiFlightModules(DisplayModuleList);
+            _AddJoysticks(DisplayModuleList);            
+
+            displayPanel1.SetModules(DisplayModuleList);
+        }
+#endif
+
+        protected void _AddMobiFlightModules(List<ListItem> DisplayModuleList)
+        {
             foreach (IModuleInfo module in _execManager.getMobiFlightModuleCache().getModuleInfo())
             {
                 DisplayModuleList.Add(new ListItem()
@@ -216,10 +200,25 @@ namespace MobiFlight.UI.Dialogs
                 // Not yet supported for pins
                 // preconditionPinSerialComboBox.Items.Add(module.Name + "/ " + module.Serial);
             }
-
-            displayPanel1.SetModules(DisplayModuleList);
         }
-#endif
+
+        protected void _AddJoysticks(List<ListItem> DisplayModuleList)
+        {
+            foreach (Joystick joystick in _execManager.GetJoystickManager().GetJoysticks())
+            {
+                if (joystick.GetAvailableOutputDevices().Count == 0) continue;
+
+                DisplayModuleList.Add(new ListItem()
+                {
+                    Value = joystick.Name + " / " + joystick.Serial,
+                    Label = $"{joystick.Name}"
+                });
+
+                // Not yet supported for pins
+                // preconditionPinSerialComboBox.Items.Add(module.Name + "/ " + module.Serial);
+            }
+        }
+
         /// <summary>
         /// sync the values from config with the config wizard form
         /// </summary>

--- a/UI/Dialogs/ConfigWizard.resx
+++ b/UI/Dialogs/ConfigWizard.resx
@@ -142,7 +142,7 @@
     <value>configRefPanel</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Parent" xml:space="preserve">
     <value>referencesGroupBox</value>
@@ -199,7 +199,7 @@
     <value>xplaneDataRefPanel1</value>
   </data>
   <data name="&gt;&gt;xplaneDataRefPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.XplaneDataRefPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.XplaneDataRefPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;xplaneDataRefPanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -229,7 +229,7 @@
     <value>variablePanel1</value>
   </data>
   <data name="&gt;&gt;variablePanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.VariablePanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.VariablePanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;variablePanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -259,7 +259,7 @@
     <value>simConnectPanel1</value>
   </data>
   <data name="&gt;&gt;simConnectPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.SimConnectPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.SimConnectPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;simConnectPanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -289,7 +289,7 @@
     <value>fsuipcConfigPanel</value>
   </data>
   <data name="&gt;&gt;fsuipcConfigPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.FsuipcConfigPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.FsuipcConfigPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;fsuipcConfigPanel.Parent" xml:space="preserve">
     <value>FsuipcSettingsPanel</value>
@@ -595,7 +595,7 @@
     <value>interpolationPanel1</value>
   </data>
   <data name="&gt;&gt;interpolationPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.InterpolationPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.InterpolationPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;interpolationPanel1.Parent" xml:space="preserve">
     <value>interpolationGroupBox</value>
@@ -1028,7 +1028,7 @@
     <value>displayPanel1</value>
   </data>
   <data name="&gt;&gt;displayPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.OutputWizard.DisplayPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.OutputWizard.DisplayPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;displayPanel1.Parent" xml:space="preserve">
     <value>displayTabPage</value>
@@ -1082,7 +1082,7 @@
     <value>preconditionPanel</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
     <value>preconditionTabPage</value>

--- a/UI/Dialogs/OrphanedSerialsDialog.cs
+++ b/UI/Dialogs/OrphanedSerialsDialog.cs
@@ -46,6 +46,7 @@ namespace MobiFlight.UI.Dialogs
                 OutputConfigItem cfg = row["settings"] as OutputConfigItem;
                 if (cfg.DisplaySerial != "" && 
                     cfg.DisplaySerial  != "-" && 
+                    !Joystick.IsJoystickSerial(cfg.DisplaySerial) &&
                     !configSerials.Contains(cfg.DisplaySerial) && 
                     !moduleSerials.Contains(cfg.DisplaySerial))
                 {

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1214,6 +1214,16 @@ namespace MobiFlight.UI
             if (serials.Count == 0) return;
             if (configFile == null) return;
 
+            foreach (OutputConfigItem item in configFile.GetOutputConfigItems())
+            {
+                if (item.DisplaySerial.Contains(Joystick.SerialPrefix) &&
+                    !serials.Contains(item.DisplaySerial) &&
+                    !NotConnectedJoysticks.Contains(item.DisplaySerial))
+                {
+                    NotConnectedJoysticks.Add(item.DisplaySerial);
+                }
+            }
+
             foreach (InputConfigItem item in configFile.GetInputConfigItems())
             {
                 if (item.ModuleSerial.Contains(Joystick.SerialPrefix) &&

--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -98,7 +98,13 @@ namespace MobiFlight.UI.Panels
                 string port = "";
                 string pin = config.Pin.DisplayPin;
 
-                if (serial != null && serial.IndexOf("SN") != 0)
+                if (serial != null && serial.IndexOf(Joystick.SerialPrefix) == 0)
+                {
+                    // disable multi-select option
+                    _MultiSelectOptions(false);
+                    pin = config.Pin.DisplayPin;
+                }
+                else if (serial != null && serial.IndexOf("SN") != 0)
                 {
                     // these are Arcaze Boards.
                     // Arcaze Boards only have "single output"

--- a/UI/Panels/Output/DisplayPinPanel.resx
+++ b/UI/Panels/Output/DisplayPinPanel.resx
@@ -643,7 +643,7 @@
     <value>MultiPinSelectPanel</value>
   </data>
   <data name="&gt;&gt;MultiPinSelectPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.PinSelectPanel, MFConnector, Version=9.0.0.5, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.PinSelectPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;MultiPinSelectPanel.Parent" xml:space="preserve">
     <value>PinSelectPanel</value>

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -314,10 +314,14 @@ namespace MobiFlight.UI.Panels.OutputWizard
                 displayTypeComboBox.Enabled = groupBoxDisplaySettings.Enabled = testSettingsGroupBox.Enabled = (serial != "");
                 // serial is empty if no module is selected (on init of form)
                 //if (serial == "") return;                
-
+                if (serial.IndexOf(Joystick.SerialPrefix) == 0)
+                {
+                    displayTypeComboBox.Items.Clear();
+                    displayTypeComboBox.Items.Add("Pin");
+                }
                 // update the available types depending on the 
                 // type of module
-                if (serial.IndexOf("SN") != 0)
+                else if (serial.IndexOf("SN") != 0)
                 {
                     displayTypeComboBox.Items.Clear();
                     displayTypeComboBox.Items.Add("Pin");
@@ -325,6 +329,8 @@ namespace MobiFlight.UI.Panels.OutputWizard
                     displayTypeComboBox.Items.Add(MobiFlightShiftRegister.TYPE);
                     //displayTypeComboBox.Items.Add(ArcazeBcd4056.TYPE);
                 }
+                // update the available types depending on the 
+                // type of module
                 else
                 {
                     displayTypeComboBox.Items.Clear();
@@ -433,6 +439,11 @@ namespace MobiFlight.UI.Panels.OutputWizard
                     panelEnabled = InitializeMobiFlightDisplays(cb, serial);
                 }
 
+                else if (serial.IndexOf(Joystick.SerialPrefix) == 0)
+                {
+                    panelEnabled = InitializeJoystickDisplays(cb, serial);
+                }
+
                 ShowActiveDisplayPanel(sender, serial, panelEnabled);
             }
             catch (Exception exc)
@@ -443,6 +454,26 @@ namespace MobiFlight.UI.Panels.OutputWizard
                                 MessageBoxButtons.OK,
                                 MessageBoxIcon.Warning);
             }
+        }
+
+        private bool InitializeJoystickDisplays(ComboBox cb, string serial)
+        {
+            Joystick joystick = _execManager.GetJoystickManager().GetJoystickBySerial(serial);
+
+            displayPinPanel.SetModule(null);
+            displayPinPanel.displayPinBrightnessPanel.Visible = false;
+            displayPinPanel.displayPinBrightnessPanel.Enabled = false;
+
+            List<ListItem> outputs = new List<ListItem>();
+            foreach (var device in joystick.GetAvailableOutputDevices())
+                outputs.Add(new ListItem() { Value = device.Value, Label = device.Label });
+
+            displayPinPanel.WideStyle = true;
+            displayPinPanel.EnablePWMSelect(false);
+            displayPinPanel.SetPorts(new List<ListItem>());
+            displayPinPanel.SetPins(outputs);
+
+            return true;
         }
 
         private void ShowActiveDisplayPanel(object sender, string serial, bool panelEnabled)

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -466,7 +466,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             List<ListItem> outputs = new List<ListItem>();
             foreach (var device in joystick.GetAvailableOutputDevices())
-                outputs.Add(new ListItem() { Value = device.Value, Label = device.Label });
+                outputs.Add(new ListItem() { Value = device.Label, Label = device.Label });
 
             displayPinPanel.WideStyle = true;
             displayPinPanel.EnablePWMSelect(false);

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FSUIPCClientDLL" version="3.2.19" targetFramework="net48" />
+  <package id="HidSharp" version="2.1.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights" version="2.20.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.20.0" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net452" />


### PR DESCRIPTION
With this addition you are now able to use Honeycomb Bravo Lights in output configs.

Confirmations:
- [x] Lights can be configured like simple outputs, e.g. LED
  <img width="467" alt="image" src="https://user-images.githubusercontent.com/86157512/193903810-2263da6b-7a2f-4e02-8301-55770e4fe50d.png">
- [x] Configs can be loaded and saved
  <img width="756" alt="image" src="https://user-images.githubusercontent.com/86157512/193903710-b82f71ad-95be-4ea0-a498-71c68a15204b.png">
- [x] Test Mode works
- [x] Lights can be referenced by meaningful names
  <img width="470" alt="image" src="https://user-images.githubusercontent.com/86157512/193903908-723a6f66-fc36-48f0-983d-0289a9e1d67c.png">
- [x] Lights turn off on shutdown
- [x] There is a notification if the joystick is not connected but used in the config
- [x] [Documentation available](https://github.com/MobiFlight/MobiFlight-Connector/wiki/Joystick-Support#honeycomb-bravo-support)

https://github.com/MobiFlight/MobiFlight-Connector/wiki/Joystick-Support#honeycomb-bravo-support