### PR TITLE
Changed order of tab, and fixed the restore of last active Tab

### DIFF
--- a/Base/SerialNumber.cs
+++ b/Base/SerialNumber.cs
@@ -5,6 +5,7 @@ namespace MobiFlight.Base
 {
     public static class SerialNumber
     {
+        public const string NOT_SET = "-";
         public const string SerialSeparator = "/ ";
 
         public static string ExtractSerial(String s)

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -88,14 +88,8 @@ namespace MobiFlight.UI.Dialogs
 
             InitializeComponent();
             comparisonSettingsPanel.Enabled = false;
-            
-            // if one opens the dialog for a new config
-            // ensure that always the first tab is shown
-            if (cfg.FSUIPC.Offset == OutputConfig.FsuipcOffset.OffsetNull)
-            {
-                lastTabActive = 0;
-            }
-            tabControlFsuipc.SelectedIndex = lastTabActive;
+
+            ActivateCorrectTab(config);
 
             // DISPLAY PANEL
             displayPanel1.Init(_execManager);
@@ -123,6 +117,17 @@ namespace MobiFlight.UI.Dialogs
             // SIMCONNECT SIMVARS PANEL
             simConnectPanel1.HubHopPresetPanel.OnGetLVarListRequested += SimConnectPanel1_OnGetLVarListRequested;
             _execManager.GetSimConnectCache().LVarListUpdated += ConfigWizard_LVarListUpdated;
+        }
+
+        private void ActivateCorrectTab(OutputConfigItem cfg)
+        {
+            // by default always the first tab is activated
+            // if one opens the dialog for an existing config
+            // we use the lastTabActive
+            if (cfg?.DisplaySerial != null && cfg?.DisplaySerial != SerialNumber.NOT_SET)
+            {
+                tabControlFsuipc.SelectedIndex = lastTabActive;
+            }
         }
 
         private void SimConnectPanel1_OnGetLVarListRequested(object sender, EventArgs e)

--- a/UI/Dialogs/InputConfigWizard.Designer.cs
+++ b/UI/Dialogs/InputConfigWizard.Designer.cs
@@ -32,10 +32,13 @@
             this.MainPanel = new System.Windows.Forms.Panel();
             this.tabControlFsuipc = new System.Windows.Forms.TabControl();
             this.preconditionTabPage = new System.Windows.Forms.TabPage();
+            this.preconditionPanel = new MobiFlight.UI.Panels.Config.PreconditionPanel();
             this.configRefTabPage = new System.Windows.Forms.TabPage();
+            this.configRefPanel = new MobiFlight.UI.Panels.Config.ConfigRefPanel();
             this.displayTabPage = new System.Windows.Forms.TabPage();
             this.groupBoxInputSettings = new System.Windows.Forms.GroupBox();
             this.displayTypeGroupBox = new System.Windows.Forms.GroupBox();
+            this.ScanForInputButton = new System.Windows.Forms.Button();
             this.DeviceNotAvailableWarningLabel = new System.Windows.Forms.Label();
             this.inputPinDropDown = new System.Windows.Forms.ComboBox();
             this.arcazeSerialLabel = new System.Windows.Forms.Label();
@@ -49,9 +52,6 @@
             this.presetsDataSet = new System.Data.DataSet();
             this.presetDataTable = new System.Data.DataTable();
             this.description = new System.Data.DataColumn();
-            this.ScanForInputButton = new System.Windows.Forms.Button();
-            this.preconditionPanel = new MobiFlight.UI.Panels.Config.PreconditionPanel();
-            this.configRefPanel = new MobiFlight.UI.Panels.Config.ConfigRefPanel();
             this.settingsColumn = new System.Data.DataColumn();
             this.MainPanel.SuspendLayout();
             this.tabControlFsuipc.SuspendLayout();
@@ -72,9 +72,9 @@
             // 
             // tabControlFsuipc
             // 
+            this.tabControlFsuipc.Controls.Add(this.displayTabPage);
             this.tabControlFsuipc.Controls.Add(this.preconditionTabPage);
             this.tabControlFsuipc.Controls.Add(this.configRefTabPage);
-            this.tabControlFsuipc.Controls.Add(this.displayTabPage);
             resources.ApplyResources(this.tabControlFsuipc, "tabControlFsuipc");
             this.tabControlFsuipc.Name = "tabControlFsuipc";
             this.tabControlFsuipc.SelectedIndex = 0;
@@ -87,12 +87,22 @@
             this.preconditionTabPage.Name = "preconditionTabPage";
             this.preconditionTabPage.UseVisualStyleBackColor = true;
             // 
+            // preconditionPanel
+            // 
+            resources.ApplyResources(this.preconditionPanel, "preconditionPanel");
+            this.preconditionPanel.Name = "preconditionPanel";
+            // 
             // configRefTabPage
             // 
             this.configRefTabPage.Controls.Add(this.configRefPanel);
             resources.ApplyResources(this.configRefTabPage, "configRefTabPage");
             this.configRefTabPage.Name = "configRefTabPage";
             this.configRefTabPage.UseVisualStyleBackColor = true;
+            // 
+            // configRefPanel
+            // 
+            resources.ApplyResources(this.configRefPanel, "configRefPanel");
+            this.configRefPanel.Name = "configRefPanel";
             // 
             // displayTabPage
             // 
@@ -121,6 +131,13 @@
             resources.ApplyResources(this.displayTypeGroupBox, "displayTypeGroupBox");
             this.displayTypeGroupBox.Name = "displayTypeGroupBox";
             this.displayTypeGroupBox.TabStop = false;
+            // 
+            // ScanForInputButton
+            // 
+            resources.ApplyResources(this.ScanForInputButton, "ScanForInputButton");
+            this.ScanForInputButton.Name = "ScanForInputButton";
+            this.ScanForInputButton.UseVisualStyleBackColor = true;
+            this.ScanForInputButton.Click += new System.EventHandler(this.ScanForInputButton_Click);
             // 
             // DeviceNotAvailableWarningLabel
             // 
@@ -218,23 +235,6 @@
             // description
             // 
             this.description.ColumnName = "description";
-            // 
-            // ScanForInputButton
-            // 
-            resources.ApplyResources(this.ScanForInputButton, "ScanForInputButton");
-            this.ScanForInputButton.Name = "ScanForInputButton";
-            this.ScanForInputButton.UseVisualStyleBackColor = true;
-            this.ScanForInputButton.Click += new System.EventHandler(this.ScanForInputButton_Click);
-            // 
-            // preconditionPanel
-            // 
-            resources.ApplyResources(this.preconditionPanel, "preconditionPanel");
-            this.preconditionPanel.Name = "preconditionPanel";
-            // 
-            // configRefPanel
-            // 
-            resources.ApplyResources(this.configRefPanel, "configRefPanel");
-            this.configRefPanel.Name = "configRefPanel";
             // 
             // settingsColumn
             // 

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -119,13 +119,8 @@ namespace MobiFlight.UI.Dialogs
 
             InitializeComponent();
 
-            // if one opens the dialog for a new config
-            // ensure that always the first tab is shown
-            //if (cfg.FSUIPCOffset == InputConfigItem.FSUIPCOffsetNull)
-            //{
-            //    lastTabActive = 0;
-            //}
-            tabControlFsuipc.SelectedIndex = lastTabActive;
+            ActivateCorrectTab(config);
+            
 
             // PRECONDITION PANEL
             preconditionPanel.Init();
@@ -133,6 +128,17 @@ namespace MobiFlight.UI.Dialogs
             {
                 tabControlFsuipc.SelectedTab = preconditionTabPage;
             };
+        }
+
+        private void ActivateCorrectTab(InputConfigItem cfg)
+        {
+            // by default always the first tab is activated
+            // if one opens the dialog for an existing config
+            // we use the lastTabActive
+            if (cfg?.ModuleSerial != null && cfg?.ModuleSerial != SerialNumber.NOT_SET)
+            {
+                tabControlFsuipc.SelectedIndex = lastTabActive;
+            }
         }
 
         private void _loadPresets()
