### PR TITLE
fix the log message

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1398,11 +1398,11 @@ namespace MobiFlight
             // Skip execution if not started
             if (!IsStarted())
             {
-                Log.Instance.log($"Config found for ${msgEventLabel} (!) Not sent, no sim running", LogSeverity.Warn);
+                Log.Instance.log($"Config found for {msgEventLabel} (!) Not sent, MobiFlight not running", LogSeverity.Warn);
                 return;
             }
 
-            Log.Instance.log($"Config found for ${msgEventLabel}", LogSeverity.Debug);
+            Log.Instance.log($"Config found for {msgEventLabel}", LogSeverity.Debug);
 
             ConnectorValue currentValue = new ConnectorValue();
             CacheCollection cacheCollection = new CacheCollection()


### PR DESCRIPTION
relates to #903 

- [x] Fix the extra $ in front of the message
- [x] reason for not executing config is "MobiFlight is not running"