### PR TITLE
Support proper Honeycomb Button and Axis Labels

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1278,7 +1278,7 @@ namespace MobiFlight
                 eventAction = MobiFlightAnalogInput.InputEventIdToString(0) + " => " +e.Value;
             }
 
-            var msgEventLabel = $"{e.Name} => {e.DeviceId} {(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} => {eventAction}";
+            var msgEventLabel = $"{e.Name} => {e.DeviceLabel} {(e.ExtPin.HasValue ? $":{e.ExtPin}" : "")} => {eventAction}";
 
             lock (inputCache)
 			{

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics.SymbolStore;
 using System.Linq;
+using System.Runtime.Remoting.Messaging;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -94,7 +96,7 @@ namespace MobiFlight
             this.joystick = joystick;
         }
 
-        private void EnumerateDevices()
+        protected virtual void EnumerateDevices()
         {
             foreach (DeviceObjectInstance device in this.joystick.GetObjects())
             {
@@ -151,7 +153,7 @@ namespace MobiFlight
             }
         }
 
-        private string CorrectButtonIndexForButtonName(string name, int v)
+        protected virtual string CorrectButtonIndexForButtonName(string name, int v)
         {
             return Regex.Replace(name, @"\d+", v.ToString()).ToString();
         }
@@ -174,6 +176,7 @@ namespace MobiFlight
         public List<ListItem> GetAvailableDevices()
         {
             List<ListItem> result = new List<ListItem>();
+
             Buttons.ForEach((item) =>
             {
                 result.Add(item.ToListItem());

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -246,7 +246,8 @@ namespace MobiFlight
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
                         Name = Name,
-                        DeviceId = POV[index].Label,
+                        DeviceId = POV[index].Name,
+                        DeviceLabel = POV[index].Label,
                         Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                         Type = DeviceType.Button,
                         Value = (int)MobiFlightButton.InputEvent.RELEASE
@@ -261,7 +262,8 @@ namespace MobiFlight
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
                         Name = Name,
-                        DeviceId = POV[index].Label,
+                        DeviceId = POV[index].Name,
+                        DeviceLabel = POV[index].Label,
                         Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                         Type = DeviceType.Button,
                         Value = (int)MobiFlightButton.InputEvent.PRESS
@@ -289,7 +291,8 @@ namespace MobiFlight
                         OnButtonPressed?.Invoke(this, new InputEventArgs()
                         {
                             Name = Name,
-                            DeviceId = Axes[CurrentAxis].Label,
+                            DeviceId = Axes[CurrentAxis].Name,
+                            DeviceLabel = Axes[CurrentAxis].Label,
                             Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                             Type = DeviceType.AnalogInput,
                             Value = newValue
@@ -311,7 +314,8 @@ namespace MobiFlight
                         OnButtonPressed?.Invoke(this, new InputEventArgs()
                         {
                             Name = Name,
-                            DeviceId = Buttons[i].Label,
+                            DeviceId = Buttons[i].Name,
+                            DeviceLabel = Buttons[i].Label,
                             Serial = SerialPrefix + joystick.Information.InstanceGuid.ToString(),
                             Type = DeviceType.Button,
                             Value = newState.Buttons[i] ? 0 : 1

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -1,15 +1,7 @@
-﻿using System;
+﻿using SharpDX.DirectInput;
+using System;
 using System.Collections.Generic;
-using System.Diagnostics.SymbolStore;
-using System.Linq;
-using System.Runtime.Remoting.Messaging;
-using System.Text;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Web.SessionState;
-using HidSharp.Utility;
-using SharpDX;
-using SharpDX.DirectInput;
 
 namespace MobiFlight
 {

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -126,11 +126,11 @@ namespace MobiFlight
 
                     } catch (ArgumentOutOfRangeException ex)
                     {
-                        Log.Instance.log($"Axis can't be mapped: {joystick.Information.InstanceName} Aspect: {aspect} Offset: {offset} Usage: {usage} Axis: {name} Label {FriendlyAxisName}.", LogSeverity.Error);
+                        Log.Instance.log($"Axis can't be mapped: {joystick.Information.InstanceName} Aspect: {aspect} Offset: {offset} Usage: {usage} Axis: {name} Label: {FriendlyAxisName}.", LogSeverity.Error);
                         continue;
                     }
                     Axes.Add(new JoystickDevice() { Name = AxisPrefix + OffsetAxisName, Label = FriendlyAxisName, Type = JoystickDeviceType.Axis });
-                    Log.Instance.log($"Added {joystick.Information.InstanceName} Aspect {aspect} + Offset: {offset} Usage: {usage} Axis: {name} Label {FriendlyAxisName}.", LogSeverity.Debug);
+                    Log.Instance.log($"Added {joystick.Information.InstanceName} Aspect {aspect} + Offset: {offset} Usage: {usage} Axis: {name} Label: {FriendlyAxisName}.", LogSeverity.Debug);
 
                 }
                 else if (IsButton)

--- a/MobiFlight/JoystickManager.cs
+++ b/MobiFlight/JoystickManager.cs
@@ -80,8 +80,15 @@ namespace MobiFlight
                 if (d.InstanceName == "Bravo Throttle Quadrant")
                 {
                     js = new Joysticks.HoneycombBravo(new SharpDX.DirectInput.Joystick(di, d.InstanceGuid));
-                } else
+                } else if (d.InstanceName == "Saitek Aviator Stick")
+                {
+                    js = new Joysticks.SaitekAviatorStick(new SharpDX.DirectInput.Joystick(di, d.InstanceGuid));
+                }
+                else
+                {
                     js = new Joystick(new SharpDX.DirectInput.Joystick(di, d.InstanceGuid));
+                }
+                        
 
                 if (!HasAxisOrButtons(js)) continue;
 

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -1,107 +1,85 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Windows.Forms.DataVisualization.Charting;
+﻿using System.Collections.Generic;
 using HidSharp;
-using HidSharp.Utility;
-using SharpDX;
 
 namespace MobiFlight.Joysticks
 {
-    internal class HoneycombBravo : Joystick
+    internal class HoneycombBravo : LabeledJoystick
     {
         int VendorId = 0x294B;
         int ProductId = 0x1901;
         HidStream Stream { get; set; }
         HidDevice Device { get; set; }
 
-        static readonly Dictionary<string, string> Labels = new Dictionary<string, string>()
-        {
-            // Mode
-            { "Button 17", "Mode - IAS" },
-            { "Button 18", "Mode - CRS" },
-            { "Button 19", "Mode - HDG" },
-            { "Button 20", "Mode - VS" },
-            { "Button 21", "Mode - ALT" },
-            // AP Buttons
-            { "Button 1", "AP - HDG" },
-            { "Button 2", "AP - NAV" },
-            { "Button 3", "AP - APR" },
-            { "Button 4", "AP - REV" },
-            { "Button 5", "AP - ALT" },
-            { "Button 6", "AP - VS" },
-            { "Button 7", "AP - IAS" },
-            { "Button 8", "AP - Autopilot" },
-            // Generic Encoder
-            { "Button 13", "Encoder - Right" },
-            { "Button 14", "Encoder - Left" },
-            // Gear
-            { "Button 31", "Gear - Up" },
-            { "Button 32", "Gear - Down" },
-            // Flaps
-            { "Button 16", "Flaps - Up" },
-            { "Button 15", "Flaps - Down" },
-            // Trim
-            { "Button 22", "Trim - Nose Down" },
-            { "Button 23", "Trim - Nose Up" },
-            // Levers
-            { "Button 24", "Lever 1 - Detent" },
-            { "Button 25", "Lever 2 - Detent" },
-            { "Button 26", "Lever 3 - Detent" },
-            { "Button 27", "Lever 4 - Detent" },
-            { "Button 28", "Lever 5 - Detent" },
-            { "Button 33", "Lever 6 - Detent" },
-            //
-            { "Button 29", "Lever 1 - Button" },
-            { "Button 9", "Lever 2 - Button" },
-            { "Button 10", "Lever 3 - Button" },
-            { "Button 11", "Lever 4 - Button" },
-            { "Button 12", "Lever 5 - Button" },
-            //
-            { "Button 30", "Lever 3 - Reverser" },
-            { "Button 48", "Lever 4 - Reverser" },
+        public HoneycombBravo(SharpDX.DirectInput.Joystick joystick) : base(joystick) {
+            Labels = new Dictionary<string, string>()
+            {
+                // Mode
+                { "Button 17", "Mode - IAS" },
+                { "Button 18", "Mode - CRS" },
+                { "Button 19", "Mode - HDG" },
+                { "Button 20", "Mode - VS" },
+                { "Button 21", "Mode - ALT" },
+                // AP Buttons
+                { "Button 1", "AP - HDG" },
+                { "Button 2", "AP - NAV" },
+                { "Button 3", "AP - APR" },
+                { "Button 4", "AP - REV" },
+                { "Button 5", "AP - ALT" },
+                { "Button 6", "AP - VS" },
+                { "Button 7", "AP - IAS" },
+                { "Button 8", "AP - Autopilot" },
+                // Generic Encoder
+                { "Button 13", "Encoder - Right" },
+                { "Button 14", "Encoder - Left" },
+                // Gear
+                { "Button 31", "Gear - Up" },
+                { "Button 32", "Gear - Down" },
+                // Flaps
+                { "Button 16", "Flaps - Up" },
+                { "Button 15", "Flaps - Down" },
+                // Trim
+                { "Button 22", "Trim - Nose Down" },
+                { "Button 23", "Trim - Nose Up" },
+                // Levers
+                { "Button 24", "Lever 1 - Detent" },
+                { "Button 25", "Lever 2 - Detent" },
+                { "Button 26", "Lever 3 - Detent" },
+                { "Button 27", "Lever 4 - Detent" },
+                { "Button 28", "Lever 5 - Detent" },
+                { "Button 33", "Lever 6 - Detent" },
+                //
+                { "Button 29", "Lever 1 - Button" },
+                { "Button 9", "Lever 2 - Button" },
+                { "Button 10", "Lever 3 - Button" },
+                { "Button 11", "Lever 4 - Button" },
+                { "Button 12", "Lever 5 - Button" },
+                //
+                { "Button 30", "Lever 3 - Reverser" },
+                { "Button 48", "Lever 4 - Reverser" },
 
-            //
-            { "Button 34", "Switch 1 - Up" },
-            { "Button 35", "Switch 1 - Down" },
-            { "Button 36", "Switch 2 - Up" },
-            { "Button 37", "Switch 2 - Down" },
-            { "Button 38", "Switch 3 - Up" },
-            { "Button 39", "Switch 3 - Down" },
-            { "Button 40", "Switch 4 - Up" },
-            { "Button 41", "Switch 4 - Down" },
-            { "Button 42", "Switch 5 - Up" },
-            { "Button 43", "Switch 5 - Down" },
-            { "Button 44", "Switch 6 - Up" },
-            { "Button 45", "Switch 6 - Down" },
-            { "Button 46", "Switch 7 - Up" },
-            { "Button 47", "Switch 7 - Down" },
-            // Axis
-            { "Y Axis", "Axis - Lever 1" },
-            { "X Axis", "Axis - Lever 2" },
-            { "Z Rotation", "Axis - Lever 3" },
-            { "Y Rotation", "Axis - Lever 4" },
-            { "X Rotation", "Axis - Lever 5" },
-            { "Z Axis", "Axis - Lever 6" },
-        };
-
-    public HoneycombBravo(SharpDX.DirectInput.Joystick joystick) : base(joystick)
-        {
-
-        }
-
-        protected override void EnumerateDevices()
-        {
-            base.EnumerateDevices();
-        }
-
-        static int GetIndexForKey(string key)
-        {
-            int result = Array.IndexOf(Labels.Keys.ToArray(), key);
-            return result;
+                //
+                { "Button 34", "Switch 1 - Up" },
+                { "Button 35", "Switch 1 - Down" },
+                { "Button 36", "Switch 2 - Up" },
+                { "Button 37", "Switch 2 - Down" },
+                { "Button 38", "Switch 3 - Up" },
+                { "Button 39", "Switch 3 - Down" },
+                { "Button 40", "Switch 4 - Up" },
+                { "Button 41", "Switch 4 - Down" },
+                { "Button 42", "Switch 5 - Up" },
+                { "Button 43", "Switch 5 - Down" },
+                { "Button 44", "Switch 6 - Up" },
+                { "Button 45", "Switch 6 - Down" },
+                { "Button 46", "Switch 7 - Up" },
+                { "Button 47", "Switch 7 - Down" },
+                // Axis
+                { "Y Axis", "Axis - Lever 1" },
+                { "X Axis", "Axis - Lever 2" },
+                { "Z Rotation", "Axis - Lever 3" },
+                { "Y Rotation", "Axis - Lever 4" },
+                { "X Rotation", "Axis - Lever 5" },
+                { "Z Axis", "Axis - Lever 6" },
+            };
         }
 
         public void Connect()
@@ -126,76 +104,40 @@ namespace MobiFlight.Joysticks
             base.SendData(data);
         }
 
-        protected override string MapDeviceNameToLabel(string name)
-        {
-            var result = name;
-            
-            if (Labels.ContainsKey(name))
-                result = Labels[name];
-
-            return result;
-        }
-
-        protected override List<JoystickDevice> GetButtonsSorted()
-        {
-            var buttons = Buttons.ToArray().ToList();
-            buttons.Sort((b1, b2) =>
-            {
-                if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
-                if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
-                return -1;
-            });
-
-            return buttons;
-        }
-
-        protected override List<JoystickDevice> GetAxisSorted()
-        {
-            var axes = Axes.ToArray().ToList();
-            Axes.Sort((b1, b2) =>
-            {
-                if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
-                if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
-                return -1;
-            });
-
-            return axes;
-        }
-
         protected override void EnumerateOutputDevices()
         {
             base.EnumerateOutputDevices();
-            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - HDG",                Name = "AP.hdg",                Byte = 1, Bit = 0 });
-            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - NAV",                Name = "AP.nav",                Byte = 1, Bit = 1 });
-            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - APR",                Name = "AP.apr",                Byte = 1, Bit = 2 });
-            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - REV",                Name = "AP.rev",                Byte = 1, Bit = 3 });
-            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - ALT",                Name = "AP.alt",                Byte = 1, Bit = 4 });
-            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - VS",                 Name = "AP.vs",                 Byte = 1, Bit = 5 });
-            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - IAS",                Name = "AP.ias",                Byte = 1, Bit = 6 });
-            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - On/Off",             Name = "AP.autopilot",          Byte = 1, Bit = 7 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - HDG", Name = "AP.hdg", Byte = 1, Bit = 0 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - NAV", Name = "AP.nav", Byte = 1, Bit = 1 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - APR", Name = "AP.apr", Byte = 1, Bit = 2 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - REV", Name = "AP.rev", Byte = 1, Bit = 3 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - ALT", Name = "AP.alt", Byte = 1, Bit = 4 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - VS", Name = "AP.vs", Byte = 1, Bit = 5 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - IAS", Name = "AP.ias", Byte = 1, Bit = 6 });
+            Lights.Add(new JoystickOutputDevice() { Label = "AP Mode - On/Off", Name = "AP.autopilot", Byte = 1, Bit = 7 });
             // -- Byte 2
-            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Left Green",            Name = "Gear.LeftGreen",        Byte = 2, Bit = 0 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Left Red",              Name = "Gear.LeftRed",          Byte = 2, Bit = 1 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Center Green",          Name = "Gear.CenterGreen",      Byte = 2, Bit = 2 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Center Red",            Name = "Gear.CenterRed",        Byte = 2, Bit = 3 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Green",           Name = "Gear.RightGreen",       Byte = 2, Bit = 4 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Red",             Name = "Gear.RightRed",         Byte = 2, Bit = 5 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Master Warning",      Name = "Light.MasterWarn",      Byte = 2, Bit = 6 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Engine Fire",         Name = "Light.EngineFire",      Byte = 2, Bit = 7 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Left Green", Name = "Gear.LeftGreen", Byte = 2, Bit = 0 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Left Red", Name = "Gear.LeftRed", Byte = 2, Bit = 1 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Center Green", Name = "Gear.CenterGreen", Byte = 2, Bit = 2 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Center Red", Name = "Gear.CenterRed", Byte = 2, Bit = 3 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Green", Name = "Gear.RightGreen", Byte = 2, Bit = 4 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Gear - Right Red", Name = "Gear.RightRed", Byte = 2, Bit = 5 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Master Warning", Name = "Light.MasterWarn", Byte = 2, Bit = 6 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Engine Fire", Name = "Light.EngineFire", Byte = 2, Bit = 7 });
             // -- Byte 3
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Oil Pressure",    Name = "Light.LowOil",          Byte = 3, Bit = 0 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Fuel Pressure",   Name = "Light.LowFuel",         Byte = 3, Bit = 1 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Anti Ice",            Name = "Light.Antiice",         Byte = 3, Bit = 2 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Starter Engaged",     Name = "Light.Starter",         Byte = 3, Bit = 3 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - APU",                 Name = "Light.APU",             Byte = 3, Bit = 4 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Master Caution",      Name = "Light.MasterCaution",   Byte = 3, Bit = 5 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Vacuum",              Name = "Light.Vacuum",          Byte = 3, Bit = 6 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Hyd Pressure",    Name = "Light.LowHydPressURE",  Byte = 3, Bit = 7 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Oil Pressure", Name = "Light.LowOil", Byte = 3, Bit = 0 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Fuel Pressure", Name = "Light.LowFuel", Byte = 3, Bit = 1 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Anti Ice", Name = "Light.Antiice", Byte = 3, Bit = 2 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Starter Engaged", Name = "Light.Starter", Byte = 3, Bit = 3 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - APU", Name = "Light.APU", Byte = 3, Bit = 4 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Master Caution", Name = "Light.MasterCaution", Byte = 3, Bit = 5 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Vacuum", Name = "Light.Vacuum", Byte = 3, Bit = 6 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Hyd Pressure", Name = "Light.LowHydPressURE", Byte = 3, Bit = 7 });
             // -- Byte 4
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Aux Fuel Pump",       Name = "Lights.AuxFuelPump",    Byte = 4, Bit = 0 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Parking Brake",       Name = "Lights.ParkingBrake",   Byte = 4, Bit = 1 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Volts",           Name = "Lights.LowVolts",       Byte = 4, Bit = 2 });
-            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Door",                Name = "Lights.door",           Byte = 4, Bit = 3 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Aux Fuel Pump", Name = "Lights.AuxFuelPump", Byte = 4, Bit = 0 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Parking Brake", Name = "Lights.ParkingBrake", Byte = 4, Bit = 1 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Volts", Name = "Lights.LowVolts", Byte = 4, Bit = 2 });
+            Lights.Add(new JoystickOutputDevice() { Label = "Lights - Door", Name = "Lights.door", Byte = 4, Bit = 3 });
         }
     }
 }

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using HidSharp;
+﻿using HidSharp;
+using System.Collections.Generic;
 
 namespace MobiFlight.Joysticks
 {

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms.DataVisualization.Charting;
 using HidSharp;
+using HidSharp.Utility;
 using SharpDX;
 
 namespace MobiFlight.Joysticks
@@ -78,6 +79,13 @@ namespace MobiFlight.Joysticks
             { "Button 45", "Switch 6 - Down" },
             { "Button 46", "Switch 7 - Up" },
             { "Button 47", "Switch 7 - Down" },
+            // Axis
+            { "Y Axis", "Axis - Lever 1" },
+            { "X Axis", "Axis - Lever 2" },
+            { "Z Rotation", "Axis - Lever 3" },
+            { "Y Rotation", "Axis - Lever 4" },
+            { "X Rotation", "Axis - Lever 5" },
+            { "Z Axis", "Axis - Lever 6" },
         };
 
     public HoneycombBravo(SharpDX.DirectInput.Joystick joystick) : base(joystick)
