### PR TITLE
Float64 numbers are displayed correctly in the `Sim Value` column

### DIFF
--- a/Base/ConnectorValue.cs
+++ b/Base/ConnectorValue.cs
@@ -21,10 +21,10 @@ namespace MobiFlight
                     result = String;
                     break;
                 case FSUIPCOffsetType.Integer:
-                    result = Float64.ToString();
+                    result = Float64.ToString("R");
                     break;
                 case FSUIPCOffsetType.Float:
-                    result = Float64.ToString();
+                    result = Float64.ToString("R");
                     break;
                 /*case FSUIPCOffsetType.UnsignedInt:
                     result = Uint64.ToString();

--- a/MobiFlightUnitTests/Base/ConnectorValueTests.cs
+++ b/MobiFlightUnitTests/Base/ConnectorValueTests.cs
@@ -20,10 +20,10 @@ namespace MobiFlight.Tests
             o.String = "TestString";
 
             o.type = FSUIPCOffsetType.Float;
-            Assert.AreEqual(Double.MaxValue.ToString(), o.ToString());
+            Assert.AreEqual(Double.MaxValue.ToString("R"), o.ToString());
 
             o.type = FSUIPCOffsetType.Integer;
-            Assert.AreEqual(Double.MaxValue.ToString(), o.ToString());
+            Assert.AreEqual(Double.MaxValue.ToString("R"), o.ToString());
 
             o.type = FSUIPCOffsetType.String;
             Assert.AreEqual("TestString", o.ToString());


### PR DESCRIPTION
fixes #1161 

- [x] Adding "R" as format type for ToString() 