### PR TITLE
GetModuleBySerial returns null instead of throwing Exception

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -507,6 +507,7 @@ namespace MobiFlight
                 if (!Modules.ContainsKey(serial)) return;
 
                 MobiFlightModule module = GetModuleBySerial(serial);
+                if (module == null) return;
 
                 if (name != null && name.Contains("|")) {
                     var pins = name.Split('|');
@@ -829,8 +830,8 @@ namespace MobiFlight
         public MobiFlightModule GetModuleBySerial(string serial)
         {
             if (Modules.ContainsKey(serial)) return Modules[serial];
-            
-            throw new IndexOutOfRangeException();
+
+            return null;
         }
 
         internal MobiFlightModule GetModule(MobiFlightModuleInfo moduleInfo)

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -822,7 +822,7 @@ namespace MobiFlight
         {
             if (!stepperModules.ContainsKey(stepper))
             {
-                throw new ArgumentOutOfRangeException();
+                throw new IndexOutOfRangeException();
             }
 
             return stepperModules[stepper];

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -477,7 +477,7 @@ namespace MobiFlight.UI.Dialogs
                 {
                     MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
 
-                    foreach (Config.BaseDevice device in module.GetConnectedInputDevices())
+                    foreach (Config.BaseDevice device in module?.GetConnectedInputDevices())
                     {
                         switch (device.Type)
                         {
@@ -562,7 +562,7 @@ namespace MobiFlight.UI.Dialogs
                 MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
 
                 // find the correct input type based on the name
-                foreach (Config.BaseDevice device in module.GetConnectedInputDevices())
+                foreach (Config.BaseDevice device in module?.GetConnectedInputDevices())
                 {
                     if ((inputTypeComboBox.SelectedItem as ListItem<Config.BaseDevice>) == null)
                         break;
@@ -673,7 +673,7 @@ namespace MobiFlight.UI.Dialogs
 
             List<ListItem> connectors = new List<ListItem>();
 
-            foreach (IConnectedDevice device in module.GetConnectedDevices())
+            foreach (IConnectedDevice device in module?.GetConnectedDevices())
             {
                 if (device.Type != DeviceType.LedModule) continue;
                 if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -477,20 +477,23 @@ namespace MobiFlight.UI.Dialogs
                 {
                     MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
 
-                    foreach (Config.BaseDevice device in module?.GetConnectedInputDevices())
+                    if (module != null)
                     {
-                        switch (device.Type)
+                        foreach (Config.BaseDevice device in module.GetConnectedInputDevices())
                         {
-                            case DeviceType.Button:
-                            case DeviceType.AnalogInput:
-                            case DeviceType.Encoder:
-                            case DeviceType.InputShiftRegister:
-                            case DeviceType.InputMultiplexer:
-                                inputTypeComboBox.Items.Add(new ListItem<Config.BaseDevice>() { Label = device.Name, Value = device });
-                                break;
+                            switch (device.Type)
+                            {
+                                case DeviceType.Button:
+                                case DeviceType.AnalogInput:
+                                case DeviceType.Encoder:
+                                case DeviceType.InputShiftRegister:
+                                case DeviceType.InputMultiplexer:
+                                    inputTypeComboBox.Items.Add(new ListItem<Config.BaseDevice>() { Label = device.Name, Value = device });
+                                    break;
+                            }
                         }
                     }
-
+                    
                     if (inputTypeComboBox.Items.Count == 0 && this.IsShown)
                     {
                         if (MessageBox.Show(
@@ -561,15 +564,18 @@ namespace MobiFlight.UI.Dialogs
             {
                 MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
 
-                // find the correct input type based on the name
-                foreach (Config.BaseDevice device in module?.GetConnectedInputDevices())
+                if (module != null)
                 {
-                    if ((inputTypeComboBox.SelectedItem as ListItem<Config.BaseDevice>) == null)
-                        break;
-                    if (device.Name != ((inputTypeComboBox.SelectedItem as ListItem<Config.BaseDevice>).Value as Config.BaseDevice)?.Name) continue;
+                    // find the correct input type based on the name
+                    foreach (Config.BaseDevice device in module.GetConnectedInputDevices())
+                    {
+                        if ((inputTypeComboBox.SelectedItem as ListItem<Config.BaseDevice>) == null)
+                            break;
+                        if (device.Name != ((inputTypeComboBox.SelectedItem as ListItem<Config.BaseDevice>).Value as Config.BaseDevice)?.Name) continue;
 
-                    currentInputType = device.Type;
-                    break;
+                        currentInputType = device.Type;
+                        break;
+                    }
                 }
             }
 
@@ -673,14 +679,19 @@ namespace MobiFlight.UI.Dialogs
 
             List<ListItem> connectors = new List<ListItem>();
 
-            foreach (IConnectedDevice device in module?.GetConnectedDevices())
+            if (module != null)
             {
-                if (device.Type != DeviceType.LedModule) continue;
-                if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;
-                for (int i = 0; i < (device as MobiFlightLedModule).SubModules; i++) {
-                    connectors.Add(new ListItem() { Label = (i + 1).ToString(), Value = (i + 1).ToString() });
+                foreach (IConnectedDevice device in module.GetConnectedDevices())
+                {
+                    if (device.Type != DeviceType.LedModule) continue;
+                    if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;
+                    for (int i = 0; i < (device as MobiFlightLedModule).SubModules; i++)
+                    {
+                        connectors.Add(new ListItem() { Label = (i + 1).ToString(), Value = (i + 1).ToString() });
+                    }
                 }
             }
+            
             displayLedDisplayPanel.SetConnectors(connectors);
         }
 

--- a/UI/Panels/Output/DisplayPinPanel.cs
+++ b/UI/Panels/Output/DisplayPinPanel.cs
@@ -175,15 +175,15 @@ namespace MobiFlight.UI.Panels
 
         private void displayPinComboBox_SelectedIndexChanged(object sender, EventArgs e)
         {
-            if (Module != null)
+            if (Module == null) return;
+
+            String pin = (sender as ComboBox).SelectedItem.ToString();
+            foreach (var item in Module.GetConnectedDevices(pin))
             {
-                String pin = (sender as ComboBox).SelectedItem.ToString();
-                foreach (var item in Module.GetConnectedDevices(pin))
-                {
-                    pwmPinPanel.Enabled = pwmPinPanel.Visible = Module.getPwmPins()
-                                                .Find(x => x.Pin == (byte)(item as MobiFlightOutput).Pin) != null;
-                    return;
-                }
+                pwmPinPanel.Enabled = pwmPinPanel.Visible 
+                                    = Module.getPwmPins()
+                                            .Find(x => x.Pin == (byte)(item as MobiFlightOutput).Pin) != null;
+                return;
             }
         }
 
@@ -204,8 +204,11 @@ namespace MobiFlight.UI.Panels
 
         private void MultiPinSelectPanel_SelectionChanged(object sender, List<ListItem> selectedPins)
         {
-            var pwmPins = Module.getPwmPins();
+            pwmPinPanel.Enabled = false;
 
+            if (Module == null) return;
+
+            var pwmPins = Module.getPwmPins();
             pwmPinPanel.Enabled = pwmPinPanel.Visible
                                 = selectedPins.All(
                                     pin => pwmPins.Find(

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -300,35 +300,39 @@ namespace MobiFlight.UI.Panels.OutputWizard
                 // type of module
                 else
                 {
-                    MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
-                    foreach (DeviceType devType in module?.GetConnectedOutputDeviceTypes())
-                    {
-                        switch (devType)
+                    MobiFlightModule module = _execManager.getMobiFlightModuleCache()
+                                                          .GetModuleBySerial(serial);
+
+                    if (module != null) { 
+                        foreach (DeviceType devType in module.GetConnectedOutputDeviceTypes())
                         {
-                            case DeviceType.LedModule:
-                                deviceTypeOptions.Add(new ListItem() { Value = ArcazeLedDigit.TYPE, Label = ArcazeLedDigit.TYPE });
-                                break;
+                            switch (devType)
+                            {
+                                case DeviceType.LedModule:
+                                    deviceTypeOptions.Add(new ListItem() { Value = ArcazeLedDigit.TYPE, Label = ArcazeLedDigit.TYPE });
+                                    break;
 
-                            case DeviceType.Output:
-                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightOutput.TYPE, Label = "LED / Output" });
-                                //displayTypeComboBox.Items.Add(ArcazeBcd4056.TYPE);
-                                break;
+                                case DeviceType.Output:
+                                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightOutput.TYPE, Label = "LED / Output" });
+                                    //displayTypeComboBox.Items.Add(ArcazeBcd4056.TYPE);
+                                    break;
 
-                            case DeviceType.Servo:
-                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightServo.TYPE, Label = MobiFlightServo.TYPE });
-                                break;
+                                case DeviceType.Servo:
+                                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightServo.TYPE, Label = MobiFlightServo.TYPE });
+                                    break;
 
-                            case DeviceType.Stepper:
-                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightStepper.TYPE, Label = MobiFlightStepper.TYPE });
-                                break;
+                                case DeviceType.Stepper:
+                                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightStepper.TYPE, Label = MobiFlightStepper.TYPE });
+                                    break;
 
-                            case DeviceType.LcdDisplay:
-                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightLcdDisplay.TYPE, Label = MobiFlightLcdDisplay.TYPE });
-                                break;
+                                case DeviceType.LcdDisplay:
+                                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightLcdDisplay.TYPE, Label = MobiFlightLcdDisplay.TYPE });
+                                    break;
 
-                            case DeviceType.ShiftRegister:
-                                deviceTypeOptions.Add(new ListItem() { Value = MobiFlightShiftRegister.TYPE, Label = MobiFlightShiftRegister.TYPE });
-                                break;
+                                case DeviceType.ShiftRegister:
+                                    deviceTypeOptions.Add(new ListItem() { Value = MobiFlightShiftRegister.TYPE, Label = MobiFlightShiftRegister.TYPE });
+                                    break;
+                            }
                         }
                     }
 
