### PR TITLE
Fixed handling of MultiplexDriver deregistration

### DIFF
--- a/MobiFlight/Config/Config.cs
+++ b/MobiFlight/Config/Config.cs
@@ -157,9 +157,11 @@ namespace MobiFlight.Config
                                 // the FromInternal() of the client (in this case InputMultiplexer) will provide them.
                                 // The MultiplexerDriver is registered as a "ghost" device in Config's items list; it won't be shown in the GUI tree.
                                 Items.Add(multiplexerDriver);
-                            } else {
-                                multiplexerDriver.registerClient();
+                            //} else {
+                            //    multiplexerDriver.registerClient();
                             }
+                            multiplexerDriver.FromInternal(InputMultiplexer.GetMultiplexerDriverConfig(item + BaseDevice.End));
+
                             currentItem = new MobiFlight.Config.InputMultiplexer(multiplexerDriver);
                             currentItem.FromInternal(item + BaseDevice.End);
                             break;

--- a/MobiFlight/Config/Config.cs
+++ b/MobiFlight/Config/Config.cs
@@ -155,6 +155,8 @@ namespace MobiFlight.Config
                                 // (in this case InputMultiplexer) will provide them
                                 // Treat the MultiplexerDriver as a regular device (add it to the items list), except it won't be shown in the GUI tree.
                                 Items.Add(multiplexerDriver);
+                            } else {
+                                multiplexerDriver.registerClient();
                             }
                             currentItem = new MobiFlight.Config.InputMultiplexer(multiplexerDriver);
                             currentItem.FromInternal(item + BaseDevice.End);

--- a/MobiFlight/Config/Config.cs
+++ b/MobiFlight/Config/Config.cs
@@ -61,7 +61,7 @@ namespace MobiFlight.Config
         {
             String[] items = value.Split(BaseDevice.End);
 
-            // Need to set aside the MultiplexerDriver reference (for subsequent devices) when we find it 
+            // Need to set aside the MultiplexerDriver reference (for subsequent client devices) when we find it 
             MobiFlight.Config.MultiplexerDriver multiplexerDriver = null;
 
             foreach (String item in items)
@@ -148,12 +148,14 @@ namespace MobiFlight.Config
                             break;
 
                         case DeviceType.InputMultiplexer:
+                            // If the multiplexerDriver is to be implicitly defined by clients:
                             // Build multiplexerDriver if none found yet 
                             if (multiplexerDriver == null) {
+                                // Store it, so another clients will not create a new one
                                 multiplexerDriver = new MobiFlight.Config.MultiplexerDriver();
-                                // multiplexerDriver is not yet init'ed with pin numbers: the FromInternal() of the client
-                                // (in this case InputMultiplexer) will provide them
-                                // Treat the MultiplexerDriver as a regular device (add it to the items list), except it won't be shown in the GUI tree.
+                                // multiplexerDriver is not yet initialized with pin numbers:
+                                // the FromInternal() of the client (in this case InputMultiplexer) will provide them.
+                                // The MultiplexerDriver is registered as a "ghost" device in Config's items list; it won't be shown in the GUI tree.
                                 Items.Add(multiplexerDriver);
                             } else {
                                 multiplexerDriver.registerClient();
@@ -172,6 +174,18 @@ namespace MobiFlight.Config
                             currentItem.FromInternal(item + BaseDevice.End);
                             break;
 
+                        // If the multiplexerDriver is to be explicitly defined by its own config line,
+                        // following 'case' is required:
+
+                        //case DeviceType.MultiplexerDriver:
+                            //if (multiplexerDriver == null) {
+                            //  multiplexerDriver = new MobiFlight.Config.MultiplexerDriver();
+                            //  currentItem = multiplexerDriver;
+                            //  currentItem.FromInternal(item + BaseDevice.End);
+	                        //} else {
+	                        //  multiplexerDriver.registerClient();
+                            //}
+                            //break;
                     }
 
                     if (currentItem != null)

--- a/MobiFlight/Config/Config.cs
+++ b/MobiFlight/Config/Config.cs
@@ -153,8 +153,6 @@ namespace MobiFlight.Config
                             if (multiplexerDriver == null) {
                                 // Store it, so another clients will not create a new one
                                 multiplexerDriver = new MobiFlight.Config.MultiplexerDriver();
-                                // multiplexerDriver is not yet initialized with pin numbers:
-                                // the FromInternal() of the client (in this case InputMultiplexer) will provide them.
                                 // The MultiplexerDriver is registered as a "ghost" device in Config's items list; it won't be shown in the GUI tree.
                                 Items.Add(multiplexerDriver);
                             //} else {

--- a/MobiFlight/Config/InputMultiplexer.cs
+++ b/MobiFlight/Config/InputMultiplexer.cs
@@ -65,17 +65,25 @@ namespace MobiFlight.Config
             NumBytes    = paramList[6];
             Name        = paramList[7];
 
+            /* TO BE DELETED before PR is accepted:
             // pass the MultiplexerDriver pins, but only if the multiplexerDriver wasn't already set
             if (Selector == null || Selector.isInitialized()) return false;
             value = ((int)DeviceType.MultiplexerDriver).ToString() + Separator + paramList[2] + Separator + paramList[3] + Separator + paramList[4] + Separator + paramList[5] + End;
             Selector.FromInternal(value);
             // The FromInternal() call takes care internally of the activation counter and the "initialized" flag
+            */
             return true;
         }
 
         public override string ToString()
         {
             return $"{Type}:{Name}";
+        }
+        
+        public static String GetMultiplexerDriverConfig(String value)
+        {
+            String[] paramList = value.Split(Separator);
+            return ((int)DeviceType.MultiplexerDriver).ToString() + Separator + paramList[2] + Separator + paramList[3] + Separator + paramList[4] + Separator + paramList[5] + End;
         }
     }
 }

