### PR TITLE
Capture and show avrdude output and error text

### DIFF
--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -125,21 +125,40 @@ namespace MobiFlight
             
             //verboseLevel = " -v -v -v -v";
 
-            String FullAvrDudePath = $@"{ArduinoIdePath}\{AvrPath}";
+            // Process() requires an absolute, rather than relative, path when using UseShellExecute = false
+            String FullAvrDudePath = Path.GetFullPath(Path.Combine(ArduinoIdePath, AvrPath));
 
             foreach (var baudRate in board.AvrDudeSettings.BaudRates)
             {
-                var proc1 = new ProcessStartInfo();
+                var p = new Process();
+
                 var attempts = board.AvrDudeSettings.Attempts != null ? $" -x attempts={board.AvrDudeSettings.Attempts}" : "";
                 string anyCommand =
-                    $@"-C""{FullAvrDudePath}\etc\avrdude.conf""{verboseLevel}{attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{port} -b{baudRate} -D -Uflash:w:""{FirmwarePath}\{firmwareName}"":i";
-                proc1.UseShellExecute = true;
-                proc1.WorkingDirectory = $@"""{FullAvrDudePath}""";
-                proc1.FileName = $@"""{FullAvrDudePath}\bin\avrdude""";
-                proc1.Arguments = anyCommand;
-                proc1.WindowStyle = ProcessWindowStyle.Hidden;
-                Log.Instance.log($"{proc1.FileName} {anyCommand}", LogSeverity.Debug);
-                Process p = Process.Start(proc1);
+                    $@"-C""{Path.Combine(FullAvrDudePath, "etc", "avrdude.conf")}""{verboseLevel}{attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{port} -b{baudRate} -D -Uflash:w:""{FirmwarePath}\{firmwareName}"":i";
+
+                // StandardOutput and StandardError can only be captured when UseShellExecute is false
+                p.StartInfo.UseShellExecute = false;
+                p.StartInfo.WorkingDirectory = FullAvrDudePath;
+                p.StartInfo.FileName = Path.Combine(FullAvrDudePath, "bin", "avrdude");
+                p.StartInfo.Arguments = anyCommand;
+
+                // When UseShellExecute is false the CreateNoWindow flag has to be used to hide the window
+                p.StartInfo.CreateNoWindow = true;
+
+                // Without setting these to true the output won't get captured
+                p.StartInfo.RedirectStandardOutput = true;
+                p.StartInfo.RedirectStandardError = true;
+
+                // Output and Error text is read asynchronously to avoid known deadlock issues
+                p.OutputDataReceived += (sender, args) => Log.Instance.log(args.Data, LogSeverity.Debug);
+                p.ErrorDataReceived += (sender, args) => Log.Instance.log(args.Data, LogSeverity.Debug);
+
+                Log.Instance.log($"{p.StartInfo.FileName} {anyCommand}", LogSeverity.Debug);
+
+                p.Start();
+                p.BeginOutputReadLine();
+                p.BeginErrorReadLine();
+
                 if (p.WaitForExit(board.AvrDudeSettings.Timeout))
                 {
                     Log.Instance.log($"Firmware upload exit code: {p.ExitCode}.", LogSeverity.Debug);
@@ -147,13 +166,13 @@ namespace MobiFlight
                     if (p.ExitCode == 0) return;
 
                     // process terminated but with an error.
-                    message = $"ExitCode: {p.ExitCode} => Something went wrong when flashing with command \n {proc1.FileName} {anyCommand}.";
+                    message = $"ExitCode: {p.ExitCode} => Something went wrong when flashing with command \n {p.StartInfo.FileName} {anyCommand}.";
                 }
                 else
                 {
                     // we timed out;
                     p.Kill();
-                    message = $"avrdude timed out! Something went wrong when flashing with command \n {proc1.FileName} {anyCommand}.";
+                    message = $"avrdude timed out! Something went wrong when flashing with command \n {p.StartInfo.FileName} {anyCommand}.";
                 }
                 Log.Instance.log(message, LogSeverity.Error);
             }

--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -151,7 +151,7 @@ namespace MobiFlight
 
                 // Output and Error text is read asynchronously to avoid known deadlock issues
                 p.OutputDataReceived += (sender, args) => Log.Instance.log(args.Data, LogSeverity.Debug);
-                p.ErrorDataReceived += (sender, args) => Log.Instance.log(args.Data, LogSeverity.Debug);
+                p.ErrorDataReceived += (sender, args) => Log.Instance.log(args.Data, LogSeverity.Error);
 
                 Log.Instance.log($"{p.StartInfo.FileName} {anyCommand}", LogSeverity.Debug);
 

--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -149,9 +149,10 @@ namespace MobiFlight
                 p.StartInfo.RedirectStandardOutput = true;
                 p.StartInfo.RedirectStandardError = true;
 
-                // Output and Error text is read asynchronously to avoid known deadlock issues
+                // Output and Error text is read asynchronously to avoid known deadlock issues. It appears
+                // all avrdude output is sent to stderr :(
                 p.OutputDataReceived += (sender, args) => Log.Instance.log(args.Data, LogSeverity.Debug);
