### PR TITLE
Reworked the display dialog for Input Actions

### DIFF
--- a/UI/Dialogs/ConfigWizard.resx
+++ b/UI/Dialogs/ConfigWizard.resx
@@ -142,7 +142,7 @@
     <value>configRefPanel</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Parent" xml:space="preserve">
     <value>referencesGroupBox</value>
@@ -199,7 +199,7 @@
     <value>xplaneDataRefPanel1</value>
   </data>
   <data name="&gt;&gt;xplaneDataRefPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.XplaneDataRefPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.XplaneDataRefPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;xplaneDataRefPanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -229,7 +229,7 @@
     <value>variablePanel1</value>
   </data>
   <data name="&gt;&gt;variablePanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.VariablePanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.VariablePanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;variablePanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -259,7 +259,7 @@
     <value>simConnectPanel1</value>
   </data>
   <data name="&gt;&gt;simConnectPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.SimConnectPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.SimConnectPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;simConnectPanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -267,53 +267,17 @@
   <data name="&gt;&gt;simConnectPanel1.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="fsuipcConfigPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="fsuipcConfigPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="fsuipcConfigPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 23</value>
-  </data>
-  <data name="fsuipcConfigPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="fsuipcConfigPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 237</value>
-  </data>
-  <data name="fsuipcConfigPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
   <data name="&gt;&gt;fsuipcConfigPanel.Name" xml:space="preserve">
     <value>fsuipcConfigPanel</value>
   </data>
   <data name="&gt;&gt;fsuipcConfigPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.FsuipcConfigPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.FsuipcConfigPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;fsuipcConfigPanel.Parent" xml:space="preserve">
     <value>FsuipcSettingsPanel</value>
   </data>
   <data name="&gt;&gt;fsuipcConfigPanel.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="fsuipcHintLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="fsuipcHintLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="fsuipcHintLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 23</value>
-  </data>
-  <data name="fsuipcHintLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="fsuipcHintLabel.Text" xml:space="preserve">
-    <value>Define the necessary FSUIPC information. Use an existing preset for common values.</value>
-  </data>
-  <data name="fsuipcHintLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>BottomLeft</value>
   </data>
   <data name="&gt;&gt;fsuipcHintLabel.Name" xml:space="preserve">
     <value>fsuipcHintLabel</value>
@@ -350,6 +314,378 @@
   </data>
   <data name="&gt;&gt;FsuipcSettingsPanel.ZOrder" xml:space="preserve">
     <value>4</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
+    <value>OffsetTypePanel</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeVariableRadioButton.Name" xml:space="preserve">
+    <value>OffsetTypeVariableRadioButton</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeVariableRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeVariableRadioButton.Parent" xml:space="preserve">
+    <value>OffsetTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeVariableRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Name" xml:space="preserve">
+    <value>OffsetTypeSimConnectRadioButton</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Parent" xml:space="preserve">
+    <value>OffsetTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Name" xml:space="preserve">
+    <value>OffsetTypeFsuipRadioButton</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Parent" xml:space="preserve">
+    <value>OffsetTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Name" xml:space="preserve">
+    <value>OffsetTypeXplaneRadioButton</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Parent" xml:space="preserve">
+    <value>OffsetTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="OffsetTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="OffsetTypePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 6</value>
+  </data>
+  <data name="OffsetTypePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 33</value>
+  </data>
+  <data name="OffsetTypePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypePanel.Name" xml:space="preserve">
+    <value>OffsetTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypePanel.Parent" xml:space="preserve">
+    <value>fsuipcTabPage</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypePanel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="fsuipcTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="fsuipcTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="fsuipcTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>616, 657</value>
+  </data>
+  <data name="fsuipcTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="fsuipcTabPage.Text" xml:space="preserve">
+    <value>Sim Variable</value>
+  </data>
+  <data name="&gt;&gt;fsuipcTabPage.Name" xml:space="preserve">
+    <value>fsuipcTabPage</value>
+  </data>
+  <data name="&gt;&gt;fsuipcTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fsuipcTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;fsuipcTabPage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;compareSpacerPanel.Name" xml:space="preserve">
+    <value>compareSpacerPanel</value>
+  </data>
+  <data name="&gt;&gt;compareSpacerPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;compareSpacerPanel.Parent" xml:space="preserve">
+    <value>compareTabPage</value>
+  </data>
+  <data name="&gt;&gt;compareSpacerPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;interpolationGroupBox.Name" xml:space="preserve">
+    <value>interpolationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;interpolationGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;interpolationGroupBox.Parent" xml:space="preserve">
+    <value>compareTabPage</value>
+  </data>
+  <data name="&gt;&gt;interpolationGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Name" xml:space="preserve">
+    <value>comparisonSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Parent" xml:space="preserve">
+    <value>compareTabPage</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;comparisonHintTtextBox.Name" xml:space="preserve">
+    <value>comparisonHintTtextBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonHintTtextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonHintTtextBox.Parent" xml:space="preserve">
+    <value>compareTabPage</value>
+  </data>
+  <data name="&gt;&gt;comparisonHintTtextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="compareTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="compareTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="compareTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>616, 657</value>
+  </data>
+  <data name="compareTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="compareTabPage.Text" xml:space="preserve">
+    <value>Compare</value>
+  </data>
+  <data name="&gt;&gt;compareTabPage.Name" xml:space="preserve">
+    <value>compareTabPage</value>
+  </data>
+  <data name="&gt;&gt;compareTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;compareTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;compareTabPage.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;displayPanel1.Name" xml:space="preserve">
+    <value>displayPanel1</value>
+  </data>
+  <data name="&gt;&gt;displayPanel1.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.OutputWizard.DisplayPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;displayPanel1.Parent" xml:space="preserve">
+    <value>displayTabPage</value>
+  </data>
+  <data name="&gt;&gt;displayPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="displayTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="displayTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="displayTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>616, 657</value>
+  </data>
+  <data name="displayTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="displayTabPage.Text" xml:space="preserve">
+    <value>Display</value>
+  </data>
+  <data name="&gt;&gt;displayTabPage.Name" xml:space="preserve">
+    <value>displayTabPage</value>
+  </data>
+  <data name="&gt;&gt;displayTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;displayTabPage.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;preconditionPanel.Name" xml:space="preserve">
+    <value>preconditionPanel</value>
+  </data>
+  <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
+    <value>preconditionTabPage</value>
+  </data>
+  <data name="&gt;&gt;preconditionPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>616, 657</value>
+  </data>
+  <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="preconditionTabPage.Text" xml:space="preserve">
+    <value>Precondition</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Name" xml:space="preserve">
+    <value>preconditionTabPage</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tabControlFsuipc.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tabControlFsuipc.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tabControlFsuipc.Size" type="System.Drawing.Size, System.Drawing">
+    <value>624, 683</value>
+  </data>
+  <data name="tabControlFsuipc.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;tabControlFsuipc.Name" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;tabControlFsuipc.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabControlFsuipc.Parent" xml:space="preserve">
+    <value>MainPanel</value>
+  </data>
+  <data name="&gt;&gt;tabControlFsuipc.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="MainPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="MainPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="MainPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>624, 683</value>
+  </data>
+  <data name="MainPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;MainPanel.Name" xml:space="preserve">
+    <value>MainPanel</value>
+  </data>
+  <data name="&gt;&gt;MainPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;MainPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;MainPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="fsuipcConfigPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="fsuipcConfigPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="fsuipcConfigPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 23</value>
+  </data>
+  <data name="fsuipcConfigPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="fsuipcConfigPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 237</value>
+  </data>
+  <data name="fsuipcConfigPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="&gt;&gt;fsuipcConfigPanel.Name" xml:space="preserve">
+    <value>fsuipcConfigPanel</value>
+  </data>
+  <data name="&gt;&gt;fsuipcConfigPanel.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Config.FsuipcConfigPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;fsuipcConfigPanel.Parent" xml:space="preserve">
+    <value>FsuipcSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;fsuipcConfigPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="fsuipcHintLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="fsuipcHintLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="fsuipcHintLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 23</value>
+  </data>
+  <data name="fsuipcHintLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="fsuipcHintLabel.Text" xml:space="preserve">
+    <value>Define the necessary FSUIPC information. Use an existing preset for common values.</value>
+  </data>
+  <data name="fsuipcHintLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>BottomLeft</value>
+  </data>
+  <data name="&gt;&gt;fsuipcHintLabel.Name" xml:space="preserve">
+    <value>fsuipcHintLabel</value>
+  </data>
+  <data name="&gt;&gt;fsuipcHintLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fsuipcHintLabel.Parent" xml:space="preserve">
+    <value>FsuipcSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;fsuipcHintLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 5</value>
@@ -501,57 +837,6 @@
   <data name="&gt;&gt;OffsetTypeXplaneRadioButton.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="OffsetTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="OffsetTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
-  </data>
-  <data name="OffsetTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 33</value>
-  </data>
-  <data name="OffsetTypePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypePanel.Name" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypePanel.Parent" xml:space="preserve">
-    <value>fsuipcTabPage</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypePanel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="fsuipcTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="fsuipcTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="fsuipcTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>616, 657</value>
-  </data>
-  <data name="fsuipcTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="fsuipcTabPage.Text" xml:space="preserve">
-    <value>Sim Variable</value>
-  </data>
-  <data name="&gt;&gt;fsuipcTabPage.Name" xml:space="preserve">
-    <value>fsuipcTabPage</value>
-  </data>
-  <data name="&gt;&gt;fsuipcTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fsuipcTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;fsuipcTabPage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="compareSpacerPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -576,6 +861,57 @@
   <data name="&gt;&gt;compareSpacerPanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="&gt;&gt;interpolationPanel1.Name" xml:space="preserve">