@@ -535,38 +539,42 @@ namespace MobiFlight.UI.Panels.OutputWizard
             List<ListItem> lcdDisplays = new List<ListItem>();
             List<ListItem> shiftRegisters = new List<ListItem>();
 
-            foreach (IConnectedDevice device in module?.GetConnectedDevices())
+            if (module!=null)
             {
-                switch (device.Type)
+                foreach (IConnectedDevice device in module.GetConnectedDevices())
                 {
-                    case DeviceType.LedModule:
-                        ledSegments.Add(new ListItem() { Value = device.Name, Label = device.Name });
-                        break;
+                    switch (device.Type)
+                    {
+                        case DeviceType.LedModule:
+                            ledSegments.Add(new ListItem() { Value = device.Name, Label = device.Name });
+                            break;
 
-                    case DeviceType.Output:
-                        outputs.Add(new ListItem() { Value = device.Name, Label = device.Name });
-                        break;
+                        case DeviceType.Output:
+                            outputs.Add(new ListItem() { Value = device.Name, Label = device.Name });
+                            break;
 
-                    case DeviceType.Servo:
-                        servos.Add(new ListItem() { Value = device.Name, Label = device.Name });
-                        break;
+                        case DeviceType.Servo:
+                            servos.Add(new ListItem() { Value = device.Name, Label = device.Name });
+                            break;
 
-                    case DeviceType.Stepper:
-                        stepper.Add(new ListItem() { Value = device.Name, Label = device.Name });
-                        break;
+                        case DeviceType.Stepper:
+                            stepper.Add(new ListItem() { Value = device.Name, Label = device.Name });
+                            break;
 
-                    case DeviceType.LcdDisplay:
-                        int Cols = (device as MobiFlightLcdDisplay).Cols;
-                        int Lines = (device as MobiFlightLcdDisplay).Lines;
-                        lcdDisplays.Add(new ListItem() { Value = device.Name + "," + Cols + "," + Lines, Label = device.Name });
-                        break;
+                        case DeviceType.LcdDisplay:
+                            int Cols = (device as MobiFlightLcdDisplay).Cols;
+                            int Lines = (device as MobiFlightLcdDisplay).Lines;
+                            lcdDisplays.Add(new ListItem() { Value = device.Name + "," + Cols + "," + Lines, Label = device.Name });
+                            break;
 
-                    case DeviceType.ShiftRegister:
-                        shiftRegisters.Add(new ListItem() { Value = device.Name, Label = device.Name });
+                        case DeviceType.ShiftRegister:
+                            shiftRegisters.Add(new ListItem() { Value = device.Name, Label = device.Name });
 
-                        break;
+                            break;
+                    }
                 }
             }
