### PR TITLE
PWM Pin option is shown only for PWM capable pins

### DIFF
--- a/Base/SerialNumber.cs
+++ b/Base/SerialNumber.cs
@@ -33,6 +33,12 @@ namespace MobiFlight.Base
             return String.Join("", tokens).Trim();
         }
 
+        public static bool IsArcazeSerial(string serial)
+        {
+            if (serial == null || serial == "") return false;
+            return !IsMidiBoardSerial(serial) && !IsMobiFlightSerial(serial) && !IsJoystickSerial(serial);
+        }
+
         public static bool IsMobiFlightSerial(string serial)
         {
             if (serial == null || serial == "") return false;

--- a/MobiFlightUnitTests/Base/SerialNumberTests.cs
+++ b/MobiFlightUnitTests/Base/SerialNumberTests.cs
@@ -90,5 +90,41 @@ namespace MobiFlight.Base.Tests
             result = SerialNumber.IsJoystickSerial(SerialNumber.ExtractSerial(serial));
             Assert.AreEqual(false, result);
         }
+
+        [TestMethod()]
+        public void IsArcazeSerialTest()
+        {
+            var serial = "GMA345/ SN-b44-4c5";
+            var result = SerialNumber.IsArcazeSerial(SerialNumber.ExtractSerial(serial));
+            Assert.AreEqual(false, result);
+
+            serial = "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000";
+            result = SerialNumber.IsArcazeSerial(SerialNumber.ExtractSerial(serial));
+            Assert.AreEqual(false, result);
+
+            serial = "Arcaze v5.36/ 000393600000";
+            result = SerialNumber.IsArcazeSerial(SerialNumber.ExtractSerial(serial));
+            Assert.AreEqual(true, result);
+        }
+
+        [TestMethod()]
+        public void IsMidiBoardSerialTest()
+        {
+            var serial = "GMA345/ SN-b44-4c5";
+            var result = SerialNumber.IsMidiBoardSerial(SerialNumber.ExtractSerial(serial));
+            Assert.AreEqual(false, result);
+
+            serial = "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000";
+            result = SerialNumber.IsMidiBoardSerial(SerialNumber.ExtractSerial(serial));
+            Assert.AreEqual(false, result);
+
+            serial = "Arcaze v5.36/ 000393600000";
+            result = SerialNumber.IsMidiBoardSerial(SerialNumber.ExtractSerial(serial));
+            Assert.AreEqual(false, result);
+
+            serial = "My MidiDevice/ MI-123456";
+            result = SerialNumber.IsMidiBoardSerial(SerialNumber.ExtractSerial(serial));
+            Assert.AreEqual(true, result);
+        }
     }
 }

--- a/UI/Panels/Output/DisplayPinPanel.Designer.cs
+++ b/UI/Panels/Output/DisplayPinPanel.Designer.cs
@@ -47,9 +47,9 @@
             this.PinSelectContainer = new System.Windows.Forms.Panel();
             this.MultiSelectPinSelectContainer = new System.Windows.Forms.Panel();
             this.PinSelectPanel = new System.Windows.Forms.Panel();
-            this.MultiPinSelectPanel = new MobiFlight.UI.Panels.PinSelectPanel();
             this.LabelPinSelectContainer = new System.Windows.Forms.Panel();
             this.label3 = new System.Windows.Forms.Label();
+            this.MultiPinSelectPanel = new MobiFlight.UI.Panels.PinSelectPanel();
             this.displayPinBrightnessPanel.SuspendLayout();
             this.displayPinBrightnessLabelPanel.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.displayPinBrightnessTrackBar)).BeginInit();
@@ -162,8 +162,8 @@
             // PinSelectContainer
             // 
             resources.ApplyResources(this.PinSelectContainer, "PinSelectContainer");
-            this.PinSelectContainer.Controls.Add(this.MultiSelectPinSelectContainer);
             this.PinSelectContainer.Controls.Add(this.PinSelectPanel);
