### PR TITLE
Allow modifiers to appear after interpolation

### DIFF
--- a/MobiFlight/Modifier/Interpolation.cs
+++ b/MobiFlight/Modifier/Interpolation.cs
@@ -79,9 +79,6 @@ namespace MobiFlight.Modifier
                     reader.ReadToNextSibling("value");
                 } while (reader.LocalName == "value");
             }
-
-            if (reader.LocalName == "interpolation")
-                reader.Read(); // this closes the interpolation node
         }
 
         public override ConnectorValue Apply(ConnectorValue connectorValue, List<ConfigRefValue> configRefs)


### PR DESCRIPTION
Fixes #1136 

I'm 99% sure this is the correct fix. There doesn't seem to be any need to do a `reader.Read()` at the end of processing the interpolation section of the XML.