### PR TITLE
Add log when XML parsing fails

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1153,6 +1153,7 @@ namespace MobiFlight.UI
             }
             catch (Exception ex)
             {
+                Log.Instance.log($"Unable to load configuration file: {ex.Message}", LogSeverity.Error);
                 MessageBox.Show(i18n._tr("uiMessageProblemLoadingConfig"), i18n._tr("Hint"));
                 return;
             }


### PR DESCRIPTION
Fixes #998 

Add a log error when XML parsing fails with the reason for the failure. Looks like this:

```
Error	11/02/2022 15:06:45	Unable to load configuration file: '', hexadecimal value 0x0B, is an invalid character. Line 1, position 524.
```

The line and position in the exception isn't accurate for some reason but the actual error is and made it quick to find out what was wrong.