### PR TITLE
Add Driving to list of supported device types

### DIFF
--- a/Boards/CJ4 MFD menu.board.json
+++ b/Boards/CJ4 MFD menu.board.json
@@ -1,0 +1,217 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "Device": "atmega328p",
+    "BaudRate": "115200",
+    "Programmer": "arduino",
+    "FirmwareBaseName": "mobiflight_micro"
+  },
+  "Connection": {
+    "ConnectionDelay": 1750,
+    "DelayAfterFirmwareUpdate": 0,
+    "DtrEnable": true,
+    "EEPROMSize": 256,
+    "ExtraConnectionRetry": true,
+    "ForceResetOnFirmwareUpdate": false,
+    "MessageSize": 32
+  },
+  "HardwareIds": [ "^VID_1B4F&PID_9206" ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "FriendlyName": "Arduino Micro",
+    "LatestFirmwareVersion": "0.0.1",
+    "MobiFlightType": "CJ4 MFD panel"
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 2,
+    "MaxButtons": 70,
+    "MaxEncoders": 2,
+    "MaxLcdI2C": 2,
+    "MaxLedSegments": 1,
+    "MaxOutputs": 8,
+    "MaxServos": 2,
+    "MaxSteppers": 2
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 100
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 101
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 102
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 103
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 104
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 105
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 106
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 107
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 108
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 109
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 110
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 111
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 112
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 113
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 114
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 115
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 116
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 117
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 118
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 119
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 120
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 121
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 122
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 123
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 124
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 24
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 8
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 5
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 22
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 20
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 21
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 19
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 18
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Pin": 10
+    }
+  ]
+}

--- a/Boards/CJ4 autopilot.board.json
+++ b/Boards/CJ4 autopilot.board.json
@@ -1,0 +1,221 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "UsbDriveSettings": {
+    "VolumeLabel": "RPI-RP2",
+    "VerificationFileName": "INFO_UF2.TXT",
+    "FirmwareBaseName": "mobiflight_raspberrypico",
+    "FirmwareExtension": "uf2"
+  },
+  "Connection": {
+    "ConnectionDelay": 1250,
+    "DelayAfterFirmwareUpdate": 1250,
+    "DtrEnable": true,
+    "EEPROMSize": 1496,
+    "ExtraConnectionRetry": false,
+    "ForceResetOnFirmwareUpdate": true,
+    "MessageSize": 64
+  },
+  "HardwareIds": [ "^VID_2E8A&PID_000A" ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "FriendlyName": "CJ4 Autopilot",
+    "LatestFirmwareVersion": "2.0.2",
+    "MobiFlightType": "CJ4 Autopilot"
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 16,
+    "MaxInputShifters": 4,
+    "MaxButtons": 68,
+    "MaxEncoders": 20,
+    "MaxLcdI2C": 2,
+    "MaxLedSegments": 4,
+    "MaxOutputs": 40,
+    "MaxServos": 10,
+    "MaxShifters": 4,
+    "MaxSteppers": 10,
+    "MaxInputMultiplexer": 2
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 0
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 1
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 3
+    },
+    {
+      "isAnalog": false,
+      "isI2C": true,
+      "isPWM": true,
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": true,
+      "isPWM": true,
+      "Pin": 5
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 7
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 8
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 11
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 12
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 13
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 14
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 15
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 16
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 17
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 18
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 19
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 20
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 21
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 22
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 23
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 24
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 25
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 26
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 27
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 28
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 29
+    }
+  ]
+}
+  