@@ -88,14 +96,6 @@ namespace MobiFlight.Joysticks
         protected override void EnumerateDevices()
         {
             base.EnumerateDevices();
-            Buttons.Sort((b1, b2) =>
-            {
-                if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
-                if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
-                return -1;
-            }
-            );
-            Axes.Sort((a1, a2) => { return a1.Label.CompareTo(a2.Label); });
         }
 
         static int GetIndexForKey(string key)
@@ -125,15 +125,8 @@ namespace MobiFlight.Joysticks
             Stream.SetFeature(data);
             base.SendData(data);
         }
-        protected override string CorrectButtonIndexForButtonName(string name, int v)
-        {
-            var result = base.CorrectButtonIndexForButtonName(name, v);
-            result = MapButtonToLabel(result);
 
-            return result;
-        }
-
-        static private string MapButtonToLabel(string name)
+        protected override string MapDeviceNameToLabel(string name)
         {
             var result = name;
             
@@ -141,6 +134,32 @@ namespace MobiFlight.Joysticks
                 result = Labels[name];
 
             return result;
+        }
+
+        protected override List<JoystickDevice> GetButtonsSorted()
+        {
+            var buttons = Buttons.ToArray().ToList();
+            buttons.Sort((b1, b2) =>
+            {
+                if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
+                if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
+                return -1;
+            });
+
+            return buttons;
+        }
+
+        protected override List<JoystickDevice> GetAxisSorted()
+        {
+            var axes = Axes.ToArray().ToList();
+            Axes.Sort((b1, b2) =>
+            {
+                if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
+                if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
+                return -1;
+            });
+
+            return axes;
         }
 
         protected override void EnumerateOutputDevices()

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -2,8 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Windows.Forms.DataVisualization.Charting;
 using HidSharp;
