### PR TITLE
Prevent Error message when opening an output config

### DIFF
--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -367,7 +367,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
                 // third tab
                 if (config.DisplayType != null && 
-                    !ComboBoxHelper.SetSelectedItem(displayTypeComboBox, config.DisplayType))
+                    !ComboBoxHelper.SetSelectedItemByValue(displayTypeComboBox, config.DisplayType))
                 {
                     Log.Instance.log($"Trying to show config but display type {config.DisplayType} not present.", LogSeverity.Error);
                 }


### PR DESCRIPTION
fixes #1145 

- [x] Use correct helper-method to select by value and not label