-                p.ErrorDataReceived += (sender, args) => Log.Instance.log(args.Data, LogSeverity.Error);
+                p.ErrorDataReceived += (sender, args) => Log.Instance.log(args.Data, LogSeverity.Debug);
 
                 Log.Instance.log($"{p.StartInfo.FileName} {anyCommand}", LogSeverity.Debug);
 


### PR DESCRIPTION
One of the gaping holes we have when trying to assist users with firmware update failures is not being able to see what avrdude is actually doing. This PR updates the way we use `Process` to call avrdude so we can capture and display the output and error text.

Standard output is logged at the debug level (since it usually isn't necessary to see). Errors are logged at the error level.

The changes required switching to using absolute, rather than relative, paths for everything. The new command line looks like this:

`D:\git\MobiFlight-Connector\bin\Debug\Arduino\hardware\tools\avr\bin\avrdude -C"D:\git\MobiFlight-Connector\bin\Debug\Arduino\hardware\tools\avr\etc\avrdude.conf" -patmega2560 -cwiring -PCOM5 -b115200 -D -Uflash:w:"D:\git\MobiFlight-Connector\bin\Debug\firmware\mobiflight_mega_2_4_1.hex":i`

According to chatgpt the lack of quotes around the path to avrdude is correct and I confirmed spaces work fine with this:

`Debug	06/05/2023 11:55:50	MobiFlightFirmwareUpdater.RunAvrDude(): D:\git\MobiFlight-Connector\bin\Debug space test\Arduino\hardware\tools\avr\bin\avrdude -C"D:\git\MobiFlight-Connector\bin\Debug space test\Arduino\hardware\tools\avr\etc\avrdude.conf" -patmega2560 -cwiring -PCOM5 -b115200 -D -Uflash:w:"D:\git\MobiFlight-Connector\bin\Debug space test\firmware\mobiflight_mega_2_4_1.hex":i`

If debug logging is enabled we now see this on successful firmware updates:

```
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): avrdude: AVR device initialized and ready to accept instructions
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): Reading | ################################################## | 100% 0.01s
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): avrdude: Device signature = 0x1e9801 (probably m2560)
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): avrdude: reading input file "D:\git\MobiFlight-Connector\bin\Debug\firmware\mobiflight_mega_2_4_1.hex"
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): avrdude: writing flash (27520 bytes):
Debug	06/05/2023 11:35:32	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:36	<>c.<RunAvrDude>b__15_1(): Writing | ################################################## | 100% 4.42s
Debug	06/05/2023 11:35:36	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:36	<>c.<RunAvrDude>b__15_1(): avrdude: 27520 bytes of flash written
Debug	06/05/2023 11:35:36	<>c.<RunAvrDude>b__15_1(): avrdude: verifying flash memory against D:\git\MobiFlight-Connector\bin\Debug\firmware\mobiflight_mega_2_4_1.hex:
Debug	06/05/2023 11:35:36	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:40	<>c.<RunAvrDude>b__15_1(): Reading | ################################################## | 100% 3.18s
Debug	06/05/2023 11:35:40	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:40	<>c.<RunAvrDude>b__15_1(): avrdude: 27520 bytes of flash verified
Debug	06/05/2023 11:35:40	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:40	<>c.<RunAvrDude>b__15_1(): avrdude done.  Thank you.
Debug	06/05/2023 11:35:40	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:40	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:35:40	<>c.<RunAvrDude>b__15_0(): 
```

Here's an example of what it looks like when trying to flash with the wrong baud rate when debug logging is turned on:

```
Debug	06/05/2023 11:40:09	<>c.<RunAvrDude>b__15_1(): avrdude: stk500v2_ReceiveMessage(): timeout
Debug	06/05/2023 11:40:14	<>c.<RunAvrDude>b__15_1(): avrdude: stk500v2_ReceiveMessage(): timeout
Info	06/05/2023 11:40:14	MobiFlightModule.Connect(): MobiflightModule.connect: Connected to Radio Stack at COM5 of type MobiFlight Mega (DTR=>True).
Debug	06/05/2023 11:40:19	MobiFlightModule.GetInfo(): Retrieved board: MobiFlight Mega, Radio Stack, 2.4.1, SN-eaf-59f.
Debug	06/05/2023 11:40:21	MobiFlightModule.get_Config(): Timeout. !InfoCommand.Ok. Retrying...
Debug	06/05/2023 11:40:24	MobiFlightModule.get_Config(): !InfoCommand.Ok. Init with empty config.
Debug	06/05/2023 11:40:24	<>c.<RunAvrDude>b__15_1(): 
Debug	06/05/2023 11:40:24	<>c.<RunAvrDude>b__15_0(): 
Debug	06/05/2023 11:40:24	MobiFlightFirmwareUpdater.RunAvrDude(): avrdude timed out! Something went wrong when flashing with command 
 D:\git\MobiFlight-Connector\bin\Debug\Arduino\hardware\tools\avr\bin\avrdude -C"D:\git\MobiFlight-Connector\bin\Debug\Arduino\hardware\tools\avr\etc\avrdude.conf" -patmega2560 -cwiring -PCOM5 -b57600 -D -Uflash:w:"D:\git\MobiFlight-Connector\bin\Debug\firmware\mobiflight_mega_2_4_1.hex":i.
```