+            this.PinSelectContainer.Controls.Add(this.MultiSelectPinSelectContainer);
             this.PinSelectContainer.Controls.Add(this.LabelPinSelectContainer);
             this.PinSelectContainer.Name = "PinSelectContainer";
             // 
@@ -180,11 +180,6 @@
             this.PinSelectPanel.Controls.Add(this.singlePinSelectFlowLayoutPanel);
             this.PinSelectPanel.Name = "PinSelectPanel";
             // 
-            // MultiPinSelectPanel
-            // 
-            resources.ApplyResources(this.MultiPinSelectPanel, "MultiPinSelectPanel");
-            this.MultiPinSelectPanel.Name = "MultiPinSelectPanel";
-            // 
             // LabelPinSelectContainer
             // 
             this.LabelPinSelectContainer.Controls.Add(this.label3);
@@ -195,6 +190,11 @@
             // 
             resources.ApplyResources(this.label3, "label3");
             this.label3.Name = "label3";
+            // 
+            // MultiPinSelectPanel
+            // 
+            resources.ApplyResources(this.MultiPinSelectPanel, "MultiPinSelectPanel");
+            this.MultiPinSelectPanel.Name = "MultiPinSelectPanel";
             // 
             // DisplayPinPanel
             // 

--- a/UI/Panels/Output/DisplayPinPanel.Designer.cs
+++ b/UI/Panels/Output/DisplayPinPanel.Designer.cs
@@ -45,8 +45,8 @@
             this.singlePinSelectFlowLayoutPanel = new System.Windows.Forms.FlowLayoutPanel();
             this.selectMultiplePinsCheckBox = new System.Windows.Forms.CheckBox();
             this.PinSelectContainer = new System.Windows.Forms.Panel();
-            this.MultiSelectPinSelectContainer = new System.Windows.Forms.Panel();
             this.PinSelectPanel = new System.Windows.Forms.Panel();
+            this.MultiSelectPinSelectContainer = new System.Windows.Forms.Panel();
             this.LabelPinSelectContainer = new System.Windows.Forms.Panel();
             this.label3 = new System.Windows.Forms.Label();
             this.MultiPinSelectPanel = new MobiFlight.UI.Panels.PinSelectPanel();
@@ -57,8 +57,8 @@
             this.pwmPinPanel.SuspendLayout();
             this.singlePinSelectFlowLayoutPanel.SuspendLayout();
             this.PinSelectContainer.SuspendLayout();
-            this.MultiSelectPinSelectContainer.SuspendLayout();
             this.PinSelectPanel.SuspendLayout();
+            this.MultiSelectPinSelectContainer.SuspendLayout();
             this.LabelPinSelectContainer.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -167,18 +167,18 @@
             this.PinSelectContainer.Controls.Add(this.LabelPinSelectContainer);
             this.PinSelectContainer.Name = "PinSelectContainer";
             // 
-            // MultiSelectPinSelectContainer
-            // 
-            resources.ApplyResources(this.MultiSelectPinSelectContainer, "MultiSelectPinSelectContainer");
-            this.MultiSelectPinSelectContainer.Controls.Add(this.selectMultiplePinsCheckBox);
-            this.MultiSelectPinSelectContainer.Name = "MultiSelectPinSelectContainer";
-            // 
             // PinSelectPanel
             // 
             resources.ApplyResources(this.PinSelectPanel, "PinSelectPanel");
             this.PinSelectPanel.Controls.Add(this.MultiPinSelectPanel);
             this.PinSelectPanel.Controls.Add(this.singlePinSelectFlowLayoutPanel);
             this.PinSelectPanel.Name = "PinSelectPanel";
+            // 
+            // MultiSelectPinSelectContainer
+            // 
+            resources.ApplyResources(this.MultiSelectPinSelectContainer, "MultiSelectPinSelectContainer");
+            this.MultiSelectPinSelectContainer.Controls.Add(this.selectMultiplePinsCheckBox);
+            this.MultiSelectPinSelectContainer.Name = "MultiSelectPinSelectContainer";
             // 
             // LabelPinSelectContainer
             // 
