### PR TITLE
Allow negative test values for stepper

### DIFF
--- a/UI/Panels/Output/StepperPanel.cs
+++ b/UI/Panels/Output/StepperPanel.cs
@@ -119,7 +119,11 @@ namespace MobiFlight.UI.Panels
 
             try
             {
-                e.Cancel = !(Int16.Parse(value) > 0);
+                // all boxes should only accept
+                // positive numbers,
+                // exception is the test value textbox
+                if (sender != stepperTestValueTextBox)
+                    e.Cancel = !(Int16.Parse(value) > 0);
             }
             catch (Exception ex)
             {
@@ -162,21 +166,16 @@ namespace MobiFlight.UI.Panels
 
         internal void SetStepperProfile(StepperProfilePreset profilePreset)
         {
+            // we assume that it is safe to update the values
+            // when we have a different id
+            if (StepperProfile?.id != profilePreset.id)
+            {
+                outputRevTextBox.Text = profilePreset.StepsPerRevolution.ToString();
+                AccelerationTextBox.Text = profilePreset.Acceleration.ToString();
+                SpeedTextBox.Text = profilePreset.Speed.ToString();
+            }
+
             this.StepperProfile = profilePreset;
-            if (outputRevTextBox.Text == "")
-            {
-                outputRevTextBox.Text = this.StepperProfile.StepsPerRevolution.ToString();
-            }
-
-            if (AccelerationTextBox.Text == "")
-            {
-                AccelerationTextBox.Text = this.StepperProfile.Acceleration.ToString();
-            }
-
-            if (SpeedTextBox.Text == "")
-            {
-                SpeedTextBox.Text = this.StepperProfile.Speed.ToString();
-            }
         }
 
         private void ResetButton_Click(object sender, EventArgs e)

--- a/UI/Panels/Output/StepperPanel.cs
+++ b/UI/Panels/Output/StepperPanel.cs
@@ -122,13 +122,17 @@ namespace MobiFlight.UI.Panels
                 // all boxes should only accept
                 // positive numbers,
                 // exception is the test value textbox
+                var v = Int16.Parse(value);
                 if (sender != stepperTestValueTextBox)
-                    e.Cancel = !(Int16.Parse(value) > 0);
+                    e.Cancel = !(v > 0);
             }
             catch (Exception ex)
             {
                 e.Cancel = true;
+                displayError(sender as Control, i18n._tr("uiMessageValidationMustBeNumber"));
+                return;
             }
+
             if (e.Cancel)
             {
                 displayError(sender as Control, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0"));


### PR DESCRIPTION
fixes #1141 

The validation method skips the check for the negative numbers for the test value.

Additionally, this PR also contains a modification of the value initialization code for the stepper profiles.
When a stepper profile changes and it is a different id, then the values are all reset.