+            
             displayPinPanel.WideStyle = true;
             displayPinPanel.SetPorts(new List<ListItem>());
             displayPinPanel.SetPins(outputs);
@@ -675,15 +683,19 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             List<ListItem> connectors = new List<ListItem>();
 
-            foreach (IConnectedDevice device in module?.GetConnectedDevices())
+            if (module != null)
             {
-                if (device.Type != DeviceType.LedModule) continue;
-                if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;
-                for (int i = 0; i < (device as MobiFlightLedModule).SubModules; i++)
+                foreach (IConnectedDevice device in module.GetConnectedDevices())
                 {
-                    connectors.Add(new ListItem() { Label = (i + 1).ToString(), Value = (i + 1).ToString() });
+                    if (device.Type != DeviceType.LedModule) continue;
+                    if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;
+                    for (int i = 0; i < (device as MobiFlightLedModule).SubModules; i++)
+                    {
+                        connectors.Add(new ListItem() { Label = (i + 1).ToString(), Value = (i + 1).ToString() });
+                    }
                 }
             }
+            
             displayLedDisplayPanel.SetConnectors(connectors);
         }
 
@@ -767,12 +779,17 @@ namespace MobiFlight.UI.Panels.OutputWizard
             bool pwmSupport = false;
 
             int numModules = 0;
