### PR TITLE
Output config displays all device configs

### DIFF
--- a/UI/Dialogs/ConfigWizard.resx
+++ b/UI/Dialogs/ConfigWizard.resx
@@ -154,7 +154,7 @@
     <value>Fill</value>
   </data>
   <data name="referencesGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 938</value>
+    <value>6, 932</value>
   </data>
   <data name="referencesGroupBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>604, 0</value>
@@ -184,13 +184,13 @@
     <value>Top</value>
   </data>
   <data name="xplaneDataRefPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 706</value>
+    <value>6, 703</value>
   </data>
   <data name="xplaneDataRefPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
   </data>
   <data name="xplaneDataRefPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 232</value>
+    <value>604, 229</value>
   </data>
   <data name="xplaneDataRefPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -214,7 +214,7 @@
     <value>Top</value>
   </data>
   <data name="variablePanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 568</value>
+    <value>6, 565</value>
   </data>
   <data name="variablePanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>4, 5, 4, 5</value>
@@ -250,7 +250,7 @@
     <value>4, 5, 4, 5</value>
   </data>
   <data name="simConnectPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 277</value>
+    <value>604, 274</value>
   </data>
   <data name="simConnectPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -266,366 +266,6 @@
   </data>
   <data name="&gt;&gt;simConnectPanel1.ZOrder" xml:space="preserve">
     <value>3</value>
-  </data>
-  <data name="&gt;&gt;fsuipcConfigPanel.Name" xml:space="preserve">
-    <value>fsuipcConfigPanel</value>
-  </data>
-  <data name="&gt;&gt;fsuipcConfigPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.FsuipcConfigPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;fsuipcConfigPanel.Parent" xml:space="preserve">
-    <value>FsuipcSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;fsuipcConfigPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;fsuipcHintLabel.Name" xml:space="preserve">
-    <value>fsuipcHintLabel</value>
-  </data>
-  <data name="&gt;&gt;fsuipcHintLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fsuipcHintLabel.Parent" xml:space="preserve">
-    <value>FsuipcSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;fsuipcHintLabel.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="FsuipcSettingsPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="FsuipcSettingsPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 39</value>
-  </data>
-  <data name="FsuipcSettingsPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 252</value>
-  </data>
-  <data name="FsuipcSettingsPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>17</value>
-  </data>
-  <data name="&gt;&gt;FsuipcSettingsPanel.Name" xml:space="preserve">
-    <value>FsuipcSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;FsuipcSettingsPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;FsuipcSettingsPanel.Parent" xml:space="preserve">
-    <value>fsuipcTabPage</value>
-  </data>
-  <data name="&gt;&gt;FsuipcSettingsPanel.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
-  </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeVariableRadioButton.Name" xml:space="preserve">
-    <value>OffsetTypeVariableRadioButton</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeVariableRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeVariableRadioButton.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeVariableRadioButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Name" xml:space="preserve">
-    <value>OffsetTypeSimConnectRadioButton</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Name" xml:space="preserve">
-    <value>OffsetTypeFsuipRadioButton</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Name" xml:space="preserve">
-    <value>OffsetTypeXplaneRadioButton</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="OffsetTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="OffsetTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
-  </data>
-  <data name="OffsetTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 33</value>
-  </data>
-  <data name="OffsetTypePanel.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypePanel.Name" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypePanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypePanel.Parent" xml:space="preserve">
-    <value>fsuipcTabPage</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypePanel.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="fsuipcTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="fsuipcTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="fsuipcTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>616, 657</value>
-  </data>
-  <data name="fsuipcTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="fsuipcTabPage.Text" xml:space="preserve">
-    <value>Sim Variable</value>
-  </data>
-  <data name="&gt;&gt;fsuipcTabPage.Name" xml:space="preserve">
-    <value>fsuipcTabPage</value>
-  </data>
-  <data name="&gt;&gt;fsuipcTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fsuipcTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;fsuipcTabPage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;compareSpacerPanel.Name" xml:space="preserve">
-    <value>compareSpacerPanel</value>
-  </data>
-  <data name="&gt;&gt;compareSpacerPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;compareSpacerPanel.Parent" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;compareSpacerPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;interpolationGroupBox.Name" xml:space="preserve">
-    <value>interpolationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;interpolationGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;interpolationGroupBox.Parent" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;interpolationGroupBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Name" xml:space="preserve">
-    <value>comparisonSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Parent" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;comparisonHintTtextBox.Name" xml:space="preserve">
-    <value>comparisonHintTtextBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonHintTtextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonHintTtextBox.Parent" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;comparisonHintTtextBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="compareTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="compareTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="compareTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>616, 657</value>
-  </data>
-  <data name="compareTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="compareTabPage.Text" xml:space="preserve">
-    <value>Compare</value>
-  </data>
-  <data name="&gt;&gt;compareTabPage.Name" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;compareTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;compareTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;compareTabPage.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;displayPanel1.Name" xml:space="preserve">
-    <value>displayPanel1</value>
-  </data>
-  <data name="&gt;&gt;displayPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.OutputWizard.DisplayPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;displayPanel1.Parent" xml:space="preserve">
-    <value>displayTabPage</value>
-  </data>
-  <data name="&gt;&gt;displayPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="displayTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="displayTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="displayTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>616, 657</value>
-  </data>
-  <data name="displayTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="displayTabPage.Text" xml:space="preserve">
-    <value>Display</value>
-  </data>
-  <data name="&gt;&gt;displayTabPage.Name" xml:space="preserve">
-    <value>displayTabPage</value>
-  </data>
-  <data name="&gt;&gt;displayTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;displayTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;displayTabPage.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;preconditionPanel.Name" xml:space="preserve">
-    <value>preconditionPanel</value>
-  </data>
-  <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
-    <value>preconditionTabPage</value>
-  </data>
-  <data name="&gt;&gt;preconditionPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
-  </data>
-  <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>616, 657</value>
-  </data>
-  <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="preconditionTabPage.Text" xml:space="preserve">
-    <value>Precondition</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Name" xml:space="preserve">
-    <value>preconditionTabPage</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="tabControlFsuipc.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="tabControlFsuipc.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="tabControlFsuipc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>624, 683</value>
-  </data>
-  <data name="tabControlFsuipc.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
-  </data>
-  <data name="&gt;&gt;tabControlFsuipc.Name" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;tabControlFsuipc.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;tabControlFsuipc.Parent" xml:space="preserve">
-    <value>MainPanel</value>
-  </data>
-  <data name="&gt;&gt;tabControlFsuipc.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="MainPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="MainPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="MainPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>624, 683</value>
-  </data>
-  <data name="MainPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;MainPanel.Name" xml:space="preserve">
-    <value>MainPanel</value>
-  </data>
-  <data name="&gt;&gt;MainPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;MainPanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;MainPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
   </data>
   <data name="fsuipcConfigPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
