### PR TITLE
Buttons only scanned with OnPress, add threshold for potis 

### DIFF
--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -30,7 +30,7 @@ namespace MobiFlight.UI.Dialogs
         ExecutionManager _execManager = null;
         int displayPanelHeight = -1;
         List<UserControl> displayPanels = new List<UserControl>();
-        
+
         InputConfigItem config = null;
         InputConfigItem originalConfig = null;
 
@@ -52,13 +52,13 @@ namespace MobiFlight.UI.Dialogs
 
         bool IsShown = false;
 
-        public InputConfigWizard(ExecutionManager mainForm, 
+        public InputConfigWizard(ExecutionManager mainForm,
                              InputConfigItem cfg,
 #if ARCAZE
-                             ArcazeCache arcazeCache, 
-                             Dictionary<string, ArcazeModuleSettings> moduleSettings, 
+                             ArcazeCache arcazeCache,
+                             Dictionary<string, ArcazeModuleSettings> moduleSettings,
 #endif
-                             DataSet dataSetConfig, 
+                             DataSet dataSetConfig,
                              String filterGuid)
         {
             Init(mainForm, cfg);
@@ -106,7 +106,7 @@ namespace MobiFlight.UI.Dialogs
 
         protected void Init(ExecutionManager mainForm, InputConfigItem cfg)
         {
-            this._execManager = mainForm;          
+            this._execManager = mainForm;
             config = cfg;
 
             // Until with have the preconditions completely refactored,
@@ -142,7 +142,7 @@ namespace MobiFlight.UI.Dialogs
             if (!System.IO.File.Exists(Properties.Settings.Default.PresetFileOutputs))
             {
                 isLoaded = false;
-                MessageBox.Show(i18n._tr("uiMessageConfigWizard_PresetsNotFound"), i18n._tr("Hint"));             
+                MessageBox.Show(i18n._tr("uiMessageConfigWizard_PresetsNotFound"), i18n._tr("Hint"));
             }
             else
             {
@@ -156,7 +156,7 @@ namespace MobiFlight.UI.Dialogs
                 catch (Exception e)
                 {
                     isLoaded = false;
-                    MessageBox.Show(i18n._tr("uiMessageConfigWizard_ErrorLoadingPresets"), i18n._tr("Hint"));                    
+                    MessageBox.Show(i18n._tr("uiMessageConfigWizard_ErrorLoadingPresets"), i18n._tr("Hint"));
                 }
             }
         }
@@ -166,7 +166,7 @@ namespace MobiFlight.UI.Dialogs
         /// sync the config wizard with the provided settings from arcaze cache such as available modules, ports, etc.
         /// </summary>
         /// <param name="arcazeCache"></param>
-        public void initWithArcazeCache (ArcazeCache arcazeCache)
+        public void initWithArcazeCache(ArcazeCache arcazeCache)
         {
             List<ListItem> PreconditionModuleList = new List<ListItem>();
 
@@ -180,7 +180,7 @@ namespace MobiFlight.UI.Dialogs
             {
                 arcazeFirmware[module.Serial] = module.Version;
 
-                PreconditionModuleList.Add(new ListItem() { 
+                PreconditionModuleList.Add(new ListItem() {
                     Value = $"{module.Name}/ {module.Serial}",
                     Label = $"{module.Name} ({module.Serial})"
                 });
@@ -208,13 +208,13 @@ namespace MobiFlight.UI.Dialogs
             preconditionPanel.SetModules(PreconditionModuleList);
         }
 #endif
-        
+
         public void initWithoutArcazeCache()
         {
             List<ListItem> PreconditionModuleList = new List<ListItem>();
             // update the display box with
             // modules
-            inputModuleNameComboBox.Items.Clear();         
+            inputModuleNameComboBox.Items.Clear();
             inputModuleNameComboBox.Items.Add(new ListItem() { Value = "-", Label = "-" });
             inputModuleNameComboBox.SelectedIndex = 0;
             inputModuleNameComboBox.DisplayMember = "Label";
@@ -259,7 +259,7 @@ namespace MobiFlight.UI.Dialogs
                 {
                     // TODO: provide error message
                 }
-            }    
+            }
 
             // second tab
             if (!ComboBoxHelper.SetSelectedItemByValue(inputTypeComboBox, config.Name))
@@ -277,8 +277,8 @@ namespace MobiFlight.UI.Dialogs
 
         private void PopulateInputPinDropdown(int numModules, int? selectedPin)
         {
-			// Originally added for Input shift registers
-			// Also used for digital input multiplexers, usually with numModules=2 (CD4067) or 1 (CD4051)
+            // Originally added for Input shift registers
+            // Also used for digital input multiplexers, usually with numModules=2 (CD4067) or 1 (CD4051)
             // The selected input in the dropdown is the shift register details, which includes the
             // number of connected modules. That gets multiplied by 8 pins per module to get the total
             // number of available pins to populate.
@@ -373,7 +373,7 @@ namespace MobiFlight.UI.Dialogs
         private void okButton_Click(object sender, EventArgs e)
         {
             if (!ValidateChildren())
-            {              
+            {
                 return;
             }
             _syncFormToConfig();
@@ -402,7 +402,7 @@ namespace MobiFlight.UI.Dialogs
                 inputTypeComboBox.ValueMember = "Value";
                 inputTypeComboBox.DisplayMember = "Label";
 
-                inputTypeComboBox.Items.Add(new ListItem<string>() { Label = InputConfigItem.TYPE_NOTSET, Value = InputConfigItem.TYPE_NOTSET});
+                inputTypeComboBox.Items.Add(new ListItem<string>() { Label = InputConfigItem.TYPE_NOTSET, Value = InputConfigItem.TYPE_NOTSET });
                 inputTypeComboBox.SelectedIndex = 0;
                 inputTypeComboBox.Enabled = true;
 
@@ -413,7 +413,7 @@ namespace MobiFlight.UI.Dialogs
                     if (config.button != null)
                     {
                         device = new Config.Button();
-                    } else if (config.encoder!= null)
+                    } else if (config.encoder != null)
                     {
                         device = new Config.Encoder();
                     }
@@ -468,11 +468,11 @@ namespace MobiFlight.UI.Dialogs
                     }
                 }
                 // Add all Joysticks
-                else { 
+                else {
                     Joystick joystick = _execManager.GetJoystickManager().GetJoystickBySerial(serial);
                     inputTypeComboBox.Items.AddRange(joystick.GetAvailableDevices().ToArray());
                 }
-                
+
                 // third tab
                 if (!ComboBoxHelper.SetSelectedItem(inputTypeComboBox, config.Name))
                 {
@@ -497,13 +497,13 @@ namespace MobiFlight.UI.Dialogs
                 if (device == null || string.IsNullOrEmpty(device?.Name))
                     return currentInputType;
                 currentInputType = device.Type;
-            } else if (!Joystick.IsJoystickSerial(serial)) { 
+            } else if (!Joystick.IsJoystickSerial(serial)) {
                 MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
 
                 // find the correct input type based on the name
                 foreach (Config.BaseDevice device in module.GetConnectedInputDevices())
                 {
-                    if ((inputTypeComboBox.SelectedItem as ListItem<Config.BaseDevice>) == null) 
+                    if ((inputTypeComboBox.SelectedItem as ListItem<Config.BaseDevice>) == null)
                         break;
                     if (device.Name != ((inputTypeComboBox.SelectedItem as ListItem<Config.BaseDevice>).Value as Config.BaseDevice)?.Name) continue;
 
@@ -535,7 +535,7 @@ namespace MobiFlight.UI.Dialogs
             {
                 bool panelEnabled = true;
                 // get the deviceinfo for the current arcaze
-                ComboBox cb = inputModuleNameComboBox;                
+                ComboBox cb = inputModuleNameComboBox;
                 String serial = SerialNumber.ExtractSerial(cb.SelectedItem.ToString());
 
                 // we remove the callback method to ensure, that it is not added more than once
@@ -607,16 +607,16 @@ namespace MobiFlight.UI.Dialogs
             catch (Exception ex)
             {
                 Log.Instance.log(ex.Message, LogSeverity.Error);
-                MessageBox.Show(i18n._tr("uiMessageNotImplementedYet"), 
-                                i18n._tr("Hint"), 
-                                MessageBoxButtons.OK, 
+                MessageBox.Show(i18n._tr("uiMessageNotImplementedYet"),
+                                i18n._tr("Hint"),
+                                MessageBoxButtons.OK,
                                 MessageBoxIcon.Warning);
             }
         }
 
         void displayLedAddressComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-            ComboBox cb = inputModuleNameComboBox;                
+            ComboBox cb = inputModuleNameComboBox;
             String serial = SerialNumber.ExtractSerial(cb.SelectedItem.ToString());
             MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
 
@@ -626,7 +626,7 @@ namespace MobiFlight.UI.Dialogs
             {
                 if (device.Type != DeviceType.LedModule) continue;
                 if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;
-                for (int i = 0; i< (device as MobiFlightLedModule).SubModules; i++) {
+                for (int i = 0; i < (device as MobiFlightLedModule).SubModules; i++) {
                     connectors.Add(new ListItem() { Label = (i + 1).ToString(), Value = (i + 1).ToString() });
                 }
             }
@@ -687,8 +687,8 @@ namespace MobiFlight.UI.Dialogs
 
         private void displayLedDisplayComboBox_Validating(object sender, CancelEventArgs e)
         {
-            if (inputTypeComboBox.Text == ArcazeLedDigit.TYPE)                
-            {                
+            if (inputTypeComboBox.Text == ArcazeLedDigit.TYPE)
+            {
                 try
                 {
                     int.Parse(displayLedDisplayPanel.displayLedAddressComboBox.Text);
@@ -701,7 +701,7 @@ namespace MobiFlight.UI.Dialogs
                     tabControlFsuipc.SelectedTab = displayTabPage;
                     displayLedDisplayPanel.displayLedAddressComboBox.Focus();
                     displayError(displayLedDisplayPanel.displayLedAddressComboBox, i18n._tr("uiMessageConfigWizard_ProvideLedDisplayAddress"));
-                }                
+                }
             }
         }
 
@@ -722,7 +722,7 @@ namespace MobiFlight.UI.Dialogs
                 }
             }
         }
-                
+
         private void tabControlFsuipc_SelectedIndexChanged(object sender, EventArgs e)
         {
             // check if running in test mode
@@ -787,6 +787,12 @@ namespace MobiFlight.UI.Dialogs
         {
             if (!InputThresholdIsExceeded(e)) return;
 
+            // For buttons, only the "positive" PRESS events matter
+            if (e.Type == DeviceType.Button && e.Value != (int)MobiFlightButton.InputEvent.PRESS)
+            {
+                return;
+            }
+
             if (inputModuleNameComboBox.InvokeRequired)
             {
                 inputModuleNameComboBox.BeginInvoke(new ScanforInput_OnButtonPressedCallback(ScanforInput_OnButtonPressed), new object[] { sender, e });
@@ -812,21 +818,22 @@ namespace MobiFlight.UI.Dialogs
             {
                 ComboBoxHelper.SetSelectedItem(inputTypeComboBox, e.DeviceLabel);
             }
-                
 
             DeactivateScanForInputMode();
         }
 
         private bool InputThresholdIsExceeded(InputEventArgs e)
         {
-            if (SerialNumber.IsJoystickSerial(e.Serial) &&
-                e.DeviceId.Contains(Joystick.AxisPrefix))
+            const int JoystickThreshold = 2000;
+            const int AnalogInputThreshold = 20;
+
+            if ((SerialNumber.IsJoystickSerial(e.Serial) &&
+                e.DeviceId.Contains(Joystick.AxisPrefix)) || e.Type == DeviceType.AnalogInput)
             {
                 if (ScanForInputThreshold.ContainsKey(e.Serial + e.DeviceId))
                 {
-                    if (Math.Abs(e.Value - ScanForInputThreshold[e.Serial + e.DeviceId]) < 500)
+                    if (Math.Abs(e.Value - ScanForInputThreshold[e.Serial + e.DeviceId]) < (SerialNumber.IsJoystickSerial(e.Serial) ? JoystickThreshold : AnalogInputThreshold))
                     {
-                        ScanForInputThreshold[e.Serial + e.DeviceId] = e.Value;
                         return false;
                     }
                 }


### PR DESCRIPTION
part of #1116 

This change 
- Only uses OnPress events for buttons for scanning, this allows to assign On-On switches correctly (incl Joystick rocker switches on the HC Bravo)
- adds the threshold logic that was used for Joysticks also for potentiometers, so that a user has to generate a bigger value change, this also prevents scanned noisy potis.
- Also unused `using` and white spaces were removed, sorry for that....