### PR TITLE
Fixing wrong placeholders in string

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -247,11 +247,11 @@ namespace MobiFlight
             {
                 // Issue #1122: A corrupted WMI registry caused exceptions when attempting to enumerate connected devices with searcher.Get().
                 // Running "winmgmt /resetrepository" fixed it.
-                Log.Instance.log($"Unable to read connected devices. This is usually caused by a corrupted WMI registry. Run 'winmgmt /resetrepository' from an elevated command line to resolve the issue. (${ex.Message})", LogSeverity.Error);
+                Log.Instance.log($"Unable to read connected devices. This is usually caused by a corrupted WMI registry. Run 'winmgmt /resetrepository' from an elevated command line to resolve the issue. ({ex.Message})", LogSeverity.Error);
             }
             catch (Exception ex)
             {
-                Log.Instance.log($"Unable to read connected devices: ${ex.Message}", LogSeverity.Error);
+                Log.Instance.log($"Unable to read connected devices: {ex.Message}", LogSeverity.Error);
             }
             return result;
         }

--- a/SimConnectMSFS/SimConnectCache.cs
+++ b/SimConnectMSFS/SimConnectCache.cs
@@ -223,8 +223,6 @@ namespace MobiFlight.SimConnectMSFS
 
         private void SimConnectCache_OnRecvClientData(SimConnect sender, SIMCONNECT_RECV_CLIENT_DATA data)
         {
-            
-
             if (data.dwRequestID != 0)
             {
                 var simData = (ClientDataValue)(data.dwData[0]);

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -218,7 +218,7 @@ namespace MobiFlight.UI.Dialogs
 
                 DisplayModuleList.Add(new ListItem()
                 {
-                    Value = $"{joystick.Name} ${SerialNumber.SerialSeparator}${joystick.Serial}",
+                    Value = $"{joystick.Name} {SerialNumber.SerialSeparator}{joystick.Serial}",
                     Label = $"{joystick.Name}"
                 });
 

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -187,7 +187,7 @@ namespace MobiFlight.UI.Dialogs
                 arcazeFirmware[module.Serial] = module.Version;
 
                 PreconditionModuleList.Add(new ListItem() {
-                    Value = $"{module.Name}${SerialNumber.SerialSeparator}{module.Serial}",
+                    Value = $"{module.Name}{SerialNumber.SerialSeparator}{module.Serial}",
                     Label = $"{module.Name} ({module.Serial})"
                 });
             }
@@ -196,7 +196,7 @@ namespace MobiFlight.UI.Dialogs
             {
                 inputModuleNameComboBox.Items.Add(new ListItem()
                 {
-                    Value = $"{module.Name}${SerialNumber.SerialSeparator}{module.Serial}",
+                    Value = $"{module.Name}{SerialNumber.SerialSeparator}{module.Serial}",
                     Label = $"{module.Name} ({module.Port})"
                 });
             }
@@ -206,7 +206,7 @@ namespace MobiFlight.UI.Dialogs
                 if (joystick.GetAvailableDevices().Count > 0)
                     inputModuleNameComboBox.Items.Add(new ListItem()
                     {
-                        Value = $"{joystick.Name} ${SerialNumber.SerialSeparator}{joystick.Serial}",
+                        Value = $"{joystick.Name} {SerialNumber.SerialSeparator}{joystick.Serial}",
                         Label = $"{joystick.Name}"
                     });
             }
@@ -230,8 +230,8 @@ namespace MobiFlight.UI.Dialogs
             {
                 inputModuleNameComboBox.Items.Add(new ListItem()
                 {
-                    Value = $"{module.Name}${SerialNumber.SerialSeparator}{module.Serial}",
-                    Label = $"{module.Name}${SerialNumber.SerialSeparator}({module.Port})"
+                    Value = $"{module.Name}{SerialNumber.SerialSeparator}{module.Serial}",
+                    Label = $"{module.Name}{SerialNumber.SerialSeparator}({module.Port})"
                 });
                 // preconditionPinSerialComboBox.Items.Add(module.Name + "/ " + module.Serial);
             }
@@ -240,7 +240,7 @@ namespace MobiFlight.UI.Dialogs
             {
                 inputModuleNameComboBox.Items.Add(new ListItem()
                 {
-                    Value = $"{joystick.Name} ${SerialNumber.SerialSeparator}{joystick.Serial}",
+                    Value = $"{joystick.Name} {SerialNumber.SerialSeparator}{joystick.Serial}",
                     Label = $"{joystick.Name}"
                 });
             }


### PR DESCRIPTION
fixes #1139 

All placeholders in the $"" string that had a format of `${myVar}` were replaced by `{myVar}`.