+using SharpDX;
 
 namespace MobiFlight.Joysticks
 {
@@ -13,9 +16,93 @@ namespace MobiFlight.Joysticks
         int ProductId = 0x1901;
         HidStream Stream { get; set; }
         HidDevice Device { get; set; }
-        public HoneycombBravo(SharpDX.DirectInput.Joystick joystick) : base(joystick)
+
+        static readonly Dictionary<string, string> Labels = new Dictionary<string, string>()
+        {
+            // Mode
+            { "Button 17", "Mode - IAS" },
+            { "Button 18", "Mode - CRS" },
+            { "Button 19", "Mode - HDG" },
+            { "Button 20", "Mode - VS" },
+            { "Button 21", "Mode - ALT" },
+            // AP Buttons
+            { "Button 1", "AP - HDG" },
+            { "Button 2", "AP - NAV" },
+            { "Button 3", "AP - APR" },
+            { "Button 4", "AP - REV" },
+            { "Button 5", "AP - ALT" },
+            { "Button 6", "AP - VS" },
+            { "Button 7", "AP - IAS" },
+            { "Button 8", "AP - Autopilot" },
+            // Generic Encoder
+            { "Button 13", "Encoder - Right" },
+            { "Button 14", "Encoder - Left" },
+            // Gear
+            { "Button 31", "Gear - Up" },
+            { "Button 32", "Gear - Down" },
+            // Flaps
+            { "Button 16", "Flaps - Up" },
+            { "Button 15", "Flaps - Down" },
+            // Trim
+            { "Button 22", "Trim - Nose Down" },
+            { "Button 23", "Trim - Nose Up" },
+            // Levers
+            { "Button 24", "Lever 1 - Detent" },
+            { "Button 25", "Lever 2 - Detent" },
+            { "Button 26", "Lever 3 - Detent" },
+            { "Button 27", "Lever 4 - Detent" },
+            { "Button 28", "Lever 5 - Detent" },
+            { "Button 33", "Lever 6 - Detent" },
+            //
+            { "Button 29", "Lever 1 - Button" },
+            { "Button 9", "Lever 2 - Button" },
+            { "Button 10", "Lever 3 - Button" },
+            { "Button 11", "Lever 4 - Button" },
+            { "Button 12", "Lever 5 - Button" },
+            //
+            { "Button 30", "Lever 3 - Reverser" },
+            { "Button 48", "Lever 4 - Reverser" },
+
+            //
+            { "Button 34", "Switch 1 - Up" },
+            { "Button 35", "Switch 1 - Down" },
+            { "Button 36", "Switch 2 - Up" },
+            { "Button 37", "Switch 2 - Down" },
+            { "Button 38", "Switch 3 - Up" },
+            { "Button 39", "Switch 3 - Down" },
+            { "Button 40", "Switch 4 - Up" },
+            { "Button 41", "Switch 4 - Down" },
+            { "Button 42", "Switch 5 - Up" },
+            { "Button 43", "Switch 5 - Down" },
+            { "Button 44", "Switch 6 - Up" },
+            { "Button 45", "Switch 6 - Down" },
+            { "Button 46", "Switch 7 - Up" },
+            { "Button 47", "Switch 7 - Down" },
+        };
+
+    public HoneycombBravo(SharpDX.DirectInput.Joystick joystick) : base(joystick)
         {
 
+        }
+
+        protected override void EnumerateDevices()
+        {
+            base.EnumerateDevices();
+            /*Buttons.Sort((b1, b2) =>
+            {
+                if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
+                if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
+                return -1;
+            }
+            );
+            Axes.Sort((a1, a2) => { return a1.Label.CompareTo(a2.Label); });
+            */
+        }
+
+        static int GetIndexForKey(string key)
+        {
+            int result = Array.IndexOf(Labels.Keys.ToArray(), key);
+            return result;
         }
 
         public void Connect()
@@ -38,6 +125,23 @@ namespace MobiFlight.Joysticks
             };
             Stream.SetFeature(data);
             base.SendData(data);
