### PR TITLE
Support proper Honeycomb Button and Axis Labels

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1338,7 +1338,7 @@ namespace MobiFlight
                 eventAction = MobiFlightAnalogInput.InputEventIdToString(0) + " => " +e.Value;
             }
 
-            var msgEventLabel = $"{e.Name} => {e.DeviceId} {(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} => {eventAction}";
+            var msgEventLabel = $"{e.Name} => {e.DeviceLabel} {(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} => {eventAction}";
 
             lock (inputCache)
 			{

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.SymbolStore;
 using System.Linq;
+using System.Runtime.Remoting.Messaging;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -94,7 +96,7 @@ namespace MobiFlight
             this.joystick = joystick;
         }
 
-        private void EnumerateDevices()
+        protected virtual void EnumerateDevices()
         {
             foreach (DeviceObjectInstance device in this.joystick.GetObjects())
             {
@@ -151,7 +153,7 @@ namespace MobiFlight
             }
         }
 
-        private string CorrectButtonIndexForButtonName(string name, int v)
+        protected virtual string CorrectButtonIndexForButtonName(string name, int v)
         {
             return Regex.Replace(name, @"\d+", v.ToString()).ToString();
         }
@@ -174,6 +176,7 @@ namespace MobiFlight
         public List<ListItem> GetAvailableDevices()
         {
             List<ListItem> result = new List<ListItem>();
+
             Buttons.ForEach((item) =>
             {
                 result.Add(item.ToListItem());

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -246,7 +246,8 @@ namespace MobiFlight
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
                         Name = Name,
-                        DeviceId = POV[index].Label,
+                        DeviceId = POV[index].Name,
+                        DeviceLabel = POV[index].Label,
                         Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                         Type = DeviceType.Button,
                         Value = (int)MobiFlightButton.InputEvent.RELEASE
@@ -261,7 +262,8 @@ namespace MobiFlight
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
                         Name = Name,
-                        DeviceId = POV[index].Label,
+                        DeviceId = POV[index].Name,
+                        DeviceLabel = POV[index].Label,
                         Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                         Type = DeviceType.Button,
                         Value = (int)MobiFlightButton.InputEvent.PRESS
@@ -289,7 +291,8 @@ namespace MobiFlight
                         OnButtonPressed?.Invoke(this, new InputEventArgs()
                         {
                             Name = Name,
-                            DeviceId = Axes[CurrentAxis].Label,
+                            DeviceId = Axes[CurrentAxis].Name,
+                            DeviceLabel = Axes[CurrentAxis].Label,
                             Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                             Type = DeviceType.AnalogInput,
                             Value = newValue
@@ -311,7 +314,8 @@ namespace MobiFlight
                         OnButtonPressed?.Invoke(this, new InputEventArgs()
                         {
                             Name = Name,
-                            DeviceId = Buttons[i].Label,
+                            DeviceId = Buttons[i].Name,
+                            DeviceLabel = Buttons[i].Label,
                             Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                             Type = DeviceType.Button,
                             Value = newState.Buttons[i] ? 0 : 1

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Windows.Forms.DataVisualization.Charting;
 using HidSharp;
+using SharpDX;
 
 namespace MobiFlight.Joysticks
 {
@@ -13,9 +16,93 @@ namespace MobiFlight.Joysticks
         int ProductId = 0x1901;
         HidStream Stream { get; set; }
         HidDevice Device { get; set; }
-        public HoneycombBravo(SharpDX.DirectInput.Joystick joystick) : base(joystick)
+
+        static readonly Dictionary<string, string> Labels = new Dictionary<string, string>()
+        {
+            // Mode
+            { "Button 17", "Mode - IAS" },
+            { "Button 18", "Mode - CRS" },
+            { "Button 19", "Mode - HDG" },
+            { "Button 20", "Mode - VS" },
+            { "Button 21", "Mode - ALT" },
+            // AP Buttons
+            { "Button 1", "AP - HDG" },
+            { "Button 2", "AP - NAV" },
+            { "Button 3", "AP - APR" },
+            { "Button 4", "AP - REV" },
+            { "Button 5", "AP - ALT" },
+            { "Button 6", "AP - VS" },
+            { "Button 7", "AP - IAS" },
+            { "Button 8", "AP - Autopilot" },
+            // Generic Encoder
+            { "Button 13", "Encoder - Right" },
+            { "Button 14", "Encoder - Left" },
+            // Gear
+            { "Button 31", "Gear - Up" },
+            { "Button 32", "Gear - Down" },
+            // Flaps
+            { "Button 16", "Flaps - Up" },
+            { "Button 15", "Flaps - Down" },
+            // Trim
+            { "Button 22", "Trim - Nose Down" },
+            { "Button 23", "Trim - Nose Up" },
+            // Levers
+            { "Button 24", "Lever 1 - Detent" },
+            { "Button 25", "Lever 2 - Detent" },
+            { "Button 26", "Lever 3 - Detent" },
+            { "Button 27", "Lever 4 - Detent" },
+            { "Button 28", "Lever 5 - Detent" },
+            { "Button 33", "Lever 6 - Detent" },
+            //
+            { "Button 29", "Lever 1 - Button" },
+            { "Button 9", "Lever 2 - Button" },
+            { "Button 10", "Lever 3 - Button" },
+            { "Button 11", "Lever 4 - Button" },
+            { "Button 12", "Lever 5 - Button" },
+            //
+            { "Button 30", "Lever 3 - Reverser" },
+            { "Button 48", "Lever 4 - Reverser" },
+
+            //
+            { "Button 34", "Switch 1 - Up" },
+            { "Button 35", "Switch 1 - Down" },
+            { "Button 36", "Switch 2 - Up" },
+            { "Button 37", "Switch 2 - Down" },
+            { "Button 38", "Switch 3 - Up" },
+            { "Button 39", "Switch 3 - Down" },
+            { "Button 40", "Switch 4 - Up" },
+            { "Button 41", "Switch 4 - Down" },
+            { "Button 42", "Switch 5 - Up" },
+            { "Button 43", "Switch 5 - Down" },
+            { "Button 44", "Switch 6 - Up" },
+            { "Button 45", "Switch 6 - Down" },
+            { "Button 46", "Switch 7 - Up" },
+            { "Button 47", "Switch 7 - Down" },
+        };
+
+    public HoneycombBravo(SharpDX.DirectInput.Joystick joystick) : base(joystick)
         {
 
+        }
+
+        protected override void EnumerateDevices()
+        {
+            base.EnumerateDevices();
+            /*Buttons.Sort((b1, b2) =>
+            {
+                if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
+                if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
+                return -1;
+            }
+            );
+            Axes.Sort((a1, a2) => { return a1.Label.CompareTo(a2.Label); });
+            */
+        }
+
+        static int GetIndexForKey(string key)
+        {
+            int result = Array.IndexOf(Labels.Keys.ToArray(), key);
+            return result;
         }
 
         public void Connect()
@@ -38,6 +125,23 @@ namespace MobiFlight.Joysticks
             };
             Stream.SetFeature(data);
             base.SendData(data);
+        }
+        protected override string CorrectButtonIndexForButtonName(string name, int v)
+        {
+            var result = base.CorrectButtonIndexForButtonName(name, v);
+            result = MapButtonToLabel(result);
+
+            return result;
+        }
+
+        static private string MapButtonToLabel(string name)
+        {
+            var result = name;
+            
+            if (Labels.ContainsKey(name))
+                result = Labels[name];
+
+            return result;
         }
 
         protected override void EnumerateOutputDevices()
@@ -74,8 +178,6 @@ namespace MobiFlight.Joysticks
             Lights.Add(new JoystickOutputDevice() { Label = "Lights - Parking Brake",       Name = "Lights.ParkingBrake",   Byte = 4, Bit = 1 });
             Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Volts",           Name = "Lights.LowVolts",       Byte = 4, Bit = 2 });
             Lights.Add(new JoystickOutputDevice() { Label = "Lights - Door",                Name = "Lights.door",           Byte = 4, Bit = 3 });
-
-
         }
     }
 }

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -88,7 +88,7 @@ namespace MobiFlight.Joysticks
         protected override void EnumerateDevices()
         {
             base.EnumerateDevices();
-            /*Buttons.Sort((b1, b2) =>
+            Buttons.Sort((b1, b2) =>
             {
                 if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
                 if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
@@ -96,7 +96,6 @@ namespace MobiFlight.Joysticks
             }
             );
             Axes.Sort((a1, a2) => { return a1.Label.CompareTo(a2.Label); });
-            */
         }
 
         static int GetIndexForKey(string key)

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -14,6 +14,7 @@ namespace MobiFlight
     {
         public string Serial { get; set; }
         public string DeviceId { get; set; }
+        public string DeviceLabel { get; set; }
         public string Name { get; set; }
         public DeviceType Type { get; set; }
         public int? ExtPin { get; set; }
@@ -504,7 +505,14 @@ namespace MobiFlight
             if (!int.TryParse(pos, out value)) return;
 
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = enc, Type = DeviceType.Encoder, Value = value });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = enc, 
+                    DeviceLabel = enc, 
+                    Type = DeviceType.Encoder, 
+                    Value = value 
+                });
             //addLog("Enc: " + enc + ":" + pos);
         }
 
