### PR TITLE
Add GroundStudio Jade Mega board to the list of boards

### DIFF
--- a/Boards/arduino_mega.board.json
+++ b/Boards/arduino_mega.board.json
@@ -29,7 +29,8 @@
     "^VID_2341&PID_0242",
     "^VID_10C4&PID_EA60",
     "^VID_2341&PID_0044",
-    "^VID_3343&PID_0042"
+    "^VID_3343&PID_0042",
+    "^VID_04D9&PID_B534"
   ],
   "Info": {
     "CanInstallFirmware": true,
@@ -49,7 +50,7 @@
     "MaxServos": 10,
     "MaxShifters": 4,
     "MaxSteppers": 10,
-    "MaxInputMultiplexer": 2,
+    "MaxInputMultiplexer": 2
   },
   "Pins": [
     {


### PR DESCRIPTION
This commit adds the VID and PID for the GroundStudio Jade Mega board.

This is a Mega board made by a Romanian company, and you can find more details about it [here](github.com/GroundStudio/GroundStudio_Jade_Mega).