### PR TITLE
Update Pico board.json file to match firmware values

### DIFF
--- a/Boards/raspberrypi_pico.board.json
+++ b/Boards/raspberrypi_pico.board.json
@@ -25,17 +25,17 @@
     "ResetFirmwareFile": "reset.raspberry_pico_1_0_2.uf2"
   },
   "ModuleLimits": {
-    "MaxAnalogInputs": 16,
+    "MaxAnalogInputs": 3,
     "MaxInputShifters": 4,
-    "MaxButtons": 68,
-    "MaxEncoders": 20,
+    "MaxButtons": 26,
+    "MaxEncoders": 8,
     "MaxLcdI2C": 2,
     "MaxLedSegments": 4,
-    "MaxOutputs": 40,
-    "MaxServos": 10,
+    "MaxOutputs": 26,
+    "MaxServos": 8,
     "MaxShifters": 4,
-    "MaxSteppers": 10,
-    "MaxInputMultiplexer": 2
+    "MaxSteppers": 6,
+    "MaxInputMultiplexer": 4
   },
   "Pins": [
     {


### PR DESCRIPTION
Fixes #1146 

Updated the board.json file to match these values from Board.h:

```C++
#define MAX_OUTPUTS         26
#define MAX_BUTTONS         26
#define MAX_LEDSEGMENTS     4
#define MAX_ENCODERS        8
#define MAX_STEPPERS        6
#define MAX_MFSERVOS        8
#define MAX_MFLCD_I2C       2
#define MAX_ANALOG_INPUTS   3
#define MAX_OUTPUT_SHIFTERS 4
#define MAX_INPUT_SHIFTERS  4
#define MAX_DIGIN_MUX       4
```