### PR TITLE
Set Arduino Mega connection delay to 1750

### DIFF
--- a/Boards/arduino_mega.board.json
+++ b/Boards/arduino_mega.board.json
@@ -2,12 +2,12 @@
   "$schema": "./mfboard.schema.json",
   "AvrDudeSettings": {
     "Device": "atmega2560",
-    "BaudRates": [ "115200" ],
+    "BaudRates": ["115200"],
     "Programmer": "wiring",
     "Timeout": 15000
   },
   "Connection": {
-    "ConnectionDelay": 1250,
+    "ConnectionDelay": 1750,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": false,
     "DelayAfterFirmwareUpdate": 0,


### PR DESCRIPTION
Fixes #1225 

Sets the delay for the mega to 1750 to match the Nano connection delay. Seems like CH340-based boards need the longer time.