+    <value>interpolationPanel1</value>
+  </data>
+  <data name="&gt;&gt;interpolationPanel1.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Config.InterpolationPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;interpolationPanel1.Parent" xml:space="preserve">
+    <value>interpolationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;interpolationPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;interpolationCheckBox.Name" xml:space="preserve">
+    <value>interpolationCheckBox</value>
+  </data>
+  <data name="&gt;&gt;interpolationCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;interpolationCheckBox.Parent" xml:space="preserve">
+    <value>interpolationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;interpolationCheckBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="interpolationGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="interpolationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 202</value>
+  </data>
+  <data name="interpolationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 172</value>
+  </data>
+  <data name="interpolationGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="interpolationGroupBox.Text" xml:space="preserve">
+    <value>Interpolation Settings</value>
+  </data>
+  <data name="&gt;&gt;interpolationGroupBox.Name" xml:space="preserve">
+    <value>interpolationGroupBox</value>
+  </data>
+  <data name="&gt;&gt;interpolationGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;interpolationGroupBox.Parent" xml:space="preserve">
+    <value>compareTabPage</value>
+  </data>
+  <data name="&gt;&gt;interpolationGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="interpolationPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -595,7 +931,7 @@
     <value>interpolationPanel1</value>
   </data>
   <data name="&gt;&gt;interpolationPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.InterpolationPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.InterpolationPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;interpolationPanel1.Parent" xml:space="preserve">
     <value>interpolationGroupBox</value>
@@ -639,32 +975,167 @@
   <data name="&gt;&gt;interpolationCheckBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="interpolationGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="&gt;&gt;comparisonSettingsPanel.Name" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.Parent" xml:space="preserve">
+    <value>comparisonSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;comparisonActiveCheckBox.Name" xml:space="preserve">
+    <value>comparisonActiveCheckBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonActiveCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonActiveCheckBox.Parent" xml:space="preserve">
+    <value>comparisonSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonActiveCheckBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="comparisonSettingsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="interpolationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 202</value>
+  <data name="comparisonSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 64</value>
   </data>
-  <data name="interpolationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 172</value>
+  <data name="comparisonSettingsGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
-  <data name="interpolationGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="comparisonSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 138</value>
   </data>
-  <data name="interpolationGroupBox.Text" xml:space="preserve">
-    <value>Interpolation Settings</value>
+  <data name="comparisonSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
   </data>
-  <data name="&gt;&gt;interpolationGroupBox.Name" xml:space="preserve">
-    <value>interpolationGroupBox</value>
+  <data name="comparisonSettingsGroupBox.Text" xml:space="preserve">
+    <value>Comparison Settings</value>
   </data>
-  <data name="&gt;&gt;interpolationGroupBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Name" xml:space="preserve">
+    <value>comparisonSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;interpolationGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Parent" xml:space="preserve">
     <value>compareTabPage</value>
   </data>
-  <data name="&gt;&gt;interpolationGroupBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;comparisonSettingsGroupBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;comparisonValueTextBox.Name" xml:space="preserve">
+    <value>comparisonValueTextBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonValueTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonValueTextBox.Parent" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;comparisonValueTextBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;comparisonElseValueTextBox.Name" xml:space="preserve">
+    <value>comparisonElseValueTextBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonElseValueTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonElseValueTextBox.Parent" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;comparisonElseValueTextBox.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="&gt;&gt;label8.Name" xml:space="preserve">
+    <value>label8</value>
+  </data>
+  <data name="&gt;&gt;label8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;comparisonIfValueTextBox.Name" xml:space="preserve">
+    <value>comparisonIfValueTextBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonIfValueTextBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonIfValueTextBox.Parent" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;comparisonIfValueTextBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;label7.Name" xml:space="preserve">
+    <value>label7</value>
+  </data>
+  <data name="&gt;&gt;label7.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;comparisonOperandComboBox.Name" xml:space="preserve">
+    <value>comparisonOperandComboBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonOperandComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonOperandComboBox.Parent" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;comparisonOperandComboBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;label6.Name" xml:space="preserve">
+    <value>label6</value>
+  </data>
+  <data name="&gt;&gt;label6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="comparisonSettingsPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="comparisonSettingsPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 36</value>
+  </data>
+  <data name="comparisonSettingsPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>592, 96</value>
+  </data>
+  <data name="comparisonSettingsPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.Name" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.Parent" xml:space="preserve">
+    <value>comparisonSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="comparisonValueTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>171, 10</value>
@@ -861,30 +1332,6 @@
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
-  <data name="comparisonSettingsPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="comparisonSettingsPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 36</value>
-  </data>
-  <data name="comparisonSettingsPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>592, 96</value>
-  </data>
-  <data name="comparisonSettingsPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Name" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Parent" xml:space="preserve">
-    <value>comparisonSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
   <data name="comparisonActiveCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -917,36 +1364,6 @@
   </data>
   <data name="&gt;&gt;comparisonActiveCheckBox.ZOrder" xml:space="preserve">
     <value>1</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 64</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 138</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.Text" xml:space="preserve">
-    <value>Comparison Settings</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Name" xml:space="preserve">
-    <value>comparisonSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Parent" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="comparisonHintTtextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -982,33 +1399,6 @@
   <data name="&gt;&gt;comparisonHintTtextBox.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="compareTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="compareTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="compareTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>616, 657</value>
-  </data>
-  <data name="compareTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="compareTabPage.Text" xml:space="preserve">
-    <value>Compare</value>
-  </data>
-  <data name="&gt;&gt;compareTabPage.Name" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;compareTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;compareTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;compareTabPage.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="displayPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -1028,40 +1418,13 @@
     <value>displayPanel1</value>
   </data>
   <data name="&gt;&gt;displayPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.OutputWizard.DisplayPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.OutputWizard.DisplayPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;displayPanel1.Parent" xml:space="preserve">
     <value>displayTabPage</value>
   </data>
   <data name="&gt;&gt;displayPanel1.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="displayTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="displayTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="displayTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>616, 657</value>
-  </data>
-  <data name="displayTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="displayTabPage.Text" xml:space="preserve">
-    <value>Display</value>
-  </data>
-  <data name="&gt;&gt;displayTabPage.Name" xml:space="preserve">
-    <value>displayTabPage</value>
-  </data>
-  <data name="&gt;&gt;displayTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;displayTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;displayTabPage.ZOrder" xml:space="preserve">
-    <value>2</value>
   </data>
   <data name="preconditionPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -1082,7 +1445,7 @@
     <value>preconditionPanel</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
     <value>preconditionTabPage</value>
@@ -1090,80 +1453,53 @@
   <data name="&gt;&gt;preconditionPanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+  <data name="&gt;&gt;button1.Name" xml:space="preserve">
+    <value>button1</value>
   </data>
-  <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+  <data name="&gt;&gt;button1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>616, 657</value>
+  <data name="&gt;&gt;button1.Parent" xml:space="preserve">
+    <value>ButtonPanel</value>
   </data>
-  <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="preconditionTabPage.Text" xml:space="preserve">
-    <value>Precondition</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Name" xml:space="preserve">
-    <value>preconditionTabPage</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tabControlFsuipc.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tabControlFsuipc.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="tabControlFsuipc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>624, 683</value>
-  </data>
-  <data name="tabControlFsuipc.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;tabControlFsuipc.Name" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;tabControlFsuipc.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControlFsuipc.Parent" xml:space="preserve">
-    <value>MainPanel</value>
-  </data>
-  <data name="&gt;&gt;tabControlFsuipc.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;button1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="MainPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <data name="&gt;&gt;cancelButton.Name" xml:space="preserve">
+    <value>cancelButton</value>
   </data>
-  <data name="MainPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
+  <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="MainPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>624, 683</value>
+  <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
+    <value>ButtonPanel</value>
   </data>
-  <data name="MainPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
-  <data name="&gt;&gt;MainPanel.Name" xml:space="preserve">
-    <value>MainPanel</value>
+  <data name="ButtonPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
   </data>
-  <data name="&gt;&gt;MainPanel.Type" xml:space="preserve">
+  <data name="ButtonPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 683</value>
+  </data>
+  <data name="ButtonPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>624, 28</value>
+  </data>
+  <data name="ButtonPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ButtonPanel.Name" xml:space="preserve">
+    <value>ButtonPanel</value>
+  </data>
+  <data name="&gt;&gt;ButtonPanel.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;MainPanel.Parent" xml:space="preserve">
+  <data name="&gt;&gt;ButtonPanel.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;MainPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;ButtonPanel.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="button1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Right</value>
@@ -1223,30 +1559,6 @@
     <value>ButtonPanel</value>
   </data>
   <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="ButtonPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
-  </data>
-  <data name="ButtonPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 683</value>
-  </data>
-  <data name="ButtonPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>624, 28</value>
-  </data>
-  <data name="ButtonPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ButtonPanel.Name" xml:space="preserve">
-    <value>ButtonPanel</value>
-  </data>
-  <data name="&gt;&gt;ButtonPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ButtonPanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;ButtonPanel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <metadata name="presetsDataSet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/UI/Panels/Action/MSFS2020CustomInputPanel.Designer.cs
+++ b/UI/Panels/Action/MSFS2020CustomInputPanel.Designer.cs
@@ -30,7 +30,6 @@
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MSFS2020CustomInputPanel));
             this.DescriptionLabel = new System.Windows.Forms.Label();
-            this.HintLabel = new System.Windows.Forms.Label();
             this.hubHopPresetPanel1 = new MobiFlight.UI.Panels.Config.HubHopPresetPanel();
             this.SuspendLayout();
             // 
@@ -39,15 +38,12 @@
             resources.ApplyResources(this.DescriptionLabel, "DescriptionLabel");
             this.DescriptionLabel.Name = "DescriptionLabel";
             // 
-            // HintLabel
-            // 
-            resources.ApplyResources(this.HintLabel, "HintLabel");
-            this.HintLabel.Name = "HintLabel";
-            // 
             // hubHopPresetPanel1
             // 
             resources.ApplyResources(this.hubHopPresetPanel1, "hubHopPresetPanel1");
+            this.hubHopPresetPanel1.FlightSimType = MobiFlight.FlightSimType.NONE;
             this.hubHopPresetPanel1.LVars = ((System.Collections.Generic.List<string>)(resources.GetObject("hubHopPresetPanel1.LVars")));
+            this.hubHopPresetPanel1.Mode = MobiFlight.UI.Panels.Config.HubHopPanelMode.Output;
             this.hubHopPresetPanel1.Name = "hubHopPresetPanel1";
             this.hubHopPresetPanel1.PresetFile = "Presets\\msfs2020_hubhop_presets.json";
             this.hubHopPresetPanel1.PresetFileUser = "Presets\\msfs2020_simvars_user.cip";