@@ -514,7 +522,15 @@ namespace MobiFlight
             String channel = arguments.ReadStringArg();
             String state = arguments.ReadStringArg();
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = deviceId, Type = DeviceType.InputShiftRegister, ExtPin = int.Parse(channel), Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = deviceId, 
+                    DeviceLabel = deviceId, 
+                    Type = DeviceType.InputShiftRegister, 
+                    ExtPin = int.Parse(channel), 
+                    Value = int.Parse(state) 
+                });
         }
 
         void OnInputMultiplexerChange(ReceivedCommand arguments)
@@ -523,7 +539,15 @@ namespace MobiFlight
             String channel = arguments.ReadStringArg();
             String state = arguments.ReadStringArg();
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = deviceId, Type = DeviceType.InputMultiplexer, ExtPin = int.Parse(channel), Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = deviceId, 
+                    DeviceLabel = deviceId,
+                    Type = DeviceType.InputMultiplexer, 
+                    ExtPin = int.Parse(channel), 
+                    Value = int.Parse(state) 
+                });
         }
 
         // Callback function that prints the Arduino status to the console
@@ -533,7 +557,14 @@ namespace MobiFlight
             String state = arguments.ReadStringArg();
             //addLog("Button: " + button + ":" + state);
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = button, Type = DeviceType.Button, Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = button, 
+                    DeviceLabel = button,
+                    Type = DeviceType.Button, 
+                    Value = int.Parse(state) 
+                });
         }
 
         // Callback function that prints the Arduino status to the console
