### PR TITLE
Use correct size for XPlane Input actions

### DIFF
--- a/HubHop/Msfs2020HubhopPresetList.cs
+++ b/HubHop/Msfs2020HubhopPresetList.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace MobiFlight.HubHop
 {
-    public class Msfs2020HubhopPreset
+public class Msfs2020HubhopPreset
     {
         public String path;
         public String vendor;
@@ -21,7 +21,7 @@ namespace MobiFlight.HubHop
         [JsonConverter(typeof(StringEnumConverter))]
         public HubHopType presetType;
         [JsonConverter(typeof(StringEnumConverter))]
-        public HubHopAction? presetAction;
+        public HubHopAction? codeType;
         public int version;
         public String status;
         public String description;

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -1275,6 +1275,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="UI\Dialogs\InputConfigWizard.resx">
       <DependentUpon>InputConfigWizard.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="UI\MainForm.de.resx">
       <DependentUpon>MainForm.cs</DependentUpon>

--- a/UI/Dialogs/InputConfigWizard.resx
+++ b/UI/Dialogs/InputConfigWizard.resx
@@ -123,13 +123,13 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="preconditionPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
+    <value>3, 3</value>
   </data>
   <data name="preconditionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 8, 6, 8</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>866, 879</value>
+    <value>658, 623</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="preconditionPanel.TabIndex" type="System.Int32, mscorlib">
@@ -139,7 +139,7 @@
     <value>preconditionPanel</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.2, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
     <value>preconditionTabPage</value>
@@ -148,16 +148,13 @@
     <value>0</value>
   </data>
   <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 29</value>
-  </data>
-  <data name="preconditionTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 22</value>
   </data>
   <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>874, 889</value>
+    <value>664, 629</value>
   </data>
   <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -184,13 +181,13 @@
     <value>0, 0</value>
   </data>
   <data name="configRefPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 8, 6, 8</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="configRefPanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>8, 8, 8, 8</value>
+    <value>5, 5, 5, 5</value>
   </data>
   <data name="configRefPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>874, 889</value>
+    <value>580, 573</value>
   </data>
   <data name="configRefPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -199,7 +196,7 @@
     <value>configRefPanel</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.4.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.5.0.2, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Parent" xml:space="preserve">
     <value>configRefTabPage</value>
@@ -208,13 +205,10 @@
     <value>0</value>
   </data>
   <data name="configRefTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 29</value>
-  </data>
-  <data name="configRefTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 22</value>
   </data>
   <data name="configRefTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>874, 889</value>
+    <value>580, 573</value>
   </data>
   <data name="configRefTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -244,16 +238,10 @@
     <value>Fill</value>
   </data>
   <data name="groupBoxInputSettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 171</value>
-  </data>
-  <data name="groupBoxInputSettings.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="groupBoxInputSettings.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 111</value>
   </data>
   <data name="groupBoxInputSettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>866, 713</value>
+    <value>574, 459</value>
   </data>
   <data name="groupBoxInputSettings.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -274,13 +262,10 @@
     <value>0</value>
   </data>
   <data name="inputPinDropDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>501, 69</value>
-  </data>
-  <data name="inputPinDropDown.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>334, 45</value>
   </data>
   <data name="inputPinDropDown.Size" type="System.Drawing.Size, System.Drawing">
-    <value>66, 28</value>
+    <value>45, 21</value>
   </data>
   <data name="inputPinDropDown.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -301,13 +286,10 @@
     <value>NoControl</value>
   </data>
   <data name="arcazeSerialLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>75, 35</value>
-  </data>
-  <data name="arcazeSerialLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>50, 23</value>
   </data>
   <data name="arcazeSerialLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 20</value>
+    <value>42, 13</value>
   </data>
   <data name="arcazeSerialLabel.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -337,13 +319,10 @@
     <value>Modul B</value>
   </data>
   <data name="inputModuleNameComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 31</value>
-  </data>
-  <data name="inputModuleNameComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>98, 20</value>
   </data>
   <data name="inputModuleNameComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>420, 28</value>
+    <value>281, 21</value>
   </data>
   <data name="inputModuleNameComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -364,13 +343,10 @@
     <value>NoControl</value>
   </data>
   <data name="inputTypeComboBoxLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>46, 74</value>
-  </data>
-  <data name="inputTypeComboBoxLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
+    <value>31, 48</value>
   </data>
   <data name="inputTypeComboBoxLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 20</value>
+    <value>61, 13</value>
   </data>
   <data name="inputTypeComboBoxLabel.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -403,13 +379,10 @@
     <value>BCD4056</value>
   </data>
   <data name="inputTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>147, 69</value>
-  </data>
-  <data name="inputTypeComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>98, 45</value>
   </data>
   <data name="inputTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>343, 28</value>
+    <value>230, 21</value>
   </data>
   <data name="inputTypeComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -430,16 +403,10 @@
     <value>Top</value>
   </data>
   <data name="displayTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 56</value>
-  </data>
-  <data name="displayTypeGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="displayTypeGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 36</value>
   </data>
   <data name="displayTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>866, 115</value>
+    <value>574, 75</value>
   </data>
   <data name="displayTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -463,16 +430,16 @@
     <value>Top</value>
   </data>
   <data name="displayTabTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 5</value>
+    <value>3, 3</value>
   </data>
   <data name="displayTabTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>18, 18, 18, 18</value>
+    <value>12, 12, 12, 12</value>
   </data>
   <data name="displayTabTextBox.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="displayTabTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>866, 51</value>
+    <value>574, 33</value>
   </data>
   <data name="displayTabTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -493,16 +460,13 @@
     <value>2</value>
   </data>
   <data name="displayTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 29</value>
-  </data>
-  <data name="displayTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>4, 22</value>
   </data>
   <data name="displayTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="displayTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>874, 889</value>
+    <value>580, 573</value>
   </data>
   <data name="displayTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -528,11 +492,8 @@
   <data name="tabControlFsuipc.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="tabControlFsuipc.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="tabControlFsuipc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>882, 922</value>
+    <value>672, 655</value>
   </data>
   <data name="tabControlFsuipc.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -555,11 +516,8 @@
   <data name="MainPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="MainPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="MainPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>882, 922</value>
+    <value>672, 655</value>
   </data>
   <data name="MainPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -583,13 +541,10 @@
     <value>NoControl</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>658, 0</value>
-  </data>
-  <data name="button1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>522, 0</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 43</value>
+    <value>75, 28</value>
   </data>
   <data name="button1.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -616,13 +571,10 @@
     <value>NoControl</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>770, 0</value>
-  </data>
-  <data name="cancelButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>597, 0</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>112, 43</value>
+    <value>75, 28</value>
   </data>
   <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -646,13 +598,10 @@
     <value>Bottom</value>
   </data>
   <data name="ButtonPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 922</value>
-  </data>
-  <data name="ButtonPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>0, 655</value>
   </data>
   <data name="ButtonPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>882, 43</value>
+    <value>672, 28</value>
   </data>
   <data name="ButtonPanel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -676,10 +625,10 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 20</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>882, 965</value>
+    <value>672, 683</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -824,9 +773,6 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
 </value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>

--- a/UI/Panels/Action/XplaneInputPanel.Designer.cs
+++ b/UI/Panels/Action/XplaneInputPanel.Designer.cs
@@ -36,11 +36,12 @@
             // 
             // xplaneGroupBox
             // 
+            this.xplaneGroupBox.AutoSize = true;
             this.xplaneGroupBox.Controls.Add(this.hubHopPresetPanel1);
             this.xplaneGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
             this.xplaneGroupBox.Location = new System.Drawing.Point(0, 0);
             this.xplaneGroupBox.Name = "xplaneGroupBox";
-            this.xplaneGroupBox.Size = new System.Drawing.Size(596, 291);
+            this.xplaneGroupBox.Size = new System.Drawing.Size(610, 291);
             this.xplaneGroupBox.TabIndex = 0;
             this.xplaneGroupBox.TabStop = false;
             this.xplaneGroupBox.Text = "Input settings";
@@ -59,20 +60,22 @@
             this.hubHopPresetPanel1.Name = "hubHopPresetPanel1";
             this.hubHopPresetPanel1.PresetFile = "Presets\\msfs2020_hubhop_presets.json";
             this.hubHopPresetPanel1.PresetFileUser = "Presets\\msfs2020_simvars_user.cip";
-            this.hubHopPresetPanel1.Size = new System.Drawing.Size(603, 189);
+            this.hubHopPresetPanel1.Size = new System.Drawing.Size(604, 189);
             this.hubHopPresetPanel1.TabIndex = 31;
             // 
             // XplaneInputPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.Controls.Add(this.xplaneGroupBox);
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "XplaneInputPanel";
-            this.Size = new System.Drawing.Size(596, 291);
+            this.Size = new System.Drawing.Size(610, 291);
             this.xplaneGroupBox.ResumeLayout(false);
             this.xplaneGroupBox.PerformLayout();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 

--- a/UI/Panels/Config/HubHopPresetPanel.Designer.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.Designer.cs
@@ -62,7 +62,7 @@
             this.SimVarNameTextBox = new System.Windows.Forms.TextBox();
             this.ExpandButton = new System.Windows.Forms.Button();
             this.CodeActionPanel = new System.Windows.Forms.Panel();
-            this.TypeComboBox = new System.Windows.Forms.ComboBox();
+            this.CodeTypeComboBox = new System.Windows.Forms.ComboBox();
             this.PresetPanel = new System.Windows.Forms.Panel();
             this.MatchLabel = new System.Windows.Forms.Label();
             this.PresetComboBox = new System.Windows.Forms.ComboBox();
@@ -466,24 +466,24 @@
             // 
             // CodeActionPanel
             // 
-            this.CodeActionPanel.Controls.Add(this.TypeComboBox);
+            this.CodeActionPanel.Controls.Add(this.CodeTypeComboBox);
             this.CodeActionPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.CodeActionPanel.Location = new System.Drawing.Point(0, 0);
             this.CodeActionPanel.Name = "CodeActionPanel";
             this.CodeActionPanel.Size = new System.Drawing.Size(600, 27);
             this.CodeActionPanel.TabIndex = 10;
             // 
-            // TypeComboBox
+            // CodeTypeComboBox
             // 
-            this.TypeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            this.TypeComboBox.FormattingEnabled = true;
-            this.TypeComboBox.Items.AddRange(new object[] {
+            this.CodeTypeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CodeTypeComboBox.FormattingEnabled = true;
+            this.CodeTypeComboBox.Items.AddRange(new object[] {
             "DataRef",
             "Command"});
-            this.TypeComboBox.Location = new System.Drawing.Point(75, 3);
-            this.TypeComboBox.Name = "TypeComboBox";
-            this.TypeComboBox.Size = new System.Drawing.Size(121, 21);
-            this.TypeComboBox.TabIndex = 9;
+            this.CodeTypeComboBox.Location = new System.Drawing.Point(75, 3);
+            this.CodeTypeComboBox.Name = "CodeTypeComboBox";
+            this.CodeTypeComboBox.Size = new System.Drawing.Size(121, 21);
+            this.CodeTypeComboBox.TabIndex = 9;
             // 
             // PresetPanel
             // 
@@ -630,7 +630,7 @@
         private System.Windows.Forms.Panel SystemFilterPanel;
         private System.Windows.Forms.Panel TextFilterPanel;
         private System.Windows.Forms.Panel Msfs2020Panel;
-        public System.Windows.Forms.ComboBox TypeComboBox;
+        public System.Windows.Forms.ComboBox CodeTypeComboBox;
         private System.Windows.Forms.Panel PresetCodePanel;
         private System.Windows.Forms.TextBox SimVarNameTextBox;
         private System.Windows.Forms.Button ExpandButton;

--- a/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.cs
@@ -93,9 +93,9 @@ namespace MobiFlight.UI.Panels.Config
                 listItems.Add(new ListItem() { Value = XplaneInputAction.INPUT_TYPE_DATAREF, Label = XplaneInputAction.INPUT_TYPE_DATAREF });
                 listItems.Add(new ListItem() { Value = XplaneInputAction.INPUT_TYPE_COMMAND, Label = XplaneInputAction.INPUT_TYPE_COMMAND });
 
-                TypeComboBox.DataSource = listItems;
-                TypeComboBox.ValueMember = "Value";
-                TypeComboBox.DisplayMember = "Label";
+                CodeTypeComboBox.DataSource = listItems;
+                CodeTypeComboBox.ValueMember = "Value";
+                CodeTypeComboBox.DisplayMember = "Label";
             }
         }
 
@@ -158,9 +158,9 @@ namespace MobiFlight.UI.Panels.Config
 
             ///
 
-            TypeComboBox.SelectedValueChanged += (sender, e) =>
+            CodeTypeComboBox.SelectedValueChanged += (sender, e) =>
             {
-                ValuePanel.Visible = Mode == HubHopPanelMode.Input && FlightSimType == FlightSimType.XPLANE && (TypeComboBox.SelectedValue.ToString() == XplaneInputAction.INPUT_TYPE_DATAREF);
+                ValuePanel.Visible = Mode == HubHopPanelMode.Input && FlightSimType == FlightSimType.XPLANE && (CodeTypeComboBox.SelectedValue.ToString() == XplaneInputAction.INPUT_TYPE_DATAREF);
             };
         }
 
@@ -260,7 +260,7 @@ namespace MobiFlight.UI.Panels.Config
         internal InputConfig.XplaneInputAction ToXplaneConfig()
         {
             MobiFlight.InputConfig.XplaneInputAction result = new InputConfig.XplaneInputAction();
-            result.InputType = TypeComboBox.SelectedValue.ToString();
+            result.InputType = CodeTypeComboBox.SelectedValue.ToString();
             result.Path = SimVarNameTextBox.Text;
             result.Expression = ValueTextBox.Text;
             return result;
@@ -435,6 +435,18 @@ namespace MobiFlight.UI.Panels.Config
             if (selectedPreset == null) return;
             DescriptionLabel.Text = selectedPreset?.description;
             SimVarNameTextBox.Text = selectedPreset?.code;
+            
+            if (FlightSimType==FlightSimType.XPLANE)
+            {
+                try
+                {
+                    CodeTypeComboBox.SelectedValue = selectedPreset.codeType.ToString();
+                }
+                catch (Exception)
+                {
+                    CodeTypeComboBox.SelectedValue = "DataRef";
+                }
+            }
 
             DescriptionLabel.Enabled = selectedItem.id != "-";
         }
@@ -674,11 +686,11 @@ namespace MobiFlight.UI.Panels.Config
 
             try
             {
-                TypeComboBox.SelectedValue = inputAction.InputType;
+                CodeTypeComboBox.SelectedValue = inputAction.InputType;
             }
             catch (Exception)
             {
-                TypeComboBox.SelectedValue = "DataRef";
+                CodeTypeComboBox.SelectedValue = "DataRef";
             }
 
             // Restore the code


### PR DESCRIPTION
fixes #956 

- [x] Panel area now resizes correctly
- [x] Also the DataRef and Commands are correctly displayed (this was missing)