@@ -686,6 +326,30 @@
   </data>
   <data name="&gt;&gt;fsuipcHintLabel.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="FsuipcSettingsPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="FsuipcSettingsPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 39</value>
+  </data>
+  <data name="FsuipcSettingsPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 252</value>
+  </data>
+  <data name="FsuipcSettingsPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="&gt;&gt;FsuipcSettingsPanel.Name" xml:space="preserve">
+    <value>FsuipcSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;FsuipcSettingsPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;FsuipcSettingsPanel.Parent" xml:space="preserve">
+    <value>fsuipcTabPage</value>
+  </data>
+  <data name="&gt;&gt;FsuipcSettingsPanel.ZOrder" xml:space="preserve">
+    <value>4</value>
   </data>
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 5</value>
@@ -837,6 +501,57 @@
   <data name="&gt;&gt;OffsetTypeXplaneRadioButton.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
+  <data name="OffsetTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="OffsetTypePanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 6</value>
+  </data>
+  <data name="OffsetTypePanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 33</value>
+  </data>
+  <data name="OffsetTypePanel.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypePanel.Name" xml:space="preserve">
+    <value>OffsetTypePanel</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypePanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypePanel.Parent" xml:space="preserve">
+    <value>fsuipcTabPage</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypePanel.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="fsuipcTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="fsuipcTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="fsuipcTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>616, 657</value>
+  </data>
+  <data name="fsuipcTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="fsuipcTabPage.Text" xml:space="preserve">
+    <value>Sim Variable</value>
+  </data>
+  <data name="&gt;&gt;fsuipcTabPage.Name" xml:space="preserve">
+    <value>fsuipcTabPage</value>
+  </data>
+  <data name="&gt;&gt;fsuipcTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fsuipcTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;fsuipcTabPage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="compareSpacerPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -860,57 +575,6 @@
   </data>
   <data name="&gt;&gt;compareSpacerPanel.ZOrder" xml:space="preserve">
     <value>0</value>
