### PR TITLE
When adding 2nd multiplexer the base pins are not displayed correctly (#894)

### DIFF
--- a/UI/Panels/Device/MFMultiplexerDriverSubPanel.resx
+++ b/UI/Panels/Device/MFMultiplexerDriverSubPanel.resx
@@ -196,7 +196,7 @@
     <value>32</value>
   </data>
   <data name="labelMaster.Text" xml:space="preserve">
-    <value>Changing these values will affect every other device using multiplexers.</value>
+    <value>These values will be shared by all multiplexers of this module.</value>
   </data>
   <data name="&gt;&gt;labelMaster.Name" xml:space="preserve">
     <value>labelMaster</value>

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -971,7 +971,7 @@ namespace MobiFlight.UI.Panels.Settings
         {
             MobiFlight.Config.MultiplexerDriver moduleMultiplexerDriver;
             
-            string moduleName = getModuleNode().Name;
+            string moduleName = getModuleNode().Text;
 
             if (!moduleMultiplexerDrivers.ContainsKey(moduleName)) {
                 // None found: we are adding first client, therefore we must also build a new MultiplexerDriver


### PR DESCRIPTION
Attribution of the multiplexer pins to the owner module was made according to attribute "Name", which apparently is not the name (and it's blank).
Changed to reference attribute "Text" instead.