@@ -214,10 +214,10 @@
             this.singlePinSelectFlowLayoutPanel.ResumeLayout(false);
             this.PinSelectContainer.ResumeLayout(false);
             this.PinSelectContainer.PerformLayout();
-            this.MultiSelectPinSelectContainer.ResumeLayout(false);
-            this.MultiSelectPinSelectContainer.PerformLayout();
             this.PinSelectPanel.ResumeLayout(false);
             this.PinSelectPanel.PerformLayout();
+            this.MultiSelectPinSelectContainer.ResumeLayout(false);
+            this.MultiSelectPinSelectContainer.PerformLayout();
             this.LabelPinSelectContainer.ResumeLayout(false);
             this.ResumeLayout(false);
 

--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -1,4 +1,5 @@
 ﻿using MobiFlight.Base;
+using MobiFlight.OutputConfig;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -18,6 +19,7 @@ namespace MobiFlight.UI.Panels
             InitializeComponent();
             displayPortComboBox.SelectedIndexChanged += displayPortComboBox_SelectedIndexChanged;
             displayPinComboBox.SelectedIndexChanged += displayPinComboBox_SelectedIndexChanged;
+            MultiPinSelectPanel.SelectionChanged += MultiPinSelectPanel_SelectionChanged;
 
             MultiPinSelectPanel.Visible = false;
             singlePinSelectFlowLayoutPanel.Visible = true;
@@ -38,7 +40,6 @@ namespace MobiFlight.UI.Panels
 
         internal void EnablePWMSelect(bool enable)
         {
-            //pwmPinPanel.Visible = Module.getPwmPins().Contains((byte)(item as MobiFlightOutput).Pin);
             pwmPinPanel.Visible = enable;
         }
 
@@ -195,7 +196,17 @@ namespace MobiFlight.UI.Panels
                 singlePinSelectFlowLayoutPanel.Visible = true;
                 PinSelectContainer.Height = singlePinSelectFlowLayoutPanel.Height;
             }
+        }
 
+        private void MultiPinSelectPanel_SelectionChanged(object sender, List<ListItem> selectedPins)
+        {
+            var pwmPins = Module.getPwmPins();
+
+            pwmPinPanel.Enabled = pwmPinPanel.Visible
+                                = selectedPins.All(
+                                    pin => pwmPins.Find(
+                                        pwmPin => pwmPin.Pin == (Module.GetConnectedDevices(pin.Value).First() as MobiFlightOutput).Pin
+                                    ) != null);
         }
     }
 }

--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -68,7 +68,11 @@ namespace MobiFlight.UI.Panels
             displayPinComboBox.Enabled = pins.Count > 0;
             displayPinComboBox.Width = WideStyle ? displayPinComboBox.MaximumSize.Width : displayPinComboBox.MinimumSize.Width;
 
-
+            if (Module != null && pins.Count > 1)
+            {
+                // this is MobiFlight Outputs
+                _MultiSelectOptions(true);
+            }
             MultiPinSelectPanel?.SetPins(pins);
         }
         private void displayPortComboBox_SelectedIndexChanged(object sender, EventArgs e)
@@ -105,7 +109,7 @@ namespace MobiFlight.UI.Panels
                     _MultiSelectOptions(false);
                     pin = config.Pin.DisplayPin;
                 }
