### PR TITLE
fix spelling mistake in module config changed - fixes #997

### DIFF
--- a/ProjectMessages/ProjectMessages.resx
+++ b/ProjectMessages/ProjectMessages.resx
@@ -308,7 +308,7 @@ You should configure them now.</value>
     <value>The config file has to be converted to work correctly. Please save with new file extension.</value>
   </data>
   <data name="MFModuleConfigChanged" xml:space="preserve">
-    <value>There are still changes not uploaded to your modules. You will loose these changes if you close the form. Do you really want to continue?</value>
+    <value>There are still changes not uploaded to your modules. You will lose these changes if you close the form. Do you really want to continue?</value>
   </data>
   <data name="uiMessageDeviceNameAlreadyUsed" xml:space="preserve">
     <value>The name of the device has already been used, please review.</value>


### PR DESCRIPTION
The sentence should read `lose` and not `loose`.