### PR TITLE
Add missing pins A6 and A7 to nano

### DIFF
--- a/Boards/arduino_micro.board.json
+++ b/Boards/arduino_micro.board.json
@@ -135,12 +135,6 @@
       "Pin": 16
     },
     {
-      "isAnalog": false,
-      "isI2C": false,
-      "isPWM": false,
-      "Pin": 17
-    },
-    {
       "isAnalog": true,
       "isI2C": false,
       "isPWM": false,

--- a/Boards/arduino_micro.board.json
+++ b/Boards/arduino_micro.board.json
@@ -32,7 +32,7 @@
     "ResetFirmwareFile": "reset.arduino_promicro_1_0_2.hex"
   },
   "ModuleLimits": {
-    "MaxAnalogInputs": 5,
+    "MaxAnalogInputs": 9,
     "MaxButtons": 18,
     "MaxEncoders": 9,
     "MaxInputShifters": 2,
@@ -73,7 +73,8 @@
       "isAnalog": true,
       "isI2C": false,
       "isPWM": false,
-      "Pin": 4
+      "Pin": 4,
+      "Name": "A6"
     },
     {
       "isAnalog": false,
@@ -85,7 +86,8 @@
       "isAnalog": true,
       "isI2C": false,
       "isPWM": true,
-      "Pin": 6
+      "Pin": 6,
+      "Name": "A7"
     },
     {
       "isAnalog": false,
@@ -97,19 +99,22 @@
       "isAnalog": true,
       "isI2C": false,
       "isPWM": false,
-      "Pin": 8
+      "Pin": 8,
+      "Name": "A8"
     },
     {
       "isAnalog": true,
       "isI2C": false,
       "isPWM": true,
-      "Pin": 9
+      "Pin": 9,
+      "Name": "A9"
     },
     {
-      "isAnalog": false,
+      "isAnalog": true,
       "isI2C": false,
       "isPWM": true,
-      "Pin": 10
+      "Pin": 10,
+      "Name": "A10"
     },
     {
       "isAnalog": false,

--- a/Boards/arduino_nano.board.json
+++ b/Boards/arduino_nano.board.json
@@ -38,7 +38,7 @@
     "ResetFirmwareFile": "reset.arduino_uno_1_0_2.hex"
   },
   "ModuleLimits": {
-    "MaxAnalogInputs": 6,
+    "MaxAnalogInputs": 8,
     "MaxButtons": 18,
     "MaxEncoders": 9,
     "MaxInputShifters": 2,
@@ -164,6 +164,20 @@
       "isPWM": false,
       "Name": "A5",
       "Pin": 19
+    },
+    {
+      "isAnalog": true,
+      "isI2C": true,
+      "isPWM": false,
+      "Name": "A6",
+      "Pin": 20
+    },
+    {
+      "isAnalog": true,
+      "isI2C": true,
+      "isPWM": false,
+      "Name": "A7",
+      "Pin": 21
     }
   ]
 }

--- a/Boards/arduino_nano.board.json
+++ b/Boards/arduino_nano.board.json
@@ -167,14 +167,14 @@
     },
     {
       "isAnalog": true,
-      "isI2C": true,
+      "isI2C": false,
       "isPWM": false,
       "Name": "A6",
       "Pin": 20
     },
     {
       "isAnalog": true,
-      "isI2C": true,
+      "isI2C": false,
       "isPWM": false,
       "Name": "A7",
       "Pin": 21


### PR DESCRIPTION
Fixes #1228 

Adds the missing A6 and A7 pins to the nano board file and increases the max number of analog pins to 8.

While the two pins work without a firmware change, the firmware also needs to update to have a max analog pin count of 8 for all the pins to be usable at the same time (see https://github.com/MobiFlight/MobiFlight-Connector/issues/1228)