### PR TITLE
BETA - Improvements for Precondition UI

### DIFF
--- a/Base/Precondition.cs
+++ b/Base/Precondition.cs
@@ -11,6 +11,7 @@ namespace MobiFlight
 {
     public class Precondition : IXmlSerializable, ICloneable
     {
+        public const string OPERAND_DEFAULT = Comparison.OPERAND_EQUAL;
         public const string LOGIC_AND = "and";
         public const string LOGIC_OR = "or";
         
@@ -19,9 +20,9 @@ namespace MobiFlight
             get {
                 if (preconditionLabel != null) return preconditionLabel;
                 if (PreconditionType=="config")
-                    return $"Config: <Ref:{PreconditionRef}>{PreconditionOperand} {PreconditionValue} <Logic:{PreconditionLogic}>";
+                    return $"Config: <Ref:{PreconditionRef}> {PreconditionOperand} {PreconditionValue} <Logic:{PreconditionLogic}>";
                 else if (PreconditionType == "variable")
-                    return $"Variable: <Variable: {PreconditionRef}> {PreconditionOperand} {PreconditionValue} <Logic:{PreconditionLogic}>";
+                    return $"Variable: <Variable:{PreconditionRef}> {PreconditionOperand} {PreconditionValue} <Logic:{PreconditionLogic}>";
                 else if (PreconditionType == "pin")
                 {
                     return $"Pin: <Serial:{PreconditionSerial}><Pin:{PreconditionPin}> {PreconditionOperand} {PreconditionValue} <Logic:{PreconditionLogic}>";
@@ -45,8 +46,9 @@ namespace MobiFlight
         public Precondition()
         {
             PreconditionType = "none";
-            PreconditionActive = true;            
+            PreconditionActive = true;
             PreconditionLogic = "and";
+            PreconditionOperand = "=";
         }
 
         public System.Xml.Schema.XmlSchema GetSchema()
@@ -72,6 +74,9 @@ namespace MobiFlight
             {
                 PreconditionRef = reader["ref"];
                 PreconditionOperand = reader["operand"];
+                if (PreconditionOperand == "")
+                    PreconditionOperand = OPERAND_DEFAULT;
+
                 PreconditionValue = reader["value"];
             }
             else if (PreconditionType == "pin")

--- a/MobiFlight/Modifier/Comparison.cs
+++ b/MobiFlight/Modifier/Comparison.cs
@@ -12,6 +12,13 @@ namespace MobiFlight.Modifier
 {
     public class Comparison : ModifierBase
     {
+        public const string OPERAND_EQUAL = "=";
+        public const string OPERAND_NOT_EQUAL = "!=";
+        public const string OPERAND_GREATER_THAN = ">";
+        public const string OPERAND_GREATER_THAN_EQUAL = ">=";
+        public const string OPERAND_LESS_THAN = "<";
+        public const string OPERAND_LESS_THAN_EQUAL = "<=";
+
         public string Operand { get; set; }
         public string Value { get; set; }
         public string IfValue { get; set; }
@@ -106,22 +113,22 @@ namespace MobiFlight.Modifier
 
             switch (Operand)
             {
-                case "!=":
+                case OPERAND_NOT_EQUAL:
                     comparisonResult = (value != comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
-                case ">":
+                case OPERAND_GREATER_THAN:
                     comparisonResult = (value > comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
-                case ">=":
+                case OPERAND_GREATER_THAN_EQUAL:
                     comparisonResult = (value >= comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
-                case "<=":
+                case OPERAND_LESS_THAN_EQUAL:
                     comparisonResult = (value <= comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
-                case "<":
+                case OPERAND_LESS_THAN:
                     comparisonResult = (value < comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
-                case "=":
+                case OPERAND_EQUAL:
                     comparisonResult = (value == comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
                 default:
@@ -180,10 +187,10 @@ namespace MobiFlight.Modifier
 
             switch (Operand)
             {
-                case "!=":
+                case OPERAND_NOT_EQUAL:
                     result = (value != comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
-                case "=":
+                case OPERAND_EQUAL:
                     result = (value == comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
             }

--- a/MobiFlightUnitTests/Base/PreconditionTests.cs
+++ b/MobiFlightUnitTests/Base/PreconditionTests.cs
@@ -21,6 +21,7 @@ namespace MobiFlight.Tests
             Assert.AreEqual(o.PreconditionType, "none", "Type is not none");
             Assert.AreEqual(o.PreconditionActive, true, "Active is not true");
             Assert.AreEqual(o.PreconditionLogic, "and", "Precondition logic is not and");
+            Assert.AreEqual(o.PreconditionOperand, Precondition.OPERAND_DEFAULT, "Precondition operand is not the OPERAND_DEFAULT");
         }
 
         [TestMethod()]

--- a/UI/Panels/Config/PreconditionPanel.resx
+++ b/UI/Panels/Config/PreconditionPanel.resx
@@ -122,26 +122,26 @@
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="addPreconditionToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 22</value>
+    <value>253, 32</value>
   </data>
   <data name="addPreconditionToolStripMenuItem.Text" xml:space="preserve">
     <value>Add Precondition</value>
   </data>
   <data name="removePreconditionToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 22</value>
+    <value>253, 32</value>
   </data>
   <data name="removePreconditionToolStripMenuItem.Text" xml:space="preserve">
     <value>Remove Precondition</value>
   </data>
   <data name="toolStripSeparator1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>185, 6</value>
+    <value>250, 6</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="toolStripSeparator1.Visible" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="addGroupToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 22</value>
+    <value>253, 32</value>
   </data>
   <data name="addGroupToolStripMenuItem.Text" xml:space="preserve">
     <value>Add group</value>
@@ -150,7 +150,7 @@
     <value>False</value>
   </data>
   <data name="removeGroupToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 22</value>
+    <value>253, 32</value>
   </data>
   <data name="removeGroupToolStripMenuItem.Text" xml:space="preserve">
     <value>Remove group</value>
@@ -159,28 +159,28 @@
     <value>False</value>
   </data>
   <data name="toolStripSeparator2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>185, 6</value>
+    <value>250, 6</value>
   </data>
   <data name="aNDToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 22</value>
+    <value>152, 34</value>
   </data>
   <data name="aNDToolStripMenuItem.Text" xml:space="preserve">
     <value>AND</value>
   </data>
   <data name="oRToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>99, 22</value>
+    <value>152, 34</value>
   </data>
   <data name="oRToolStripMenuItem.Text" xml:space="preserve">
     <value>OR</value>
   </data>
   <data name="logicSelectToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>188, 22</value>
+    <value>253, 32</value>
   </data>
   <data name="logicSelectToolStripMenuItem.Text" xml:space="preserve">
     <value>Logic operator</value>
   </data>
   <data name="preconditionTreeContextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>189, 126</value>
+    <value>254, 176</value>
   </data>
   <data name="&gt;&gt;preconditionTreeContextMenuStrip.Name" xml:space="preserve">
     <value>preconditionTreeContextMenuStrip</value>
@@ -193,7 +193,10 @@
     <value>Fill</value>
   </data>
   <data name="preconditionListTreeView.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
+    <value>4, 24</value>
+  </data>
+  <data name="preconditionListTreeView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionListTreeView.Nodes" mimetype="application/x-microsoft.net.object.binary.base64">
     <value>
@@ -237,7 +240,7 @@
 </value>
   </data>
   <data name="preconditionListTreeView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>462, 74</value>
+    <value>694, 114</value>
   </data>
   <data name="preconditionListTreeView.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -258,10 +261,13 @@
     <value>Bottom</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 90</value>
+    <value>4, 138</value>
+  </data>
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>462, 36</value>
+    <value>694, 55</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -285,10 +291,16 @@
     <value>Top</value>
   </data>
   <data name="preconditionListgroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 32</value>
+    <value>0, 49</value>
+  </data>
+  <data name="preconditionListgroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="preconditionListgroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionListgroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>468, 129</value>
+    <value>702, 198</value>
   </data>
   <data name="preconditionListgroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -315,13 +327,13 @@
     <value>0, 0</value>
   </data>
   <data name="preconditionTabTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>12, 12, 12, 12</value>
+    <value>18, 18, 18, 18</value>
   </data>
   <data name="preconditionTabTextBox.Multiline" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="preconditionTabTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>468, 32</value>
+    <value>702, 49</value>
   </data>
   <data name="preconditionTabTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -351,10 +363,13 @@
     <value>Arcaze Pin</value>
   </data>
   <data name="preConditionTypeComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>106, 20</value>
+    <value>159, 31</value>
+  </data>
+  <data name="preConditionTypeComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preConditionTypeComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>121, 21</value>
+    <value>180, 28</value>
   </data>
   <data name="preConditionTypeComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -375,10 +390,13 @@
     <value>NoControl</value>
   </data>
   <data name="preconditionTypeLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>11, 23</value>
+    <value>16, 35</value>
+  </data>
+  <data name="preconditionTypeLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="preconditionTypeLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 16</value>
+    <value>132, 25</value>
   </data>
   <data name="preconditionTypeLabel.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -407,8 +425,14 @@
   <data name="preconditionSelectGroupBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="preconditionSelectGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="preconditionSelectGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
   <data name="preconditionSelectGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>468, 57</value>
+    <value>702, 88</value>
   </data>
   <data name="preconditionSelectGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -447,10 +471,13 @@
     <value>Off</value>
   </data>
   <data name="preconditionPinValueComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>103, 70</value>
+    <value>154, 108</value>
+  </data>
+  <data name="preconditionPinValueComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionPinValueComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 21</value>
+    <value>68, 28</value>
   </data>
   <data name="preconditionPinValueComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>21</value>
@@ -471,10 +498,13 @@
     <value>NoControl</value>
   </data>
   <data name="preconditionPinValueLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 73</value>
+    <value>4, 112</value>
+  </data>
+  <data name="preconditionPinValueLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="preconditionPinValueLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 16</value>
+    <value>142, 25</value>
   </data>
   <data name="preconditionPinValueLabel.TabIndex" type="System.Int32, mscorlib">
     <value>20</value>
@@ -516,10 +546,13 @@
     <value>!=</value>
   </data>
   <data name="preconditionPinComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>153, 43</value>
+    <value>230, 66</value>
+  </data>
+  <data name="preconditionPinComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionPinComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 21</value>
+    <value>68, 28</value>
   </data>
   <data name="preconditionPinComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -555,10 +588,13 @@
     <value>!=</value>
   </data>
   <data name="preconditionPortComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>103, 43</value>
+    <value>154, 66</value>
+  </data>
+  <data name="preconditionPortComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionPortComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>47, 21</value>
+    <value>68, 28</value>
   </data>
   <data name="preconditionPortComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -579,10 +615,13 @@
     <value>NoControl</value>
   </data>
   <data name="preconditonPinLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>16, 46</value>
+    <value>24, 71</value>
+  </data>
+  <data name="preconditonPinLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="preconditonPinLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>81, 15</value>
+    <value>122, 23</value>
   </data>
   <data name="preconditonPinLabel.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -612,10 +651,13 @@
     <value>Arcaze Pin</value>
   </data>
   <data name="preconditionPinSerialComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>103, 16</value>
+    <value>154, 25</value>
+  </data>
+  <data name="preconditionPinSerialComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionPinSerialComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 21</value>
+    <value>306, 28</value>
   </data>
   <data name="preconditionPinSerialComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -636,10 +678,13 @@
     <value>NoControl</value>
   </data>
   <data name="preconditionPinSerialLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 19</value>
+    <value>8, 29</value>
+  </data>
+  <data name="preconditionPinSerialLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="preconditionPinSerialLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>92, 16</value>
+    <value>138, 25</value>
   </data>
   <data name="preconditionPinSerialLabel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -666,10 +711,13 @@
     <value>Top</value>
   </data>
   <data name="preconditionPinPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 91</value>
+    <value>4, 139</value>
+  </data>
+  <data name="preconditionPinPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionPinPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>462, 108</value>
+    <value>694, 166</value>
   </data>
   <data name="preconditionPinPanel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -687,10 +735,13 @@
     <value>0</value>
   </data>
   <data name="preconditionRefValueTextBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>149, 45</value>
+    <value>224, 69</value>
+  </data>
+  <data name="preconditionRefValueTextBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionRefValueTextBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 20</value>
+    <value>92, 26</value>
   </data>
   <data name="preconditionRefValueTextBox.TabIndex" type="System.Int32, mscorlib">
     <value>19</value>
@@ -726,10 +777,13 @@
     <value>!=</value>
   </data>
   <data name="preconditionRefOperandComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>104, 44</value>
+    <value>156, 68</value>
+  </data>
+  <data name="preconditionRefOperandComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionRefOperandComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>39, 21</value>
+    <value>56, 28</value>
   </data>
   <data name="preconditionRefOperandComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -750,10 +804,13 @@
     <value>NoControl</value>
   </data>
   <data name="preconditionConfigRefOperandLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 43</value>
+    <value>4, 66</value>
+  </data>
+  <data name="preconditionConfigRefOperandLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="preconditionConfigRefOperandLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>95, 21</value>
+    <value>142, 32</value>
   </data>
   <data name="preconditionConfigRefOperandLabel.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -783,10 +840,13 @@
     <value>Arcaze Pin</value>
   </data>
   <data name="preconditionConfigComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>103, 16</value>
+    <value>154, 25</value>
+  </data>
+  <data name="preconditionConfigComboBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionConfigComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>205, 21</value>
+    <value>306, 28</value>
   </data>
   <data name="preconditionConfigComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -807,10 +867,13 @@
     <value>NoControl</value>
   </data>
   <data name="preconditionConfigLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>8, 19</value>
+    <value>12, 29</value>
+  </data>
+  <data name="preconditionConfigLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="preconditionConfigLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>89, 16</value>
+    <value>134, 25</value>
   </data>
   <data name="preconditionConfigLabel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -837,10 +900,13 @@
     <value>Top</value>
   </data>
   <data name="preconditionRuleConfigPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
+    <value>4, 24</value>
+  </data>
+  <data name="preconditionRuleConfigPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionRuleConfigPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>462, 75</value>
+    <value>694, 115</value>
   </data>
   <data name="preconditionRuleConfigPanel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -864,10 +930,16 @@
     <value>Top</value>
   </data>
   <data name="preconditionSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 57</value>
+    <value>0, 88</value>
+  </data>
+  <data name="preconditionSettingsGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="preconditionSettingsGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>468, 202</value>
+    <value>702, 310</value>
   </data>
   <data name="preconditionSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -891,10 +963,13 @@
     <value>Top</value>
   </data>
   <data name="preconditionSettingsPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 161</value>
+    <value>0, 247</value>
+  </data>
+  <data name="preconditionSettingsPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionSettingsPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>468, 259</value>
+    <value>702, 398</value>
   </data>
   <data name="preconditionSettingsPanel.TabIndex" type="System.Int32, mscorlib">
     <value>22</value>
@@ -914,11 +989,17 @@
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>342</value>
+  </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>9, 20</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>468, 476</value>
+    <value>702, 732</value>
   </data>
   <data name="&gt;&gt;addPreconditionToolStripMenuItem.Name" xml:space="preserve">
     <value>addPreconditionToolStripMenuItem</value>


### PR DESCRIPTION
fixes #1040
fixes #1056 
part of #1020

This PR makes sure that
- [x] Missing precondition references are displayed with a warning icon
- [x] Missing precondition references won't throw an unhandled exception anymore
- [x] New preconditions have default operand "="