--- a/Boards/Collins-FMS-3000.board.json
+++ b/Boards/Collins-FMS-3000.board.json
@@ -1,0 +1,458 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "Device": "atmega328p",
+    "BaudRate": "115200",
+    "Programmer": "arduino",
+    "FirmwareBaseName": "mobiflight_nano"
+  },
+  "Connection": {
+    "ConnectionDelay": 1750,
+    "DelayAfterFirmwareUpdate": 0,
+    "DtrEnable": true,
+    "EEPROMSize": 256,
+    "ExtraConnectionRetry": true,
+    "ForceResetOnFirmwareUpdate": false,
+    "MessageSize": 32
+  },
+  "HardwareIds": ["^VID_1B4F&PID_9206"],
+  "Info": {
+    "CanInstallFirmware": true,
+    "FriendlyName": "Arduino Pro Micro",
+    "LatestFirmwareVersion": "0.0.1",
+    "MobiFlightType": "Collins FMS 3000"
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 2,
+    "MaxButtons": 70,
+    "MaxEncoders": 2,
+    "MaxLcdI2C": 2,
+    "MaxLedSegments": 1,
+    "MaxOutputs": 8,
+    "MaxServos": 2,
+    "MaxSteppers": 2
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "L1",
+      "Pin": 0
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "L2",
+      "Pin": 1
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "L3",
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "L4",
+      "Pin": 3
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "L5",
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "L6",
+      "Pin": 5
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "MSG",
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "DIR",
+      "Pin": 7
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "IDX",
+      "Pin": 8
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "TUN",
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "A",
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "H",
+      "Pin": 11
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "O",
+      "Pin": 12
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "V",
+      "Pin": 13
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "FPLN",
+      "Pin": 14
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "B",
+      "Pin": 15
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "I",
+      "Pin": 16
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "P",
+      "Pin": 17
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "W",
+      "Pin": 18
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "LEGS",
+      "Pin": 19
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "C",
+      "Pin": 20
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "J",
+      "Pin": 21
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "Q",
+      "Pin": 22
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "X",
+      "Pin": 23
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "DEP",
+      "Pin": 24
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "D",
+      "Pin": 25
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "K",
+      "Pin": 26
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "R",
+      "Pin": 27
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "Y",
+      "Pin": 28
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "PERF",
+      "Pin": 29
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "E",
+      "Pin": 30
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "L",
+      "Pin": 31
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "S",
+      "Pin": 32
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "Z",
+      "Pin": 33
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "DSPL",
+      "Pin": 34
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "F",
+      "Pin": 35
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "M",
+      "Pin": 36
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "T",
+      "Pin": 37
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "SP",
+      "Pin": 38
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "MFD",
+      "Pin": 39
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "G",
+      "Pin": 40
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "N",
+      "Pin": 41
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "U",
+      "Pin": 42
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "SLSH",
+      "Pin": 43
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "DATA",
+      "Pin": 44
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "1",
+      "Pin": 45
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "4",
+      "Pin": 46
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "7",
+      "Pin": 47
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "DOT",
+      "Pin": 48
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "PREV",
+      "Pin": 49
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "2",
+      "Pin": 50
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "5",
+      "Pin": 51
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "8",
+      "Pin": 52
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "0",
+      "Pin": 53
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "3",
+      "Pin": 54
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "6",
+      "Pin": 55
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "9",
+      "Pin": 56
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "PLUS",
+      "Pin": 57
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "R1",
+      "Pin": 58
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "R2",
+      "Pin": 59
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "R3",
+      "Pin": 60
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "R4",
+      "Pin": 61
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "R5",
+      "Pin": 62
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "R6",
+      "Pin": 63
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "EXEC",
+      "Pin": 64
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "NEXT",
+      "Pin": 65
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "CLR",
+      "Pin": 66
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "BRT",
+      "Pin": 67
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "Name": "DIM",
+      "Pin": 68
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Name": "BRIGHTNESS",
+      "Pin": 69
+    }
+  ]
+}

--- a/Boards/cj4elec.board.json
+++ b/Boards/cj4elec.board.json
@@ -1,0 +1,191 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "BaudRate": "57600",
+    "Device": "atmega32u4",
+    "FirmwareBaseName": "mobiflight_deice",
+    "Programmer": "avr109"
+  },
+  "Connection": {
+    "ConnectionDelay": 1250,
+    "DelayAfterFirmwareUpdate": 1250,
+    "DtrEnable": true,
+    "EEPROMSize": 256,
+    "ExtraConnectionRetry": false,
+    "ForceResetOnFirmwareUpdate": true,
+    "MessageSize": 32
+  },
+  "HardwareIds": [
+    "^VID_2341&PID_0036"
+  ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "FriendlyName": "Arduino Micro Pro",
+    "LatestFirmwareVersion": "0.0.1",
+    "MobiFlightType": "CJ4 Elec"
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 6,
+    "MaxButtons": 18,
+    "MaxEncoders": 0,
+    "MaxLcdI2C": 1,
+    "MaxLedSegments": 0,
+    "MaxOutputs": 18,
+    "MaxServos": 0,
+    "MaxSteppers": 0,
+    "MaxShifters": 2,
+    "MaxInputShifters":  0
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 0
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 1
+    },
+    {
+      "isAnalog": false,
+      "isI2C": true,
+      "isPWM": false,
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": true,
+      "isPWM": true,
+      "Pin": 3
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 5
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 7
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 8
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 11
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 12
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 13
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 14
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 15
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 16
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 17
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 18,
+      "Name": "A0"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 19,
+      "Name": "A1"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 20,
+      "Name": "A2"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 21,
+      "Name": "A3"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 22,
+      "Name": "A4"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 23,
+      "Name": "A5"
+    }
+  ]
+}

