### PR TITLE
Move LoadConfig() out of connect() for stable board detection

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -392,6 +392,7 @@ namespace MobiFlight
                     ModuleConnecting?.Invoke(this, "Connecting to MobiFlight Modules", progressValue);
                     module.Connect();
                     module.GetInfo();
+                    module.LoadConfig();
                     ModuleConnecting?.Invoke(this, "Connecting to MobiFlight Modules", progressValue);
                 }));
             }

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -293,9 +293,9 @@ namespace MobiFlight
                 System.Threading.Thread.Sleep(Board.Connection.ConnectionDelay);
             }
 
-            //if (!this.Connected) return;
-            //ResetBoard();
-            LoadConfig();
+            // if (!this.Connected) return;
+            // ResetBoard();
+            // LoadConfig();
         }
 
         public void ResetBoard()

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -1271,6 +1271,7 @@ namespace MobiFlight.UI.Panels.Settings
             {
                 module.Connect();
                 newInfo = module.GetInfo() as MobiFlightModuleInfo;
+                module.LoadConfig();
             }
             else
             {


### PR DESCRIPTION
related to #1205 

This is a potential improvement because during initial connect the config is not immediately loaded, and thereby we prevent to send a lot of data at once just right after connecting.

Changes:
- `LoadConfig` removed from `connect` method
- `LoadConfig` now explicitly called only for MobiFlight boards, after `GetInfo`

Feedback from the user who reported #1205 - it didn't make a difference, but I think it is an optimization to keep and see how it behaves for other users