-                else if (!SerialNumber.IsMobiFlightSerial(serial))
+                else if (SerialNumber.IsArcazeSerial(serial))
                 {
                     // these are Arcaze Boards.
                     // Arcaze Boards only have "single output"
@@ -114,7 +118,7 @@ namespace MobiFlight.UI.Panels
 
                     // disable multi-select option
                     _MultiSelectOptions(false);
-                } else {
+                } else if (SerialNumber.IsMobiFlightSerial(serial)) {
 
                     // this is MobiFlight Outputs
                     _MultiSelectOptions(true);

--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -17,6 +17,7 @@ namespace MobiFlight.UI.Panels
         {
             InitializeComponent();
             displayPortComboBox.SelectedIndexChanged += displayPortComboBox_SelectedIndexChanged;
+            displayPinComboBox.SelectedIndexChanged += displayPinComboBox_SelectedIndexChanged;
 
             MultiPinSelectPanel.Visible = false;
             singlePinSelectFlowLayoutPanel.Visible = true;

--- a/UI/Panels/Output/DisplayPinPanel.resx
+++ b/UI/Panels/Output/DisplayPinPanel.resx
@@ -484,13 +484,13 @@
     <value>2, 3, 3, 3</value>
   </data>
   <data name="displayPinComboBox.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>220, 0</value>
+    <value>235, 0</value>
   </data>
   <data name="displayPinComboBox.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>47, 0</value>
   </data>
   <data name="displayPinComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>122, 21</value>
+    <value>137, 21</value>
   </data>
   <data name="displayPinComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -590,6 +590,9 @@
   </data>
   <data name="MultiPinSelectPanel.MinimumSize" type="System.Drawing.Size, System.Drawing">
     <value>150, 100</value>
+  </data>
+  <data name="MultiPinSelectPanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 3, 3</value>
   </data>
   <data name="MultiPinSelectPanel.Size" type="System.Drawing.Size, System.Drawing">
     <value>194, 101</value>

--- a/UI/Panels/Output/DisplayPinPanel.resx
+++ b/UI/Panels/Output/DisplayPinPanel.resx
@@ -517,7 +517,7 @@
     <value>0, 3, 0, 3</value>
   </data>
   <data name="singlePinSelectFlowLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 28</value>
+    <value>194, 28</value>
   </data>
   <data name="singlePinSelectFlowLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -570,6 +570,69 @@
   <data name="PinSelectContainer.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
     <value>GrowAndShrink</value>
   </data>
+  <data name="PinSelectPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="MultiPinSelectPanel.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="MultiPinSelectPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
+    <value>GrowAndShrink</value>
+  </data>
+  <data name="MultiPinSelectPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="MultiPinSelectPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 28</value>
+  </data>
+  <data name="MultiPinSelectPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="MultiPinSelectPanel.MinimumSize" type="System.Drawing.Size, System.Drawing">
+    <value>150, 100</value>
+  </data>
+  <data name="MultiPinSelectPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 101</value>
+  </data>
+  <data name="MultiPinSelectPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;MultiPinSelectPanel.Name" xml:space="preserve">
+    <value>MultiPinSelectPanel</value>
+  </data>
+  <data name="&gt;&gt;MultiPinSelectPanel.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.PinSelectPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;MultiPinSelectPanel.Parent" xml:space="preserve">
+    <value>PinSelectPanel</value>
+  </data>
+  <data name="&gt;&gt;MultiPinSelectPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="PinSelectPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="PinSelectPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>106, 0</value>
+  </data>
+  <data name="PinSelectPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>194, 129</value>
+  </data>
+  <data name="PinSelectPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>12</value>
+  </data>
+  <data name="&gt;&gt;PinSelectPanel.Name" xml:space="preserve">
+    <value>PinSelectPanel</value>
+  </data>
+  <data name="&gt;&gt;PinSelectPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;PinSelectPanel.Parent" xml:space="preserve">
+    <value>PinSelectContainer</value>
+  </data>
+  <data name="&gt;&gt;PinSelectPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="MultiSelectPinSelectContainer.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -601,69 +664,6 @@
     <value>PinSelectContainer</value>
   </data>
   <data name="&gt;&gt;MultiSelectPinSelectContainer.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="PinSelectPanel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="MultiPinSelectPanel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="MultiPinSelectPanel.AutoSizeMode" type="System.Windows.Forms.AutoSizeMode, System.Windows.Forms">
-    <value>GrowAndShrink</value>
-  </data>
-  <data name="MultiPinSelectPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="MultiPinSelectPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 28</value>
-  </data>
-  <data name="MultiPinSelectPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
-  <data name="MultiPinSelectPanel.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>150, 100</value>
-  </data>
-  <data name="MultiPinSelectPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 101</value>
-  </data>
-  <data name="MultiPinSelectPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;MultiPinSelectPanel.Name" xml:space="preserve">
-    <value>MultiPinSelectPanel</value>
-  </data>
-  <data name="&gt;&gt;MultiPinSelectPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.PinSelectPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
-  </data>
-  <data name="&gt;&gt;MultiPinSelectPanel.Parent" xml:space="preserve">
-    <value>PinSelectPanel</value>
-  </data>
-  <data name="&gt;&gt;MultiPinSelectPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="PinSelectPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="PinSelectPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>106, 0</value>
-  </data>
-  <data name="PinSelectPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>494, 129</value>
-  </data>
-  <data name="PinSelectPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
-  </data>
-  <data name="&gt;&gt;PinSelectPanel.Name" xml:space="preserve">
-    <value>PinSelectPanel</value>
-  </data>
-  <data name="&gt;&gt;PinSelectPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;PinSelectPanel.Parent" xml:space="preserve">
-    <value>PinSelectContainer</value>
-  </data>
-  <data name="&gt;&gt;PinSelectPanel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
   <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">

--- a/UI/Panels/Output/PinSelectPanel.Designer.cs
+++ b/UI/Panels/Output/PinSelectPanel.Designer.cs
@@ -53,10 +53,10 @@
             "Test 14",
             "Test 15",
             "Test 16"});