@@ -725,7 +731,6 @@ namespace MobiFlight.UI.Dialogs
 
         private void tabControlFsuipc_SelectedIndexChanged(object sender, EventArgs e)
         {
-            // check if running in test mode
             lastTabActive = (sender as TabControl).SelectedIndex;
         }
 

--- a/UI/Dialogs/InputConfigWizard.resx
+++ b/UI/Dialogs/InputConfigWizard.resx
@@ -117,126 +117,18 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="preconditionPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="preconditionPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="preconditionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="preconditionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>658, 623</value>
-  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="preconditionPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;preconditionPanel.Name" xml:space="preserve">
-    <value>preconditionPanel</value>
-  </data>
-  <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
-    <value>preconditionTabPage</value>
-  </data>
-  <data name="&gt;&gt;preconditionPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
-  </data>
-  <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>664, 629</value>
-  </data>
-  <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="preconditionTabPage.Text" xml:space="preserve">
-    <value>Precondition</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Name" xml:space="preserve">
-    <value>preconditionTabPage</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;preconditionTabPage.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="configRefPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="configRefPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="configRefPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="configRefPanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 5, 5, 5</value>
-  </data>
-  <data name="configRefPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>664, 629</value>
-  </data>
-  <data name="configRefPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;configRefPanel.Name" xml:space="preserve">
-    <value>configRefPanel</value>
-  </data>
-  <data name="&gt;&gt;configRefPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;configRefPanel.Parent" xml:space="preserve">
-    <value>configRefTabPage</value>
-  </data>
-  <data name="&gt;&gt;configRefPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="configRefTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
-  </data>
-  <data name="configRefTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>664, 629</value>
-  </data>
-  <data name="configRefTabPage.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="configRefTabPage.Text" xml:space="preserve">
-    <value>Config References</value>
-  </data>
-  <data name="&gt;&gt;configRefTabPage.Name" xml:space="preserve">
-    <value>configRefTabPage</value>
-  </data>
-  <data name="&gt;&gt;configRefTabPage.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;configRefTabPage.Parent" xml:space="preserve">
-    <value>tabControlFsuipc</value>
-  </data>
-  <data name="&gt;&gt;configRefTabPage.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
   <data name="groupBoxInputSettings.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="groupBoxInputSettings.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
   <data name="groupBoxInputSettings.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="groupBoxInputSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>3, 111</value>
   </data>