--- a/MobiFlight/Config/MultiplexerDriver.cs
+++ b/MobiFlight/Config/MultiplexerDriver.cs
@@ -31,12 +31,8 @@ namespace MobiFlight.Config
 
         public bool registerClient()
         {
-            bool res = false;
-            if (_initCounter > 0) {
-                _initCounter++;
-                res = true;
-            }
-            return res;
+            _initCounter++;
+            return true;
         }
 
         public bool unregisterClient()
@@ -49,19 +45,17 @@ namespace MobiFlight.Config
             return res;
         }
 
-        public bool Initialize(String[] pinNos)
+        public bool SetPins(String[] pinNos)
         {
             if (pinNos.Length < 4) return false;
             for (var i = 0; i < 4; i++) {
                 if (!byte.TryParse(pinNos[i], out byte result))
                 {
-                    Log.Instance.log($"Unable to convert multiplexer pin number \"{pinNos[i]}\" to a byte.", LogSeverity.Error);
+                    Log.Instance.log($"Unable to convert multiplexer selector pin number \"{pinNos[i]}\" to a byte. Multiplexer driver is probably not correctly initialized.", LogSeverity.Error);
                     return false;
                 }
-                if ((result) < 0) return false;
             }
             Array.Copy(pinNos, PinSx, 4); 
-            if(_initCounter == 0) _initCounter++;
             return true;
         }
 
@@ -109,10 +103,9 @@ namespace MobiFlight.Config
                 pins[1] = paramList[2];
                 pins[2] = paramList[3];
                 pins[3] = paramList[4];
-                res = Initialize(pins);
-            } else {
-                _initCounter++;
+                res = SetPins(pins);
             }
+            registerClient();
 
             return res;
         }

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -427,9 +427,9 @@ namespace MobiFlight
                             device.Name = GenerateUniqueDeviceName(inputMultiplexers.Keys.ToArray(), device.Name);
                             inputMultiplexers.Add(device.Name, new MobiFlightInputMultiplexer() { Name = device.Name });
                             break;