+        }
+        protected override string CorrectButtonIndexForButtonName(string name, int v)
+        {
+            var result = base.CorrectButtonIndexForButtonName(name, v);
+            result = MapButtonToLabel(result);
+
+            return result;
+        }
+
+        static private string MapButtonToLabel(string name)
+        {
+            var result = name;
+            
+            if (Labels.ContainsKey(name))
+                result = Labels[name];
+
+            return result;
         }
 
         protected override void EnumerateOutputDevices()
@@ -74,8 +178,6 @@ namespace MobiFlight.Joysticks
             Lights.Add(new JoystickOutputDevice() { Label = "Lights - Parking Brake",       Name = "Lights.ParkingBrake",   Byte = 4, Bit = 1 });
             Lights.Add(new JoystickOutputDevice() { Label = "Lights - Low Volts",           Name = "Lights.LowVolts",       Byte = 4, Bit = 2 });
             Lights.Add(new JoystickOutputDevice() { Label = "Lights - Door",                Name = "Lights.door",           Byte = 4, Bit = 3 });
-
-
         }
     }
 }

--- a/MobiFlight/Joysticks/HoneycombBravo.cs
+++ b/MobiFlight/Joysticks/HoneycombBravo.cs
@@ -88,7 +88,7 @@ namespace MobiFlight.Joysticks
         protected override void EnumerateDevices()
         {
             base.EnumerateDevices();
-            /*Buttons.Sort((b1, b2) =>
+            Buttons.Sort((b1, b2) =>
             {
                 if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
                 if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
@@ -96,7 +96,6 @@ namespace MobiFlight.Joysticks
             }
             );
             Axes.Sort((a1, a2) => { return a1.Label.CompareTo(a2.Label); });
-            */
         }
 
         static int GetIndexForKey(string key)