-  </data>
-  <data name="&gt;&gt;interpolationPanel1.Name" xml:space="preserve">
-    <value>interpolationPanel1</value>
-  </data>
-  <data name="&gt;&gt;interpolationPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.InterpolationPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;interpolationPanel1.Parent" xml:space="preserve">
-    <value>interpolationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;interpolationPanel1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;interpolationCheckBox.Name" xml:space="preserve">
-    <value>interpolationCheckBox</value>
-  </data>
-  <data name="&gt;&gt;interpolationCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;interpolationCheckBox.Parent" xml:space="preserve">
-    <value>interpolationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;interpolationCheckBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="interpolationGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="interpolationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 202</value>
-  </data>
-  <data name="interpolationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 172</value>
-  </data>
-  <data name="interpolationGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="interpolationGroupBox.Text" xml:space="preserve">
-    <value>Interpolation Settings</value>
-  </data>
-  <data name="&gt;&gt;interpolationGroupBox.Name" xml:space="preserve">
-    <value>interpolationGroupBox</value>
-  </data>
-  <data name="&gt;&gt;interpolationGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;interpolationGroupBox.Parent" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;interpolationGroupBox.ZOrder" xml:space="preserve">
-    <value>1</value>
   </data>
   <data name="interpolationPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -975,167 +639,32 @@
   <data name="&gt;&gt;interpolationCheckBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Name" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Parent" xml:space="preserve">
-    <value>comparisonSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;comparisonActiveCheckBox.Name" xml:space="preserve">
-    <value>comparisonActiveCheckBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonActiveCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonActiveCheckBox.Parent" xml:space="preserve">
-    <value>comparisonSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonActiveCheckBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="interpolationGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="comparisonSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 64</value>
+  <data name="interpolationGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 202</value>
   </data>
-  <data name="comparisonSettingsGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+  <data name="interpolationGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 172</value>
   </data>
-  <data name="comparisonSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>604, 138</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="comparisonSettingsGroupBox.Text" xml:space="preserve">
-    <value>Comparison Settings</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Name" xml:space="preserve">
-    <value>comparisonSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.Parent" xml:space="preserve">
-    <value>compareTabPage</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsGroupBox.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;comparisonValueTextBox.Name" xml:space="preserve">
-    <value>comparisonValueTextBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonValueTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonValueTextBox.Parent" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;comparisonValueTextBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;comparisonElseValueTextBox.Name" xml:space="preserve">
-    <value>comparisonElseValueTextBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonElseValueTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonElseValueTextBox.Parent" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;comparisonElseValueTextBox.ZOrder" xml:space="preserve">
+  <data name="interpolationGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
   </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
+  <data name="interpolationGroupBox.Text" xml:space="preserve">
+    <value>Interpolation Settings</value>
   </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;interpolationGroupBox.Name" xml:space="preserve">
+    <value>interpolationGroupBox</value>
   </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
+  <data name="&gt;&gt;interpolationGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="&gt;&gt;interpolationGroupBox.Parent" xml:space="preserve">
+    <value>compareTabPage</value>
   </data>
-  <data name="&gt;&gt;comparisonIfValueTextBox.Name" xml:space="preserve">
-    <value>comparisonIfValueTextBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonIfValueTextBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TextBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonIfValueTextBox.Parent" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;comparisonIfValueTextBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label7.Name" xml:space="preserve">
-    <value>label7</value>
-  </data>
-  <data name="&gt;&gt;label7.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label7.Parent" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;comparisonOperandComboBox.Name" xml:space="preserve">
-    <value>comparisonOperandComboBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonOperandComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonOperandComboBox.Parent" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;comparisonOperandComboBox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="&gt;&gt;label6.Name" xml:space="preserve">
-    <value>label6</value>
-  </data>
-  <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>6</value>
-  </data>
-  <data name="comparisonSettingsPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="comparisonSettingsPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 36</value>
-  </data>
-  <data name="comparisonSettingsPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>592, 96</value>
-  </data>
-  <data name="comparisonSettingsPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Name" xml:space="preserve">
-    <value>comparisonSettingsPanel</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.Parent" xml:space="preserve">
-    <value>comparisonSettingsGroupBox</value>
-  </data>
-  <data name="&gt;&gt;comparisonSettingsPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
+  <data name="&gt;&gt;interpolationGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="comparisonValueTextBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>171, 10</value>
@@ -1332,6 +861,30 @@
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
     <value>6</value>
   </data>
