### PR TITLE
Check for active in ExecutionManager:ExecuteConfig()

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -485,7 +485,7 @@ namespace MobiFlight
                 try
                 {
                     processedValue = value;
-                    foreach (var modifier in cfg.Modifiers.Items)
+                    foreach (var modifier in cfg.Modifiers.Items.Where(m => m.Active))
                     {
                         processedValue = modifier.Apply(processedValue, configRefs);
                     }

--- a/MobiFlight/Modifier/Comparison.cs
+++ b/MobiFlight/Modifier/Comparison.cs
@@ -164,11 +164,6 @@ namespace MobiFlight.Modifier
             string result = connectorValue.String;
             string value = connectorValue.String;
 
-            if (!Active)
-            {
-                return connectorValue.String;
-            }
-
             string comparisonValue = Value;
             string comparisonIfValue = IfValue;
             string comparisonElseValue = ElseValue;

--- a/MobiFlight/Modifier/Comparison.cs
+++ b/MobiFlight/Modifier/Comparison.cs
@@ -89,11 +89,6 @@ namespace MobiFlight.Modifier
 
             Double value = connectorValue.Float64;
             
-            if (!Active)
-            {
-                return result;
-            }
-
             if (Value == "")
             {
                 return result;

--- a/MobiFlight/Modifier/Interpolation.cs
+++ b/MobiFlight/Modifier/Interpolation.cs
@@ -88,7 +88,7 @@ namespace MobiFlight.Modifier
         {
             ConnectorValue result = connectorValue.Clone() as ConnectorValue;
 
-            if (!Active || Count == 0) return result;
+            if (Count == 0) return result;
 
             switch (connectorValue.type)
             {
@@ -108,7 +108,7 @@ namespace MobiFlight.Modifier
         public string Apply(string strValue)
         {
             string result = strValue;
-            if (Count > 0 && Active)
+            if (Count > 0)
             {
                 result = Math.Round(Value(float.Parse(strValue)), 0).ToString();
             }

--- a/MobiFlight/Modifier/Transformation.cs
+++ b/MobiFlight/Modifier/Transformation.cs
@@ -95,8 +95,6 @@ namespace MobiFlight.Modifier
         {
             string result = value.ToString();
 
-            if (!Active) return result;
-
             // we have to use the US culture because "." must be used as decimal separator
             string exp = Expression.Replace("$", value.ToString());
 
@@ -132,8 +130,6 @@ namespace MobiFlight.Modifier
 
         protected string Apply(string value)
         {
-            if (!Active) return value;
-
             if (SubStrStart > value.Length) return "";
 
             int length = (SubStrEnd - SubStrStart);

--- a/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
@@ -38,9 +38,8 @@ namespace MobiFlight.Modifier.Tests
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
-            t.Expression = "$*0.5";
-            Assert.AreEqual("1", t.ProtectedApply(1, configRefs));
             t.Active = true;
+            t.Expression = "$*0.5";
             Assert.AreEqual("0.5", t.ProtectedApply(1, configRefs));
             t.Expression = "$*2";
             Assert.AreEqual("2", t.ProtectedApply(1, configRefs));
@@ -54,9 +53,7 @@ namespace MobiFlight.Modifier.Tests
             // test the substring stuff
             t.SubStrStart = 1;
             t.SubStrEnd = 5;
-            t.Active = false;
             string test = "UnitTest";
-            Assert.AreEqual(test, t.ProtectedApply(test));
             t.Active = true;
             Assert.AreEqual("nitT", t.ProtectedApply(test));
 

--- a/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
@@ -38,7 +38,6 @@ namespace MobiFlight.Modifier.Tests
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
 
-            t.Active = true;
             t.Expression = "$*0.5";
             Assert.AreEqual("0.5", t.ProtectedApply(1, configRefs));
             t.Expression = "$*2";
@@ -54,7 +53,6 @@ namespace MobiFlight.Modifier.Tests
             t.SubStrStart = 1;
             t.SubStrEnd = 5;
             string test = "UnitTest";
-            t.Active = true;
             Assert.AreEqual("nitT", t.ProtectedApply(test));
 
             // if SubStrEnd > length 


### PR DESCRIPTION
Fixes #1048 

Instead of adding a test for `Active` inside every `Apply()` method of every current and future modifier, move the test into `ExecuteConfig()` and just pre-filter out any modifier that doesn't have `Active` set to `true`.

Verified this works when `<modifiers>` is empty inside the config file. Verified it picks up active and inactive transforms, comparisons, and blinks.