### PR TITLE
Use "LED / Output" for the simple output devices

### DIFF
--- a/MobiFlight/OutputConfigItem.cs
+++ b/MobiFlight/OutputConfigItem.cs
@@ -336,15 +336,15 @@ namespace MobiFlight
             {
                 writer.WriteAttributeString("bcdPins", String.Join(",", BcdPins));
             }
-            else if (DisplayType == DeviceType.Servo.ToString("F"))
+            else if (DisplayType == MobiFlightServo.TYPE)
             {
                 Servo.WriteXml(writer);
             }
-            else if (DisplayType == DeviceType.Stepper.ToString("F"))
+            else if (DisplayType == MobiFlightStepper.TYPE)
             {
                 Stepper.WriteXml(writer);
             }
-            else if (DisplayType == OutputConfig.LcdDisplay.Type)
+            else if (DisplayType == MobiFlightLcdDisplay.TYPE)
             {
                 if (LcdDisplay == null) LcdDisplay = new OutputConfig.LcdDisplay();
                 LcdDisplay.WriteXml(writer);

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -557,7 +557,13 @@ namespace MobiFlight.UI.Panels
                         row["arcazeSerial"] = cfgItem.DisplaySerial.ToString().Split('/')[0];
                     
                         row["OutputType"] = cfgItem.DisplayType;
-                        switch(cfgItem.DisplayType)
+
+                        // only exception for the type label
+                        if (cfgItem.DisplayType == "Pin" || 
+                            cfgItem.DisplayType == MobiFlightOutput.TYPE)
+                            row["OutputType"] = "LED / Output";
+
+                        switch (cfgItem.DisplayType)
                         {
                             case MobiFlightLedModule.TYPE:
                                 row["OutputName"] = cfgItem.LedModule.DisplayLedAddress;

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -303,37 +303,39 @@ namespace MobiFlight.UI.Panels.OutputWizard
 #endif
             // check which extension type is available to current serial
             ComboBox cb = (sender as ComboBox);
+            List<ListItem> deviceTypeOptions = new List<ListItem>();
+            displayTypeComboBox.DataSource = null;
+            displayTypeComboBox.Items.Clear();
+
+            // disable test button
+            // in case that no display is selected
+            String rawSerial = cb.SelectedItem.ToString();
+            String serial = SerialNumber.ExtractSerial(rawSerial);
+
+            displayTypeComboBox.Enabled = groupBoxDisplaySettings.Enabled = testSettingsGroupBox.Enabled = (serial != "");
+
 
             try
             {
-                // disable test button
-                // in case that no display is selected
-                String rawSerial = cb.SelectedItem.ToString();
-                String serial = SerialNumber.ExtractSerial(rawSerial);
-
-                displayTypeComboBox.Enabled = groupBoxDisplaySettings.Enabled = testSettingsGroupBox.Enabled = (serial != "");
+                
                 // serial is empty if no module is selected (on init of form)
                 //if (serial == "") return;                
                 if (serial.IndexOf(Joystick.SerialPrefix) == 0)
                 {
-                    displayTypeComboBox.Items.Clear();
-                    displayTypeComboBox.Items.Add("Pin");
+                    deviceTypeOptions.Add(new ListItem() { Value = "Pin", Label = "LED / Output" });
                 }
                 // update the available types depending on the 
                 // type of module
                 else if (serial.IndexOf("SN") != 0)
                 {
-                    displayTypeComboBox.Items.Clear();
-                    displayTypeComboBox.Items.Add("Pin");
-                    displayTypeComboBox.Items.Add(ArcazeLedDigit.TYPE);
-                    displayTypeComboBox.Items.Add(MobiFlightShiftRegister.TYPE);
-                    //displayTypeComboBox.Items.Add(ArcazeBcd4056.TYPE);
+                    deviceTypeOptions.Add(new ListItem() { Value = "Pin", Label = "LED / Output" } );
+                    deviceTypeOptions.Add(new ListItem() { Value = ArcazeLedDigit.TYPE, Label = ArcazeLedDigit.TYPE } );
+                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightShiftRegister.TYPE, Label = MobiFlightShiftRegister.TYPE } );
                 }
                 // update the available types depending on the 
                 // type of module
                 else
                 {
-                    displayTypeComboBox.Items.Clear();
                     MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
                     foreach (DeviceType devType in module.GetConnectedOutputDeviceTypes())
                     {
@@ -343,33 +345,33 @@ namespace MobiFlight.UI.Panels.OutputWizard
                         switch (devType)
                         {
                             case DeviceType.LedModule:
-                                displayTypeComboBox.Items.Add(ArcazeLedDigit.TYPE);
+                                deviceTypeOptions.Add(new ListItem() { Value = ArcazeLedDigit.TYPE, Label = ArcazeLedDigit.TYPE });
                                 break;
 
                             case DeviceType.Output:
-                                displayTypeComboBox.Items.Add("Pin");
+                                deviceTypeOptions.Add(new ListItem() { Value = "Pin", Label = "LED / Output" });
                                 //displayTypeComboBox.Items.Add(ArcazeBcd4056.TYPE);
                                 break;
 
                             case DeviceType.Servo:
-                                displayTypeComboBox.Items.Add(DeviceType.Servo.ToString("F"));
+                                deviceTypeOptions.Add(new ListItem() { Value = DeviceType.Servo.ToString("F"), Label = DeviceType.Servo.ToString("F") });
                                 break;
 
                             case DeviceType.Stepper:
-                                displayTypeComboBox.Items.Add(DeviceType.Stepper.ToString("F"));
+                                deviceTypeOptions.Add(new ListItem() { Value = DeviceType.Stepper.ToString("F"), Label = DeviceType.Stepper.ToString("F") });
                                 break;
 
                             case DeviceType.LcdDisplay:
-                                displayTypeComboBox.Items.Add(DeviceType.LcdDisplay.ToString("F"));
+                                deviceTypeOptions.Add(new ListItem() { Value = DeviceType.LcdDisplay.ToString("F"), Label = DeviceType.LcdDisplay.ToString("F") });
                                 break;
 
                             case DeviceType.ShiftRegister:
-                                displayTypeComboBox.Items.Add(MobiFlightShiftRegister.TYPE);
+                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightShiftRegister.TYPE, Label = MobiFlightShiftRegister.TYPE });
                                 break;
                         }
                     }
 