--- a/Boards/deice.board.json
+++ b/Boards/deice.board.json
@@ -1,0 +1,193 @@
+{
+  "$schema": "./mfboard.schema.json",
+  "AvrDudeSettings": {
+    "BaudRate": "57600",
+    "Device": "atmega32u4",
+    "FirmwareBaseName": "mobiflight_deice",
+    "Programmer": "avr109"
+  },
+  "Connection": {
+    "ConnectionDelay": 1250,
+    "DelayAfterFirmwareUpdate": 1250,
+    "DtrEnable": true,
+    "EEPROMSize": 256,
+    "ExtraConnectionRetry": false,
+    "ForceResetOnFirmwareUpdate": true,
+    "MessageSize": 32
+  },
+  "HardwareIds": [
+    "^VID_1B4F&PID_9206",
+    "^VID_2341&PID_8036",
+    "^VID_2341&PID_8037"
+  ],
+  "Info": {
+    "CanInstallFirmware": true,
+    "FriendlyName": "Arduino Micro Pro",
+    "LatestFirmwareVersion": "0.0.1",
+    "MobiFlightType": "De-ice panel"
+  },
+  "ModuleLimits": {
+    "MaxAnalogInputs": 6,
+    "MaxButtons": 18,
+    "MaxEncoders": 0,
+    "MaxLcdI2C": 0,
+    "MaxLedSegments": 0,
+    "MaxOutputs": 18,
+    "MaxServos": 0,
+    "MaxSteppers": 0,
+    "MaxShifters": 2,
+    "MaxInputShifters":  0
+  },
+  "Pins": [
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 0
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 1
+    },
+    {
+      "isAnalog": false,
+      "isI2C": true,
+      "isPWM": false,
+      "Pin": 2
+    },
+    {
+      "isAnalog": false,
+      "isI2C": true,
+      "isPWM": true,
+      "Pin": 3
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 4
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 5
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 6
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 7
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 8
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 9
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 10
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 11
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 12
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": true,
+      "Pin": 13
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 14
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 15
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 16
+    },
+    {
+      "isAnalog": false,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 17
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 18,
+      "Name": "A0"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 19,
+      "Name": "A1"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 20,
+      "Name": "A2"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 21,
+      "Name": "A3"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 22,
+      "Name": "A4"
+    },
+    {
+      "isAnalog": true,
+      "isI2C": false,
+      "isPWM": false,
+      "Pin": 23,
+      "Name": "A5"
+    }
+  ]
+}

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -151,7 +151,8 @@ namespace MobiFlight
                 d.Type == SharpDX.DirectInput.DeviceType.Gamepad ||
                 d.Type == SharpDX.DirectInput.DeviceType.Flight ||
                 d.Type == SharpDX.DirectInput.DeviceType.Supplemental ||
-                d.Type == SharpDX.DirectInput.DeviceType.FirstPerson;
+                d.Type == SharpDX.DirectInput.DeviceType.FirstPerson ||
+                d.Type == SharpDX.DirectInput.DeviceType.Driving;
         }
 
         private void Js_OnAxisChanged(object sender, InputEventArgs e)

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -11,11 +11,11 @@ namespace MobiFlight
 {
     public class JoystickManager
     {
-        private static readonly List<SharpDX.DirectInput.DeviceType> SupportedDeviceTypes = new List<SharpDX.DirectInput.DeviceType>
+        private static readonly SharpDX.DirectInput.DeviceType[] SupportedDeviceTypes =
         {
             SharpDX.DirectInput.DeviceType.Joystick,
             SharpDX.DirectInput.DeviceType.Gamepad,
-            SharpDX.DirectInput.DeviceType.Driving,
+//            SharpDX.DirectInput.DeviceType.Driving,
             SharpDX.DirectInput.DeviceType.Flight,
             SharpDX.DirectInput.DeviceType.FirstPerson,
             SharpDX.DirectInput.DeviceType.Supplemental

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -894,6 +894,21 @@
     <None Include="Boards\arduino_uno.board.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Boards\CJ4 autopilot.board.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Boards\CJ4 MFD menu.board.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Boards\cj4elec.board.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Boards\Collins-FMS-3000.board.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Include="Boards\deice.board.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Include="Boards\mfboard.schema.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -239,7 +239,7 @@ namespace MobiFlight.UI.Panels.Settings
             // set the add device icon enabled
             addDeviceToolStripDropDownButton.Enabled = isMobiFlightBoard;
             removeDeviceToolStripButton.Enabled = isMobiFlightBoard & (node.Level > 0);
-            uploadToolStripButton.Enabled = isMobiFlightBoard && ((moduleNode.Nodes.Count > 0) || (moduleNode.ImageKey == "Changed"));
+            uploadToolStripButton.Enabled = isMobiFlightBoard && moduleNode.ImageKey == "Changed";
             openToolStripButton.Enabled = isMobiFlightBoard;
             saveToolStripButton.Enabled = isMobiFlightBoard && moduleNode.Nodes.Count > 0;
 


### PR DESCRIPTION
Fixes #1253 

Add `Driving` to the list of supported DirectInput types.