@@ -56,9 +52,9 @@
             // 
             resources.ApplyResources(this, "$this");
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.HintLabel);
             this.Controls.Add(this.hubHopPresetPanel1);
             this.Controls.Add(this.DescriptionLabel);
+            this.DoubleBuffered = true;
             this.Name = "MSFS2020CustomInputPanel";
             this.ResumeLayout(false);
             this.PerformLayout();
@@ -67,7 +63,6 @@
 
         #endregion
         private System.Windows.Forms.Label DescriptionLabel;
-        private System.Windows.Forms.Label HintLabel;
         private Config.HubHopPresetPanel hubHopPresetPanel1;
     }
 }

--- a/UI/Panels/Action/MSFS2020CustomInputPanel.cs
+++ b/UI/Panels/Action/MSFS2020CustomInputPanel.cs
@@ -19,6 +19,7 @@ namespace MobiFlight.UI.Panels.Action
         {
             InitializeComponent();
             hubHopPresetPanel1.Mode = Config.HubHopPanelMode.Input;
+            hubHopPresetPanel1.FlightSimType = FlightSimType.MSFS2020;
             hubHopPresetPanel1.LoadPresets();
             Disposed += (sender, args) => { hubHopPresetPanel1.Dispose(); };
         }       

--- a/UI/Panels/Action/MSFS2020CustomInputPanel.de.resx
+++ b/UI/Panels/Action/MSFS2020CustomInputPanel.de.resx
@@ -120,7 +120,23 @@
   <data name="DescriptionLabel.Text" xml:space="preserve">
     <value>Dein Custom-Code, der in MSFS2020 ausgeführt werden soll:</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="HintLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 212</value>
+  </data>
   <data name="HintLabel.Text" xml:space="preserve">
     <value>Unterstützt Eingabe-Wert (@) und Platzhalter (?,#, etc.)</value>
+  </data>
+  <data name="hubHopPresetPanel1.LVars" mimetype="application/x-microsoft.net.object.binary.base64">
+    <value>
+        AAEAAAD/////AQAAAAAAAAAMAgAAAJoBbXNjb3JsaWIsIFZlcnNpb249NC4wLjAuMCwgQ3VsdHVyZT1u
+        ZXV0cmFsLCBQdWJsaWNLZXlUb2tlbj1iNzdhNWM1NjE5MzRlMDg5XV0sIG1zY29ybGliLCBWZXJzaW9u
+        PTQuMC4wLjAsIEN1bHR1cmU9bmV1dHJhbCwgUHVibGljS2V5VG9rZW49Yjc3YTVjNTYxOTM0ZTA4OQUB
+        AAAAMFN5c3RlbS5Db2xsZWN0aW9ucy5HZW5lcmljLkxpc3RgMVtbU3lzdGVtLlN0cmluZwMAAAAGX2l0
+        ZW1zBV9zaXplCF92ZXJzaW9uBgAACAgCAAAACQMAAAAAAAAAAAAAABEDAAAAAAAAAAs=
+</value>
+  </data>
+  <data name="hubHopPresetPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>600, 186</value>
   </data>
 </root>

--- a/UI/Panels/Action/MSFS2020CustomInputPanel.resx
+++ b/UI/Panels/Action/MSFS2020CustomInputPanel.resx
@@ -128,11 +128,8 @@
   <data name="DescriptionLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="DescriptionLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
   <data name="DescriptionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>880, 40</value>
+    <value>600, 26</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="DescriptionLabel.TabIndex" type="System.Int32, mscorlib">
@@ -151,44 +148,7 @@
     <value>$this</value>
   </data>
   <data name="&gt;&gt;DescriptionLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="HintLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="HintLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="HintLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 369</value>
-  </data>
-  <data name="HintLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 0, 4, 0</value>
-  </data>
-  <data name="HintLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>105, 0, 0, 0</value>
-  </data>
-  <data name="HintLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>880, 38</value>
-  </data>
-  <data name="HintLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>29</value>
-  </data>
-  <data name="HintLabel.Text" xml:space="preserve">
-    <value>Supports input value (@) and placeholders ($,#, etc.)
-</value>
-  </data>
-  <data name="&gt;&gt;HintLabel.Name" xml:space="preserve">
-    <value>HintLabel</value>
-  </data>
-  <data name="&gt;&gt;HintLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;HintLabel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;HintLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="hubHopPresetPanel1.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -200,7 +160,7 @@
     <value>Top</value>
   </data>
   <data name="hubHopPresetPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 40</value>
+    <value>0, 26</value>
   </data>
   <data name="hubHopPresetPanel1.LVars" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
@@ -211,11 +171,14 @@
         ZW1zBV9zaXplCF92ZXJzaW9uBgAACAgCAAAACQMAAAAAAAAAAAAAABEDAAAAAAAAAAs=
 </value>
   </data>
+  <data name="hubHopPresetPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>1, 1, 1, 1</value>
+  </data>
   <data name="hubHopPresetPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>400, 0</value>
+    <value>267, 0</value>
   </data>
   <data name="hubHopPresetPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>880, 329</value>
+    <value>600, 186</value>
   </data>
   <data name="hubHopPresetPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -224,25 +187,31 @@
     <value>hubHopPresetPanel1</value>
   </data>
   <data name="&gt;&gt;hubHopPresetPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.HubHopPresetPanel, MFConnector, Version=9.2.0.4, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.HubHopPresetPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;hubHopPresetPanel1.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
   <data name="&gt;&gt;hubHopPresetPanel1.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 20</value>
+    <value>6, 13</value>
   </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+  <data name="$this.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="$this.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="$this.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>600, 200</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>880, 741</value>
+    <value>600, 212</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>MSFS2020CustomInputPanel</value>

--- a/UI/Panels/Action/XplaneInputPanel.Designer.cs
+++ b/UI/Panels/Action/XplaneInputPanel.Designer.cs
@@ -29,22 +29,8 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(XplaneInputPanel));
-            this.xplaneGroupBox = new System.Windows.Forms.GroupBox();
             this.hubHopPresetPanel1 = new MobiFlight.UI.Panels.Config.HubHopPresetPanel();
-            this.xplaneGroupBox.SuspendLayout();
             this.SuspendLayout();
-            // 
-            // xplaneGroupBox
-            // 
-            this.xplaneGroupBox.AutoSize = true;
-            this.xplaneGroupBox.Controls.Add(this.hubHopPresetPanel1);
-            this.xplaneGroupBox.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.xplaneGroupBox.Location = new System.Drawing.Point(0, 0);
-            this.xplaneGroupBox.Name = "xplaneGroupBox";
-            this.xplaneGroupBox.Size = new System.Drawing.Size(610, 291);
-            this.xplaneGroupBox.TabIndex = 0;
-            this.xplaneGroupBox.TabStop = false;
-            this.xplaneGroupBox.Text = "Input settings";
             // 
             // hubHopPresetPanel1
             // 
@@ -52,7 +38,7 @@
             this.hubHopPresetPanel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.hubHopPresetPanel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.hubHopPresetPanel1.FlightSimType = MobiFlight.FlightSimType.NONE;
-            this.hubHopPresetPanel1.Location = new System.Drawing.Point(3, 16);
+            this.hubHopPresetPanel1.Location = new System.Drawing.Point(0, 0);
             this.hubHopPresetPanel1.LVars = ((System.Collections.Generic.List<string>)(resources.GetObject("hubHopPresetPanel1.LVars")));
             this.hubHopPresetPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.hubHopPresetPanel1.MinimumSize = new System.Drawing.Size(603, 0);
@@ -60,7 +46,7 @@
             this.hubHopPresetPanel1.Name = "hubHopPresetPanel1";
             this.hubHopPresetPanel1.PresetFile = "Presets\\msfs2020_hubhop_presets.json";
             this.hubHopPresetPanel1.PresetFileUser = "Presets\\msfs2020_simvars_user.cip";
-            this.hubHopPresetPanel1.Size = new System.Drawing.Size(604, 189);
+            this.hubHopPresetPanel1.Size = new System.Drawing.Size(603, 189);
             this.hubHopPresetPanel1.TabIndex = 31;
             // 
             // XplaneInputPanel
@@ -68,20 +54,18 @@
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.Controls.Add(this.xplaneGroupBox);
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.Controls.Add(this.hubHopPresetPanel1);
             this.Margin = new System.Windows.Forms.Padding(2);
+            this.MinimumSize = new System.Drawing.Size(600, 200);
             this.Name = "XplaneInputPanel";
-            this.Size = new System.Drawing.Size(610, 291);
-            this.xplaneGroupBox.ResumeLayout(false);
-            this.xplaneGroupBox.PerformLayout();
+            this.Size = new System.Drawing.Size(600, 200);
             this.ResumeLayout(false);
             this.PerformLayout();
 
         }
 
         #endregion
-
-        private System.Windows.Forms.GroupBox xplaneGroupBox;
         private Config.HubHopPresetPanel hubHopPresetPanel1;
     }
 }

--- a/UI/Panels/Action/XplaneInputPanel.cs
+++ b/UI/Panels/Action/XplaneInputPanel.cs
@@ -20,6 +20,7 @@ namespace MobiFlight.UI.Panels.Action
             hubHopPresetPanel1.Mode = Config.HubHopPanelMode.Input;
             hubHopPresetPanel1.PresetFile = @"Presets\xplane_hubhop_presets.json";
             hubHopPresetPanel1.LoadPresets();