-                    if (displayTypeComboBox.Items.Count == 0 && this.Visible)
+                    if (deviceTypeOptions.Count == 0 && this.Visible)
                     {
                         if (MessageBox.Show(
                                 i18n._tr("uiMessageSelectedModuleDoesNotContainAnyOutputDevices"),
@@ -389,6 +391,10 @@ namespace MobiFlight.UI.Panels.OutputWizard
                         }
                     }
                 }
+
+                displayTypeComboBox.DataSource = deviceTypeOptions;
+                displayTypeComboBox.ValueMember = "Value";
+                displayTypeComboBox.DisplayMember = "Label";
 
                 // config can be null
                 // because module information is set
@@ -478,7 +484,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
         private void ShowActiveDisplayPanel(object sender, string serial, bool panelEnabled)
         {
-            if ((sender as ComboBox).Text == "Pin")
+            if ((sender as ComboBox).SelectedValue as string == "Pin")
             {
                 displayPinPanel.Enabled = panelEnabled;
                 displayPinPanel.Height = displayPanelHeight;

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -1,5 +1,6 @@
 ﻿using MobiFlight.Base;
 using MobiFlight.InputConfig;
+using MobiFlight.UI.Panels.Settings.Device;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -242,7 +243,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
         internal void syncToConfig()
         {
             if (OutputTypeComboBox.SelectedIndex == 0) { 
-                config.DisplayType = displayTypeComboBox.Text;
+                config.DisplayType = (displayTypeComboBox.SelectedItem as ListItem).Value;
                 config.DisplayTrigger = "normal";
                 config.DisplaySerial = displayModuleNameComboBox.SelectedItem.ToString();
 
@@ -322,13 +323,13 @@ namespace MobiFlight.UI.Panels.OutputWizard
                 //if (serial == "") return;                
                 if (serial.IndexOf(Joystick.SerialPrefix) == 0)
                 {
-                    deviceTypeOptions.Add(new ListItem() { Value = "Pin", Label = "LED / Output" });
+                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightOutput.TYPE, Label = "LED / Output" });
                 }
                 // update the available types depending on the 
                 // type of module
                 else if (serial.IndexOf("SN") != 0)
                 {
-                    deviceTypeOptions.Add(new ListItem() { Value = "Pin", Label = "LED / Output" } );
+                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightOutput.TYPE, Label = "LED / Output" } );
                     deviceTypeOptions.Add(new ListItem() { Value = ArcazeLedDigit.TYPE, Label = ArcazeLedDigit.TYPE } );
                     deviceTypeOptions.Add(new ListItem() { Value = MobiFlightShiftRegister.TYPE, Label = MobiFlightShiftRegister.TYPE } );
                 }