-            foreach (IConnectedDevice device in module?.GetConnectedDevices())
+
+            if(module!= null)
             {
-                if (device.Type != DeviceType.ShiftRegister) continue;
-                if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;
-                numModules = (device as MobiFlightShiftRegister).NumberOfShifters;
+                foreach (IConnectedDevice device in module.GetConnectedDevices())
+                {
+                    if (device.Type != DeviceType.ShiftRegister) continue;
+                    if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;
+                    numModules = (device as MobiFlightShiftRegister).NumberOfShifters;
+                }
             }
+            
             displayShiftRegisterPanel.SetNumModules(numModules);
         }
 

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -301,7 +301,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
                 else
                 {
                     MobiFlightModule module = _execManager.getMobiFlightModuleCache().GetModuleBySerial(serial);
-                    foreach (DeviceType devType in module.GetConnectedOutputDeviceTypes())
+                    foreach (DeviceType devType in module?.GetConnectedOutputDeviceTypes())
                     {
                         switch (devType)
                         {
@@ -535,8 +535,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
             List<ListItem> lcdDisplays = new List<ListItem>();
             List<ListItem> shiftRegisters = new List<ListItem>();
 
-
-            foreach (IConnectedDevice device in module.GetConnectedDevices())
+            foreach (IConnectedDevice device in module?.GetConnectedDevices())
             {
                 switch (device.Type)
                 {
@@ -676,7 +675,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             List<ListItem> connectors = new List<ListItem>();
 
-            foreach (IConnectedDevice device in module.GetConnectedDevices())
+            foreach (IConnectedDevice device in module?.GetConnectedDevices())
             {
                 if (device.Type != DeviceType.LedModule) continue;
                 if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;
@@ -699,9 +698,17 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             try
             {
-                MobiFlightStepper stepper = _execManager.getMobiFlightModuleCache()
-                                                .GetModuleBySerial(serial)
-                                                .GetStepper(stepperAddress);
+                MobiFlightModule module = _execManager.getMobiFlightModuleCache()
+                                                      .GetModuleBySerial(serial);
+
+                if (module == null) {
+                    // we want to execute the catch block below
+                    // GetModuleBySerial used to throw this exception
+                    // see #1157
+                    throw new IndexOutOfRangeException(); 
+                }
+
+                MobiFlightStepper stepper = module.GetStepper(stepperAddress);
 
                 stepperPanel.SetStepperProfile(stepper.Profile);
                 stepperPanel.ShowManualCalibration(!stepper.HasAutoZero);
@@ -729,9 +736,12 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             string serial = SerialNumber.ExtractSerial(config.DisplaySerial);
 
-            MobiFlightStepper stepper = _execManager.getMobiFlightModuleCache()
-                                                    .GetModuleBySerial(serial)
-                                                    .GetStepper(config.Stepper.Address);
+            MobiFlightModule module = _execManager.getMobiFlightModuleCache()
+                                                    .GetModuleBySerial(serial);
+
+            if (module == null) return;
+
+            MobiFlightStepper stepper = module.GetStepper(config.Stepper.Address);
 
             int CurrentValue = stepper.Position();
             int NextValue = (CurrentValue + e.Steps);
@@ -757,7 +767,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
             bool pwmSupport = false;
 
             int numModules = 0;
-            foreach (IConnectedDevice device in module.GetConnectedDevices())
+            foreach (IConnectedDevice device in module?.GetConnectedDevices())
             {
                 if (device.Type != DeviceType.ShiftRegister) continue;
                 if (device.Name != ((sender as ComboBox).SelectedItem as ListItem).Value) continue;


### PR DESCRIPTION
fixes #1157 

I refactored the GetModuleBySerial so that it returns a ```null``` instead of throwing the exception which in some cases was not surrounded by a proper catch block.

I think the convention to return null instead of the exception is better practice.