### PR TITLE
Provide correct error label when xplane connection is missing

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -464,7 +464,7 @@ namespace MobiFlight
                 // If not connected to X-Plane show an error message
                 if (cfg.SourceType == SourceType.XPLANE && !xplaneCache.IsConnected())
                 {
-                    row.ErrorText = i18n._tr("uiMessageNoSimConnectConnection");
+                    row.ErrorText = i18n._tr("uiMessageNoXplaneConnection");
                 }
                 // In any other case remove the error message
                 else

--- a/ProjectMessages/ProjectMessages.Designer.cs
+++ b/ProjectMessages/ProjectMessages.Designer.cs
@@ -975,6 +975,15 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No active X-Plane connection.
+        /// </summary>
+        internal static string uiMessageNoXplaneConnection {
+            get {
+                return ResourceManager.GetString("uiMessageNoXplaneConnection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value must be a number and greater than 0..
         /// </summary>
         internal static string uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0 {

--- a/ProjectMessages/ProjectMessages.de.resx
+++ b/ProjectMessages/ProjectMessages.de.resx
@@ -574,4 +574,8 @@ Please manually flash the boards using "upload firmware" and select the correct 
   <data name="uiMessageResetHint" xml:space="preserve">
     <value>Board zurücksetzen</value>
   </data>
+  <data name="uiMessageNoXplaneConnection" xml:space="preserve">
+    <value>Keine aktive X-Plane Verbindung</value>
+    <comment>No active X-Plane connection</comment>
+  </data>
 </root>

--- a/ProjectMessages/ProjectMessages.resx
+++ b/ProjectMessages/ProjectMessages.resx
@@ -571,4 +571,7 @@ Check log for more details.</value>
   <data name="uiMessageResetHint" xml:space="preserve">
     <value>Reset Board</value>
   </data>
+  <data name="uiMessageNoXplaneConnection" xml:space="preserve">
+    <value>No active X-Plane connection</value>
+  </data>
 </root>

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -1,14 +1,9 @@
-﻿using System;
+﻿using MobiFlight.UI.Dialogs;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Data;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
-using MobiFlight.UI.Dialogs;
-using MobiFlight.Base;
 
 namespace MobiFlight.UI.Panels
 {


### PR DESCRIPTION
fixes #1088 

- [x] Added specific error message
- [x] i18n - EN and DE are covered