### PR TITLE
FSUIPC presets will now show integer values again

### DIFF
--- a/Base/ConnectorValue.cs
+++ b/Base/ConnectorValue.cs
@@ -21,7 +21,7 @@ namespace MobiFlight
                     result = String;
                     break;
                 case FSUIPCOffsetType.Integer:
-                    result = Float64.ToString("R");
+                    result = Math.Round(Float64).ToString();
                     break;
                 case FSUIPCOffsetType.Float:
                     result = Float64.ToString("R");

--- a/MobiFlight/Modifier/Comparison.cs
+++ b/MobiFlight/Modifier/Comparison.cs
@@ -152,7 +152,6 @@ namespace MobiFlight.Modifier
             try
             {
                 result.Float64 = Double.Parse(comparisonResult);
-                result.type = FSUIPCOffsetType.Float;
                 if (result.Float64.ToString()!=comparisonResult.ToString())
                 {
                     result.String = comparisonResult;

--- a/MobiFlightUnitTests/Base/ConnectorValueTests.cs
+++ b/MobiFlightUnitTests/Base/ConnectorValueTests.cs
@@ -23,7 +23,7 @@ namespace MobiFlight.Tests
             Assert.AreEqual(Double.MaxValue.ToString("R"), o.ToString());
 
             o.type = FSUIPCOffsetType.Integer;
-            Assert.AreEqual(Double.MaxValue.ToString("R"), o.ToString());
+            Assert.AreEqual(Double.MaxValue.ToString(), o.ToString());
 
             o.type = FSUIPCOffsetType.String;
             Assert.AreEqual("TestString", o.ToString());

--- a/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
@@ -118,10 +118,13 @@ namespace MobiFlight.Modifier.Tests
 
             Assert.AreEqual(1, c.Apply(value, new List<ConfigRefValue>()).Float64);
             Assert.AreNotEqual(2, c.Apply(value, new List<ConfigRefValue>()).Float64);
+            Assert.AreEqual(FSUIPCOffsetType.Integer, c.Apply(value, new List<ConfigRefValue>()).type);
 
+            value.type = FSUIPCOffsetType.Float;
             value.Float64 = 1;
             Assert.AreEqual(2, c.Apply(value, new List<ConfigRefValue>()).Float64);
             Assert.AreNotEqual(1, c.Apply(value, new List<ConfigRefValue>()).Float64);
+            Assert.AreEqual(FSUIPCOffsetType.Float, c.Apply(value, new List<ConfigRefValue>()).type);
 
 
             c.Active = true;
@@ -133,7 +136,7 @@ namespace MobiFlight.Modifier.Tests
             value.type = FSUIPCOffsetType.Integer;
             value.Float64 = 0;
 
-            Assert.AreEqual(FSUIPCOffsetType.Float, c.Apply(value, new List<ConfigRefValue>()).type);
+            Assert.AreEqual(FSUIPCOffsetType.Integer, c.Apply(value, new List<ConfigRefValue>()).type);
             Assert.AreEqual("0", c.Apply(value, new List<ConfigRefValue>()).Float64.ToString());
 
             c.Active = true;


### PR DESCRIPTION
fixes #1172 

- [x] Maintain `FSUIPCOffsetType.Integer` in Connector Value
- [x] if of type `FSUIPCOffsetType.Integer`, ToString() now applies `Math.Round()` to the internal Float64 value 
- [x] Updated unit tests
- [x] Test in sim with FSUIPC7 and Autopilot Heading - was not working before fix, now it is working.