### PR TITLE
Fixes problem with LCD lines longer than display

### DIFF
--- a/Base/Extensions.cs
+++ b/Base/Extensions.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MobiFlight.Base
+{
+    public static class Extensions
+    {
+        public static string Truncate(this string value, int maxLength)
+        {
+            if (string.IsNullOrEmpty(value)) return value;
+            return value.Length <= maxLength ? value : value.Substring(0, maxLength);
+        }
+    }
+}

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -419,7 +419,6 @@ namespace MobiFlight
 #if ARCAZE
             arcazeCache.clearGetValues();
 #endif
-
             // iterate over the config row by row
             foreach (DataGridViewRow row in dataGridViewConfig.Rows)
             {
@@ -533,7 +532,6 @@ namespace MobiFlight
                     throw resultExc;
                 }
             }
-
             // this update will trigger potential writes to the offsets
             // that came from the inputs and are waiting to be written
             // fsuipcCache.Write();
@@ -1454,6 +1452,7 @@ namespace MobiFlight
 
         private void UpdateInputPreconditions()
         {
+            inputsDataGridView.SuspendLayout();
             foreach (DataGridViewRow gridViewRow in inputsDataGridView.Rows)
             {
                 try
@@ -1488,6 +1487,7 @@ namespace MobiFlight
                     continue;
                 }
             }
+            inputsDataGridView.ResumeLayout();
         }
 
         private bool LogIfNotJoystickOrJoystickAxisEnabled(String Serial, DeviceType type)

--- a/MobiFlight/MobiFlightLcdDisplay.cs
+++ b/MobiFlight/MobiFlightLcdDisplay.cs
@@ -94,8 +94,8 @@ namespace MobiFlight
             {
                 if (line < lcdConfig.Lines.Count)
                 {
-                    string cLine = lcdConfig.Lines[line];
-                    string finalLine = lcdConfig.Lines[line].Clone() as string;
+                    string cLine = lcdConfig.Lines[line].Truncate(Cols);
+                    string finalLine = cLine.Clone() as string;
                     string tmpLine;
 
                     foreach (ConfigRefValue rep in replacements)

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Base\CacheInterface.cs" />
     <Compile Include="Base\ConfigRef.cs" />
     <Compile Include="Base\ConfigRefList.cs" />
+    <Compile Include="Base\Extensions.cs" />
     <Compile Include="Base\FullCacheInterface.cs" />
     <Compile Include="Base\i18n.cs" />
     <Compile Include="Base\PreconditionList.cs" />

--- a/MobiFlightUnitTests/MobiFlight/MobiFlightLcdDisplayTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/MobiFlightLcdDisplayTests.cs
@@ -100,6 +100,19 @@ namespace MobiFlight.Tests
             result = o.Apply(lcdConfig, value, replacements);
 
             Assert.AreEqual("abcd 2345           ", result, "Apply was not correct");
+
+
+            // make sure too long lines don't break the logic
+            o.Lines = 2;
+            o.Cols = 20;
+            lcdConfig.Lines.Clear();
+            lcdConfig.Lines.Add("123456789012345678901");
+            lcdConfig.Lines.Add("bbbbb                ");
+            replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "a" }, Value = "abcd" });
+            replacements.Add(new ConfigRefValue { ConfigRef = new ConfigRef { Placeholder = "b" }, Value = "12345" });
+            result = o.Apply(lcdConfig, value, replacements);
+
+            Assert.AreEqual("1234567890123456789012345               ", result, "Apply was not correct");
         }
     }
 }


### PR DESCRIPTION
relates to #972 

The new replacement logic didn't deal with the edge case that lines from the LCD config can be longer because of a UI short coming.

- [x] Add new unit tests
- [x] Truncate every line to max length of LCD Columns
