### PR TITLE
Resolve crash with interpolation dialog

### DIFF
--- a/UI/Panels/Config/InterpolationPanel.cs
+++ b/UI/Panels/Config/InterpolationPanel.cs
@@ -49,7 +49,7 @@ namespace MobiFlight.UI.Panels.Config
 
             dt.Rows.Clear();
             
-            foreach (float Key in i.GetValues().Keys)
+            foreach (double Key in i.GetValues().Keys)
             {
                 DataRow row = dt.NewRow();
                 row["Input"] = Key.ToString();


### PR DESCRIPTION
Fixes #1042 

Change the data type from float to double. No more crashy crash.