### PR TITLE
Clean up all the build warnings

### DIFF
--- a/ApplicationInsights.config
+++ b/ApplicationInsights.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
+  <ConnectionString>InstrumentationKey=712d6bd9-733d-4735-b173-ba30ade778fb</ConnectionString>
   <TelemetrySinks>
     <Add Name="default">
       <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel" />

--- a/Base/AppTelemetry.cs
+++ b/Base/AppTelemetry.cs
@@ -89,7 +89,7 @@ namespace MobiFlight.Base
                 String key = "input." + item.Type;
                 if (item.ModuleSerial.Contains(Joystick.SerialPrefix))
                 {
-                    key = key + ".joystick";
+                    key += ".joystick";
                 }
                 if (!trackingEvent.Metrics.ContainsKey(key)) trackingEvent.Metrics[key] = 0;
                 trackingEvent.Metrics[key] += 1;
@@ -163,9 +163,11 @@ namespace MobiFlight.Base
         public void log(string message, LogSeverity severity)
         {
             String msg = DateTime.Now + "(" + DateTime.Now.Millisecond + ")" + ": " + message;
-            
-            EventTelemetry myevent = new EventTelemetry();
-            myevent.Name = "log";
+
+            EventTelemetry myevent = new EventTelemetry
+            {
+                Name = "log"
+            };
             myevent.Properties.Add("message", msg);
             myevent.Properties.Add("severity", severity.ToString());
             AppTelemetry.Instance.GetClient().TrackEvent(myevent);                        

--- a/Base/AppTelemetry.cs
+++ b/Base/AppTelemetry.cs
@@ -31,8 +31,9 @@ namespace MobiFlight.Base
 
         private void InitTelemetryClient()
         {
+            // Issue #1168: Remove the InstrumentationKey from here and move it to the ApplicationInsights.config
+            // file based on the instructions in https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560.
             TelemetryConfiguration configuration = TelemetryConfiguration.Active;
-            configuration.InstrumentationKey = "712d6bd9-733d-4735-b173-ba30ade778fb";
 #if (!DEBUG)
             configuration.DisableTelemetry = !enabled;
 #else

--- a/MobiFlight-Installer/MobiFlight-Installer/MobiFlightInstaller.csproj
+++ b/MobiFlight-Installer/MobiFlight-Installer/MobiFlightInstaller.csproj
@@ -13,6 +13,7 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/MobiFlight-Installer/MobiFlight-Installer/MobiFlightInstaller.csproj
+++ b/MobiFlight-Installer/MobiFlight-Installer/MobiFlightInstaller.csproj
@@ -44,6 +44,8 @@
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.IO.Compression.ZipFile, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.Compression.ZipFile.4.3.0\lib\net46\System.IO.Compression.ZipFile.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/MobiFlight-Installer/MobiFlight-Installer/model/CmdLineParams.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/model/CmdLineParams.cs
@@ -100,7 +100,7 @@ namespace MobiFlightInstaller
                     {
                         if (args[pos + 1][0] != '/') result = args[pos + 1];
                     }
-                    catch (Exception e)
+                    catch (Exception)
                     {
                         // do nothing
                     }

--- a/MobiFlight-Installer/MobiFlight-Installer/model/Log.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/model/Log.cs
@@ -89,7 +89,6 @@ namespace MobiFlightInstaller
     public class LogAppenderFile : ILogAppender
     {
         private String FileName = "install.log.txt";
-        private StreamWriter writer = null;
         // This delegate enables asynchronous calls for setting
         // the text property on a TextBox control.
         delegate void logCallback(string message, LogSeverity severity);

--- a/MobiFlight-Installer/MobiFlight-Installer/packages.config
+++ b/MobiFlight-Installer/MobiFlight-Installer/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net46" />
+  <package id="System.IO.Compression.ZipFile" version="4.3.0" targetFramework="net48" />
 </packages>

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -159,7 +159,7 @@
       <HintPath>lib\NCalc.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>packages\protobuf-net.3.1.33\lib\net462\protobuf-net.dll</HintPath>
@@ -175,7 +175,7 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Buffers.4.5.1\lib\netstandard1.1\System.Buffers.dll</HintPath>
+      <HintPath>packages\System.Buffers.4.5.1\lib\net461\System.Buffers.dll</HintPath>
     </Reference>
     <Reference Include="System.CodeDom, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.CodeDom.7.0.0\lib\net462\System.CodeDom.dll</HintPath>
@@ -933,13 +933,13 @@
     <None Include="firmware\reset.raspberry_pico_1_0_2.uf2">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
     <None Include="Presets\msfs2020_simvars.cip">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
     <None Include="Presets\msfs2020_eventids.cip">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
     <None Include="Presets\msfs2020_eventids_user.cip.inactive">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -41,6 +41,7 @@
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup>
     <GenerateManifests>false</GenerateManifests>

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/FsuipcOffsetInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/FsuipcOffsetInputActionTests.cs
@@ -161,7 +161,7 @@ namespace MobiFlight.InputConfig.Tests
                 o.execute(cacheCollection, new InputEventArgs() { Value = 359 }, configrefs);
                 Assert.Fail();
             }
-            catch (FormatException ex)
+            catch (FormatException)
             {
                 Assert.AreEqual(0, mock.Writes.Count, "The message count is not as expected");
             }

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -17,6 +17,7 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <TargetFrameworkProfile />
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -39,7 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
@@ -422,6 +422,7 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
@@ -465,7 +466,6 @@
     <None Include="assets\HubHop\Msfs2020HubhopPresetListTests\test01.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CmdMessenger\CommandMessenger.Transport.Serial\CommandMessenger.Transport.Serial.csproj">

--- a/MobiFlightUnitTests/mock/FSUIPC/FSUIPCCacheMock.cs
+++ b/MobiFlightUnitTests/mock/FSUIPC/FSUIPCCacheMock.cs
@@ -10,9 +10,9 @@ namespace MobiFlightUnitTests.mock.FSUIPC
 {
     class FSUIPCCacheMock : FSUIPCCacheInterface
     {
-        public event EventHandler Closed;
-        public event EventHandler Connected;
-        public event EventHandler ConnectionLost;
+        public event EventHandler Closed { add { } remove { } }
+        public event EventHandler Connected { add { } remove { } }
+        public event EventHandler ConnectionLost { add { } remove { } }
 
         public List<FSUIPCMockOffset> Writes = new List<FSUIPCMockOffset>();
         public List<FSUIPCMockOffset> Reads = new List<FSUIPCMockOffset>();

--- a/MobiFlightUnitTests/mock/SimConnectMSFS/SimConnectCacheMock.cs
+++ b/MobiFlightUnitTests/mock/SimConnectMSFS/SimConnectCacheMock.cs
@@ -12,9 +12,9 @@ namespace MobiFlightUnitTests.mock.SimConnectMSFS
         public List<String> Writes = new List<String>();
         public List<String> Reads = new List<String>();
 
-        public event EventHandler Closed;
-        public event EventHandler Connected;
-        public event EventHandler ConnectionLost;
+        public event EventHandler Closed { add { } remove { } }
+        public event EventHandler Connected { add { } remove { } }
+        public event EventHandler ConnectionLost { add { } remove { } }
 
         public void Clear()
         {
@@ -130,7 +130,7 @@ namespace MobiFlightUnitTests.mock.SimConnectMSFS
 
     class FSUIPCMockOffset
     {
-        public int Offset;
-        public String Value;
+        public int Offset = 0;
+        public String Value = null;
     }
 }

--- a/MobiFlightUnitTests/mock/xplane/XplaneCacheMock.cs
+++ b/MobiFlightUnitTests/mock/xplane/XplaneCacheMock.cs
@@ -18,9 +18,9 @@ namespace MobiFlightUnitTests.mock.xplane
         Dictionary<String, DataRefElement> SubscribedDataRefs = new Dictionary<String, DataRefElement>();
         private bool _connected;
 
-        public event EventHandler Closed;
-        public event EventHandler ConnectionLost;
-        public event EventHandler Connected;
+        public event EventHandler Closed { add { } remove { } }
+        public event EventHandler ConnectionLost { add { } remove { } }
+        public event EventHandler Connected { add { } remove { } }
 
         internal void Clear()
         {

--- a/MobiFlightUnitTests/packages.config
+++ b/MobiFlightUnitTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net48" />
   <package id="XPlaneConnector" version="1.3.0" targetFramework="net48" />
 </packages>

--- a/UI/Dialogs/TimeoutMessageDialog.Designer.cs
+++ b/UI/Dialogs/TimeoutMessageDialog.Designer.cs
@@ -123,7 +123,7 @@ namespace MobiFlight.UI.Dialogs
         private System.Windows.Forms.Panel ContentPanel;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.Button CancelButton;
+        private new System.Windows.Forms.Button CancelButton;
         private System.Windows.Forms.Button OkButton;
         private System.Windows.Forms.CheckBox checkBox1;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;

--- a/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.cs
@@ -158,8 +158,6 @@ namespace MobiFlight.UI.Panels.Config
             SimVarNameTextBox.TextChanged += SimVarNameTextBox_TextChanged;
             FilterTextBox.TextChanged += textBox1_TextChanged;
 
-            ///
-
             CodeTypeComboBox.SelectedValueChanged += (sender, e) =>
             {
                 ValuePanel.Visible = Mode == HubHopPanelMode.Input && FlightSimType == FlightSimType.XPLANE && (CodeTypeComboBox.SelectedValue.ToString() == XplaneInputAction.INPUT_TYPE_DATAREF);

--- a/VersionInfo/VersionInfo.csproj
+++ b/VersionInfo/VersionInfo.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/packages.config
+++ b/packages.config
@@ -5,12 +5,12 @@
   <package id="Microsoft.ApplicationInsights" version="2.21.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.21.0" targetFramework="net48" />
   <package id="Microsoft.Web.WebView2" version="1.0.1518.46" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net48" />
   <package id="protobuf-net" version="3.1.33" targetFramework="net48" />
   <package id="protobuf-net.Core" version="3.1.33" targetFramework="net48" />
-  <package id="SharpDX" version="4.2.0" targetFramework="net452" />
-  <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net452" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net452" requireReinstallation="true" />
+  <package id="SharpDX" version="4.2.0" targetFramework="net48" />
+  <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net48" />
+  <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.CodeDom" version="7.0.0" targetFramework="net48" />
   <package id="System.Collections.Immutable" version="7.0.0" targetFramework="net48" />
   <package id="System.Diagnostics.DiagnosticSource" version="7.0.0" targetFramework="net48" />


### PR DESCRIPTION
Fixes #1168 

* Add empty `add {}` and `remove {}` methods to get rid of unused event warnings (there's another way to do this but it requires a higher C# language version than the one we use)
* Remove unused exception variables
* Remove empty doc comment
* Add default assignments to properties that are never assigned anywhere
* Reinstall nuget packages to sync all the target framework versions
* Migrate telemetry key to config file (this is the only change that is an actual functionality change, need to verify telemetry still works)

<img width="521" alt="image" src="https://user-images.githubusercontent.com/9524118/222470057-3c936d66-15a1-43e1-ad67-95d7cd73e1ec.png">
