### PR TITLE
Disable CheckForUpdate and Telemetry for DEBUG sessions

### DIFF
--- a/Base/AppTelemetry.cs
+++ b/Base/AppTelemetry.cs
@@ -33,7 +33,11 @@ namespace MobiFlight.Base
         {
             TelemetryConfiguration configuration = TelemetryConfiguration.Active;
             configuration.InstrumentationKey = "712d6bd9-733d-4735-b173-ba30ade778fb";
+#if (!DEBUG)
             configuration.DisableTelemetry = !enabled;
+#else
+            configuration.DisableTelemetry = true;
+#endif
             telemetryClient = new Microsoft.ApplicationInsights.TelemetryClient(configuration);
             telemetryClient.Context.Component.Version = Assembly.GetEntryAssembly().GetName().Version.ToString();
             telemetryClient.Context.Session.Id = Guid.NewGuid().ToString();

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -317,8 +317,9 @@ namespace MobiFlight.UI
             runToolStripButton.Enabled = RunIsAvailable();
             runTestToolStripButton.Enabled = TestRunIsAvailable();
 
+#if (!DEBUG)
             AutoUpdateChecker.CheckForUpdate(false, true);
-
+#endif
             CheckForWasmModuleUpdate();
 
             // Track config loaded event


### PR DESCRIPTION
As a developer I do a lot of build and run loops and the following normal features are now disabled

- [x] The app doesn't check for updates, because we are currently usually working on the latest
- [x] The app doesn't send telemetry data, because we don't want to distort the feedback (e.g. number of starts of mobiflight)

## Notes
If a developer wants to test telemetry or the auto update feature simply remove the check or make it evaluate statically as true.

fixes #1021 
fixes #1023