### PR TITLE
Make Attempts an optional setting

### DIFF
--- a/Boards/arduino_mega.board.json
+++ b/Boards/arduino_mega.board.json
@@ -1,7 +1,6 @@
 {
   "$schema": "./mfboard.schema.json",
   "AvrDudeSettings": {
-    "Attempts":  1,
     "Device": "atmega2560",
     "BaudRates": [ "115200" ],
     "Programmer": "wiring",

--- a/Boards/mfboard.schema.json
+++ b/Boards/mfboard.schema.json
@@ -11,12 +11,12 @@
       "title": "Avrdudesettings",
       "type": "object",
       "description": "Settings for flashing Arduino devices with avrdude.",
-      "required": [ "Attempts", "BaudRates", "Device", "FirmwareBaseName", "Programmer" ],
+      "required": [ "BaudRates", "Device", "FirmwareBaseName", "Programmer" ],
       "properties": {
         "Attempts": {
           "$id": "#root/AvrDudeSettings/Attempts",
           "title": "Attempts",
-          "description": "Number of times AvrDude should retry connecting to the device.",
+          "description": "Number of times AvrDude should retry connecting to the device. If omitted then -x attempts will not be passed to avrdude.",
           "type": "integer"
         },
         "BaudRate": {

--- a/MobiFlight/Board.cs
+++ b/MobiFlight/Board.cs
@@ -12,9 +12,9 @@ namespace MobiFlight
     public class AvrDudeSettings
     {
         /// <summary>
-        /// Number of times AvrDude should retry connecting to the device.
+        /// Number of times AvrDude should retry connecting to the device. If null then -x attempts will not be passed to avrdude.
         /// </summary>
-        public int Attempts;
+        public int? Attempts;
 
         /// <summary>
         /// Baud rate to use with AvrDude. Deprecated. Use BaudRates instead.

--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -107,9 +107,9 @@ namespace MobiFlight
             foreach (var baudRate in board.AvrDudeSettings.BaudRates)
             {
                 var proc1 = new ProcessStartInfo();
-                var attempts = board.AvrDudeSettings.Attempts != null ? $"-x attempts={board.AvrDudeSettings.Attempts}" : "";
+                var attempts = board.AvrDudeSettings.Attempts != null ? $" -x attempts={board.AvrDudeSettings.Attempts}" : "";
                 string anyCommand =
-                    $@"-C""{FullAvrDudePath}\etc\avrdude.conf"" {verboseLevel} {attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{Port} -b{baudRate} -D -Uflash:w:""{FirmwarePath}\{FirmwareName}"":i";
+                    $@"-C""{FullAvrDudePath}\etc\avrdude.conf""{verboseLevel}{attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{Port} -b{baudRate} -D -Uflash:w:""{FirmwarePath}\{FirmwareName}"":i";
                 proc1.UseShellExecute = true;
                 proc1.WorkingDirectory = $@"""{FullAvrDudePath}""";
                 proc1.FileName = $@"""{FullAvrDudePath}\bin\avrdude""";

--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -107,8 +107,9 @@ namespace MobiFlight
             foreach (var baudRate in board.AvrDudeSettings.BaudRates)
             {
                 var proc1 = new ProcessStartInfo();
+                var attempts = board.AvrDudeSettings.Attempts != null ? $"-x attempts={board.AvrDudeSettings.Attempts}" : "";
                 string anyCommand =
-                    $@"-C""{FullAvrDudePath}\etc\avrdude.conf"" {verboseLevel} -x attempts={board.AvrDudeSettings.Attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{Port} -b{baudRate} -D -Uflash:w:""{FirmwarePath}\{FirmwareName}"":i";
+                    $@"-C""{FullAvrDudePath}\etc\avrdude.conf"" {verboseLevel} {attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{Port} -b{baudRate} -D -Uflash:w:""{FirmwarePath}\{FirmwareName}"":i";
                 proc1.UseShellExecute = true;
                 proc1.WorkingDirectory = $@"""{FullAvrDudePath}""";
                 proc1.FileName = $@"""{FullAvrDudePath}\bin\avrdude""";


### PR DESCRIPTION
Fixes #1034

* Makes `Attempts` an optional setting in the schema
* Makes `Attempts` a nullable value in the `Board` object
* Update the avrdude command line to only pass `-x attempts=` if the `Attempts` property is set in the board.json

Verified the Mega can now be flashed and the Nano still flashes correctly.