### PR TITLE
Default device name for 2nd InputMultiplexer exceeds 16 characters (#885)

### DIFF
--- a/MobiFlight/Config/InputMultiplexer.cs
+++ b/MobiFlight/Config/InputMultiplexer.cs
@@ -21,14 +21,14 @@ namespace MobiFlight.Config
 
         public InputMultiplexer()
         {
-            Name = "InputMultiplexer";
+            Name = "Multiplexer";
             _type = DeviceType.InputMultiplexer;
             _muxClient = true;
             Selector = null;
         }
 
         public InputMultiplexer(MobiFlight.Config.MultiplexerDriver muxSelector) { 
-            Name = "InputMultiplexer"; 
+            Name = "Multiplexer"; 
             _type = DeviceType.InputMultiplexer;
             _muxClient = true;
             Selector = muxSelector;

--- a/MobiFlight/MobiFlightInputMultiplexer.cs
+++ b/MobiFlight/MobiFlightInputMultiplexer.cs
@@ -22,7 +22,7 @@ namespace MobiFlight
 
 
         private DeviceType _type = DeviceType.InputMultiplexer;
-        private String _name = "InputMultiplexer";
+        private String _name = "Multiplexer";
         public int ModuleNumber { get; set; }
 
         public String Name


### PR DESCRIPTION
Name changed from "InputMultiplexer" to a generic "Multiplexer"