### PR TITLE
Update timeout value for nano boards

### DIFF
--- a/Boards/arduino_nano.board.json
+++ b/Boards/arduino_nano.board.json
@@ -5,7 +5,7 @@
     "Device": "atmega328p",
     "BaudRates": [ "115200", "57600" ],
     "Programmer": "arduino",
-    "Timeout": 15000
+    "Timeout": 20000
   },
   "Connection": {
     "ConnectionDelay": 1750,


### PR DESCRIPTION
Fixes #1202 

Increase the timeout to 20000ms per testing from Jaime.