### PR TITLE
Handle possible crash when loading a board configuration

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -743,7 +743,7 @@ namespace MobiFlight
                 if (!double.TryParse(value, out dValue)) return;
 
                 int iValue = (int)Math.Round(dValue,0);
-                module.setShiftRegisterOutput(shiftRegName, outputPin, iValue.ToString());
+                module.SetShiftRegisterOutput(shiftRegName, outputPin, iValue.ToString());
             }
             catch (Exception e)
             {

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -315,6 +315,9 @@ namespace MobiFlight
             analogInputs.Clear();
             shiftRegisters.Clear();
 
+            // Issue #1171: A user reported a crash when MobiFlight attempted to load a board configuration due to
+            // int.TryParse() failing. Add a try/catch to handle any possible bad data that comes from the board
+            // when processing the configuration.
             try
             {
                 foreach (Config.BaseDevice device in Config.Items)

--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -173,7 +173,7 @@ namespace MobiFlight.UI.Panels
                 String pin = (sender as ComboBox).SelectedItem.ToString();
                 foreach (var item in Module.GetConnectedDevices(pin))
                 {
-                    pwmPinPanel.Enabled = pwmPinPanel.Visible = Module.getPwmPins()
+                    pwmPinPanel.Enabled = pwmPinPanel.Visible = Module.GetPwmPins()
                                                 .Find(x => x.Pin == (byte)(item as MobiFlightOutput).Pin) != null;
                     return;
                 }


### PR DESCRIPTION
Fixes #1170 

* Add a try/catch around the core LoadConfig() code, with an error log that identifies what the issue might be
* Clean up all Visual Studio style messages in MobiFlightModule.cs since the file was touched by this change