### PR TITLE
Joystick: Skipping Update Buttons if no buttons are registered.

### DIFF
--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -256,7 +256,9 @@ namespace MobiFlight
 
         private void UpdateButtons(JoystickState newState)
         {
-            for (int i = 0; i != newState.Buttons.Length; i++)
+            if (Buttons.Count==0) return;
+
+            for (int i = 0; i < newState.Buttons.Length; i++)
             {
                 if (!StateExists() || state.Buttons.Length < i || state.Buttons[i] != newState.Buttons[i])
                 {


### PR DESCRIPTION
Also changed the if condition from `!=` to `<`

Does not resolve the problem for the user as described in his issue #883 
But it does prevent an exception when pressing a button.