@@ -543,7 +574,14 @@ namespace MobiFlight
             String value = arguments.ReadStringArg();
             //addLog("Button: " + button + ":" + state);
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = name, Type = DeviceType.AnalogInput, Value = int.Parse(value) });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = name, 
+                    DeviceLabel = name,
+                    Type = DeviceType.AnalogInput, 
+                    Value = int.Parse(value) 
+                });
         }
 
         // Callback function that prints the Arduino Debug Print to the console
@@ -1000,7 +1038,7 @@ namespace MobiFlight
                 }
             }
 
-            result.Sort();
+            result.Sort((a, b) => { return a.Name.CompareTo(b.Name); });
             return result;
         }
 

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -999,6 +999,8 @@ namespace MobiFlight
                         break;
                 }
             }
+
+            result.Sort();
             return result;
         }
 

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -2,13 +2,9 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using MobiFlight;
 using MobiFlight.Base;
-using MobiFlight.UI.Panels;
+using MobiFlight.Config;
 using MobiFlight.UI.Panels.Input;
 
 namespace MobiFlight.UI.Dialogs
@@ -283,7 +279,14 @@ namespace MobiFlight.UI.Dialogs
         protected bool _syncFormToConfig()
         {
             config.ModuleSerial = inputModuleNameComboBox.SelectedItem.ToString();
-            config.Name = inputTypeComboBox.Text;
+
+            if (Joystick.IsJoystickSerial(SerialNumber.ExtractSerial(config.ModuleSerial)))
+            {
+                config.Name = (inputTypeComboBox.SelectedItem as ListItem).Value;
+            } else
+            {
+                config.Name = (inputTypeComboBox.SelectedItem as ListItem<BaseDevice>).Value.Name;
+            }  
 
             configRefPanel.syncToConfig(config);
 

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -245,7 +245,7 @@ namespace MobiFlight.UI.Dialogs
             }    
 
             // second tab
-            if (!ComboBoxHelper.SetSelectedItem(inputTypeComboBox, config.Name))
+            if (!ComboBoxHelper.SetSelectedItemByValue(inputTypeComboBox, config.Name))
             {
                 // TODO: provide error message
                 Log.Instance.log($"{GetType().Name}:_syncConfigToForm : Exception on selecting item in Display Type ComboBox", LogSeverity.Debug);


### PR DESCRIPTION
- [x] Buttons have proper names, e.g. AP Mode - HDG
- [ ] Axis have proper names
- [x] Backward compatible with loading old configs
- [x] Configs store the internal button name, so that when the label changes, the config will still load correctly
- [ ] Documentation
- [ ] i18n