### PR TITLE
Add installer for MobiFlight Connector

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,6 +60,12 @@ jobs:
       run: (Get-FileHash Release/MobiFlightConnector-${{ github.event.release.tag_name }}.zip -Algorithm SHA1).Hash | Out-File Release/MobiFlightConnector-${{ github.event.release.tag_name }}.sha1 
       shell: pwsh
       
+    - name: Create setup exe
+      uses: joncloud/makensis-action@v4
+      with:
+        script-file: ./Build/setup.nsi
+        arguments: "/V3" 
+      
     - name: Release
       uses: softprops/action-gh-release@v1
       env:
@@ -68,3 +74,4 @@ jobs:
         files: |
           Release/*.zip
           Release/*.sha1
+          Build/MobiFlight-Setup.exe

--- a/.gitignore
+++ b/.gitignore
@@ -480,3 +480,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 .idea/
 *.sln.iml
+/Build/mobiflight-setup.exe

--- a/Build/setup.nsi
+++ b/Build/setup.nsi
@@ -1,35 +1,108 @@
 # define name of installer
-OutFile "mobiflight-setup.exe"
+!define APPNAME "MobiFlight Connector"
+OutFile "MobiFlight-Setup.exe"
+
+!include LogicLib.nsh
+!include MUI2.nsh
  
 # define installation directory
-InstallDir $DESKTOP
+InstallDir "$LOCALAPPDATA\MobiFlight\${APPNAME}"
  
 # For removing Start Menu shortcut in Windows 7
-RequestExecutionLevel user
+RequestExecutionLevel admin
+Unicode True
+
+; The icon in the top right corner of the installer windows and the desktop icon.
+!define MUI_ICON "..\mobiflight.ico"
+; The icon for the installer in the directory, not in Add or Remove Programs.
+!define MUI_UNICON "..\mobiflight.ico"
+!define MUI_ABORTWARNING
+; !insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_INSTFILES
+
+!define MUI_FINISHPAGE_RUN "$INSTDIR\MFConnector.exe"
+!define MUI_FINISHPAGE_SHOWREADME
+!define MUI_FINISHPAGE_SHOWREADME_NOTCHECKED
+!define MUI_FINISHPAGE_SHOWREADME_TEXT "Create Desktop Shortcut"
+!define MUI_FINISHPAGE_SHOWREADME_FUNCTION CreateDesktopOnFinish
+
+!insertmacro MUI_PAGE_FINISH
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "English"
+
+Name "${APPNAME}"
+Icon "..\mobiflight.ico"
+UninstallIcon "..\mobiflight.ico"
+
+Function CreateDesktopOnFinish
+CreateShortcut "$DESKTOP\${APPNAME}.lnk" "$INSTDIR\MFConnector.exe"
+FunctionEnd
  
+
+Function .onInit
+    System::Call 'kernel32::OpenMutex(i 0x100000, i 0, t "{57699317-1D72-4B54-82BC-CF6B38254550}")p.R0'
+    IntPtrCmp $R0 0 notRunning
+        System::Call 'kernel32::CloseHandle(p $R0)'
+        MessageBox MB_OK|MB_ICONEXCLAMATION "${APPNAME} is running. Please close it first" /SD IDOK
+        Abort
+    notRunning:
+FunctionEnd
+
 # start default section
-Section
- 
+Section "install"
+    SetRegView 64
     # set the installation directory as the destination for the following actions
     SetOutPath $INSTDIR
+
+    # Add the MobiFlight installer
+    File "..\Release\MobiFlight-Installer.exe"
+    File "..\mobiflight.ico"
  
     # create the uninstaller
     WriteUninstaller "$INSTDIR\uninstall.exe"
+
+    ExecWait '"$INSTDIR\MobiFlight-Installer.exe" /installOnly'
  
     # create a shortcut named "new shortcut" in the start menu programs directory
     # point the new shortcut at the program uninstaller
-    CreateShortcut "$SMPROGRAMS\new shortcut.lnk" "$INSTDIR\uninstall.exe"
+    CreateShortcut "$SMPROGRAMS\${APPNAME}.lnk" "$INSTDIR\MFConnector.exe"
+
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayName" "${APPNAME}"
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "DisplayIcon" "$instdir\mobiflight.ico"
+    WriteRegStr HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
+    WriteRegDWORD HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "NoModify" 1
+	WriteRegDWORD HKLM "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "NoRepair" 1
 SectionEnd
- 
+
+Function un.onInit
+    System::Call 'kernel32::OpenMutex(i 0x100000, i 0, t "{57699317-1D72-4B54-82BC-CF6B38254550}")p.R0'
+    IntPtrCmp $R0 0 notRunning
+        System::Call 'kernel32::CloseHandle(p $R0)'
+        MessageBox MB_OK|MB_ICONEXCLAMATION "${APPNAME} is running. Please close it first" /SD IDOK
+        Abort
+    notRunning:
+FunctionEnd
 # uninstaller section start
 Section "uninstall"
- 
+    SetRegView 64
+    
     # Remove the link from the start menu
-    Delete "$SMPROGRAMS\new shortcut.lnk"
+    Delete "$SMPROGRAMS\${APPNAME}.lnk"
+
+    Delete "$DESKTOP\${APPNAME}.lnk"
  
-    # Delete the uninstaller
-    Delete $INSTDIR\uninstaller.exe
+    # Delete the uninstall
+    Delete $INSTDIR\uninstall.exe
  
-    RMDir $INSTDIR
+    # Delete all files from the installation folder
+    RMDir /r $INSTDIR
+
+    # Delete all setting files
+    RMDir /r $LOCALAPPDATA\MobiFlight
+
+    DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
 # uninstaller section end
 SectionEnd

--- a/MobiFlight-Installer/MobiFlight-Installer/Program.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/Program.cs
@@ -33,6 +33,7 @@ namespace MobiFlightInstaller
                 Log.Instance.log("Installer start", LogSeverity.Debug);
 
                 CmdLineParams cmdParams = new CmdLineParams(Environment.GetCommandLineArgs());
+                MobiFlightUpdaterModel.InstallOnly = cmdParams.InstallOnly;
 
                 var updateUrl = MobiFlightUpdaterModel.MobiFlightUpdateUrl;
                 if (cmdParams.CacheId != null)

--- a/MobiFlight-Installer/MobiFlight-Installer/model/CmdLineParams.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/model/CmdLineParams.cs
@@ -15,6 +15,7 @@ namespace MobiFlightInstaller
         string install = null;
         string configFile = null;
         string cacheId = "";
+        bool installOnly = false;
 
         public string Install
         {
@@ -35,6 +36,11 @@ namespace MobiFlightInstaller
             get { return expert; }
         }
 
+        public bool InstallOnly
+        {
+            get { return installOnly; }
+        }
+
 
         public string ConfigFile
         {
@@ -52,6 +58,7 @@ namespace MobiFlightInstaller
             check = _hasCfgParam("check", args);
             checkBeta = _hasCfgParam("beta", args);
             expert = _hasCfgParam("expert", args);
+            installOnly = _hasCfgParam("installOnly", args);
 
             configFile = _getCfgParamValue("cfg", args, null);
             cacheId = _getCfgParamValue("cacheId", args, null);

--- a/MobiFlight-Installer/MobiFlight-Installer/model/MobiFlightUpdaterModel.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/model/MobiFlightUpdaterModel.cs
@@ -27,6 +27,7 @@ namespace MobiFlightInstaller
         public static string InstallerUpdateUrl = ""; // URL to check for installer upgrade, Set to empty to avoid installer autoUpgrade
         public static string InstallerActualVersion = "0.0.0";
         public static int RequestTimeoutInMilliseconds = 5000;
+        public static bool InstallOnly = false;
         
         public static string CacheId = null;
 
@@ -241,7 +242,8 @@ namespace MobiFlightInstaller
             if (!File.Exists(ProcessEXEName))
                 return;
 
-            Process.Start(ProcessEXEName, Args);
+            if (!InstallOnly)
+                Process.Start(ProcessEXEName, Args);
 
             Environment.Exit(0);
         }


### PR DESCRIPTION
fixes #953 

- [x] MobiFlight Connector provides a setup installer
- [x] MobiFlight Connector installs to LocalApps
- [x] Installer creates a Desktop Shortcut
- [x] Installer creates a Program Files Menu entry
- [x] Installer provides uninstall option
- [x] Installer will install Mobiflight only one time in one directory
- [x] Installer is a standard open source project that we can re-use to save time
- [x] Installer doesn't trigger AV alerts - at least not on the major ones.
- [x] Installer is included in the build process and automatically creates a setup package for releases

**Additional context**
relates to the following issues:
fixes #912
fixes #1102 