@@ -349,20 +350,20 @@ namespace MobiFlight.UI.Panels.OutputWizard
                                 break;
 
                             case DeviceType.Output:
-                                deviceTypeOptions.Add(new ListItem() { Value = "Pin", Label = "LED / Output" });
+                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightOutput.TYPE, Label = "LED / Output" });
                                 //displayTypeComboBox.Items.Add(ArcazeBcd4056.TYPE);
                                 break;
 
                             case DeviceType.Servo:
-                                deviceTypeOptions.Add(new ListItem() { Value = DeviceType.Servo.ToString("F"), Label = DeviceType.Servo.ToString("F") });
+                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightServo.TYPE, Label = MobiFlightServo.TYPE });
                                 break;
 
                             case DeviceType.Stepper:
-                                deviceTypeOptions.Add(new ListItem() { Value = DeviceType.Stepper.ToString("F"), Label = DeviceType.Stepper.ToString("F") });
+                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightStepper.TYPE, Label = MobiFlightStepper.TYPE });
                                 break;
 
                             case DeviceType.LcdDisplay:
-                                deviceTypeOptions.Add(new ListItem() { Value = DeviceType.LcdDisplay.ToString("F"), Label = DeviceType.LcdDisplay.ToString("F") });
+                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightLcdDisplay.TYPE, Label = MobiFlightLcdDisplay.TYPE });
                                 break;
 
                             case DeviceType.ShiftRegister:
@@ -484,7 +485,8 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
         private void ShowActiveDisplayPanel(object sender, string serial, bool panelEnabled)
         {
-            if ((sender as ComboBox).SelectedValue as string == "Pin")
+            if ((sender as ComboBox).SelectedValue as string == "Pin" ||
+                (sender as ComboBox).SelectedValue as string == MobiFlightOutput.TYPE)
             {
                 displayPinPanel.Enabled = panelEnabled;
                 displayPinPanel.Height = displayPanelHeight;


### PR DESCRIPTION
fixes #930 

- [x] list view shows device type "LED / Output"
- [x] config wizard uses device type "LED / Output"
- [x] configs can be saved & loaded
- [x] old configs can be loaded
- [x] ~~unit tests are updated~~ (not required)

### device settings
<img width="432" alt="image" src="https://user-images.githubusercontent.com/86157512/194702569-35b3fd69-d243-4091-beae-28a18b3becc7.png">

### list view
<img width="757" alt="image" src="https://user-images.githubusercontent.com/86157512/194702608-1465644e-d983-4a0a-9f5b-9ede49df67c5.png">

### config wizard
<img width="471" alt="image" src="https://user-images.githubusercontent.com/86157512/194702600-d9a14bac-f78b-411b-9969-e0ab339e0b35.png">

## notes
- config entries are not "pin" anymore but of type "output" - loading routine was capable already to read both versions. this will not affect anyone.
- labels are not internationalized
- pin logic is a bit static, technical debt.