### PR TITLE
Add Multiplexer to a Pro Micro board fails (#926)

### DIFF
--- a/MobiFlight/Config/MultiplexerDriver.cs
+++ b/MobiFlight/Config/MultiplexerDriver.cs
@@ -53,7 +53,7 @@ namespace MobiFlight.Config
         {
             if (pinNos.Length < 4) return false;
             for (var i = 0; i < 4; i++) {
-                if (byte.Parse(pinNos[i]) <= 0) return false;
+                if (byte.Parse(pinNos[i]) < 0) return false;
             }
             Array.Copy(pinNos, PinSx, 4); 
             if(_initCounter == 0) _initCounter++;


### PR DESCRIPTION
Mux selector pins with value <=0 caused the object to be considered as uninitialized (initial values are set to negative numbers); should have correctly been "< 0".
Only affected ProMicro because on other Arduinos pin 0 is reserved and it's not available for assignment.