### PR TITLE
Solution for Input action panel problems reported for 9.6.0.5

### DIFF
--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -472,8 +472,12 @@ namespace MobiFlight.UI.Dialogs
             {
                 // We have a joystick 
                 // which right now is only buttons
-                if (inputTypeComboBox.SelectedItem.ToString().Contains(Joystick.AxisPrefix))
+                if (inputTypeComboBox.SelectedItem.ToString().Contains(Joystick.ButtonPrefix))
+                    currentInputType = DeviceType.Button;
+                else if (inputTypeComboBox.SelectedItem.ToString().Contains(Joystick.AxisPrefix))
                     currentInputType = DeviceType.AnalogInput;
+                else if (inputTypeComboBox.SelectedItem.ToString().Contains(Joystick.PovPrefix))
+                    currentInputType = DeviceType.Button;
             }
 
             return currentInputType;

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -846,6 +846,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
         private void OutputTypeComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
             DisplayTypePanel.Visible = OutputTypeIsDisplay();
+            groupBoxDisplaySettings.Visible = OutputTypeIsDisplay();
 
             InputActionTypePanel.Visible = OutputTypeIsInputAction();
             inputActionGroupBox.Visible = OutputTypeIsInputAction();


### PR DESCRIPTION
Fixes #1095

- [x] Joystick button action panel visible again input configs
- [x] InputAction in Output config hides output display groupbox depending on the type (output vs inputaction)