+            Disposed += (sender, args) => { hubHopPresetPanel1.Dispose(); };
         }
         internal void syncFromConfig(InputConfig.XplaneInputAction inputAction)
         {

--- a/UI/Panels/Config/HubHopPresetPanel.Designer.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.Designer.cs
@@ -69,6 +69,8 @@
             this.label3 = new System.Windows.Forms.Label();
             this.DescriptionLabel = new System.Windows.Forms.Label();
             this.ShowExpertSettingsCheckBox = new System.Windows.Forms.CheckBox();
+            this.HintLabelPresetCodeLabel = new System.Windows.Forms.Label();
+            this.panel1 = new System.Windows.Forms.Panel();
             this.FilterGroupBox.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
             this.FilterVendorPanel.SuspendLayout();
@@ -85,6 +87,7 @@
             this.PresetCodePanel.SuspendLayout();
             this.CodeActionPanel.SuspendLayout();
             this.PresetPanel.SuspendLayout();
+            this.panel1.SuspendLayout();
             this.SuspendLayout();
             // 
             // FilterGroupBox
@@ -95,7 +98,7 @@
             this.FilterGroupBox.Dock = System.Windows.Forms.DockStyle.Top;
             this.FilterGroupBox.Location = new System.Drawing.Point(0, 0);
             this.FilterGroupBox.Name = "FilterGroupBox";
-            this.FilterGroupBox.Size = new System.Drawing.Size(603, 65);
+            this.FilterGroupBox.Size = new System.Drawing.Size(600, 65);
             this.FilterGroupBox.TabIndex = 12;
             this.FilterGroupBox.TabStop = false;
             this.FilterGroupBox.Text = "Filter Preset List";
@@ -114,7 +117,7 @@
             this.flowLayoutPanel1.Margin = new System.Windows.Forms.Padding(2);
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(70, 0, 0, 0);
-            this.flowLayoutPanel1.Size = new System.Drawing.Size(597, 46);
+            this.flowLayoutPanel1.Size = new System.Drawing.Size(594, 46);
             this.flowLayoutPanel1.TabIndex = 16;
             // 
             // FilterVendorPanel
@@ -267,7 +270,7 @@
             this.PresetGroupBox.Location = new System.Drawing.Point(0, 65);
             this.PresetGroupBox.Name = "PresetGroupBox";
             this.PresetGroupBox.Padding = new System.Windows.Forms.Padding(0, 3, 3, 0);
-            this.PresetGroupBox.Size = new System.Drawing.Size(603, 364);
+            this.PresetGroupBox.Size = new System.Drawing.Size(600, 346);
             this.PresetGroupBox.TabIndex = 13;
             this.PresetGroupBox.TabStop = false;
             this.PresetGroupBox.Text = "Select Preset";
@@ -279,9 +282,9 @@
             this.ExpertSettingsPanel.Controls.Add(this.Msfs2020Panel);
             this.ExpertSettingsPanel.Controls.Add(this.CustomCodePanel);
             this.ExpertSettingsPanel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.ExpertSettingsPanel.Location = new System.Drawing.Point(0, 124);
+            this.ExpertSettingsPanel.Location = new System.Drawing.Point(0, 121);
             this.ExpertSettingsPanel.Name = "ExpertSettingsPanel";
-            this.ExpertSettingsPanel.Size = new System.Drawing.Size(600, 240);
+            this.ExpertSettingsPanel.Size = new System.Drawing.Size(597, 225);
             this.ExpertSettingsPanel.TabIndex = 9;
             // 
             // Msfs2020Panel
@@ -290,9 +293,9 @@
             this.Msfs2020Panel.Controls.Add(this.AVarExamplePanel);
             this.Msfs2020Panel.Controls.Add(this.ExampleLabel);
             this.Msfs2020Panel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.Msfs2020Panel.Location = new System.Drawing.Point(0, 140);
+            this.Msfs2020Panel.Location = new System.Drawing.Point(0, 146);
             this.Msfs2020Panel.Name = "Msfs2020Panel";
-            this.Msfs2020Panel.Size = new System.Drawing.Size(600, 100);
+            this.Msfs2020Panel.Size = new System.Drawing.Size(597, 79);
             this.Msfs2020Panel.TabIndex = 9;
             // 
             // LVarExamplePanel
@@ -304,13 +307,13 @@
             this.LVarExamplePanel.Location = new System.Drawing.Point(0, 44);
             this.LVarExamplePanel.Name = "LVarExamplePanel";
             this.LVarExamplePanel.Padding = new System.Windows.Forms.Padding(0, 0, 10, 0);
-            this.LVarExamplePanel.Size = new System.Drawing.Size(600, 26);
+            this.LVarExamplePanel.Size = new System.Drawing.Size(597, 26);
             this.LVarExamplePanel.TabIndex = 9;
             // 
             // LVarListButton
             // 
             this.LVarListButton.Dock = System.Windows.Forms.DockStyle.Right;
-            this.LVarListButton.Location = new System.Drawing.Point(487, 0);
+            this.LVarListButton.Location = new System.Drawing.Point(484, 0);
             this.LVarListButton.Name = "LVarListButton";
             this.LVarListButton.Size = new System.Drawing.Size(103, 26);
             this.LVarListButton.TabIndex = 6;
@@ -324,7 +327,7 @@
             this.label4.Location = new System.Drawing.Point(0, 0);
             this.label4.Name = "label4";
             this.label4.Padding = new System.Windows.Forms.Padding(74, 3, 3, 3);
-            this.label4.Size = new System.Drawing.Size(590, 26);
+            this.label4.Size = new System.Drawing.Size(587, 26);
             this.label4.TabIndex = 5;
             this.label4.Text = "Local Variables (L-Vars) - (L:YourLvarName)";
             this.label4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -337,13 +340,13 @@
             this.AVarExamplePanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.AVarExamplePanel.Location = new System.Drawing.Point(0, 18);
             this.AVarExamplePanel.Name = "AVarExamplePanel";
-            this.AVarExamplePanel.Size = new System.Drawing.Size(600, 26);
+            this.AVarExamplePanel.Size = new System.Drawing.Size(597, 26);
             this.AVarExamplePanel.TabIndex = 10;
             // 
             // linkLabel1
             // 
             this.linkLabel1.Dock = System.Windows.Forms.DockStyle.Right;
-            this.linkLabel1.Location = new System.Drawing.Point(487, 0);
+            this.linkLabel1.Location = new System.Drawing.Point(484, 0);
             this.linkLabel1.Name = "linkLabel1";
             this.linkLabel1.Padding = new System.Windows.Forms.Padding(0, 0, 10, 0);
             this.linkLabel1.Size = new System.Drawing.Size(113, 26);
@@ -358,7 +361,7 @@
             this.label5.Location = new System.Drawing.Point(0, 0);
             this.label5.Name = "label5";
             this.label5.Padding = new System.Windows.Forms.Padding(74, 3, 3, 3);
-            this.label5.Size = new System.Drawing.Size(600, 26);
+            this.label5.Size = new System.Drawing.Size(597, 26);
             this.label5.TabIndex = 8;
             this.label5.Text = "Aircraft Variables (A-Vars) - (A:COM ACTIVE FREQUENCY:1, Number)";
             this.label5.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -370,7 +373,7 @@
             this.ExampleLabel.Location = new System.Drawing.Point(0, 0);
             this.ExampleLabel.Name = "ExampleLabel";
             this.ExampleLabel.Padding = new System.Windows.Forms.Padding(74, 3, 3, 3);
-            this.ExampleLabel.Size = new System.Drawing.Size(600, 18);
+            this.ExampleLabel.Size = new System.Drawing.Size(597, 18);
             this.ExampleLabel.TabIndex = 4;
             this.ExampleLabel.Text = "Examples:";
             // 
@@ -385,7 +388,7 @@
             this.CustomCodePanel.Location = new System.Drawing.Point(0, 0);
             this.CustomCodePanel.Name = "CustomCodePanel";
             this.CustomCodePanel.Padding = new System.Windows.Forms.Padding(0, 0, 0, 5);
-            this.CustomCodePanel.Size = new System.Drawing.Size(600, 140);
+            this.CustomCodePanel.Size = new System.Drawing.Size(597, 146);
             this.CustomCodePanel.TabIndex = 11;
             // 
             // ValuePanel
@@ -396,19 +399,19 @@
             this.ValuePanel.Controls.Add(this.ValueLabel);
             this.ValuePanel.Controls.Add(this.HintLabel);
             this.ValuePanel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.ValuePanel.Location = new System.Drawing.Point(0, 57);
+            this.ValuePanel.Location = new System.Drawing.Point(0, 75);
             this.ValuePanel.Name = "ValuePanel";
             this.ValuePanel.Padding = new System.Windows.Forms.Padding(4);
-            this.ValuePanel.Size = new System.Drawing.Size(600, 78);
+            this.ValuePanel.Size = new System.Drawing.Size(597, 66);
             this.ValuePanel.TabIndex = 33;
             // 
             // ValueTextBox
             // 
             this.ValueTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.ValueTextBox.Location = new System.Drawing.Point(75, 26);
+            this.ValueTextBox.Location = new System.Drawing.Point(75, 21);
             this.ValueTextBox.Name = "ValueTextBox";
-            this.ValueTextBox.Size = new System.Drawing.Size(470, 20);
+            this.ValueTextBox.Size = new System.Drawing.Size(461, 20);
             this.ValueTextBox.TabIndex = 5;
             // 
             // ValueLabel
@@ -425,9 +428,9 @@
             this.HintLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.HintLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.HintLabel.Location = new System.Drawing.Point(75, 49);
+            this.HintLabel.Location = new System.Drawing.Point(75, 44);
             this.HintLabel.Name = "HintLabel";
-            this.HintLabel.Size = new System.Drawing.Size(464, 25);
+            this.HintLabel.Size = new System.Drawing.Size(461, 18);
             this.HintLabel.TabIndex = 30;
             this.HintLabel.Text = "Supports variable value ($), input value (@) and placeholders (?,#, etc.)\r\n";
             // 
@@ -435,29 +438,29 @@
             // 
             this.PresetCodePanel.AutoSize = true;
             this.PresetCodePanel.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.PresetCodePanel.Controls.Add(this.SimVarNameTextBox);
-            this.PresetCodePanel.Controls.Add(this.ExpandButton);
+            this.PresetCodePanel.Controls.Add(this.panel1);
+            this.PresetCodePanel.Controls.Add(this.HintLabelPresetCodeLabel);
             this.PresetCodePanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.PresetCodePanel.Location = new System.Drawing.Point(0, 27);
             this.PresetCodePanel.Name = "PresetCodePanel";
-            this.PresetCodePanel.Size = new System.Drawing.Size(600, 30);
+            this.PresetCodePanel.Size = new System.Drawing.Size(597, 48);
             this.PresetCodePanel.TabIndex = 11;
             // 
             // SimVarNameTextBox
             // 
             this.SimVarNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.SimVarNameTextBox.Location = new System.Drawing.Point(75, 6);
+            this.SimVarNameTextBox.Location = new System.Drawing.Point(75, 3);
             this.SimVarNameTextBox.MaxLength = 1024;
             this.SimVarNameTextBox.Multiline = true;
             this.SimVarNameTextBox.Name = "SimVarNameTextBox";
-            this.SimVarNameTextBox.Size = new System.Drawing.Size(464, 21);
+            this.SimVarNameTextBox.Size = new System.Drawing.Size(461, 21);
             this.SimVarNameTextBox.TabIndex = 9;
             // 
             // ExpandButton
             // 
             this.ExpandButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.ExpandButton.Location = new System.Drawing.Point(545, 5);
+            this.ExpandButton.Location = new System.Drawing.Point(541, 3);
             this.ExpandButton.Name = "ExpandButton";
             this.ExpandButton.Size = new System.Drawing.Size(21, 21);
             this.ExpandButton.TabIndex = 10;
@@ -470,7 +473,7 @@
             this.CodeActionPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.CodeActionPanel.Location = new System.Drawing.Point(0, 0);
             this.CodeActionPanel.Name = "CodeActionPanel";
-            this.CodeActionPanel.Size = new System.Drawing.Size(600, 27);
+            this.CodeActionPanel.Size = new System.Drawing.Size(597, 27);
             this.CodeActionPanel.TabIndex = 10;
             // 
             // CodeTypeComboBox
@@ -496,13 +499,13 @@
             this.PresetPanel.Dock = System.Windows.Forms.DockStyle.Top;
             this.PresetPanel.Location = new System.Drawing.Point(0, 16);
             this.PresetPanel.Name = "PresetPanel";
-            this.PresetPanel.Size = new System.Drawing.Size(600, 108);
+            this.PresetPanel.Size = new System.Drawing.Size(597, 105);
             this.PresetPanel.TabIndex = 3;
             // 
             // MatchLabel
             // 
             this.MatchLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.MatchLabel.Location = new System.Drawing.Point(428, 3);
+            this.MatchLabel.Location = new System.Drawing.Point(425, 3);
             this.MatchLabel.Name = "MatchLabel";
             this.MatchLabel.Size = new System.Drawing.Size(169, 18);
             this.MatchLabel.TabIndex = 16;
@@ -518,7 +521,7 @@
             this.PresetComboBox.FormattingEnabled = true;
             this.PresetComboBox.Location = new System.Drawing.Point(75, 3);
             this.PresetComboBox.Name = "PresetComboBox";
-            this.PresetComboBox.Size = new System.Drawing.Size(351, 21);
+            this.PresetComboBox.Size = new System.Drawing.Size(348, 21);
             this.PresetComboBox.TabIndex = 7;
             // 
             // label3
@@ -539,7 +542,7 @@
             this.DescriptionLabel.Location = new System.Drawing.Point(75, 43);
             this.DescriptionLabel.Name = "DescriptionLabel";
             this.DescriptionLabel.Padding = new System.Windows.Forms.Padding(5);
-            this.DescriptionLabel.Size = new System.Drawing.Size(459, 39);
+            this.DescriptionLabel.Size = new System.Drawing.Size(464, 39);
             this.DescriptionLabel.TabIndex = 18;
             // 
             // ShowExpertSettingsCheckBox
@@ -552,6 +555,29 @@
             this.ShowExpertSettingsCheckBox.Text = "Show Preset Code";
             this.ShowExpertSettingsCheckBox.UseVisualStyleBackColor = true;
             // 
+            // HintLabelPresetCodeLabel
+            // 
+            this.HintLabelPresetCodeLabel.Dock = System.Windows.Forms.DockStyle.Bottom;
+            this.HintLabelPresetCodeLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.HintLabelPresetCodeLabel.Location = new System.Drawing.Point(0, 27);
+            this.HintLabelPresetCodeLabel.Name = "HintLabelPresetCodeLabel";
+            this.HintLabelPresetCodeLabel.Padding = new System.Windows.Forms.Padding(73, 0, 0, 0);
+            this.HintLabelPresetCodeLabel.Size = new System.Drawing.Size(597, 21);
+            this.HintLabelPresetCodeLabel.TabIndex = 31;
+            this.HintLabelPresetCodeLabel.Text = "Supports input value (@) and placeholders ($,#, etc.)";
+            // 
+            // panel1
+            // 
+            this.panel1.AutoSize = true;
+            this.panel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.panel1.Controls.Add(this.ExpandButton);
+            this.panel1.Controls.Add(this.SimVarNameTextBox);
+            this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Name = "panel1";
+            this.panel1.Size = new System.Drawing.Size(597, 27);
+            this.panel1.TabIndex = 32;
+            // 
             // HubHopPresetPanel
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -560,10 +586,11 @@
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Controls.Add(this.PresetGroupBox);
             this.Controls.Add(this.FilterGroupBox);
+            this.DoubleBuffered = true;
             this.Margin = new System.Windows.Forms.Padding(2);
-            this.MinimumSize = new System.Drawing.Size(603, 0);
+            this.MinimumSize = new System.Drawing.Size(600, 0);
             this.Name = "HubHopPresetPanel";
-            this.Size = new System.Drawing.Size(603, 429);
+            this.Size = new System.Drawing.Size(600, 411);
             this.FilterGroupBox.ResumeLayout(false);
             this.FilterGroupBox.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
@@ -591,6 +618,8 @@
             this.CodeActionPanel.ResumeLayout(false);
             this.PresetPanel.ResumeLayout(false);
             this.PresetPanel.PerformLayout();
+            this.panel1.ResumeLayout(false);
+            this.panel1.PerformLayout();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -639,5 +668,7 @@
         private System.Windows.Forms.TextBox ValueTextBox;
         private System.Windows.Forms.Label ValueLabel;
         private System.Windows.Forms.Label HintLabel;
+        private System.Windows.Forms.Label HintLabelPresetCodeLabel;
+        private System.Windows.Forms.Panel panel1;
     }
 }