+  <data name="comparisonSettingsPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="comparisonSettingsPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 36</value>
+  </data>
+  <data name="comparisonSettingsPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>592, 96</value>
+  </data>
+  <data name="comparisonSettingsPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.Name" xml:space="preserve">
+    <value>comparisonSettingsPanel</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.Parent" xml:space="preserve">
+    <value>comparisonSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="comparisonActiveCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -1364,6 +917,36 @@
   </data>
   <data name="&gt;&gt;comparisonActiveCheckBox.ZOrder" xml:space="preserve">
     <value>1</value>
+  </data>
+  <data name="comparisonSettingsGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="comparisonSettingsGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 64</value>
+  </data>
+  <data name="comparisonSettingsGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="comparisonSettingsGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>604, 138</value>
+  </data>
+  <data name="comparisonSettingsGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="comparisonSettingsGroupBox.Text" xml:space="preserve">
+    <value>Comparison Settings</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Name" xml:space="preserve">
+    <value>comparisonSettingsGroupBox</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.Parent" xml:space="preserve">
+    <value>compareTabPage</value>
+  </data>
+  <data name="&gt;&gt;comparisonSettingsGroupBox.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="comparisonHintTtextBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -1399,6 +982,33 @@
   <data name="&gt;&gt;comparisonHintTtextBox.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="compareTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="compareTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="compareTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>616, 657</value>
+  </data>
+  <data name="compareTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="compareTabPage.Text" xml:space="preserve">
+    <value>Compare</value>
+  </data>
+  <data name="&gt;&gt;compareTabPage.Name" xml:space="preserve">
+    <value>compareTabPage</value>
+  </data>
+  <data name="&gt;&gt;compareTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;compareTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;compareTabPage.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="displayPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
@@ -1425,6 +1035,33 @@
   </data>
   <data name="&gt;&gt;displayPanel1.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="displayTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="displayTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
+  </data>
+  <data name="displayTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>616, 657</value>
+  </data>
+  <data name="displayTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="displayTabPage.Text" xml:space="preserve">
+    <value>Display</value>
+  </data>
+  <data name="&gt;&gt;displayTabPage.Name" xml:space="preserve">
+    <value>displayTabPage</value>
+  </data>
+  <data name="&gt;&gt;displayTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;displayTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;displayTabPage.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="preconditionPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -1453,53 +1090,80 @@
   <data name="&gt;&gt;preconditionPanel.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;button1.Name" xml:space="preserve">
-    <value>button1</value>
+  <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
   </data>
-  <data name="&gt;&gt;button1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 6, 6, 6</value>
   </data>
-  <data name="&gt;&gt;button1.Parent" xml:space="preserve">
-    <value>ButtonPanel</value>
+  <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>616, 657</value>
   </data>
-  <data name="&gt;&gt;button1.ZOrder" xml:space="preserve">
+  <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="preconditionTabPage.Text" xml:space="preserve">
+    <value>Precondition</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Name" xml:space="preserve">
+    <value>preconditionTabPage</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="tabControlFsuipc.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="tabControlFsuipc.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="tabControlFsuipc.Size" type="System.Drawing.Size, System.Drawing">
+    <value>624, 683</value>
+  </data>
+  <data name="tabControlFsuipc.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;tabControlFsuipc.Name" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;tabControlFsuipc.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;tabControlFsuipc.Parent" xml:space="preserve">
+    <value>MainPanel</value>
+  </data>
+  <data name="&gt;&gt;tabControlFsuipc.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;cancelButton.Name" xml:space="preserve">
-    <value>cancelButton</value>
+  <data name="MainPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="&gt;&gt;cancelButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="MainPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
   </data>
-  <data name="&gt;&gt;cancelButton.Parent" xml:space="preserve">
-    <value>ButtonPanel</value>
+  <data name="MainPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>624, 683</value>
   </data>