--- a/MobiFlight/Joysticks/LabeledJoystick.cs
+++ b/MobiFlight/Joysticks/LabeledJoystick.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Generic;
+using System;
+using System.Linq;
+
+namespace MobiFlight.Joysticks
+{
+    public class LabeledJoystick : Joystick
+    {
+        protected Dictionary<string, string> Labels = new Dictionary<string, string>();
+
+        public LabeledJoystick(SharpDX.DirectInput.Joystick joystick) : base(joystick) { }
+
+        protected override List<JoystickDevice> GetButtonsSorted()
+        {
+            var buttons = Buttons.ToArray().ToList();
+            buttons.Sort(SortByPositionInDictionary);
+
+            return buttons;
+        }
+
+        protected override string MapDeviceNameToLabel(string name)
+        {
+            var result = name;
+
+            if (Labels.ContainsKey(name))
+                result = Labels[name];
+
+            return result;
+        }
+
+        protected override List<JoystickDevice> GetAxisSorted()
+        {
+            var axes = Axes.ToArray().ToList();
+            Axes.Sort(SortByPositionInDictionary);
+
+            return axes;
+        }
+
+        public int GetIndexForKey(string key)
+        {
+            int result = Array.IndexOf(Labels.Keys.ToArray(), key);
+            return result;
+        }
+
+        int SortByPositionInDictionary(JoystickDevice b1, JoystickDevice b2)
+        {
+            if (GetIndexForKey(b1.Name) == GetIndexForKey(b2.Name)) return 0;
+            if (GetIndexForKey(b1.Name) > GetIndexForKey(b2.Name)) return 1;
+            return -1;
+        }
+    }
+}

