### PR TITLE
Add check for capslock when creating a new input config

### DIFF
--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -275,7 +275,7 @@ namespace MobiFlight.UI.Panels
                     dgv.BeginEdit(true);
                     if (e.KeyCode != Keys.F2)
                     {
-                        (dgv.EditingControl as TextBox).Text = (e.Shift) ? e.KeyCode.ToString() : e.KeyCode.ToString().ToLower();
+                        (dgv.EditingControl as TextBox).Text = (e.Shift || Control.IsKeyLocked(Keys.CapsLock)) ? e.KeyCode.ToString() : e.KeyCode.ToString().ToLower();
                         (dgv.EditingControl as TextBox).Select(1, 0);
                     }
                 }


### PR DESCRIPTION
Fixes #1018

Easy fix, same as the one I did to fix #730 (PR: #739)