--- a/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.cs
@@ -66,6 +66,7 @@ namespace MobiFlight.UI.Panels.Config
             AVarExamplePanel.Visible = panelMode == HubHopPanelMode.Output && FlightSimType == FlightSimType.MSFS2020;
             ExampleLabel.Visible = panelMode == HubHopPanelMode.Output && FlightSimType == FlightSimType.MSFS2020;
             ValuePanel.Visible = panelMode == HubHopPanelMode.Input && FlightSimType == FlightSimType.XPLANE;
+            HintLabelPresetCodeLabel.Visible = FlightSimType == FlightSimType.MSFS2020;
 
             if (panelMode == HubHopPanelMode.Input)
             {

--- a/UI/Panels/OutputWizard/DisplayPanel.Designer.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.Designer.cs
@@ -72,9 +72,9 @@
             // 
             // InputActionTypePanel
             // 
-            resources.ApplyResources(this.InputActionTypePanel, "InputActionTypePanel");
             this.InputActionTypePanel.Controls.Add(this.InputTypeAnalogRadioButton);
             this.InputActionTypePanel.Controls.Add(this.InputTypeButtonRadioButton);
+            resources.ApplyResources(this.InputActionTypePanel, "InputActionTypePanel");
             this.InputActionTypePanel.Name = "InputActionTypePanel";
             // 
             // InputTypeAnalogRadioButton
@@ -95,11 +95,11 @@
             // 
             // DisplayTypePanel
             // 
-            resources.ApplyResources(this.DisplayTypePanel, "DisplayTypePanel");
             this.DisplayTypePanel.Controls.Add(this.arcazeSerialLabel);
             this.DisplayTypePanel.Controls.Add(this.displayModuleNameComboBox);
             this.DisplayTypePanel.Controls.Add(this.displayTypeComboBoxLabel);
             this.DisplayTypePanel.Controls.Add(this.displayTypeComboBox);
+            resources.ApplyResources(this.DisplayTypePanel, "DisplayTypePanel");
             this.DisplayTypePanel.Name = "DisplayTypePanel";
             // 
             // arcazeSerialLabel
@@ -109,12 +109,12 @@
             // 
             // displayModuleNameComboBox
             // 
-            resources.ApplyResources(this.displayModuleNameComboBox, "displayModuleNameComboBox");
             this.displayModuleNameComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.displayModuleNameComboBox.FormattingEnabled = true;
             this.displayModuleNameComboBox.Items.AddRange(new object[] {
             resources.GetString("displayModuleNameComboBox.Items"),
             resources.GetString("displayModuleNameComboBox.Items1")});
+            resources.ApplyResources(this.displayModuleNameComboBox, "displayModuleNameComboBox");
             this.displayModuleNameComboBox.Name = "displayModuleNameComboBox";
             this.displayModuleNameComboBox.SelectedIndexChanged += new System.EventHandler(this.displaySerialComboBox_SelectedIndexChanged);
             // 
@@ -125,31 +125,31 @@
             // 
             // displayTypeComboBox
             // 
-            resources.ApplyResources(this.displayTypeComboBox, "displayTypeComboBox");
             this.displayTypeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.displayTypeComboBox.FormattingEnabled = true;
             this.displayTypeComboBox.Items.AddRange(new object[] {
             resources.GetString("displayTypeComboBox.Items"),
             resources.GetString("displayTypeComboBox.Items1"),
             resources.GetString("displayTypeComboBox.Items2")});
+            resources.ApplyResources(this.displayTypeComboBox, "displayTypeComboBox");
             this.displayTypeComboBox.Name = "displayTypeComboBox";
             this.displayTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.displayTypeComboBox_SelectedIndexChanged);
             // 
             // OutputTypePanel
             // 
-            resources.ApplyResources(this.OutputTypePanel, "OutputTypePanel");
             this.OutputTypePanel.Controls.Add(this.OutputTypeComboBox);
             this.OutputTypePanel.Controls.Add(this.OutputTypeLabel);
+            resources.ApplyResources(this.OutputTypePanel, "OutputTypePanel");
             this.OutputTypePanel.Name = "OutputTypePanel";
             // 
             // OutputTypeComboBox
             // 
