### PR TITLE
Enable the upload button after opening a config

### DIFF
--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -848,6 +848,7 @@ namespace MobiFlight.UI.Panels.Settings
 
                 moduleNode.ImageKey = "Changed";
                 moduleNode.SelectedImageKey = "Changed";
+                uploadToolStripButton.Enabled = true;
             }
         }
 


### PR DESCRIPTION
Fixes #1000 

Enable the upload button whenever a config is loaded successfully.