-  <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="MainPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
-  <data name="ButtonPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Bottom</value>
+  <data name="&gt;&gt;MainPanel.Name" xml:space="preserve">
+    <value>MainPanel</value>
   </data>
-  <data name="ButtonPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 683</value>
-  </data>
-  <data name="ButtonPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>624, 28</value>
-  </data>
-  <data name="ButtonPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;ButtonPanel.Name" xml:space="preserve">
-    <value>ButtonPanel</value>
-  </data>
-  <data name="&gt;&gt;ButtonPanel.Type" xml:space="preserve">
+  <data name="&gt;&gt;MainPanel.Type" xml:space="preserve">
     <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;ButtonPanel.Parent" xml:space="preserve">
+  <data name="&gt;&gt;MainPanel.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;ButtonPanel.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="&gt;&gt;MainPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="button1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Right</value>
@@ -1559,6 +1223,30 @@
     <value>ButtonPanel</value>
   </data>
   <data name="&gt;&gt;cancelButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="ButtonPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Bottom</value>
+  </data>
+  <data name="ButtonPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 683</value>
+  </data>
+  <data name="ButtonPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>624, 28</value>
+  </data>
+  <data name="ButtonPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;ButtonPanel.Name" xml:space="preserve">
+    <value>ButtonPanel</value>
+  </data>
+  <data name="&gt;&gt;ButtonPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;ButtonPanel.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;ButtonPanel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <metadata name="presetsDataSet.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -5,13 +5,8 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Windows.Forms.DataVisualization.Charting;
-using static MobiFlight.UI.Panels.Settings.Device.MFStepperPanel;
 
 namespace MobiFlight.UI.Panels.OutputWizard
 {
@@ -22,7 +17,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
         public event EventHandler<EventArgs> DisplayPanelValidatingError;
 
 #if ARCAZE
-        Dictionary<String, String> arcazeFirmware = new Dictionary<String, String>();
+        Dictionary<String, string> arcazeFirmware = new Dictionary<String, String>();
         Dictionary<string, ArcazeModuleSettings> moduleSettings;
 #endif
 
@@ -75,7 +70,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
             displayModuleNameComboBox.Items.Add(new ListItem() { Value = "-", Label = "" });
             displayModuleNameComboBox.Items.AddRange(ModuleList.ToArray());
 
-            // Pre selct the first module if there is only one in the list.
+            // Pre select the first module if there is only one in the list.
             if (displayModuleNameComboBox.Items.Count == 2)
                 displayModuleNameComboBox.SelectedIndex = 1;
             else
@@ -135,7 +130,6 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
                 if (config.DisplayType != null && !ComboBoxHelper.SetSelectedItemByValue(displayTypeComboBox, config.DisplayType))
                 {
-                    // TODO: provide error message
                     Log.Instance.log($"Trying to show config but display type {config.DisplayType} not present.", LogSeverity.Error);
                 }
 
@@ -169,11 +163,11 @@ namespace MobiFlight.UI.Panels.OutputWizard
             }
             else
             {
-                AnalogInputConfig analogInputConfig = new AnalogInputConfig();
+                var analogInputConfig = new AnalogInputConfig();
                 analogInputConfig.onChange = config.AnalogInputConfig?.onChange;
                 analogPanel1.syncFromConfig(analogInputConfig);
 
-                ButtonInputConfig buttonInputConfig = new ButtonInputConfig();
+                var buttonInputConfig = new ButtonInputConfig();
                 buttonInputConfig.onPress = config.ButtonInputConfig?.onPress;
                 buttonInputConfig.onRelease = config.ButtonInputConfig?.onRelease;
                 buttonPanel1.syncFromConfig(buttonInputConfig);
@@ -203,11 +197,11 @@ namespace MobiFlight.UI.Panels.OutputWizard
             if (OutputTypeIsDisplay()) 
             {
                 if (displayTypeComboBox.SelectedItem == null) return;
+                if ((displayTypeComboBox.SelectedItem as ListItem).Value == "-") return;
 
                 config.DisplayType = (displayTypeComboBox.SelectedItem as ListItem).Value;
                 config.DisplayTrigger = "normal";
                 config.DisplaySerial = displayModuleNameComboBox.SelectedItem.ToString();
-
 
                 switch (config.DisplayType)
                 {
@@ -264,6 +258,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
             // check which extension type is available to current serial
             ComboBox cb = (sender as ComboBox);
             List<ListItem> deviceTypeOptions = new List<ListItem>();
+
             displayTypeComboBox.DataSource = null;
             displayTypeComboBox.Items.Clear();
 
@@ -274,12 +269,23 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             displayTypeComboBox.Enabled = groupBoxDisplaySettings.Enabled = testSettingsGroupBox.Enabled = (serial != "");
 
-
             try
             {
+
+                // serial is empty if no module is selected (e.g. on init of form)
+                // but we add all available devices to be able to display the 
+                // config even if the module is not currently connected
+                // e.g., when a user shares a config with somebody else.
+                if (serial == "")
+                {
+                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightOutput.TYPE, Label = "LED / Output" });
+                    deviceTypeOptions.Add(new ListItem() { Value = ArcazeLedDigit.TYPE, Label = ArcazeLedDigit.TYPE });
+                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightServo.TYPE, Label = MobiFlightServo.TYPE });
+                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightStepper.TYPE, Label = MobiFlightStepper.TYPE });
+                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightLcdDisplay.TYPE, Label = MobiFlightLcdDisplay.TYPE });
+                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightShiftRegister.TYPE, Label = MobiFlightShiftRegister.TYPE });
+                }
                 