-            resources.ApplyResources(this.OutputTypeComboBox, "OutputTypeComboBox");
             this.OutputTypeComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.OutputTypeComboBox.FormattingEnabled = true;
             this.OutputTypeComboBox.Items.AddRange(new object[] {
             resources.GetString("OutputTypeComboBox.Items"),
             resources.GetString("OutputTypeComboBox.Items1")});
+            resources.ApplyResources(this.OutputTypeComboBox, "OutputTypeComboBox");
             this.OutputTypeComboBox.Name = "OutputTypeComboBox";
             this.OutputTypeComboBox.SelectedIndexChanged += new System.EventHandler(this.OutputTypeComboBox_SelectedIndexChanged);
             // 
@@ -160,9 +160,9 @@
             // 
             // testSettingsGroupBox
             // 
-            resources.ApplyResources(this.testSettingsGroupBox, "testSettingsGroupBox");
             this.testSettingsGroupBox.Controls.Add(this.displayPinTestStopButton);
             this.testSettingsGroupBox.Controls.Add(this.displayPinTestButton);
+            resources.ApplyResources(this.testSettingsGroupBox, "testSettingsGroupBox");
             this.testSettingsGroupBox.Name = "testSettingsGroupBox";
             this.testSettingsGroupBox.TabStop = false;
             // 

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -49,15 +49,6 @@ namespace MobiFlight.UI.Panels.OutputWizard
         public DisplayPanel()
         {
             InitializeComponent();
-            analogPanel1.OnPanelChanged += (s, e) => {
-                inputActionGroupBox.AutoSize = false;
-                inputActionGroupBox.Height = (s as UserControl).Height + 80 + AnalogInputActionLabel.Height;
-            };
-
-            buttonPanel1.OnPanelChanged += (s, e) => {
-                inputActionGroupBox.AutoSize = false;
-                inputActionGroupBox.Height = (s as UserControl).Height + 80 + ButtonInputActionLabel.Height;
-            };
         }
 
         public void SetConfigRefsDataView(DataView dv, string filterGuid)
@@ -823,6 +814,12 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             InputActionTypePanel.Visible = OutputTypeIsInputAction();
             inputActionGroupBox.Visible = OutputTypeIsInputAction();
+
+            if (OutputTypeIsInputAction())
+            {
+                InputTypeButtonRadioButton.Checked = config.AnalogInputConfig?.onChange == null;
+                InputTypeAnalogRadioButton.Checked = config.AnalogInputConfig?.onChange != null;
+            } 
         }
 
         private void InputTypeButtonRadioButton_CheckedChanged(object sender, EventArgs e)

--- a/UI/Panels/OutputWizard/DisplayPanel.resx
+++ b/UI/Panels/OutputWizard/DisplayPanel.resx
@@ -117,732 +117,732 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <data name="&gt;&gt;displayPinTestStopButton.Name" xml:space="preserve">
-    <value>displayPinTestStopButton</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Text" xml:space="preserve">
-    <value>Choose your display type which is used for output from the list below.</value>
-  </data>
-  <data name="&gt;&gt;groupBoxDisplaySettings.Parent" xml:space="preserve">
-    <value>OutputDevicePanel</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="DisplayPanelTextLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="analogPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="arcazeSerialLabel.Text" xml:space="preserve">
-    <value>Module</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="displayTypeComboBoxLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
-  </data>
-  <data name="&gt;&gt;displayModuleNameComboBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="displayPinTestStopButton.Text" xml:space="preserve">
-    <value>Stop</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="testSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 151</value>
-  </data>
-  <data name="ButtonInputActionLabel.Text" xml:space="preserve">
-    <value>Define an action that will be executed when your config value changes.
-Value can be "1" or "0" to trigger "OnPress" and "OnRelease" respectively. </value>
-  </data>
-  <data name="&gt;&gt;AnalogInputActionLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="InputActionTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="OutputDevicePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 36</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialLabel.Parent" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="&gt;&gt;inputActionGroupBox.Name" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="DisplayTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="&gt;&gt;analogPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Input.AnalogPanel, MFConnector, Version=9.2.0.2, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="displayTypeGroupBox.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 200</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>86, 21</value>
-  </data>
-  <data name="OutputTypeComboBox.Items1" xml:space="preserve">
-    <value>Input Action</value>
-  </data>
-  <data name="&gt;&gt;displayTypeGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;inputActionGroupBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="AnalogInputActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Input.ButtonPanel, MFConnector, Version=9.2.0.2, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="displayModuleNameComboBox.Items1" xml:space="preserve">
-    <value>Modul B</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;InputTypeAnalogRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="displayTypeComboBox.Items1" xml:space="preserve">
-    <value>Display Module</value>
-  </data>
-  <data name="OutputTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>138, 21</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 6</value>
-  </data>
-  <data name="analogPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>300, 0</value>
-  </data>
-  <data name="AnalogInputActionLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="displayModuleNameComboBox.Items" xml:space="preserve">
-    <value>Modul A</value>
-  </data>
   <data name="displayTypeGroupBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="&gt;&gt;displayModuleNameComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBoxDisplaySettings.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="ButtonInputActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="displayTypeGroupBox.Text" xml:space="preserve">
-    <value>Display type</value>
-  </data>
-  <data name="OutputTypeLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>93, 17</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ButtonInputActionLabel.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="arcazeSerialLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 5</value>
-  </data>
-  <data name="&gt;&gt;inputActionGroupBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="inputActionGroupBox.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>0, 80</value>
-  </data>
-  <data name="&gt;&gt;AnalogInputActionLabel.Name" xml:space="preserve">
-    <value>AnalogInputActionLabel</value>
-  </data>
-  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 500</value>
-  </data>
-  <data name="groupBoxDisplaySettings.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="AnalogInputActionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 53</value>
-  </data>
-  <data name="displayTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="displayPinTestButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>DisplayPanel</value>
-  </data>
-  <data name="&gt;&gt;DisplayTypePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;groupBoxDisplaySettings.Name" xml:space="preserve">
-    <value>groupBoxDisplaySettings</value>
-  </data>
-  <data name="&gt;&gt;analogPanel1.Name" xml:space="preserve">
-    <value>analogPanel1</value>
-  </data>
-  <data name="displayPinTestButton.Text" xml:space="preserve">
-    <value>Test</value>
-  </data>
-  <data name="displayTypeComboBox.Items" xml:space="preserve">
-    <value>Pin</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeLabel.Parent" xml:space="preserve">
-    <value>OutputTypePanel</value>
-  </data>
-  <data name="displayPinTestStopButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 23</value>
-  </data>
-  <data name="OutputDevicePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="inputActionGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 111</value>
-  </data>
-  <data name="displayPinTestStopButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="&gt;&gt;InputTypeButtonRadioButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="OutputTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="&gt;&gt;inputActionGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="InputActionTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 100</value>
-  </data>
-  <data name="&gt;&gt;InputTypeButtonRadioButton.Parent" xml:space="preserve">
-    <value>InputActionTypePanel</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestStopButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="&gt;&gt;DisplayPanelTextLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="buttonPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="displayModuleNameComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 4</value>
-  </data>
-  <data name="&gt;&gt;analogPanel1.Parent" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;groupBoxDisplaySettings.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="buttonPanel1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="AnalogInputActionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 37</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>129, 17</value>
-  </data>
-  <data name="&gt;&gt;OutputDevicePanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 31</value>
-  </data>
-  <data name="&gt;&gt;displayTypeGroupBox.Parent" xml:space="preserve">
-    <value>OutputDevicePanel</value>
-  </data>
-  <data name="ButtonInputActionLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 37</value>
-  </data>
-  <data name="&gt;&gt;displayTypeGroupBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestButton.Parent" xml:space="preserve">
-    <value>testSettingsGroupBox</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 5, 0, 0</value>
-  </data>
-  <data name="&gt;&gt;ButtonInputActionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="displayTypeComboBox.Items2" xml:space="preserve">
-    <value>BCD4056</value>
-  </data>
-  <data name="displayTypeGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="inputActionGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="DisplayTypePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 36</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.Text" xml:space="preserve">
-    <value>OnChange</value>
-  </data>
-  <data name="&gt;&gt;OutputTypePanel.Name" xml:space="preserve">
-    <value>OutputTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OutputDevicePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel1.Name" xml:space="preserve">
-    <value>buttonPanel1</value>
-  </data>
-  <data name="OutputDevicePanel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="analogPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 90</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="OutputTypePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;InputActionTypePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeComboBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="displayModuleNameComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 21</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="arcazeSerialLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="displayTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>281, 21</value>
-  </data>
-  <data name="ButtonInputActionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 5</value>
-  </data>
-  <data name="&gt;&gt;analogPanel1.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBoxLabel.Parent" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="testSettingsGroupBox.Text" xml:space="preserve">
-    <value>Test current settings</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputTypeButtonRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OutputTypePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;testSettingsGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="analogPanel1.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="displayPinTestStopButton.TabIndex" type="System.Int32, mscorlib">
-    <value>19</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestStopButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="displayPinTestButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
-    <value>ImageBeforeText</value>
-  </data>
-  <data name="DisplayPanelTextLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="AnalogInputActionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="&gt;&gt;testSettingsGroupBox.Name" xml:space="preserve">
-    <value>testSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ButtonInputActionLabel.Parent" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;displayModuleNameComboBox.Parent" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeLabel.Name" xml:space="preserve">
-    <value>OutputTypeLabel</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeComboBox.Name" xml:space="preserve">
-    <value>OutputTypeComboBox</value>
-  </data>
-  <data name="groupBoxDisplaySettings.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="OutputTypeLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="displayPinTestButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>241, 12</value>
-  </data>
-  <data name="&gt;&gt;InputTypeAnalogRadioButton.Parent" xml:space="preserve">
-    <value>InputActionTypePanel</value>
-  </data>
-  <data name="buttonPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="displayTypeGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
-  </data>
-  <data name="&gt;&gt;AnalogInputActionLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;InputActionTypePanel.Name" xml:space="preserve">
-    <value>InputActionTypePanel</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBoxLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;testSettingsGroupBox.Parent" xml:space="preserve">
-    <value>OutputDevicePanel</value>
-  </data>
-  <data name="&gt;&gt;AnalogInputActionLabel.Parent" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="displayPinTestButton.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="displayPinTestButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>58, 23</value>
-  </data>
-  <data name="testSettingsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="&gt;&gt;buttonPanel1.Parent" xml:space="preserve">
-    <value>inputActionGroupBox</value>
-  </data>
-  <data name="displayPinTestStopButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>305, 12</value>
-  </data>
-  <data name="&gt;&gt;DisplayPanelTextLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="displayModuleNameComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="inputActionGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="displayPinTestButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="InputActionTypePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>263, 6</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBoxLabel.Name" xml:space="preserve">
-    <value>displayTypeComboBoxLabel</value>
-  </data>
-  <data name="arcazeSerialLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="displayPinTestStopButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="ButtonInputActionLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBox.Parent" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="buttonPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="&gt;&gt;displayModuleNameComboBox.Name" xml:space="preserve">
-    <value>displayModuleNameComboBox</value>
-  </data>
-  <data name="displayPinTestStopButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="analogPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 18</value>
-  </data>
-  <data name="analogPanel1.TabIndex" type="System.Int32, mscorlib">
-    <value>18</value>
-  </data>
-  <data name="&gt;&gt;ButtonInputActionLabel.Name" xml:space="preserve">
-    <value>ButtonInputActionLabel</value>
-  </data>
-  <data name="OutputTypeLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="groupBoxDisplaySettings.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="&gt;&gt;OutputTypePanel.Parent" xml:space="preserve">
-    <value>displayTypeGroupBox</value>
-  </data>
-  <data name="displayTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="groupBoxDisplaySettings.Text" xml:space="preserve">
-    <value>Display settings</value>
-  </data>
-  <data name="&gt;&gt;DisplayTypePanel.Name" xml:space="preserve">
-    <value>DisplayTypePanel</value>
-  </data>
-  <data name="displayTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>108, 31</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.Text" xml:space="preserve">
-    <value>Use type of</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialLabel.Name" xml:space="preserve">
-    <value>arcazeSerialLabel</value>
-  </data>
-  <data name="DisplayTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 57</value>
-  </data>
-  <data name="inputActionGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 227</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="displayPinTestStopButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
-    <value>ImageBeforeText</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="arcazeSerialLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>83, 21</value>
-  </data>
-  <data name="&gt;&gt;OutputTypeComboBox.Parent" xml:space="preserve">
-    <value>OutputTypePanel</value>
-  </data>
-  <data name="groupBoxDisplaySettings.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 132</value>
-  </data>
-  <data name="OutputTypeLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="arcazeSerialLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="testSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 40</value>
-  </data>
-  <data name="buttonPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>300, 0</value>
-  </data>
-  <data name="&gt;&gt;OutputDevicePanel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;InputActionTypePanel.Parent" xml:space="preserve">
-    <value>displayTypeGroupBox</value>
-  </data>
-  <data name="AnalogInputActionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 5</value>
-  </data>
-  <data name="OutputTypeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 5</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBoxLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="InputTypeButtonRadioButton.Text" xml:space="preserve">
-    <value>OnPress / OnRelease</value>
-  </data>
-  <data name="OutputTypeComboBox.Items" xml:space="preserve">
-    <value>Output Device</value>
-  </data>
-  <data name="&gt;&gt;displayTypeGroupBox.Name" xml:space="preserve">
-    <value>displayTypeGroupBox</value>
-  </data>
-  <data name="OutputTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
-  </data>
-  <data name="&gt;&gt;InputTypeAnalogRadioButton.Name" xml:space="preserve">
-    <value>InputTypeAnalogRadioButton</value>
-  </data>
-  <data name="&gt;&gt;testSettingsGroupBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;displayPinTestButton.Name" xml:space="preserve">
-    <value>displayPinTestButton</value>
-  </data>
-  <data name="groupBoxDisplaySettings.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 19</value>
-  </data>
-  <data name="buttonPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 18</value>
-  </data>
-  <data name="inputActionGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="displayTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 132</value>
-  </data>
-  <data name="OutputDevicePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>457, 191</value>
-  </data>
-  <data name="&gt;&gt;displayTypeComboBox.Name" xml:space="preserve">
-    <value>displayTypeComboBox</value>
-  </data>
-  <data name="&gt;&gt;DisplayPanelTextLabel.Name" xml:space="preserve">
-    <value>DisplayPanelTextLabel</value>
-  </data>
-  <data name="displayTypeComboBoxLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="OutputDevicePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>21</value>
-  </data>
-  <data name="&gt;&gt;InputTypeAnalogRadioButton.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="displayPinTestStopButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="&gt;&gt;DisplayPanelTextLabel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;OutputDevicePanel.Name" xml:space="preserve">
-    <value>OutputDevicePanel</value>
-  </data>
-  <data name="InputTypeAnalogRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
   </data>
   <data name="InputTypeAnalogRadioButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="inputActionGroupBox.Text" xml:space="preserve">
