### PR TITLE
LCD Display placeholders are replaced correctly in all cases

### DIFF
--- a/MobiFlight/MobiFlightLcdDisplay.cs
+++ b/MobiFlight/MobiFlightLcdDisplay.cs
@@ -84,30 +84,38 @@ namespace MobiFlight
         public string Apply(LcdDisplay lcdConfig, string value, List<ConfigRefValue> replacements)
         {
             String result = "";
-            replacements.Add(new ConfigRefValue
+            replacements.Insert(0,new ConfigRefValue
             {
                 ConfigRef = new ConfigRef { Placeholder = "$", Ref = "" },
                 Value = value
-            });                                              
+            });
 
             for (int line = 0; line != Lines; line++)
             {
                 if (line < lcdConfig.Lines.Count)
                 {
-                    String cLine = lcdConfig.Lines[line];
+                    string cLine = lcdConfig.Lines[line];
+                    string finalLine = lcdConfig.Lines[line].Clone() as string;
+                    string tmpLine;
+
                     foreach (ConfigRefValue rep in replacements)
                     {
-                        cLine = _ApplyReplacement(cLine, rep.ConfigRef.Placeholder[0], rep.Value);
+                        tmpLine = _ApplyReplacement(cLine, rep.ConfigRef.Placeholder[0], rep.Value);
+                        for (var i = 0; i < tmpLine.Length; i++)
+                        {
+                            if (tmpLine[i] == cLine[i]) continue;
+
+                            finalLine = finalLine.Remove(i, 1).Insert(i, tmpLine[i].ToString());
+                        }
                     }
 
-                    if (cLine.Length > Cols) { cLine = cLine.Substring(0, Cols); }
-
-                    result += cLine + new string(' ', Cols - cLine.Length);
-                } else
+                    result += finalLine + new string(' ', Cols - finalLine.Length);
+                }
+                else
                 {
                     result += new string(' ', Cols);
                 }
-                
+
             }
             return result;
         }

--- a/MobiFlightUnitTests/MobiFlight/MobiFlightLcdDisplayTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/MobiFlightLcdDisplayTests.cs
@@ -17,35 +17,48 @@ namespace MobiFlight.Tests
         {
             MobiFlightLcdDisplay o = new MobiFlightLcdDisplay();
             OutputConfig.LcdDisplay lcdConfig = new OutputConfig.LcdDisplay();
+            String value = "12345";
+            String result = "";
+            
             // let the display know what size it is
             o.Cols = 20;
             o.Lines = 1;
 
+            /// -------------
             // Test1: one line
-            String value = "12345";
             List<ConfigRefValue> replacements = new List<ConfigRefValue>();
-
+            value = "12345";
+            lcdConfig.Lines.Clear();
             lcdConfig.Lines.Add("COM1: $$$.$$");
-
-            String result = "";
             result = o.Apply(lcdConfig, value, replacements);
 
             Assert.AreEqual("COM1: 123.45        ", result, "Apply was not correct");
             
+            /// -------------
             // Test2: two lines, but only one configured
+            lcdConfig.Lines.Clear();
+            lcdConfig.Lines.Add("COM1: $$$.$$");
             lcdConfig.Lines.Add("COM2: ###.##");
             replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "#"}, Value = "12345" });            
             result = o.Apply(lcdConfig, value, replacements);
 
             Assert.AreEqual("COM1: 123.45        ", result, "Apply was not correct");
 
+            /// -------------
             // Test3: two lines and two lines configured
+            lcdConfig.Lines.Clear();
+            lcdConfig.Lines.Add("COM1: $$$.$$");
+            lcdConfig.Lines.Add("COM2: ###.##");
             o.Lines = 2;
             result = o.Apply(lcdConfig, value, replacements);
 
             Assert.AreEqual("COM1: 123.45        "+
                             "COM2: 123.45        ", result, "Apply was not correct");
             
+            /// -------------
+            lcdConfig.Lines.Clear();
+            lcdConfig.Lines.Add("COM1: $$$.$$");
+            lcdConfig.Lines.Add("COM2: ###.##");
             replacements.Clear();
             replacements.Add(new ConfigRefValue {ConfigRef = new ConfigRef { Placeholder = "#"}, Value = "123" });             
             result = o.Apply(lcdConfig, value, replacements);
@@ -53,6 +66,11 @@ namespace MobiFlight.Tests
             Assert.AreEqual("COM1: 123.45        " +
                             "COM2:   1.23        ", result, "Apply was not correct. Wrong padding.");
 
+            /// -------------
+            lcdConfig.Lines.Clear();
+            lcdConfig.Lines.Add("COM1: $$$.$$");
+            lcdConfig.Lines.Add("COM2: ###.##");
+            //value = "";
             replacements.Clear();
             replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "$"}, Value = "" });  // zero length string, replace them all
             replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "#"}, Value = "123" }); // too short, padding needed
@@ -60,16 +78,28 @@ namespace MobiFlight.Tests
 
             Assert.AreEqual("COM1:    .          " +
                             "COM2:   1.23        ", result, "Apply was not correct. Wrong replacement of zero length string.");
-
+            
+            lcdConfig.Lines.Clear();
+            lcdConfig.Lines.Add("COM1: $$$.$$");
+            lcdConfig.Lines.Add("COM2: ###.##");
+            //value = null;
             replacements.Clear();
             replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "$"}, Value = null });  // zero length string, replace them all
-
             replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "#"}, Value = "123" }); // too short, padding needed
             result = o.Apply(lcdConfig, value, replacements);
 
             Assert.AreEqual("COM1:    .          " +
                             "COM2:   1.23        ", result, "Apply was not correct. Wrong replacement of zero length string.");
 
+            // replace placeholder by placeholder
+            o.Lines = 1;
+            lcdConfig.Lines.Clear();
+            lcdConfig.Lines.Add("aaaa bbbb");
+            replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "a" }, Value = "abcd" });
+            replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "b" }, Value = "12345" });
+            result = o.Apply(lcdConfig, value, replacements);
+
+            Assert.AreEqual("abcd 2345           ", result, "Apply was not correct");
         }
     }
 }


### PR DESCRIPTION
fixes #880 

- [x] The use case where placeholder are replaced with values, that are again placeholder is covered.
- [x] Unit tests created