### PR TITLE
Fixing the Honeycomb LEDs for float values

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -667,7 +667,10 @@ namespace MobiFlight
                 Joystick joystick = joystickManager.GetJoystickBySerial(serial);
                 if(joystick != null)
                 {
-                    joystick.SetOutputDeviceState(cfg.Pin.DisplayPin, value);
+                    byte state = 0;
+                    if (value != "0") state = 1;
+
+                    joystick.SetOutputDeviceState(cfg.Pin.DisplayPin, state);
                     joystick.UpdateOutputDeviceStates();
                     joystick.Update();
                 } else

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -399,8 +399,6 @@ namespace MobiFlight
             foreach(var light in Lights)
             {
                 if (light.Label != name) continue;
-
-                state = (byte)(state > 0 ? 1 : 0);
                 if (light.State == state) continue;
 
                 light.State = state;

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -392,16 +392,18 @@ namespace MobiFlight
             return UsageMap[usage];
         }
 
-        public void SetOutputDeviceState(string name, string value)
+        public void SetOutputDeviceState(string name, byte state)
         {
-            byte state = byte.Parse(value);
+            double tempValue;
 
             foreach(var light in Lights)
             {
                 if (light.Label != name) continue;
+
+                state = (byte)(state > 0 ? 1 : 0);
                 if (light.State == state) continue;
 
-                light.State = (byte) (state > 0 ? 1 : 0);
+                light.State = state;
                 RequiresOutputUpdate = true;
                 return;
             }

--- a/MobiFlight/Joystick.cs
+++ b/MobiFlight/Joystick.cs
@@ -394,8 +394,6 @@ namespace MobiFlight
 
         public void SetOutputDeviceState(string name, byte state)
         {
-            double tempValue;
-
             foreach(var light in Lights)
             {
                 if (light.Label != name) continue;


### PR DESCRIPTION
fixes #1175 

- [x] applying same logic as for LEDs and OutputShiftRegister
- [x] changed `SetOutputDeviceState` function param to `byte`
- [x] fixed test for value change and required update 