### PR TITLE
Fix FLOAT64 problem for FSUIPC

### DIFF
--- a/FSUIPC/FsuipcHelper.cs
+++ b/FSUIPC/FsuipcHelper.cs
@@ -106,8 +106,7 @@ namespace MobiFlight.FSUIPC
                                                 cfg.FSUIPC.Size
                                                 );
 
-                    result.Float64 = (int)(Math.Round(value64, 0));
-
+                    result.Float64 = value64;
                     break;
             }
             return result;

--- a/FSUIPC/FsuipcHelper.cs
+++ b/FSUIPC/FsuipcHelper.cs
@@ -100,8 +100,9 @@ namespace MobiFlight.FSUIPC
 
                     result.Float64 = value32;
                     break;
+
                 case 8:
-                    Double value64 = (Double)fsuipcCache.getDoubleValue(
+                    Double value64 = fsuipcCache.getDoubleValue(
                                                 cfg.FSUIPC.Offset,
                                                 cfg.FSUIPC.Size
                                                 );

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -1,6 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build"
-  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
@@ -132,8 +131,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\ArcazeHid.dll</HintPath>
     </Reference>
-    <Reference Include="fsuipcClient, Version=3.2.19.388, Culture=neutral, PublicKeyToken=7e7559b53e380b17, processorArchitecture=MSIL">
-      <HintPath>packages\FSUIPCClientDLL.3.2.19\lib\net40\fsuipcClient.dll</HintPath>
+    <Reference Include="fsuipcClient, Version=3.2.25.395, Culture=neutral, PublicKeyToken=7e7559b53e380b17, processorArchitecture=MSIL">
+      <HintPath>packages\FSUIPCClientDLL.3.2.25\lib\net40\fsuipcClient.dll</HintPath>
     </Reference>
     <Reference Include="HidSharp, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\HidSharp.2.1.0\lib\net35\HidSharp.dll</HintPath>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSUIPCClientDLL" version="3.2.19" targetFramework="net48" />
+  <package id="FSUIPCClientDLL" version="3.2.25" targetFramework="net48" />
   <package id="HidSharp" version="2.1.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights" version="2.20.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.20.0" targetFramework="net48" />


### PR DESCRIPTION
fixes #1002 

For some reason the code in the `FSUIPCHelper` class was doing `Math.Round` whereas the code that used to be in the `ExecutionManager` didn't do that. When I removed the code from `EM` and instead switched to the `FSUIPCHelper` to avoid duplicate code, this wrong behavior was introduced.

