### PR TITLE
Setting CultureInfo for app globally to prevent errors with floats

### DIFF
--- a/Base/ConnectorValue.cs
+++ b/Base/ConnectorValue.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -20,10 +21,10 @@ namespace MobiFlight
                     result = String;
                     break;
                 case FSUIPCOffsetType.Integer:
-                    result = Float64.ToString();
+                    result = Float64.ToString(CultureInfo.InvariantCulture);
                     break;
                 case FSUIPCOffsetType.Float:
-                    result = Float64.ToString();
+                    result = Float64.ToString(CultureInfo.InvariantCulture);
                     break;
                 /*case FSUIPCOffsetType.UnsignedInt:
                     result = Uint64.ToString();

--- a/Base/ConnectorValue.cs
+++ b/Base/ConnectorValue.cs
@@ -21,10 +21,10 @@ namespace MobiFlight
                     result = String;
                     break;
                 case FSUIPCOffsetType.Integer:
-                    result = Float64.ToString(CultureInfo.InvariantCulture);
+                    result = Float64.ToString();
                     break;
                 case FSUIPCOffsetType.Float:
-                    result = Float64.ToString(CultureInfo.InvariantCulture);
+                    result = Float64.ToString();
                     break;
                 /*case FSUIPCOffsetType.UnsignedInt:
                     result = Uint64.ToString();

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -646,7 +646,7 @@ namespace MobiFlight
                             tmp.Comparison.ElseValue = "0";
 
                             connectorValue.type = FSUIPCOffsetType.Float;
-                            if (!Double.TryParse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out connectorValue.Float64))
+                            if (!Double.TryParse(value, out connectorValue.Float64))
                             {
                                 // likely to be a string
                                 connectorValue.type = FSUIPCOffsetType.String;

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1390,7 +1390,7 @@ namespace MobiFlight
             	if (inputCache[inputKey].Count == 0)
             	{
                 	if (LogIfNotJoystickOrJoystickAxisEnabled(e.Serial, e.Type))
-                    	    Log.Instance.log($"No config found for ${msgEventLabel}", LogSeverity.Debug);
+                    	    Log.Instance.log($"No config found for {msgEventLabel}", LogSeverity.Debug);
                 	return;
             	}
             }

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -13,6 +13,7 @@ using MobiFlight.Config;
 using MobiFlight.OutputConfig;
 using MobiFlight.InputConfig;
 using MobiFlight.xplane;
+using System.Globalization;
 
 namespace MobiFlight
 {
@@ -645,7 +646,7 @@ namespace MobiFlight
                             tmp.Comparison.ElseValue = "0";
 
                             connectorValue.type = FSUIPCOffsetType.Float;
-                            if (!Double.TryParse(value, out connectorValue.Float64))
+                            if (!Double.TryParse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out connectorValue.Float64))
                             {
                                 // likely to be a string
                                 connectorValue.type = FSUIPCOffsetType.String;

--- a/MobiFlight/InputConfig/VJoyInputAction.cs
+++ b/MobiFlight/InputConfig/VJoyInputAction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Xml;
@@ -69,7 +70,7 @@ namespace MobiFlight.InputConfig
 
             if (axisString != "--")
             {
-                UInt16 vJoyIntValue = (UInt16)Math.Round(Double.Parse(value));
+                UInt16 vJoyIntValue = (UInt16)Math.Round(Double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture));
                 if (VJoyHelper.setAxisVal(vJoyID,axisString,vJoyIntValue))
                 {
                     Log.Instance.log("set Axis:" + axisString + " ID:" + vJoyID + " to " + vJoyIntValue, LogSeverity.Debug);

--- a/MobiFlight/InputConfig/VJoyInputAction.cs
+++ b/MobiFlight/InputConfig/VJoyInputAction.cs
@@ -70,7 +70,7 @@ namespace MobiFlight.InputConfig
 
             if (axisString != "--")
             {
-                UInt16 vJoyIntValue = (UInt16)Math.Round(Double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture));
+                UInt16 vJoyIntValue = (UInt16)Math.Round(Double.Parse(value));
                 if (VJoyHelper.setAxisVal(vJoyID,axisString,vJoyIntValue))
                 {
                     Log.Instance.log("set Axis:" + axisString + " ID:" + vJoyID + " to " + vJoyIntValue, LogSeverity.Debug);

--- a/MobiFlight/InputConfig/VariableInputAction.cs
+++ b/MobiFlight/InputConfig/VariableInputAction.cs
@@ -1,6 +1,7 @@
 ﻿using MobiFlight.Base;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 
@@ -74,7 +75,7 @@ namespace MobiFlight.InputConfig
             {
                 try
                 {
-                    Variable.Number = double.Parse(value);
+                    Variable.Number = double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture);
                 }
                 catch (Exception)
                 {

--- a/MobiFlight/InputConfig/VariableInputAction.cs
+++ b/MobiFlight/InputConfig/VariableInputAction.cs
@@ -75,7 +75,7 @@ namespace MobiFlight.InputConfig
             {
                 try
                 {
-                    Variable.Number = double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture);
+                    Variable.Number = double.Parse(value);
                 }
                 catch (Exception)
                 {

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -413,13 +413,13 @@ namespace MobiFlight
                     foreach(string pin in pins) {
                         if (!string.IsNullOrEmpty(pin.Trim()))
                         {
-                            var iValue = (Int32)Math.Round(Double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture));
+                            var iValue = (Int32)Math.Round(Double.Parse(value));
                             module.SetPin("base", pin, iValue);
                         }
                     };
                 } else
                 {
-                    var iValue = (Int32)Math.Round(Double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture));
+                    var iValue = (Int32)Math.Round(Double.Parse(value));
                     module.SetPin("base", name, iValue);
                 }
 
@@ -507,7 +507,7 @@ namespace MobiFlight
 
                 if (value != null)
                 {
-                    var intValue = (Int32)Math.Round(Double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture));
+                    var intValue = (Int32)Math.Round(Double.Parse(value));
                     module.SetDisplayBrightness(address, connector - 1, intValue.ToString());
                 }                
             }
@@ -536,7 +536,7 @@ namespace MobiFlight
                 MobiFlightModule module = Modules[serial];
                 double dValue;
                 
-                if (!double.TryParse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return;
+                if (!double.TryParse(value, out dValue)) return;
 
                 int iValue = (int)dValue;
 
@@ -557,7 +557,7 @@ namespace MobiFlight
                 MobiFlightModule module = Modules[serial];
 
                 double dValue;
-                if (!double.TryParse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return;
+                if (!double.TryParse(value, out dValue)) return;
 
                 int iValue = (int)dValue;
 
@@ -654,7 +654,7 @@ namespace MobiFlight
 
                 MobiFlightModule module = Modules[serial];
                 double dValue;
-                if (!double.TryParse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return;
+                if (!double.TryParse(value, out dValue)) return;
 
                 int iValue = (int)Math.Round(dValue,0);
                 module.setShiftRegisterOutput(shiftRegName, outputPin, iValue.ToString());

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -412,12 +412,12 @@ namespace MobiFlight
                     foreach(string pin in pins) {
                         if (!string.IsNullOrEmpty(pin.Trim()))
                         {
-                             module.SetPin("base", pin, Int16.Parse(value));
+                             module.SetPin("base", pin, (int) Double.Parse(value));
                         }
                     };
                 } else
                 {
-                    module.SetPin("base", name, Int16.Parse(value));
+                    module.SetPin("base", name, (int) Double.Parse(value));
                 }
 
                 
@@ -504,7 +504,8 @@ namespace MobiFlight
 
                 if (value != null)
                 {
-                    module.SetDisplayBrightness(address, connector - 1, value);
+                    var intValue = (int)Double.Parse(value);
+                    module.SetDisplayBrightness(address, connector - 1, intValue.ToString());
                 }                
             }
             catch (Exception e)
@@ -530,8 +531,10 @@ namespace MobiFlight
                 if (!Modules.ContainsKey(serial)) return;
 
                 MobiFlightModule module = Modules[serial];
-                int iValue;
-                if (!int.TryParse(value, out iValue)) return;
+                double dValue;
+                if (!double.TryParse(value, out dValue)) return;
+
+                int iValue = (int)dValue;
 
                 module.SetServo(address, iValue, min, max, maxRotationPercent);
             }
@@ -548,8 +551,13 @@ namespace MobiFlight
                 if (!Modules.ContainsKey(serial)) return;
 
                 MobiFlightModule module = Modules[serial];
-                int iValue;
-                if (!int.TryParse(value, out iValue)) return;
+
+                double dValue;
+                if (!double.TryParse(value, out dValue)) return;
+
+                int iValue = (int)dValue;
+
+
                 if (module.GetStepper(address).OutputRevolutionSteps != outputRevolutionSteps)
                 {
                     module.GetStepper(address).OutputRevolutionSteps = outputRevolutionSteps;
@@ -641,7 +649,11 @@ namespace MobiFlight
                 if (!Modules.ContainsKey(serial)) return;
 
                 MobiFlightModule module = Modules[serial];
-                module.setShiftRegisterOutput(shiftRegName, outputPin, value);
+                double dValue;
+                if (!double.TryParse(value, out dValue)) return;
+
+                int iValue = (int)Math.Round(dValue,0);
+                module.setShiftRegisterOutput(shiftRegName, outputPin, iValue.ToString());
             }
             catch (Exception e)
             {

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -8,6 +8,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Management;
+using System.Globalization;
 
 namespace MobiFlight
 {
@@ -412,12 +413,14 @@ namespace MobiFlight
                     foreach(string pin in pins) {
                         if (!string.IsNullOrEmpty(pin.Trim()))
                         {
-                             module.SetPin("base", pin, (int) Double.Parse(value));
+                            var iValue = (Int32)Math.Round(Double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture));
+                            module.SetPin("base", pin, iValue);
                         }
                     };
                 } else
                 {
-                    module.SetPin("base", name, (int) Double.Parse(value));
+                    var iValue = (Int32)Math.Round(Double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture));
+                    module.SetPin("base", name, iValue);
                 }
 
                 
@@ -504,7 +507,7 @@ namespace MobiFlight
 
                 if (value != null)
                 {
-                    var intValue = (int)Double.Parse(value);
+                    var intValue = (Int32)Math.Round(Double.Parse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture));
                     module.SetDisplayBrightness(address, connector - 1, intValue.ToString());
                 }                
             }
@@ -532,7 +535,8 @@ namespace MobiFlight
 
                 MobiFlightModule module = Modules[serial];
                 double dValue;
-                if (!double.TryParse(value, out dValue)) return;
+                
+                if (!double.TryParse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return;
 
                 int iValue = (int)dValue;
 
@@ -553,7 +557,7 @@ namespace MobiFlight
                 MobiFlightModule module = Modules[serial];
 
                 double dValue;
-                if (!double.TryParse(value, out dValue)) return;
+                if (!double.TryParse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return;
 
                 int iValue = (int)dValue;
 
@@ -650,7 +654,7 @@ namespace MobiFlight
 
                 MobiFlightModule module = Modules[serial];
                 double dValue;
-                if (!double.TryParse(value, out dValue)) return;
+                if (!double.TryParse(value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out dValue)) return;
 
                 int iValue = (int)Math.Round(dValue,0);
                 module.setShiftRegisterOutput(shiftRegName, outputPin, iValue.ToString());

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -193,6 +193,7 @@ namespace MobiFlight
         }
 
         public const int CommandTimeout = 2500;
+        public const int MessageSizeReductionValue = 10;
 
         const int KeepAliveIntervalInMinutes = 5; // 5 Minutes
         DateTime lastUpdate = new DateTime();
@@ -259,8 +260,7 @@ namespace MobiFlight
                 CurrentSerialSettings = { PortName = _comPort, BaudRate = baudRate, DtrEnable = Board.Connection.DtrEnable } // object initializer
             };
 
-            // _cmdMessenger = new CmdMessenger(_transportLayer, ',', ';', '\\', Board.Connection.MessageSize)
-            _cmdMessenger = new CmdMessenger(_transportLayer, BoardType.Bit16, ',', ';', '\\', 64);
+            _cmdMessenger = new CmdMessenger(_transportLayer, BoardType.Bit16, ',', ';', '\\', Board.Connection.MessageSize);
 
             // Attach the callbacks to the Command Messenger
             AttachCommandCallBacks();
@@ -771,7 +771,7 @@ namespace MobiFlight
             Log.Instance.log("Reset config: " + (int)MobiFlightModule.Command.ResetConfig, LogSeverity.Debug);
             _cmdMessenger.SendCommand(command);
 
-            foreach (string MessagePart in this.Config.ToInternal(this.Board.Connection.MessageSize - 4))
+            foreach (string MessagePart in this.Config.ToInternal(this.Board.Connection.MessageSize - MessageSizeReductionValue))
             {
                 Log.Instance.log("Uploading config (Part): " + MessagePart, LogSeverity.Debug);
                 command = new SendCommand((int)MobiFlightModule.Command.SetConfig, (int)MobiFlightModule.Command.Status, CommandTimeout);

--- a/MobiFlight/Modifier/Blink.cs
+++ b/MobiFlight/Modifier/Blink.cs
@@ -93,7 +93,7 @@ namespace MobiFlight.Modifier
                     case FSUIPCOffsetType.Float:
                     case FSUIPCOffsetType.Integer:
                         string tmpValue = BlinkValue;
-                        if (Double.TryParse(tmpValue, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out value.Float64))
+                        if (Double.TryParse(tmpValue, out value.Float64))
                         {
                             result.Float64 = value.Float64;
                         }

--- a/MobiFlight/Modifier/Blink.cs
+++ b/MobiFlight/Modifier/Blink.cs
@@ -93,7 +93,7 @@ namespace MobiFlight.Modifier
                     case FSUIPCOffsetType.Float:
                     case FSUIPCOffsetType.Integer:
                         string tmpValue = BlinkValue;
-                        if (Double.TryParse(tmpValue, out value.Float64))
+                        if (Double.TryParse(tmpValue, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out value.Float64))
                         {
                             result.Float64 = value.Float64;
                         }

--- a/MobiFlight/Modifier/Comparison.cs
+++ b/MobiFlight/Modifier/Comparison.cs
@@ -99,7 +99,7 @@ namespace MobiFlight.Modifier
                 return result;
             }
 
-            Double comparisonValue = Double.Parse(Value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture);
+            Double comparisonValue = Double.Parse(Value);
             string comparisonIfValue = IfValue != "" ? IfValue : value.ToString();
             string comparisonElseValue = ElseValue != "" ? ElseValue : value.ToString();
             string comparisonResult = "";

--- a/MobiFlight/Modifier/Comparison.cs
+++ b/MobiFlight/Modifier/Comparison.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -98,7 +99,7 @@ namespace MobiFlight.Modifier
                 return result;
             }
 
-            Double comparisonValue = Double.Parse(Value);
+            Double comparisonValue = Double.Parse(Value, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture);
             string comparisonIfValue = IfValue != "" ? IfValue : value.ToString();
             string comparisonElseValue = ElseValue != "" ? ElseValue : value.ToString();
             string comparisonResult = "";

--- a/MobiFlight/Modifier/Transformation.cs
+++ b/MobiFlight/Modifier/Transformation.cs
@@ -70,7 +70,7 @@ namespace MobiFlight.Modifier
                 case FSUIPCOffsetType.Float:
                 case FSUIPCOffsetType.Integer:
                     string tmpValue = Apply(value.Float64, configRefs);
-                    if (Double.TryParse(tmpValue, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out value.Float64))
+                    if (Double.TryParse(tmpValue, out value.Float64))
                     {
                         value.Float64 = value.Float64;
                     } 
@@ -93,12 +93,12 @@ namespace MobiFlight.Modifier
 
         protected string Apply(double value, List<ConfigRefValue> configRefs)
         {
-            string result = value.ToString(CultureInfo.InvariantCulture);
+            string result = value.ToString();
 
             if (!Active) return result;
 
             // we have to use the US culture because "." must be used as decimal separator
-            string exp = Expression.Replace("$", value.ToString(CultureInfo.InvariantCulture));
+            string exp = Expression.Replace("$", value.ToString());
 
             foreach (ConfigRefValue configRef in configRefs)
             {
@@ -121,7 +121,7 @@ namespace MobiFlight.Modifier
             {
                 double dValue;
                 if (double.TryParse(ncalcResult, out dValue)) {
-                    result = dValue.ToString(CultureInfo.InvariantCulture);
+                    result = dValue.ToString();
                 }
                 else
                     result = ncalcResult;

--- a/MobiFlight/Modifier/Transformation.cs
+++ b/MobiFlight/Modifier/Transformation.cs
@@ -93,12 +93,12 @@ namespace MobiFlight.Modifier
 
         protected string Apply(double value, List<ConfigRefValue> configRefs)
         {
-            string result = value.ToString();
+            string result = value.ToString(CultureInfo.InvariantCulture);
 
             if (!Active) return result;
 
             // we have to use the US culture because "." must be used as decimal separator
-            string exp = Expression.Replace("$", value.ToString(new CultureInfo("en-US")));
+            string exp = Expression.Replace("$", value.ToString(CultureInfo.InvariantCulture));
 
             foreach (ConfigRefValue configRef in configRefs)
             {
@@ -119,7 +119,12 @@ namespace MobiFlight.Modifier
 
             if (ncalcResult!=null)
             {
-                result = ncalcResult;
+                double dValue;
+                if (double.TryParse(ncalcResult, out dValue)) {
+                    result = dValue.ToString(CultureInfo.InvariantCulture);
+                }
+                else
+                    result = ncalcResult;
             }
 
             return result;

--- a/MobiFlight/Modifier/Transformation.cs
+++ b/MobiFlight/Modifier/Transformation.cs
@@ -70,7 +70,7 @@ namespace MobiFlight.Modifier
                 case FSUIPCOffsetType.Float:
                 case FSUIPCOffsetType.Integer:
                     string tmpValue = Apply(value.Float64, configRefs);
-                    if (Double.TryParse(tmpValue, out value.Float64))
+                    if (Double.TryParse(tmpValue, System.Globalization.NumberStyles.Any, CultureInfo.InvariantCulture, out value.Float64))
                     {
                         value.Float64 = value.Float64;
                     } 

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -1105,6 +1105,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UI\Panels\OutputConfigPanel.de.resx">
       <DependentUpon>OutputConfigPanel.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\Panels\OutputConfigPanel.resx">
       <DependentUpon>OutputConfigPanel.cs</DependentUpon>

--- a/MobiFlightUnitTests/Base/ConnectorValueTests.cs
+++ b/MobiFlightUnitTests/Base/ConnectorValueTests.cs
@@ -20,10 +20,10 @@ namespace MobiFlight.Tests
             o.String = "TestString";
 
             o.type = FSUIPCOffsetType.Float;
-            Assert.AreEqual(Double.MaxValue.ToString(CultureInfo.InvariantCulture), o.ToString());
+            Assert.AreEqual(Double.MaxValue.ToString(), o.ToString());
 
             o.type = FSUIPCOffsetType.Integer;
-            Assert.AreEqual(Double.MaxValue.ToString(CultureInfo.InvariantCulture), o.ToString());
+            Assert.AreEqual(Double.MaxValue.ToString(), o.ToString());
 
             o.type = FSUIPCOffsetType.String;
             Assert.AreEqual("TestString", o.ToString());

--- a/MobiFlightUnitTests/Base/ConnectorValueTests.cs
+++ b/MobiFlightUnitTests/Base/ConnectorValueTests.cs
@@ -2,6 +2,7 @@
 using MobiFlight;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -19,10 +20,10 @@ namespace MobiFlight.Tests
             o.String = "TestString";
 
             o.type = FSUIPCOffsetType.Float;
-            Assert.AreEqual(Double.MaxValue.ToString(), o.ToString());
+            Assert.AreEqual(Double.MaxValue.ToString(CultureInfo.InvariantCulture), o.ToString());
 
             o.type = FSUIPCOffsetType.Integer;
-            Assert.AreEqual(Double.MaxValue.ToString(), o.ToString());
+            Assert.AreEqual(Double.MaxValue.ToString(CultureInfo.InvariantCulture), o.ToString());
 
             o.type = FSUIPCOffsetType.String;
             Assert.AreEqual("TestString", o.ToString());

--- a/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
@@ -3,6 +3,7 @@ using MobiFlight;
 using MobiFlight.Modifier;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -32,6 +33,10 @@ namespace MobiFlight.Modifier.Tests
         {
             TransformationForDeprecatedTest t = new TransformationForDeprecatedTest();
             List<ConfigRefValue> configRefs = new List<ConfigRefValue>();
+
+            // this is needed for correct conversion
+            CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+            CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
             t.Expression = "$*0.5";
             Assert.AreEqual("1", t.ProtectedApply(1, configRefs));

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using System.Threading;
 using MobiFlight.UI;
 using System.Configuration;
+using System.Globalization;
 
 namespace MobiFlight
 {
@@ -23,6 +24,10 @@ namespace MobiFlight
 
                 CheckForCorruptSettings();
 
+                // this is needed for correct conversion
+                CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
+                CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+                
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(true);
                 Application.Run(new MainForm());

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -33,7 +33,7 @@ using System.Runtime.InteropServices;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("9.5.0")]
-[assembly: AssemblyFileVersion("9.5.0")]
+[assembly: AssemblyVersion("9.5.0.2")]
+[assembly: AssemblyFileVersion("9.5.0.2")]
 [assembly: NeutralResourcesLanguage("en")]
 


### PR DESCRIPTION
We observed a problem with the internal conversion of floats and ncalc.
I tried many things to add CultureInfo to the ToString() functions.

Solution in the end:
Set the CultureInfo globally in the App.