### PR TITLE
Allow for device names (e.g. joysticks) to contain "/"

### DIFF
--- a/Base/SerialNumber.cs
+++ b/Base/SerialNumber.cs
@@ -34,12 +34,19 @@ namespace MobiFlight.Base
 
         public static bool IsMobiFlightSerial(string serial)
         {
+            if (serial == null || serial == "") return false;
             return (serial.IndexOf("SN") == 0);
         }
 
         public static bool IsJoystickSerial(string serial)
         {
+            if (serial == null || serial == "") return false;
             return (serial.IndexOf(Joystick.SerialPrefix) == 0);
+        }
+
+        public static bool IsRawSerial(string serial)
+        {
+            return (serial != null && serial.Contains(SerialSeparator));
         }
     }
 }

--- a/Base/SerialNumber.cs
+++ b/Base/SerialNumber.cs
@@ -1,31 +1,35 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics.Eventing.Reader;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Forms.DataVisualization.Charting;
 
 namespace MobiFlight.Base
 {
     public static class SerialNumber
     {
+        public const string SerialSeparator = "/ ";
+
         public static string ExtractSerial(String s)
         {
+            string[] serialSeparator = { SerialSeparator };
             if (s == null) return "";
 
-            if (!s.Contains("/")) return "";
+            if (!s.Contains(SerialSeparator)) return "";
 
-            return s.Split('/')[1].Trim();
+            var tokens = s.Split(serialSeparator, StringSplitOptions.RemoveEmptyEntries);
+
+            return tokens.Last().Trim();
         }
 
         public static string ExtractDeviceName(String s)
         {
+            string[] serialSeparator = { SerialSeparator };
             if (s == null) return "";
 
-            if (!s.Contains("/")) return "";
+            if (!s.Contains(SerialSeparator)) return "";
 
-            return s.Split('/')[0].Trim();
+            var tokens = s.Split(serialSeparator, StringSplitOptions.None);
+            tokens = tokens.Take(tokens.Length - 1).ToArray();
+
+            return String.Join("", tokens).Trim();
         }
 
         public static bool IsMobiFlightSerial(string serial)

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1095,7 +1095,7 @@ namespace MobiFlight
                 cfg.DisplaySerial!=null && (cfg.DisplaySerial.Contains("/"))
             )
             {
-                lastSerial = cfg.DisplaySerial.Split('/')[1].Trim();
+                lastSerial = SerialNumber.ExtractSerial(cfg.DisplaySerial);
                 lastRow.Selected = false;
                 try
                 {

--- a/MobiFlightUnitTests/Base/SerialNumberTests.cs
+++ b/MobiFlightUnitTests/Base/SerialNumberTests.cs
@@ -28,6 +28,11 @@ namespace MobiFlight.Base.Tests
             result = SerialNumber.ExtractSerial(serial);
             Assert.IsNotNull(result);
             Assert.AreEqual("000393600000", result);
+
+            serial = "MFG Crosswind V2/3 / JS-b0875190-3b89-11ed-8007-444553540000";
+            result = SerialNumber.ExtractSerial(serial);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("JS-b0875190-3b89-11ed-8007-444553540000", result);
         }
 
         [TestMethod()]
@@ -47,6 +52,11 @@ namespace MobiFlight.Base.Tests
             result = SerialNumber.ExtractDeviceName(serial);
             Assert.IsNotNull(result);
             Assert.AreEqual("Arcaze v5.36", result);
+
+            serial = "MFG Crosswind V2/3 / JS-b0875190-3b89-11ed-8007-444553540000";
+            result = SerialNumber.ExtractDeviceName(serial);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("MFG Crosswind V2/3", result);
         }
 
         [TestMethod()]

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -213,7 +213,7 @@ namespace MobiFlight.UI.Dialogs
 
                 DisplayModuleList.Add(new ListItem()
                 {
-                    Value = joystick.Name + " / " + joystick.Serial,
+                    Value = $"{joystick.Name} ${SerialNumber.SerialSeparator}${joystick.Serial}",
                     Label = $"{joystick.Name}"
                 });
 

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -181,7 +181,7 @@ namespace MobiFlight.UI.Dialogs
                 arcazeFirmware[module.Serial] = module.Version;
 
                 PreconditionModuleList.Add(new ListItem() {
-                    Value = $"{module.Name}/ {module.Serial}",
+                    Value = $"{module.Name}${SerialNumber.SerialSeparator}{module.Serial}",
                     Label = $"{module.Name} ({module.Serial})"
                 });
             }