-            this.checkedListBox.Location = new System.Drawing.Point(0, 0);
+            this.checkedListBox.Location = new System.Drawing.Point(3, 3);
             this.checkedListBox.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.checkedListBox.Name = "checkedListBox";
-            this.checkedListBox.Size = new System.Drawing.Size(385, 269);
+            this.checkedListBox.Size = new System.Drawing.Size(379, 263);
             this.checkedListBox.TabIndex = 6;
             // 
             // PinSelectPanel
@@ -67,6 +67,7 @@
             this.Controls.Add(this.checkedListBox);
             this.MinimumSize = new System.Drawing.Size(225, 162);
             this.Name = "PinSelectPanel";
+            this.Padding = new System.Windows.Forms.Padding(3);
             this.Size = new System.Drawing.Size(385, 269);
             this.ResumeLayout(false);
 

--- a/UI/Panels/Output/PinSelectPanel.Designer.cs
+++ b/UI/Panels/Output/PinSelectPanel.Designer.cs
@@ -58,6 +58,7 @@
             this.checkedListBox.Name = "checkedListBox";
             this.checkedListBox.Size = new System.Drawing.Size(379, 263);
             this.checkedListBox.TabIndex = 6;
+            this.checkedListBox.SelectedIndexChanged += new System.EventHandler(this.checkedListBox_SelectedIndexChanged);
             // 
             // PinSelectPanel
             // 

--- a/UI/Panels/Output/PinSelectPanel.cs
+++ b/UI/Panels/Output/PinSelectPanel.cs
@@ -14,6 +14,7 @@ namespace MobiFlight.UI.Panels
     {
         public const char POSITION_SEPERATOR = '|';
         public bool WideStyle = false;
+        public event EventHandler<List<ListItem>> SelectionChanged;
 
         public PinSelectPanel()
         {
@@ -77,5 +78,16 @@ namespace MobiFlight.UI.Panels
             return pins.ToString();
         }
 
+        private void checkedListBox_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            var selection = new List<ListItem>();
+
+            foreach (ListItem checkedItem in checkedListBox.CheckedItems)
+            {
+                selection.Add(checkedItem);
+            }
+
+            SelectionChanged?.Invoke(this, selection);
+        }
     }
 }


### PR DESCRIPTION
fixes #1201 

- PWM pin option only displayed when a PWM-capable pin is selected
- PWM option now also available for multi-selection when all checked pins support PWM
- Fixed `Dock`-property and added padding to multiselect
- Multi-select option is displayed correctly

![1201-pwm-option](https://user-images.githubusercontent.com/86157512/235363512-2eb401ca-15da-47f3-91d7-359b8f879bc8.gif)

- Added `IsArcazeSerial` as method to make it clear and similar to all the other boards. Arcaze Serial is detected when all other Serial Types are returning `false` (MobiFlight, Joystick, MidiBoard)
- Added unit tests (also for Midi Board Serial)