--- a/MobiFlight/Joysticks/LabeledJoystick.cs
+++ b/MobiFlight/Joysticks/LabeledJoystick.cs
@@ -1,5 +1,5 @@
-﻿using System.Collections.Generic;
-using System;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace MobiFlight.Joysticks

--- a/MobiFlight/Joysticks/SaitekAviatorStick.cs
+++ b/MobiFlight/Joysticks/SaitekAviatorStick.cs
@@ -1,13 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading.Tasks;
-using System.Windows.Forms.DataVisualization.Charting;
-using HidSharp;
-using HidSharp.Utility;
-using SharpDX;
+﻿using System.Collections.Generic;
 
 namespace MobiFlight.Joysticks
 {

--- a/MobiFlight/Joysticks/SaitekAviatorStick.cs
+++ b/MobiFlight/Joysticks/SaitekAviatorStick.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows.Forms.DataVisualization.Charting;
+using HidSharp;
+using HidSharp.Utility;
+using SharpDX;
+
+namespace MobiFlight.Joysticks
+{
+    internal class SaitekAviatorStick : LabeledJoystick
+    {
+        int VendorId = 0x06A3;
+        int ProductId = 0x0461;
+
+        public SaitekAviatorStick(SharpDX.DirectInput.Joystick joystick) : base(joystick) {
+            Labels = new Dictionary<string, string>()
+            {
+                // Button 1-4 are not labeled
+                // ---
+                // Front switches
+                { "Button 5", "Button - T1" },
+                { "Button 6", "Button - T2" },
+                { "Button 7", "Button - T3" },
+                { "Button 8", "Button - T4" },
+                { "Button 9", "Button - T5" },
+                { "Button 10", "Button - T6" },
+                { "Button 11", "Button - T7" },
+                { "Button 12", "Button - T8" },
+                { "Button 13", "Mode A" },
+                { "Button 14", "Mode B" }
+                // Throttles & Axis are not labeled
+            };
+        }
+    }
+}

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -14,6 +14,7 @@ namespace MobiFlight
     {
         public string Serial { get; set; }
         public string DeviceId { get; set; }
+        public string DeviceLabel { get; set; }
         public string Name { get; set; }
         public DeviceType Type { get; set; }
         public int? ExtPin { get; set; }
@@ -504,7 +505,14 @@ namespace MobiFlight
             if (!int.TryParse(pos, out value)) return;
 
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = enc, Type = DeviceType.Encoder, Value = value });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = enc, 
+                    DeviceLabel = enc, 
+                    Type = DeviceType.Encoder, 
+                    Value = value 
+                });
             //addLog("Enc: " + enc + ":" + pos);
         }
 