-                // serial is empty if no module is selected (on init of form)
-                //if (serial == "") return;                
                 if (serial.IndexOf(Joystick.SerialPrefix) == 0)
                 {
                     deviceTypeOptions.Add(new ListItem() { Value = MobiFlightOutput.TYPE, Label = "LED / Output" });
@@ -349,6 +355,8 @@ namespace MobiFlight.UI.Panels.OutputWizard
                     }
                 }
 
+                deviceTypeOptions.Insert(0, new ListItem() { Value = "-", Label = "-" });
+
                 displayTypeComboBox.DataSource = deviceTypeOptions;
                 displayTypeComboBox.ValueMember = "Value";
                 displayTypeComboBox.DisplayMember = "Label";
@@ -382,6 +390,9 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             try
             {
+                /*if (((sender as ComboBox).SelectedItem as ListItem) == null) return;
+                if (((sender as ComboBox).SelectedItem as ListItem).Value == "-") { return;  }*/
+
                 bool panelEnabled = true;
                 ComboBox cb = displayModuleNameComboBox;
                 String serial = SerialNumber.ExtractSerial(cb.SelectedItem.ToString());
@@ -438,6 +449,8 @@ namespace MobiFlight.UI.Panels.OutputWizard
             var SelectedItemValue = ((sender as ComboBox).SelectedItem as ListItem)?.Value;
             if (SelectedItemValue == null) return;
 
+            testSettingsGroupBox.Visible = true;
+
             if (SelectedItemValue == "Pin" ||
                 SelectedItemValue == MobiFlightOutput.TYPE)
             {
@@ -480,6 +493,11 @@ namespace MobiFlight.UI.Panels.OutputWizard
             {
                 displayShiftRegisterPanel.Enabled = panelEnabled;
                 displayShiftRegisterPanel.Height = displayPanelHeight;
+            } else
+            {
+                displayNothingSelectedPanel.Enabled = true;
+                displayNothingSelectedPanel.Height = displayPanelHeight;
+                testSettingsGroupBox.Visible = false;
             }
         }
 
@@ -827,8 +845,6 @@ namespace MobiFlight.UI.Panels.OutputWizard
         private void OutputTypeComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             DisplayTypePanel.Visible = OutputTypeIsDisplay();
-            groupBoxDisplaySettings.Visible = OutputTypeIsDisplay();
-            testSettingsGroupBox.Visible = OutputTypeIsDisplay();
 
             InputActionTypePanel.Visible = OutputTypeIsInputAction();
             inputActionGroupBox.Visible = OutputTypeIsInputAction();


### PR DESCRIPTION
This change has the following improvements:

- [x] The device type drop down includes a "-" to not automatically select a display on module change
- [x] The board drop down is still auto-selected to the first board, when only one board is connected
- [x] The device config is displayed also in the case that the original board is not connected
- [x] If a connected board has the same device type as the config, then the config will be assigned 
- [x] If you create a config without selecting a output device, nothing will be preselected or saved to the config (no board, no device type, etc)
- [x] If a config doesn't have an output device the output list shows "-" in all three columns

fixes #1072 