+  <data name="InputTypeAnalogRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="InputTypeAnalogRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>263, 6</value>
+  </data>
+  <data name="InputTypeAnalogRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>76, 17</value>
+  </data>
+  <data name="InputTypeAnalogRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="InputTypeAnalogRadioButton.Text" xml:space="preserve">
+    <value>OnChange</value>
+  </data>
+  <data name="&gt;&gt;InputTypeAnalogRadioButton.Name" xml:space="preserve">
+    <value>InputTypeAnalogRadioButton</value>
+  </data>
+  <data name="&gt;&gt;InputTypeAnalogRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InputTypeAnalogRadioButton.Parent" xml:space="preserve">
+    <value>InputActionTypePanel</value>
+  </data>
+  <data name="&gt;&gt;InputTypeAnalogRadioButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 6</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>129, 17</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="InputTypeButtonRadioButton.Text" xml:space="preserve">
+    <value>OnPress / OnRelease</value>
+  </data>
+  <data name="&gt;&gt;InputTypeButtonRadioButton.Name" xml:space="preserve">
+    <value>InputTypeButtonRadioButton</value>
+  </data>
+  <data name="&gt;&gt;InputTypeButtonRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InputTypeButtonRadioButton.Parent" xml:space="preserve">
+    <value>InputActionTypePanel</value>
+  </data>
+  <data name="&gt;&gt;InputTypeButtonRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="InputActionTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="InputActionTypePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 100</value>
+  </data>
+  <data name="InputActionTypePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 29</value>
+  </data>
+  <data name="InputActionTypePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
+  </data>
+  <data name="&gt;&gt;InputActionTypePanel.Name" xml:space="preserve">
+    <value>InputActionTypePanel</value>
+  </data>
+  <data name="&gt;&gt;InputActionTypePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;InputActionTypePanel.Parent" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;InputActionTypePanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="arcazeSerialLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="arcazeSerialLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 5</value>
+  </data>
+  <data name="arcazeSerialLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>83, 21</value>
+  </data>
+  <data name="arcazeSerialLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="arcazeSerialLabel.Text" xml:space="preserve">
+    <value>Module</value>
+  </data>
+  <data name="arcazeSerialLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;arcazeSerialLabel.Name" xml:space="preserve">
+    <value>arcazeSerialLabel</value>
+  </data>
+  <data name="&gt;&gt;arcazeSerialLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;arcazeSerialLabel.Parent" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;arcazeSerialLabel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="displayModuleNameComboBox.Items" xml:space="preserve">
+    <value>Modul A</value>
+  </data>
+  <data name="displayModuleNameComboBox.Items1" xml:space="preserve">
+    <value>Modul B</value>
+  </data>
+  <data name="displayModuleNameComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 4</value>
+  </data>
+  <data name="displayModuleNameComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>281, 21</value>
+  </data>
+  <data name="displayModuleNameComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;displayModuleNameComboBox.Name" xml:space="preserve">
+    <value>displayModuleNameComboBox</value>
+  </data>
+  <data name="&gt;&gt;displayModuleNameComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayModuleNameComboBox.Parent" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;displayModuleNameComboBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>16, 31</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>86, 21</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>14</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.Text" xml:space="preserve">
+    <value>Use type of</value>
+  </data>
+  <data name="displayTypeComboBoxLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBoxLabel.Name" xml:space="preserve">
+    <value>displayTypeComboBoxLabel</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBoxLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBoxLabel.Parent" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBoxLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="displayTypeComboBox.Items" xml:space="preserve">
+    <value>Pin</value>
+  </data>
+  <data name="displayTypeComboBox.Items1" xml:space="preserve">
+    <value>Display Module</value>
+  </data>
+  <data name="displayTypeComboBox.Items2" xml:space="preserve">
+    <value>BCD4056</value>
+  </data>
+  <data name="displayTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>108, 31</value>
+  </data>
+  <data name="displayTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>281, 21</value>
+  </data>
+  <data name="displayTypeComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBox.Name" xml:space="preserve">
+    <value>displayTypeComboBox</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBox.Parent" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;displayTypeComboBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="DisplayTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="DisplayTypePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 43</value>
+  </data>
+  <data name="DisplayTypePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 57</value>
+  </data>
+  <data name="DisplayTypePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;DisplayTypePanel.Name" xml:space="preserve">
+    <value>DisplayTypePanel</value>
+  </data>
+  <data name="&gt;&gt;DisplayTypePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DisplayTypePanel.Parent" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;DisplayTypePanel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="OutputTypeComboBox.Items" xml:space="preserve">
+    <value>Output Device</value>
+  </data>
+  <data name="OutputTypeComboBox.Items1" xml:space="preserve">
     <value>Input Action</value>
   </data>
   <data name="OutputTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>108, 4</value>
   </data>
-  <data name="&gt;&gt;buttonPanel1.ZOrder" xml:space="preserve">
+  <data name="OutputTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>138, 21</value>
+  </data>
+  <data name="OutputTypeComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeComboBox.Name" xml:space="preserve">
+    <value>OutputTypeComboBox</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeComboBox.Parent" xml:space="preserve">
+    <value>OutputTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeComboBox.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="InputTypeAnalogRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>76, 17</value>
+  <data name="OutputTypeLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;InputActionTypePanel.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="OutputTypeLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 5</value>
   </data>
