### PR TITLE
Update check happens first thing after startup

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -120,6 +120,11 @@ namespace MobiFlight.UI
 
         private void MainForm_Shown(object sender, EventArgs e)
         {
+            // Check for updates before loading anything else
+#if (!DEBUG)
+            AutoUpdateChecker.CheckForUpdate(false, true);
+#endif
+
             if (Properties.Settings.Default.Started == 0)
             {
                 OnFirstStart();
@@ -131,6 +136,7 @@ namespace MobiFlight.UI
             }
 
             Properties.Settings.Default.Started = Properties.Settings.Default.Started + 1;
+
 
             // this is everything that used to be directly in the constructor
             inputsTabControl.DrawItem += new DrawItemEventHandler(tabControl1_DrawItem);
@@ -317,9 +323,6 @@ namespace MobiFlight.UI
             runToolStripButton.Enabled = RunIsAvailable();
             runTestToolStripButton.Enabled = TestRunIsAvailable();
 
-#if (!DEBUG)
-            AutoUpdateChecker.CheckForUpdate(false, true);
-#endif
             CheckForWasmModuleUpdate();
 
             // Track config loaded event


### PR DESCRIPTION
Moved the update check to when the app is shown instead of after the modules have been loaded. This will allow us to fix bugs introduced easier with a new update.

There a few other locations we could check this for, personally I think this is the most straight forward place to do it.

fixes #1081