@@ -514,7 +522,15 @@ namespace MobiFlight
             String channel = arguments.ReadStringArg();
             String state = arguments.ReadStringArg();
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = deviceId, Type = DeviceType.InputShiftRegister, ExtPin = int.Parse(channel), Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = deviceId, 
+                    DeviceLabel = deviceId, 
+                    Type = DeviceType.InputShiftRegister, 
+                    ExtPin = int.Parse(channel), 
+                    Value = int.Parse(state) 
+                });
         }
 
         void OnInputMultiplexerChange(ReceivedCommand arguments)
@@ -523,7 +539,15 @@ namespace MobiFlight
             String channel = arguments.ReadStringArg();
             String state = arguments.ReadStringArg();
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = deviceId, Type = DeviceType.InputMultiplexer, ExtPin = int.Parse(channel), Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = deviceId, 
+                    DeviceLabel = deviceId,
+                    Type = DeviceType.InputMultiplexer, 
+                    ExtPin = int.Parse(channel), 
+                    Value = int.Parse(state) 
+                });
         }
 
         // Callback function that prints the Arduino status to the console
@@ -533,7 +557,14 @@ namespace MobiFlight
             String state = arguments.ReadStringArg();
             //addLog("Button: " + button + ":" + state);
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = button, Type = DeviceType.Button, Value = int.Parse(state) });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = button, 
+                    DeviceLabel = button,
+                    Type = DeviceType.Button, 
+                    Value = int.Parse(state) 
+                });
         }
 
         // Callback function that prints the Arduino status to the console
