### PR TITLE
Initialize Log Levels correctly in ComboBox in Settings dialog

### DIFF
--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MobiFlight.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.2.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -121,7 +121,7 @@ namespace MobiFlight.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("info")]
+        [global::System.Configuration.DefaultSettingValueAttribute("Info")]
         public string LogLevel {
             get {
                 return ((string)(this["LogLevel"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -27,7 +27,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="LogLevel" Type="System.String" Scope="User">
-      <Value Profile="(Default)">info</Value>
+      <Value Profile="(Default)">Info</Value>
     </Setting>
     <Setting Name="ArduinoIdePathDefault" Type="System.String" Scope="User">
       <Value Profile="(Default)">Arduino</Value>

--- a/UI/Panels/Settings/GeneralPanel.cs
+++ b/UI/Panels/Settings/GeneralPanel.cs
@@ -17,7 +17,12 @@ namespace MobiFlight.UI.Panels.Settings
             InitializeComponent();
         }
 
-        public void loadSettings()
+        public static List<string> GetAvailableLogSeverityLevels()
+        {
+            return Enum.GetNames(typeof(LogSeverity)).ToList();
+        }
+
+        protected void InitializeLanguageComboBox()
         {
             languageComboBox.Items.Clear();
 
@@ -30,12 +35,30 @@ namespace MobiFlight.UI.Panels.Settings
             languageComboBox.DisplayMember = "Label";
             languageComboBox.ValueMember = "Value";
             languageComboBox.SelectedIndex = 0;
+        }
 
+        protected void InitializeLogLevelComboBox()
+        {
+            List<ListItem> LogLevels = new List<ListItem>();
+            foreach (var level in GetAvailableLogSeverityLevels())
+            {
+                LogLevels.Add(new ListItem() { Value = level, Label = level });
+            }
+            logLevelComboBox.DataSource = LogLevels;
+            logLevelComboBox.DisplayMember = "Label";
+            logLevelComboBox.ValueMember = "Value";
+            logLevelComboBox.SelectedIndex = 0;
+        }
+
+        public void loadSettings()
+        {
             //
             // TAB General
             //
             // Recent Files max count
             recentFilesNumericUpDown.Value = Properties.Settings.Default.RecentFilesMaxCount;
+
+            InitializeLanguageComboBox();
 
             // TestMode speed
             // (1s) 0 - 4 (50ms)
@@ -51,6 +74,7 @@ namespace MobiFlight.UI.Panels.Settings
             fsuipcPollIntervalTrackBar.Value = Math.Max(fsuipcPollIntervalTrackBar.Minimum, (fsuipcPollIntervalTrackBar.Maximum + fsuipcPollIntervalTrackBar.Minimum - ExecutionSpeedInTicks));
 
             // Debug Mode
+            InitializeLogLevelComboBox();
             logLevelCheckBox.Checked = Properties.Settings.Default.LogEnabled;
             ComboBoxHelper.SetSelectedItem(logLevelComboBox, Properties.Settings.Default.LogLevel);
             LogJoystickAxisCheckBox.Checked = Properties.Settings.Default.LogJoystickAxis;
@@ -81,7 +105,7 @@ namespace MobiFlight.UI.Panels.Settings
 
             // log settings
             Properties.Settings.Default.LogEnabled = logLevelCheckBox.Checked;
-            Properties.Settings.Default.LogLevel = logLevelComboBox.SelectedItem as String;
+            Properties.Settings.Default.LogLevel = (logLevelComboBox.SelectedItem as ListItem).Value;
             Log.Instance.Enabled = logLevelCheckBox.Checked;
             Log.Instance.Severity = (LogSeverity)Enum.Parse(typeof(LogSeverity), Properties.Settings.Default.LogLevel);
 

--- a/app.config
+++ b/app.config
@@ -51,7 +51,7 @@
         <value>False</value>
       </setting>
       <setting name="LogLevel" serializeAs="String">
-        <value>info</value>
+        <value>Info</value>
       </setting>
       <setting name="ArduinoIdePathDefault" serializeAs="String">
         <value>Arduino</value>


### PR DESCRIPTION
fixes #954 

- [x] DropDown has list of log levels as data source
- [x] item is selected on 1st based on the default settings ("Info")
- [x] there is no empty selection option 