@@ -541,6 +433,114 @@
     <value>tabControlFsuipc</value>
   </data>
   <data name="&gt;&gt;displayTabPage.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="preconditionPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="preconditionPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="preconditionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="preconditionPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>658, 623</value>
+  </data>
+  <data name="preconditionPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;preconditionPanel.Name" xml:space="preserve">
+    <value>preconditionPanel</value>
+  </data>
+  <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
+    <value>preconditionTabPage</value>
+  </data>
+  <data name="&gt;&gt;preconditionPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
+  </data>
+  <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>664, 629</value>
+  </data>
+  <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="preconditionTabPage.Text" xml:space="preserve">
+    <value>Precondition</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Name" xml:space="preserve">
+    <value>preconditionTabPage</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;preconditionTabPage.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="configRefPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="configRefPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="configRefPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="configRefPanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 5, 5, 5</value>
+  </data>
+  <data name="configRefPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>664, 629</value>
+  </data>
+  <data name="configRefPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;configRefPanel.Name" xml:space="preserve">
+    <value>configRefPanel</value>
+  </data>
+  <data name="&gt;&gt;configRefPanel.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;configRefPanel.Parent" xml:space="preserve">
+    <value>configRefTabPage</value>
+  </data>
+  <data name="&gt;&gt;configRefPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="configRefTabPage.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 22</value>
+  </data>
+  <data name="configRefTabPage.Size" type="System.Drawing.Size, System.Drawing">
+    <value>664, 629</value>
+  </data>
+  <data name="configRefTabPage.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="configRefTabPage.Text" xml:space="preserve">
+    <value>Config References</value>
+  </data>
+  <data name="&gt;&gt;configRefTabPage.Name" xml:space="preserve">
+    <value>configRefTabPage</value>
+  </data>
+  <data name="&gt;&gt;configRefTabPage.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TabPage, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;configRefTabPage.Parent" xml:space="preserve">
+    <value>tabControlFsuipc</value>
+  </data>
+  <data name="&gt;&gt;configRefTabPage.ZOrder" xml:space="preserve">
     <value>2</value>
   </data>
   <data name="tabControlFsuipc.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">


### PR DESCRIPTION
fixes #1129 

- [x] Tab order is changed, Input Device comes first
- [x] For new configs, the first tab is always the active tab
- [x] Last Active tab is restored when editing an existing config

## notes ##
For both, Output Config Wizard & Input Config Wizard, when a user configures something and changes between tabs, the tab index of the tab that was last active is saved.
Next time the user opens the config wizard, the last active tab will be activated again, in case the user edits an existing config. 