### PR TITLE
Prevent the exception when sorting by column header

### DIFF
--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -116,10 +116,11 @@ namespace MobiFlight.UI.Panels
                     } //if
 
                     InputConfigItem cfg;
-                    DataRow row = null;
                     bool create = false;
+                    DataRow row = (inputsDataGridView.Rows[e.RowIndex].DataBoundItem as DataRowView)?.Row;
 
-                    row = (inputsDataGridView.Rows[e.RowIndex].DataBoundItem as DataRowView).Row;
+                    if (row == null) 
+                        break;
 
                     // the row had been saved but no config object has been created
                     // TODO: move this logic to an appropriate event, e.g. when leaving the gridrow focus of the new row
@@ -202,7 +203,9 @@ namespace MobiFlight.UI.Panels
                 // duplicate it
                 // duplicate row 
                 // link to new config item 
-                DataRow currentRow = (row.DataBoundItem as DataRowView).Row;
+                DataRow currentRow = (row.DataBoundItem as DataRowView)?.Row;
+                if (currentRow == null) continue;
+
                 DataRow newRow = inputsDataTable.NewRow();
 
                 foreach (DataColumn col in inputsDataTable.Columns)
@@ -357,7 +360,7 @@ namespace MobiFlight.UI.Panels
                 // handle clicks on header cells or row-header cells
                 if (dgv.CurrentRow.Index < 0 || dgv.CurrentCell.ColumnIndex < 0) return;
 
-                if ((inputsDataGridView.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["description"] != null)
+                if ((inputsDataGridView.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView)?.Row["description"] != null)
                 {
                     bool Active = (bool)(inputsDataGridView.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["active"];
                     String Description = (inputsDataGridView.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["description"].ToString();
@@ -492,7 +495,9 @@ namespace MobiFlight.UI.Panels
                 // ignore new rows since they cannot be copied nor deleted
                 if (row.IsNewRow) continue;
 
-                DataRow currentRow = (row.DataBoundItem as DataRowView).Row;
+                DataRow currentRow = (row.DataBoundItem as DataRowView)?.Row;
+                if (currentRow == null) continue;
+
                 bool Active = (bool) currentRow["active"];
                 String Description = currentRow["description"] as String;
                 InputConfigItem cfg = currentRow["settings"] as InputConfigItem;
@@ -593,7 +598,7 @@ namespace MobiFlight.UI.Panels
                     SelectedGuids.Clear();
                     foreach (DataGridViewRow row in (sender as DataGridView).SelectedRows)
                     {
-                        DataRow currentRow = (row.DataBoundItem as DataRowView).Row;
+                        DataRow currentRow = (row.DataBoundItem as DataRowView)?.Row;
                         if (currentRow != null)
                             SelectedGuids.Add(currentRow["guid"].ToString());
                     }

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -210,7 +210,7 @@ namespace MobiFlight.UI.Panels
                     SelectedGuids.Clear();
                     foreach (DataGridViewRow row in (sender as DataGridView).SelectedRows)
                     {
-                        DataRow currentRow = (row.DataBoundItem as DataRowView).Row;
+                        DataRow currentRow = (row.DataBoundItem as DataRowView)?.Row;
                         if (currentRow != null)
                             SelectedGuids.Add(currentRow["guid"].ToString());
                     }
@@ -256,7 +256,9 @@ namespace MobiFlight.UI.Panels
                 // duplicate it
                 // duplicate row 
                 // link to new config item 
-                DataRow currentRow = (row.DataBoundItem as DataRowView).Row;
+                DataRow currentRow = (row.DataBoundItem as DataRowView)?.Row;
+                if (currentRow == null) continue; 
+                
                 DataRow newRow = configDataTable.NewRow();
 
                 foreach (DataColumn col in configDataTable.Columns)
@@ -375,12 +377,12 @@ namespace MobiFlight.UI.Panels
 
                         // the row had been saved but no config object has been created
                         // TODO: move this logic to an appropriate event, e.g. when leaving the gridrow focus of the new row
-                        if ((dataGridViewConfig.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["settings"].GetType() == typeof(System.DBNull))
+                        if (row["settings"].GetType() == typeof(System.DBNull))
                         {
-                            (dataGridViewConfig.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["settings"] = new OutputConfigItem();
+                            row["settings"] = new OutputConfigItem();
                         }
 
-                        cfg = ((dataGridViewConfig.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["settings"] as OutputConfigItem);
+                        cfg = row["settings"] as OutputConfigItem;
 
                         EditConfigWithWizard(
                                  row,
@@ -405,7 +407,7 @@ namespace MobiFlight.UI.Panels
                 // handle clicks on header cells or row-header cells
                 if (dgv.CurrentRow.Index < 0 || dgv.CurrentCell.ColumnIndex < 0) return;
 
-                if ((dataGridViewConfig.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["description"] != null)
+                if ((dataGridViewConfig.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView)?.Row["description"] != null)
                 {
                     bool Active = (bool)(dataGridViewConfig.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["active"];
                     String Description = (dataGridViewConfig.Rows[dgv.CurrentRow.Index].DataBoundItem as DataRowView).Row["description"].ToString();
@@ -684,7 +686,9 @@ namespace MobiFlight.UI.Panels
                 // ignore new rows since they cannot be copied nor deleted
                 if (row.IsNewRow) continue;
 
-                DataRow currentRow = (row.DataBoundItem as DataRowView).Row;
+                DataRow currentRow = (row.DataBoundItem as DataRowView)?.Row;
+                if (currentRow == null) continue; 
+                
                 bool Active = (bool)currentRow["active"];
                 String Description = currentRow["description"] as String;
                 OutputConfigItem cfg = currentRow["settings"] as OutputConfigItem;
@@ -698,9 +702,6 @@ namespace MobiFlight.UI.Panels
             // do somehting here
             foreach (DataGridViewRow row in dataGridViewConfig.SelectedRows)
             {
-                // ignore new rows since they cannot be copied nor deleted
-                //if (row.IsNewRow) continue;
-
                 int index = row.Index;
                 PasteFromClipboard(index+1);
                 return;


### PR DESCRIPTION
fixes #1162 

- [x] Add `?` to the places where DataBoundItem is access and not yet checked for `null`