@@ -543,7 +574,14 @@ namespace MobiFlight
             String value = arguments.ReadStringArg();
             //addLog("Button: " + button + ":" + state);
             if (OnInputDeviceAction != null)
-                OnInputDeviceAction(this, new InputEventArgs() { Serial = this.Serial, Name = Name, DeviceId = name, Type = DeviceType.AnalogInput, Value = int.Parse(value) });
+                OnInputDeviceAction(this, new InputEventArgs() { 
+                    Serial = this.Serial, 
+                    Name = Name, 
+                    DeviceId = name, 
+                    DeviceLabel = name,
+                    Type = DeviceType.AnalogInput, 
+                    Value = int.Parse(value) 
+                });
         }
 
         // Callback function that prints the Arduino Debug Print to the console
@@ -1000,7 +1038,7 @@ namespace MobiFlight
                 }
             }
 
-            result.Sort();
+            result.Sort((a, b) => { return a.Name.CompareTo(b.Name); });
             return result;
         }
 

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -999,6 +999,8 @@ namespace MobiFlight
                         break;
                 }
             }
+
+            result.Sort();
             return result;
         }
 

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -252,6 +252,8 @@
     <Compile Include="MobiFlight\Joystick.cs" />
     <Compile Include="MobiFlight\JoystickManager.cs" />
     <Compile Include="MobiFlight\InputConfig\MSFS2020EventIdInputAction.cs" />
+    <Compile Include="MobiFlight\Joysticks\LabeledJoystick.cs" />
+    <Compile Include="MobiFlight\Joysticks\SaitekAviatorStick.cs" />
     <Compile Include="MobiFlight\Joysticks\HoneycombBravo.cs" />
     <Compile Include="MobiFlight\MaximumDeviceNumberReachedMobiFlightException.cs" />
     <Compile Include="MobiFlight\MobiFlightAnalogInput.cs" />

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -2,13 +2,9 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using MobiFlight;
 using MobiFlight.Base;
-using MobiFlight.UI.Panels;
+using MobiFlight.Config;
 using MobiFlight.UI.Panels.Input;
 
 namespace MobiFlight.UI.Dialogs
@@ -285,7 +281,14 @@ namespace MobiFlight.UI.Dialogs
         protected bool _syncFormToConfig()
         {
             config.ModuleSerial = inputModuleNameComboBox.SelectedItem.ToString();
-            config.Name = inputTypeComboBox.Text;
+
+            if (Joystick.IsJoystickSerial(SerialNumber.ExtractSerial(config.ModuleSerial)))
+            {
+                config.Name = (inputTypeComboBox.SelectedItem as ListItem).Value;
+            } else
+            {
+                config.Name = (inputTypeComboBox.SelectedItem as ListItem<BaseDevice>).Value.Name;
+            }  
 
             configRefPanel.syncToConfig(config);
 

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -247,7 +247,7 @@ namespace MobiFlight.UI.Dialogs
             }    
 
             // second tab
-            if (!ComboBoxHelper.SetSelectedItem(inputTypeComboBox, config.Name))
+            if (!ComboBoxHelper.SetSelectedItemByValue(inputTypeComboBox, config.Name))
             {
                 // TODO: provide error message
                 Log.Instance.log("Exception on selecting item in display type ComboBox.", LogSeverity.Error);


### PR DESCRIPTION
- [x] Buttons have proper names, e.g. AP Mode - HDG
- [x] Axis have proper names
- [x] Backward compatible with loading old configs
- [x] Configs store the internal button name, so that when the label changes, the config will still load correctly
- [ ] Documentation
- [ ] ~~~i18n~~~

## Note
I also added a joystick sub class for the Saitek Aviator Stick (i have it here on my desk conveniently) - axis and buttons can simply be put in the one label file.
