### PR TITLE
Change how the form is populated if speed and accleration is 0

### DIFF
--- a/UI/Panels/Output/StepperPanel.cs
+++ b/UI/Panels/Output/StepperPanel.cs
@@ -38,8 +38,13 @@ namespace MobiFlight.UI.Panels
 
             inputRevTextBox.Text            = config.Stepper.InputRev.ToString();
             outputRevTextBox.Text           = config.Stepper.OutputRev.ToString();
-            SpeedTextBox.Text               = config.Stepper.Speed.ToString();
-            AccelerationTextBox.Text        = config.Stepper.Acceleration.ToString();
+
+            if (config.Stepper.Speed>0)
+                SpeedTextBox.Text               = config.Stepper.Speed.ToString();
+
+            if (config.Stepper.Acceleration>0)
+                AccelerationTextBox.Text        = config.Stepper.Acceleration.ToString();
+
             stepperTestValueTextBox.Text    = config.Stepper.TestValue.ToString();
             CompassModeCheckBox.Checked     = config.Stepper.CompassMode;
         }


### PR DESCRIPTION
fixes #1190 

If the config value is 0, then we don't update the default values.