### PR TITLE
Use TryParse() instead of Parse()

### DIFF
--- a/MobiFlight/Config/MultiplexerDriver.cs
+++ b/MobiFlight/Config/MultiplexerDriver.cs
@@ -53,7 +53,12 @@ namespace MobiFlight.Config
         {
             if (pinNos.Length < 4) return false;
             for (var i = 0; i < 4; i++) {
-                if (byte.Parse(pinNos[i]) < 0) return false;
+                if (!byte.TryParse(pinNos[i], out byte result))
+                {
+                    Log.Instance.log($"Unable to convert multiplexer pin number \"{pinNos[i]}\" to a byte.", LogSeverity.Error);
+                    return false;
+                }
+                if ((result) < 0) return false;
             }
             Array.Copy(pinNos, PinSx, 4); 
             if(_initCounter == 0) _initCounter++;


### PR DESCRIPTION
Fixes #1105

No idea what the root cause of this is but at least it won't crash anymore.