@@ -190,7 +190,7 @@ namespace MobiFlight.UI.Dialogs
             {
                 inputModuleNameComboBox.Items.Add(new ListItem()
                 {
-                    Value = $"{module.Name}/ {module.Serial}",
+                    Value = $"{module.Name}${SerialNumber.SerialSeparator}{module.Serial}",
                     Label = $"{module.Name} ({module.Port})"
                 });
             }
@@ -200,7 +200,7 @@ namespace MobiFlight.UI.Dialogs
                 if (joystick.GetAvailableDevices().Count > 0)
                     inputModuleNameComboBox.Items.Add(new ListItem()
                     {
-                        Value = $"{joystick.Name} / {joystick.Serial}",
+                        Value = $"{joystick.Name} ${SerialNumber.SerialSeparator}{joystick.Serial}",
                         Label = $"{joystick.Name}"
                     });
             }
@@ -224,8 +224,8 @@ namespace MobiFlight.UI.Dialogs
             {
                 inputModuleNameComboBox.Items.Add(new ListItem()
                 {
-                    Value = $"{module.Name}/ {module.Serial}",
-                    Label = $"{module.Name} ({module.Port})"
+                    Value = $"{module.Name}${SerialNumber.SerialSeparator}{module.Serial}",
+                    Label = $"{module.Name}${SerialNumber.SerialSeparator}({module.Port})"
                 });
                 // preconditionPinSerialComboBox.Items.Add(module.Name + "/ " + module.Serial);
             }
@@ -234,7 +234,7 @@ namespace MobiFlight.UI.Dialogs
             {
                 inputModuleNameComboBox.Items.Add(new ListItem()
                 {
-                    Value = $"{joystick.Name} / {joystick.Serial}",
+                    Value = $"{joystick.Name} ${SerialNumber.SerialSeparator}{joystick.Serial}",
                     Label = $"{joystick.Name}"
                 });
             }