-                            // The MultiplexerDriver does not belong here (a "MobiFlightMultiplexerDriverS" doesn't even exist) because all I/O devices here
-                            // are only those meant to be linked to a user input event or output data, while MultiplexerDrivers are not addressable
-                            // by the user (and shouldn't show in the UI).
+                            // DeviceType.MultiplexerDriver does not belong here (a "multiplexerDrivers" collection doesn't even exist)
+                            // because all I/O devices here are only those meant to be linked to a user input event or output data,
+                            // while MultiplexerDrivers are not addressable by the user (and shouldn't show in the UI).
                     }
                 }
                 catch (Exception ex)

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -1325,6 +1325,8 @@ namespace MobiFlight
                         usedPins.Add(Convert.ToByte((device as InputMultiplexer).Selector.PinSx[3]));
                         break;
 
+                    // If the multiplexerDriver is to be handled as a regular device
+                    // but explicitly defined by its own config line, following 'case' is required:
                     //case DeviceType.MultiplexerDriver:
                     //    usedPins.Add(Convert.ToByte((device as MultiplexerDriver).PinSx[0]));
                     //    usedPins.Add(Convert.ToByte((device as MultiplexerDriver).PinSx[1]));

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -335,7 +335,7 @@ namespace MobiFlight.UI.Panels.Settings
                     // MultiplexerDrivers should not appear in the tree, therefore they are stored in a dictionary 
                     // (by module name) for easy retrieval
                     if(device.Type == DeviceType.MultiplexerDriver) {
-                        moduleMultiplexerDrivers.Add(moduleInfo.Name, device as MobiFlight.Config.MultiplexerDriver);
+                        moduleMultiplexerDrivers.Add(moduleNode.Text, device as MobiFlight.Config.MultiplexerDriver);
                     } else {
                         TreeNode deviceNode = new TreeNode(device.Name);
                         deviceNode.Tag = device;
@@ -612,8 +612,8 @@ namespace MobiFlight.UI.Panels.Settings
                         if (statistics[MobiFlightInputMultiplexer.TYPE] == tempModule.Board.ModuleLimits.MaxInputMultiplexer) {
                             throw new MaximumDeviceNumberReachedMobiFlightException(MobiFlightInputMultiplexer.TYPE, tempModule.Board.ModuleLimits.MaxInputMultiplexer);
                         }
-                        // getOrAddModuleMultiplexerDriver() takes care of creating the MultiplexerDriver if not done yet:
-                        cfgItem = new MobiFlight.Config.InputMultiplexer(getOrAddModuleMultiplexerDriver(freePinList));
+                        // getModuleMultiplexerDriver() takes care of creating the MultiplexerDriver if not done yet:
+                        cfgItem = new MobiFlight.Config.InputMultiplexer(getModuleMultiplexerDriver(freePinList));
                         (cfgItem as MobiFlight.Config.InputMultiplexer).DataPin = freePinList.ElementAt(0).ToString();
                         break;
 
@@ -796,10 +796,6 @@ namespace MobiFlight.UI.Panels.Settings
 
             MobiFlight.Config.Config newConfig = new MobiFlight.Config.Config();
             newConfig.ModuleName = module.Name;
-
-            foreach (MobiFlight.Config.MultiplexerDriver multiplexerDriver in moduleMultiplexerDrivers.Values) {
-                newConfig.Items.Add(multiplexerDriver as MobiFlight.Config.BaseDevice);
-            }
 
             foreach (TreeNode node in moduleNode.Nodes)
             {
@@ -1028,19 +1024,15 @@ namespace MobiFlight.UI.Panels.Settings
             return device.isMuxClient;
         }
 
-        private MobiFlight.Config.MultiplexerDriver getModuleMultiplexerDriver()
+        private MobiFlight.Config.MultiplexerDriver findModuleMultiplexerDriver(bool addIfNotFound)
         {
             MobiFlight.Config.MultiplexerDriver moduleMultiplexerDriver;
             
             string moduleName = getModuleNode().Text;
 
-            if (!moduleMultiplexerDrivers.ContainsKey(moduleName)) {
+            if (!moduleMultiplexerDrivers.ContainsKey(moduleName) && addIfNotFound) {
                 // None found: we are adding first client, therefore we must also build a new MultiplexerDriver
                 moduleMultiplexerDriver = new MobiFlight.Config.MultiplexerDriver();
-                // append it to module's configuration first,
-                TreeNode moduleNode = getModuleNode();
-                (moduleNode.Tag as MobiFlightModule).Config.Items.Add(moduleMultiplexerDriver);
-                // then also add it to the GUI list
                 moduleMultiplexerDrivers.Add(moduleName, moduleMultiplexerDriver);
             } else {
                 moduleMultiplexerDriver = moduleMultiplexerDrivers[moduleName];
@@ -1048,14 +1040,9 @@ namespace MobiFlight.UI.Panels.Settings
             return moduleMultiplexerDriver;
         }
 
-        /// <summary>
-        /// Helper function to return the MultiplexerDriver device belonging to the current module
-        /// Initializes module values if not yet done
-        /// </summary>
-        /// <returns>Object if existing, null otherwise</returns>
-        private MobiFlight.Config.MultiplexerDriver getOrAddModuleMultiplexerDriver(List<MobiFlightPin> freePins)
+        private MobiFlight.Config.MultiplexerDriver getModuleMultiplexerDriver(List<MobiFlightPin> freePins)
         {
-            var multiplexerDriver = getModuleMultiplexerDriver();
+            var multiplexerDriver = findModuleMultiplexerDriver(true);
 
             // If multiplexerDriver has no users yet, initialize it
             if (!multiplexerDriver.isInitialized()) {
@@ -1067,10 +1054,9 @@ namespace MobiFlight.UI.Panels.Settings
                     pins[i] = freePins.ElementAt(i).ToString();
                 }
                 freePins.RemoveRange(0, 4);
-                multiplexerDriver.Initialize(pins);     // this also registers (if first client, which we are)
-            } else {
-                multiplexerDriver.registerClient();
+                multiplexerDriver.SetPins(pins);
             }
+            multiplexerDriver.registerClient();
             return multiplexerDriver;
         }
 
@@ -1081,10 +1067,12 @@ namespace MobiFlight.UI.Panels.Settings
         {
             MobiFlight.Config.MultiplexerDriver multiplexerDriver;
             
-            multiplexerDriver = getModuleMultiplexerDriver();
-            multiplexerDriver.unregisterClient();
-            if (!multiplexerDriver.isInitialized()) {
-                moduleMultiplexerDrivers.Remove(getModuleNode().Name);
+            multiplexerDriver = findModuleMultiplexerDriver(false);
+            if(multiplexerDriver != null) {
+                multiplexerDriver.unregisterClient();
+                if (!multiplexerDriver.isInitialized()) {
+                    moduleMultiplexerDrivers.Remove(getModuleNode().Text);
+                }
             }
         }
 

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -1036,7 +1036,7 @@ namespace MobiFlight.UI.Panels.Settings
         /// Initializes module values if not yet done
         /// </summary>
         /// <param name="addIfNotFound">if true, an element will be created if none exists</param>
-        /// <returns>Object if existing, null otherwise</returns>
+        /// <returns>Object</returns>
         private MobiFlight.Config.MultiplexerDriver findModuleMultiplexerDriver(bool addIfNotFound)
         {
             MobiFlight.Config.MultiplexerDriver moduleMultiplexerDriver;


### PR DESCRIPTION
Fixes #1105
Modified:
- Fixed registration calls/reg. counter updates in MultiplexerDriver
- Modified functions to lookup an existing MultiplexDriver in MobiFlightPanel; changed their names to reflect the modified purpose
- Added or corrected a few comments about Multiplexer Driver handling

The first commit contains only code changes; the second commits contains only comments, so it should be easier to review.