### PR TITLE
Further extend width of output pin combobox

### DIFF
--- a/UI/Panels/Output/DisplayPinPanel.Designer.cs
+++ b/UI/Panels/Output/DisplayPinPanel.Designer.cs
@@ -47,9 +47,9 @@
             this.PinSelectContainer = new System.Windows.Forms.Panel();
             this.MultiSelectPinSelectContainer = new System.Windows.Forms.Panel();
             this.PinSelectPanel = new System.Windows.Forms.Panel();
+            this.MultiPinSelectPanel = new MobiFlight.UI.Panels.PinSelectPanel();
             this.LabelPinSelectContainer = new System.Windows.Forms.Panel();
             this.label3 = new System.Windows.Forms.Label();
-            this.MultiPinSelectPanel = new MobiFlight.UI.Panels.PinSelectPanel();
             this.displayPinBrightnessPanel.SuspendLayout();
             this.displayPinBrightnessLabelPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.displayPinBrightnessTrackBar)).BeginInit();
@@ -175,10 +175,15 @@
             // 
             // PinSelectPanel
             // 
+            resources.ApplyResources(this.PinSelectPanel, "PinSelectPanel");
             this.PinSelectPanel.Controls.Add(this.MultiPinSelectPanel);
             this.PinSelectPanel.Controls.Add(this.singlePinSelectFlowLayoutPanel);
-            resources.ApplyResources(this.PinSelectPanel, "PinSelectPanel");
             this.PinSelectPanel.Name = "PinSelectPanel";
+            // 
+            // MultiPinSelectPanel
+            // 
+            resources.ApplyResources(this.MultiPinSelectPanel, "MultiPinSelectPanel");
+            this.MultiPinSelectPanel.Name = "MultiPinSelectPanel";
             // 
             // LabelPinSelectContainer
             // 
@@ -190,11 +195,6 @@
             // 
             resources.ApplyResources(this.label3, "label3");
             this.label3.Name = "label3";
-            // 
-            // MultiPinSelectPanel
-            // 
-            resources.ApplyResources(this.MultiPinSelectPanel, "MultiPinSelectPanel");
-            this.MultiPinSelectPanel.Name = "MultiPinSelectPanel";
             // 
             // DisplayPinPanel
             // 
@@ -217,6 +217,7 @@
             this.MultiSelectPinSelectContainer.ResumeLayout(false);
             this.MultiSelectPinSelectContainer.PerformLayout();
             this.PinSelectPanel.ResumeLayout(false);
+            this.PinSelectPanel.PerformLayout();
             this.LabelPinSelectContainer.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/UI/Panels/Output/DisplayPinPanel.resx
+++ b/UI/Panels/Output/DisplayPinPanel.resx
@@ -163,7 +163,7 @@
     <value>2, 0, 2, 0</value>
   </data>
   <data name="displayPinBrightnessDimLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>273, 26</value>
+    <value>438, 26</value>
   </data>
   <data name="displayPinBrightnessDimLabel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -196,7 +196,7 @@
     <value>NoControl</value>
   </data>
   <data name="displayPinBrightnessMediumLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>300, 45</value>
+    <value>465, 45</value>
   </data>
   <data name="displayPinBrightnessMediumLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 0, 2, 0</value>
@@ -271,7 +271,7 @@
     <value>0, 0</value>
   </data>
   <data name="displayPinBrightnessTrackBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>329, 45</value>
+    <value>494, 45</value>
   </data>
   <data name="displayPinBrightnessTrackBar.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -295,7 +295,7 @@
     <value>106, 0</value>
   </data>
   <data name="displayPinBrightnessLabelPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>329, 71</value>
+    <value>494, 71</value>
   </data>
   <data name="displayPinBrightnessLabelPanel.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -373,7 +373,7 @@
     <value>0, 161</value>
   </data>
   <data name="displayPinBrightnessPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>435, 71</value>
+    <value>600, 71</value>
   </data>
   <data name="displayPinBrightnessPanel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -460,7 +460,7 @@
     <value>0, 32</value>
   </data>
   <data name="pwmPinPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>435, 32</value>
+    <value>600, 32</value>
   </data>
   <data name="pwmPinPanel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -484,7 +484,7 @@
     <value>2, 3, 3, 3</value>
   </data>
   <data name="displayPinComboBox.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>122, 0</value>
+    <value>220, 0</value>
   </data>
   <data name="displayPinComboBox.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>47, 0</value>
@@ -517,7 +517,7 @@
     <value>0, 3, 0, 3</value>
   </data>
   <data name="singlePinSelectFlowLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 28</value>
+    <value>494, 28</value>
   </data>
   <data name="singlePinSelectFlowLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -577,13 +577,16 @@
     <value>GrowAndShrink</value>
   </data>
   <data name="MultiSelectPinSelectContainer.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+    <value>Right</value>
   </data>
   <data name="MultiSelectPinSelectContainer.Location" type="System.Drawing.Point, System.Drawing">
-    <value>288, 0</value>
+    <value>300, 0</value>
+  </data>
+  <data name="MultiSelectPinSelectContainer.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>300, 0</value>
   </data>
   <data name="MultiSelectPinSelectContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 129</value>
+    <value>300, 129</value>
   </data>
   <data name="MultiSelectPinSelectContainer.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -599,6 +602,12 @@
   </data>
   <data name="&gt;&gt;MultiSelectPinSelectContainer.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="PinSelectPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="MultiPinSelectPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="MultiPinSelectPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
@@ -616,7 +625,7 @@
     <value>150, 100</value>
   </data>
   <data name="MultiPinSelectPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 101</value>
+    <value>494, 101</value>
   </data>
   <data name="MultiPinSelectPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -634,13 +643,13 @@
     <value>0</value>
   </data>
   <data name="PinSelectPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Left</value>
+    <value>Fill</value>
   </data>
   <data name="PinSelectPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>106, 0</value>
   </data>
   <data name="PinSelectPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>182, 129</value>
+    <value>494, 129</value>
   </data>
   <data name="PinSelectPanel.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -718,7 +727,7 @@
     <value>0, 0</value>
   </data>
   <data name="PinSelectContainer.Size" type="System.Drawing.Size, System.Drawing">
-    <value>435, 129</value>
+    <value>600, 129</value>
   </data>
   <data name="PinSelectContainer.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -742,7 +751,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>435, 232</value>
+    <value>600, 232</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>DisplayPinPanel</value>


### PR DESCRIPTION
Fix #1196.
Now even longer labels to describe output pins for joysticks and midiboards are possible.