-  <data name="&gt;&gt;InputTypeButtonRadioButton.Name" xml:space="preserve">
-    <value>InputTypeButtonRadioButton</value>
+  <data name="OutputTypeLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 17</value>
   </data>
-  <data name="OutputTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 27</value>
-  </data>
-  <data name="analogPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="displayPinTestButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
+  <data name="OutputTypeLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
   </data>
   <data name="OutputTypeLabel.Text" xml:space="preserve">
     <value>Choose</value>
   </data>
+  <data name="OutputTypeLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeLabel.Name" xml:space="preserve">
+    <value>OutputTypeLabel</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeLabel.Parent" xml:space="preserve">
+    <value>OutputTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OutputTypeLabel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="OutputTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="OutputTypePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="OutputTypePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 27</value>
+  </data>
+  <data name="OutputTypePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;OutputTypePanel.Name" xml:space="preserve">
+    <value>OutputTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OutputTypePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OutputTypePanel.Parent" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;OutputTypePanel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="displayTypeGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="displayTypeGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="displayTypeGroupBox.MaximumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 200</value>
+  </data>
+  <data name="displayTypeGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 132</value>
+  </data>
+  <data name="displayTypeGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="displayTypeGroupBox.Text" xml:space="preserve">
+    <value>Display type</value>
+  </data>
+  <data name="&gt;&gt;displayTypeGroupBox.Name" xml:space="preserve">
+    <value>displayTypeGroupBox</value>
+  </data>
+  <data name="&gt;&gt;displayTypeGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayTypeGroupBox.Parent" xml:space="preserve">
+    <value>OutputDevicePanel</value>
+  </data>
+  <data name="&gt;&gt;displayTypeGroupBox.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="displayPinTestStopButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
   <data name="displayPinTestStopButton.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
+  </data>
+  <data name="displayPinTestStopButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="displayPinTestStopButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="displayPinTestStopButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>305, 12</value>
+  </data>
+  <data name="displayPinTestStopButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 23</value>
+  </data>
+  <data name="displayPinTestStopButton.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="displayPinTestStopButton.Text" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="displayPinTestStopButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="displayPinTestStopButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
+    <value>ImageBeforeText</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestStopButton.Name" xml:space="preserve">
+    <value>displayPinTestStopButton</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestStopButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestStopButton.Parent" xml:space="preserve">
+    <value>testSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestStopButton.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="displayPinTestButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="displayPinTestButton.ImageAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="displayPinTestButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="displayPinTestButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>241, 12</value>
+  </data>
+  <data name="displayPinTestButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>58, 23</value>
+  </data>
+  <data name="displayPinTestButton.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="displayPinTestButton.Text" xml:space="preserve">
+    <value>Test</value>
+  </data>
+  <data name="displayPinTestButton.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="displayPinTestButton.TextImageRelation" type="System.Windows.Forms.TextImageRelation, System.Windows.Forms">
+    <value>ImageBeforeText</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestButton.Name" xml:space="preserve">
+    <value>displayPinTestButton</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestButton.Parent" xml:space="preserve">
+    <value>testSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;displayPinTestButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="testSettingsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="testSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 137</value>
+  </data>
+  <data name="testSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 40</value>
+  </data>
+  <data name="testSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="testSettingsGroupBox.Text" xml:space="preserve">
+    <value>Test current settings</value>
+  </data>
+  <data name="&gt;&gt;testSettingsGroupBox.Name" xml:space="preserve">
+    <value>testSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;testSettingsGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;testSettingsGroupBox.Parent" xml:space="preserve">
+    <value>OutputDevicePanel</value>
+  </data>
+  <data name="&gt;&gt;testSettingsGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="groupBoxDisplaySettings.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="groupBoxDisplaySettings.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="groupBoxDisplaySettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="groupBoxDisplaySettings.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 132</value>
+  </data>
+  <data name="groupBoxDisplaySettings.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 5</value>
+  </data>
+  <data name="groupBoxDisplaySettings.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="groupBoxDisplaySettings.Text" xml:space="preserve">
+    <value>Display settings</value>
+  </data>
+  <data name="&gt;&gt;groupBoxDisplaySettings.Name" xml:space="preserve">
+    <value>groupBoxDisplaySettings</value>
+  </data>
+  <data name="&gt;&gt;groupBoxDisplaySettings.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBoxDisplaySettings.Parent" xml:space="preserve">
+    <value>OutputDevicePanel</value>
+  </data>
+  <data name="&gt;&gt;groupBoxDisplaySettings.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="inputActionGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="buttonPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="buttonPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="buttonPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="buttonPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 90</value>
+  </data>
+  <data name="buttonPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>300, 0</value>
+  </data>
+  <data name="buttonPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 194</value>
+  </data>
+  <data name="buttonPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="&gt;&gt;buttonPanel1.Name" xml:space="preserve">
+    <value>buttonPanel1</value>
+  </data>
+  <data name="&gt;&gt;buttonPanel1.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Input.ButtonPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;buttonPanel1.Parent" xml:space="preserve">
+    <value>inputActionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;buttonPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="analogPanel1.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="analogPanel1.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="analogPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="analogPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 90</value>
+  </data>
+  <data name="analogPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>300, 0</value>
+  </data>
+  <data name="analogPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 194</value>
+  </data>
+  <data name="analogPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>18</value>
+  </data>
+  <data name="&gt;&gt;analogPanel1.Name" xml:space="preserve">
+    <value>analogPanel1</value>
+  </data>
+  <data name="&gt;&gt;analogPanel1.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Input.AnalogPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;analogPanel1.Parent" xml:space="preserve">
+    <value>inputActionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;analogPanel1.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="AnalogInputActionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="AnalogInputActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="AnalogInputActionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 53</value>
+  </data>
+  <data name="AnalogInputActionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 5, 5, 5</value>
+  </data>
+  <data name="AnalogInputActionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 37</value>
+  </data>
+  <data name="AnalogInputActionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
   </data>
   <data name="AnalogInputActionLabel.Text" xml:space="preserve">
     <value>Define an action that will be executed when your config value changes.
 You can reference the current config value with @ (not $).</value>
   </data>
-  <data name="displayTypeGroupBox.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
+  <data name="&gt;&gt;AnalogInputActionLabel.Name" xml:space="preserve">
+    <value>AnalogInputActionLabel</value>
   </data>
-  <data name="DisplayTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 43</value>
+  <data name="&gt;&gt;AnalogInputActionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="ButtonInputActionLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>20</value>
+  <data name="&gt;&gt;AnalogInputActionLabel.Parent" xml:space="preserve">
+    <value>inputActionGroupBox</value>
   </data>
-  <data name="&gt;&gt;DisplayTypePanel.Parent" xml:space="preserve">
-    <value>displayTypeGroupBox</value>
-  </data>
-  <data name="groupBoxDisplaySettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="DisplayPanelTextLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
+  <data name="&gt;&gt;AnalogInputActionLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="ButtonInputActionLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="InputActionTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>451, 29</value>
-  </data>
-  <data name="displayPinTestButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="ButtonInputActionLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="OutputTypeComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>22</value>
+  <data name="ButtonInputActionLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
   </data>
-  <data name="&gt;&gt;DisplayTypePanel.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="ButtonInputActionLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 5, 5, 5</value>
   </data>
-  <data name="testSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+  <data name="ButtonInputActionLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>451, 37</value>
   </data>
-  <data name="&gt;&gt;OutputTypePanel.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="ButtonInputActionLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>20</value>
   </data>
-  <data name="displayTypeComboBox.TabIndex" type="System.Int32, mscorlib">
+  <data name="ButtonInputActionLabel.Text" xml:space="preserve">
+    <value>Define an action that will be executed when your config value changes.
+Value can be "1" or "0" to trigger "OnPress" and "OnRelease" respectively. </value>
+  </data>
+  <data name="&gt;&gt;ButtonInputActionLabel.Name" xml:space="preserve">
+    <value>ButtonInputActionLabel</value>
+  </data>
+  <data name="&gt;&gt;ButtonInputActionLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ButtonInputActionLabel.Parent" xml:space="preserve">
+    <value>inputActionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;ButtonInputActionLabel.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
-  <data name="buttonPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 90</value>
+  <data name="inputActionGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="&gt;&gt;displayPinTestStopButton.Parent" xml:space="preserve">
-    <value>testSettingsGroupBox</value>
+  <data name="inputActionGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 213</value>
+  </data>
+  <data name="inputActionGroupBox.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>0, 80</value>
+  </data>
+  <data name="inputActionGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 287</value>
+  </data>
+  <data name="inputActionGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>19</value>
+  </data>
+  <data name="inputActionGroupBox.Text" xml:space="preserve">
+    <value>Input Action</value>
+  </data>
+  <data name="&gt;&gt;inputActionGroupBox.Name" xml:space="preserve">
+    <value>inputActionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;inputActionGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputActionGroupBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;inputActionGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="OutputDevicePanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="OutputDevicePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="OutputDevicePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 36</value>
+  </data>
+  <data name="OutputDevicePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 177</value>
+  </data>
+  <data name="OutputDevicePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>21</value>
+  </data>
+  <data name="&gt;&gt;OutputDevicePanel.Name" xml:space="preserve">
+    <value>OutputDevicePanel</value>
+  </data>
+  <data name="&gt;&gt;OutputDevicePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OutputDevicePanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;OutputDevicePanel.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="DisplayPanelTextLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 5, 0, 0</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 36</value>
+  </data>
+  <data name="DisplayPanelTextLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>22</value>
+  </data>
+  <data name="DisplayPanelTextLabel.Text" xml:space="preserve">
+    <value>Choose your display type which is used for output from the list below.</value>
+  </data>
+  <data name="&gt;&gt;DisplayPanelTextLabel.Name" xml:space="preserve">
+    <value>DisplayPanelTextLabel</value>
+  </data>
+  <data name="&gt;&gt;DisplayPanelTextLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;DisplayPanelTextLabel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;DisplayPanelTextLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>457, 500</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>DisplayPanel</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>


### PR DESCRIPTION
fixes #1050 

- [x] X-Plane input action in output config now shows all information
- [x] MSFS2020 and X-Plane using HubhopPreset component with same resize settings
- [x] Input Configs still work correctly 