### PR TITLE
Add try/catch for invalid PMDG input event values

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1437,11 +1437,18 @@ namespace MobiFlight
 #if SIMCONNECT
                 Log.Instance.log($"{msgEventLabel} => executing \"{row["description"]}\"", LogSeverity.Info);
 
-                tuple.Item1.execute(
-                    cacheCollection,
-                    e,
-                    GetRefs(tuple.Item1.ConfigRefs))
-                    ;
+                try
+                {
+                    tuple.Item1.execute(
+                        cacheCollection,
+                        e,
+                        GetRefs(tuple.Item1.ConfigRefs))
+                        ;
+                }
+                catch (Exception ex)
+                {
+                    Log.Instance.log($"Error excuting \"{row["description"]}\": {ex.Message}", LogSeverity.Error);
+                }
 #endif
 
             }

--- a/MobiFlight/InputConfig/PmdgEventIdInputAction.cs
+++ b/MobiFlight/InputConfig/PmdgEventIdInputAction.cs
@@ -72,7 +72,14 @@ namespace MobiFlight.InputConfig
 
             value = Replace(value, replacements);
 
-            cacheCollection.fsuipcCache.setEventID(EventId, (int) UInt32.Parse(value));
+            try
+            {
+                cacheCollection.fsuipcCache.setEventID(EventId, (int)UInt32.Parse(value));
+            }
+            catch
+            {
+                Log.Instance.log($"Unable to convert eventId {EventId} value {value} to an integer.", LogSeverity.Error);
+            }
         }
 
         public override bool Equals(object obj)


### PR DESCRIPTION
Fixes #1006 

I did look at other places higher up to add a try/catch and didn't see anywhere obvious to cleanly add one.