--- a/UI/Panels/Config/PreconditionPanel.cs
+++ b/UI/Panels/Config/PreconditionPanel.cs
@@ -336,7 +336,7 @@ namespace MobiFlight.UI.Panels.Config
                 }
                 else if (p.PreconditionType == "pin")
                 {
-                    label = label.Replace("<Serial:" + p.PreconditionSerial + ">", p.PreconditionSerial.Split('/')[0]);
+                    label = label.Replace("<Serial:" + p.PreconditionSerial + ">", SerialNumber.ExtractDeviceName(p.PreconditionSerial));
                 }
                 else
                 {

--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MobiFlight.Base;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -90,7 +91,7 @@ namespace MobiFlight.UI.Panels
             String serial = config.DisplaySerial;
             if (serial != null && serial.Contains('/'))
             {
-                serial = serial.Split('/')[1].Trim();
+                serial = SerialNumber.ExtractSerial(serial);
             }
 
             if (config.Pin.DisplayPin != null && config.Pin.DisplayPin != "")

--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -89,23 +89,20 @@ namespace MobiFlight.UI.Panels
         {
 
             String serial = config.DisplaySerial;
-            if (serial != null && serial.Contains('/'))
-            {
-                serial = SerialNumber.ExtractSerial(serial);
-            }
+            serial = SerialNumber.ExtractSerial(serial);
 
             if (config.Pin.DisplayPin != null && config.Pin.DisplayPin != "")
             {
                 string port = "";
                 string pin = config.Pin.DisplayPin;
 
-                if (serial != null && serial.IndexOf(Joystick.SerialPrefix) == 0)
+                if (SerialNumber.IsJoystickSerial(serial))
                 {
                     // disable multi-select option
                     _MultiSelectOptions(false);
                     pin = config.Pin.DisplayPin;
                 }
-                else if (serial != null && serial.IndexOf("SN") != 0)
+                else if (!SerialNumber.IsMobiFlightSerial(serial))
                 {
                     // these are Arcaze Boards.
                     // Arcaze Boards only have "single output"

--- a/UI/Panels/Output/PinSelectPanel.cs
+++ b/UI/Panels/Output/PinSelectPanel.cs
@@ -6,6 +6,7 @@ using System.Data;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using MobiFlight.Base;
 
 namespace MobiFlight.UI.Panels
 {
@@ -49,7 +50,7 @@ namespace MobiFlight.UI.Panels
         {
             if (serial != null && serial.Contains('/'))
             {
-                serial = serial.Split('/')[1].Trim();
+                serial = SerialNumber.ExtractSerial(serial);
             }
 
             var splitPins = pins.Split(POSITION_SEPERATOR);

--- a/UI/Panels/Output/PinSelectPanel.cs
+++ b/UI/Panels/Output/PinSelectPanel.cs
@@ -48,7 +48,7 @@ namespace MobiFlight.UI.Panels
 
         internal void SetSelectedPinsFromString(string pins, string serial)
         {
-            if (serial != null && serial.Contains('/'))
+            if (SerialNumber.IsRawSerial(serial))
             {
                 serial = SerialNumber.ExtractSerial(serial);
             }

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -1,4 +1,5 @@
-﻿using MobiFlight.UI.Dialogs;
+﻿using MobiFlight.Base;
+using MobiFlight.UI.Dialogs;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -551,7 +552,7 @@ namespace MobiFlight.UI.Panels
                     row["fsuipcOffset"] = "0x" + cfgItem.FSUIPC.Offset.ToString("X4");
                     if (cfgItem.DisplaySerial != null && cfgItem.DisplaySerial != "-")
                     {
-                        row["arcazeSerial"] = cfgItem.DisplaySerial.ToString().Split('/')[0];
+                        row["arcazeSerial"] = SerialNumber.ExtractDeviceName(cfgItem.DisplaySerial);
                     
                         row["OutputType"] = cfgItem.DisplayType;
 

--- a/UI/Panels/Settings/ArcazePanel.cs
+++ b/UI/Panels/Settings/ArcazePanel.cs
@@ -9,6 +9,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using SimpleSolutions.Usb;
 using System.Xml.Serialization;
+using MobiFlight.Base;
 
 namespace MobiFlight.UI.Panels.Settings
 {
@@ -134,8 +135,8 @@ namespace MobiFlight.UI.Panels.Settings
             if (IgnoreArcazeModuleSettingsChangeEvents) return;
 
             ArcazeModuleSettings settingsToSave = null;
-            if (serial.Contains("/"))
-                serial = serial.Split('/')[1].Trim();
+            if (SerialNumber.IsRawSerial(serial))
+                serial = SerialNumber.ExtractSerial(serial);
 
             foreach (ArcazeModuleSettings settings in moduleSettings)
             {
@@ -180,8 +181,8 @@ namespace MobiFlight.UI.Panels.Settings
 
             foreach (ArcazeModuleSettings settings in moduleSettings)
             {
-                if (serial.Contains("/"))
-                    serial = serial.Split('/')[1].Trim();
+                if (SerialNumber.IsRawSerial(serial))
+                    serial = SerialNumber.ExtractSerial(serial);
 
                 if (settings.serial != serial) continue;
 


### PR DESCRIPTION
fixes #1131 

The problem was the "/" in the device name. So I made sure that we always cut off at the last slash.
I also replaced all code snippets that were not using the `SerialNumber` class and the methods it provides yet.

- [x] Add unit tests for the problem cases
- [x] All unit tests are still working