### PR TITLE
Fix column name when updating input preconditions

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1458,7 +1458,7 @@ namespace MobiFlight
                 try
                 {
                     if (gridViewRow.DataBoundItem == null) continue;
-                    if (!(bool)gridViewRow.Cells["active"].Value) continue;
+                    if (!(bool)gridViewRow.Cells["inputActive"].Value) continue;
 
                     DataRowView rowView = gridViewRow.DataBoundItem as DataRowView;
                     InputConfigItem cfg = rowView.Row["settings"] as InputConfigItem;


### PR DESCRIPTION
Resolves #986 

The code that checks to see if the input line is active is using the wrong column name. It should be `inputActive` instead of `active`.