### PR TITLE
Only check removable drives as candidate boards

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -82,15 +82,11 @@ namespace MobiFlight
         {
             var result = new List<MobiFlightModuleInfo>();
 
-            foreach (var drive in DriveInfo.GetDrives())
+            // Issue 1074: Failing to check for IsReady caused an IOException on certain machines
+            // when trying to read the volume label when the drive wasn't actually ready.
+            // Issue 1089: Network drives take *forever* to return the drive info slowing down startup. Only check removable drives.
+            foreach (var drive in DriveInfo.GetDrives().Where(d => (d.DriveType == DriveType.Removable && d.IsReady)))
             {
-                // Issue 1074: Failing to check for IsReady caused an IOException on certain machines
-                // when trying to read the volume label when the drive wasn't actually ready.
-                if (!drive.IsReady)
-                {
-                    continue;
-                }
-
                 Board candidateBoard;
                 try 
                 { 

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -89,7 +89,7 @@ namespace MobiFlight
             {
                 Board candidateBoard;
                 try 
-                { 
+                {
                     candidateBoard = BoardDefinitions.GetBoardByUsbVolumeLabel(drive.VolumeLabel);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Fixes #1089 

Added a filter to only check removable drives as candidates for flashing. This skips network drives which were reported to cause long delays when launching MobiFlight. Also refactored the IsReady check into the same Where clause.

I tested without this change and I didn't see any performance impact when I had a network drive mapped so I can't 100% confirm this fixes 1089. I did run with this change and some extra temporary logging added and confirmed the only drive checked by the code was my connected Pico in BOOTSEL mode. All network drives and physical disks were ignored.