### PR TITLE
Add keyboard support for stepper calibration

### DIFF
--- a/UI/Panels/Output/StepperPanel.Designer.cs
+++ b/UI/Panels/Output/StepperPanel.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace MobiFlight.UI.Panels
+﻿using System.Windows.Forms;
+
+namespace MobiFlight.UI.Panels
 {
     partial class StepperPanel
     {
@@ -22,9 +24,9 @@
 
         #region Vom Komponenten-Designer generierter Code
 
-        /// <summary> 
-        /// Erforderliche Methode für die Designerunterstützung. 
-        /// Der Inhalt der Methode darf nicht mit dem Code-Editor geändert werden.
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent()
         {
@@ -131,10 +133,7 @@
             // 
             this.stepperAddressesComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.stepperAddressesComboBox.FormattingEnabled = true;
-            this.stepperAddressesComboBox.Items.AddRange(new object[] {
-            resources.GetString("stepperAddressesComboBox.Items"),
-            resources.GetString("stepperAddressesComboBox.Items1"),
-            resources.GetString("stepperAddressesComboBox.Items2")});
+            this.stepperAddressesComboBox.Items.AddRange(new object[] { resources.GetString("stepperAddressesComboBox.Items"), resources.GetString("stepperAddressesComboBox.Items1"), resources.GetString("stepperAddressesComboBox.Items2") });
             resources.ApplyResources(this.stepperAddressesComboBox, "stepperAddressesComboBox");
             this.stepperAddressesComboBox.Name = "stepperAddressesComboBox";
             // 
@@ -206,6 +205,7 @@
             this.trackBar1.Maximum = 5;
             this.trackBar1.Name = "trackBar1";
             this.trackBar1.Value = 1;
+            this.trackBar1.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.enter_KeyPress);
             // 
             // ManualCalibrateLabel
             // 
@@ -298,7 +298,6 @@
             this.groupBox3.ResumeLayout(false);
             this.groupBox3.PerformLayout();
             this.ResumeLayout(false);
-
         }
 
         #endregion

--- a/UI/Panels/Output/StepperPanel.Designer.cs
+++ b/UI/Panels/Output/StepperPanel.Designer.cs
@@ -43,6 +43,7 @@ namespace MobiFlight.UI.Panels
             this.label2 = new System.Windows.Forms.Label();
             this.stepperAddressesComboBox = new System.Windows.Forms.ComboBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
+            this.label9 = new System.Windows.Forms.Label();
             this.button2 = new System.Windows.Forms.Button();
             this.button1 = new System.Windows.Forms.Button();
             this.label8 = new System.Windows.Forms.Label();
@@ -139,6 +140,7 @@ namespace MobiFlight.UI.Panels
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.label9);
             this.groupBox2.Controls.Add(this.button2);
             this.groupBox2.Controls.Add(this.button1);
             this.groupBox2.Controls.Add(this.label8);
@@ -153,10 +155,17 @@ namespace MobiFlight.UI.Panels
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.TabStop = false;
             // 
+            // label9
+            // 
+            resources.ApplyResources(this.label9, "label9");
+            this.label9.Name = "label9";
+            // 
             // button2
             // 
+            this.button2.BackColor = System.Drawing.SystemColors.Control;
             resources.ApplyResources(this.button2, "button2");
             this.button2.Name = "button2";
+            this.toolTip1.SetToolTip(this.button2, resources.GetString("button2.ToolTip"));
             this.button2.UseVisualStyleBackColor = true;
             this.button2.Click += new System.EventHandler(this.button2_Click);
             // 
@@ -164,6 +173,7 @@ namespace MobiFlight.UI.Panels
             // 
             resources.ApplyResources(this.button1, "button1");
             this.button1.Name = "button1";
+            this.toolTip1.SetToolTip(this.button1, resources.GetString("button1.ToolTip"));
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
@@ -299,6 +309,8 @@ namespace MobiFlight.UI.Panels
             this.groupBox3.PerformLayout();
             this.ResumeLayout(false);
         }
+
+        private System.Windows.Forms.Label label9;
 
         #endregion
 

--- a/UI/Panels/Output/StepperPanel.cs
+++ b/UI/Panels/Output/StepperPanel.cs
@@ -136,17 +136,17 @@ namespace MobiFlight.UI.Panels
         {
             if (!(sender as Control).Parent.Enabled) return;
 
-            String value = ((TextBox)sender).Text.Trim();
+            String value = (sender as TextBox).Text.Trim();
 
             if (value == "") e.Cancel = true;
             if (e.Cancel)
             {
-                displayError((Control)sender, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustNonEmpty"));
+                displayError(sender as Control, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustNonEmpty"));
                 return;
             }
             else
             {
-                removeError((Control)sender);
+                removeError(sender as Control);
             }
 
             try
@@ -159,18 +159,18 @@ namespace MobiFlight.UI.Panels
             catch (Exception ex)
             {
                 e.Cancel = true;
-                displayError((Control)sender, i18n._tr("uiMessageValidationMustBeNumber"));
+                displayError(sender as Control, i18n._tr("uiMessageValidationMustBeNumber"));
                 return;
             }
 
             if (e.Cancel)
             {
-                displayError((Control)sender, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0"));
+                displayError(sender as Control, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0"));
                 return;
             }
             else
             {
-                removeError((Control)sender);
+                removeError(sender as Control);
             }
         }
 

--- a/UI/Panels/Output/StepperPanel.cs
+++ b/UI/Panels/Output/StepperPanel.cs
@@ -11,6 +11,7 @@ namespace MobiFlight.UI.Panels
         public event EventHandler<ManualCalibrationTriggeredEventArgs> OnManualCalibrationTriggered;
         public event EventHandler<StepperConfigChangedEventArgs> OnSetZeroTriggered;
         public event EventHandler<StepperConfigChangedEventArgs> OnStepperSelected;
+        
         protected StepperProfilePreset StepperProfile;
 
         int[] StepValues = { -50, -10, -1, 1, 10, 50 };
@@ -67,7 +68,7 @@ namespace MobiFlight.UI.Panels
             stepperAddressesComboBox.SelectedValue = value;
         }
 
-        public void SetAdresses(List<ListItem> pins)
+        public void SetAddresses(List<ListItem> pins)
         {
             stepperAddressesComboBox.DataSource = new List<ListItem>(pins);
             stepperAddressesComboBox.DisplayMember = "Label";
@@ -84,25 +85,55 @@ namespace MobiFlight.UI.Panels
 
         private void button1_Click(object sender, EventArgs e)
         {
-            if (OnManualCalibrationTriggered != null)
-            {
-                ManualCalibrationTriggeredEventArgs eventArgs = new ManualCalibrationTriggeredEventArgs();
-                eventArgs.StepperAddress = stepperAddressesComboBox.SelectedValue.ToString();
-                eventArgs.Steps = StepValues[trackBar1.Value];
-
-                OnManualCalibrationTriggered(this, eventArgs);
-            }
+            TriggerManualCalibration();
         }
 
+        private void TriggerManualCalibration()
+        {
+            if (OnManualCalibrationTriggered == null)
+                return;
+            
+            var eventArgs = new ManualCalibrationTriggeredEventArgs
+                {
+                    StepperAddress = stepperAddressesComboBox.SelectedValue.ToString(),
+                    Steps = StepValues[trackBar1.Value]
+                };
+
+             OnManualCalibrationTriggered(this, eventArgs);
+            
+        }
+        
         private void button2_Click(object sender, EventArgs e)
         {
-            OnSetZeroTriggered?.Invoke(stepperAddressesComboBox.SelectedValue,
-                                   new StepperConfigChangedEventArgs()
-                                   {
-                                       StepperAddress = stepperAddressesComboBox.SelectedValue.ToString()
-                                   });
+            SetZero();
         }
 
+        private void SetZero()
+        {
+            OnSetZeroTriggered?.Invoke(stepperAddressesComboBox.SelectedValue,
+                new StepperConfigChangedEventArgs()
+                {
+                    StepperAddress = stepperAddressesComboBox.SelectedValue.ToString()
+                });
+        }
+        
+        private void enter_KeyPress(object sender, KeyPressEventArgs e)
+        {
+            switch (e.KeyChar)
+            {
+                case (char)Keys.Return:
+                case (char)Keys.D0:
+                case (char)Keys.NumPad0:
+                    SetZero();
+                    break;
+                
+                case (char)Keys.Space:
+                    TriggerManualCalibration();
+                    break;
+            }
+        }
+        
+        
         private void inputRevTextBox_Validating(object sender, CancelEventArgs e)
         {
             if (!(sender as Control).Parent.Enabled) return;
@@ -145,7 +176,7 @@ namespace MobiFlight.UI.Panels
             }
         }
 
-        private void displayError(Control control, String message)
+        private void displayError(Control control, string message)
         {
             errorProvider.SetError(
                     control,
@@ -162,7 +193,7 @@ namespace MobiFlight.UI.Panels
 
         private void stepperAddressesComboBox_SelectedValueChanged(object sender, EventArgs e)
         {
-            if ((sender as ComboBox).Items.Count == 0) return;
+            if (((ComboBox)sender).Items.Count == 0) return;
             if (OnStepperSelected != null)
                 OnStepperSelected(sender, new StepperConfigChangedEventArgs() { StepperAddress = stepperAddressesComboBox.SelectedValue.ToString() });
 
@@ -218,6 +249,6 @@ namespace MobiFlight.UI.Panels
 
     public class StepperConfigChangedEventArgs : EventArgs
     {
-        public String StepperAddress { get; set; }
+        public string StepperAddress { get; set; }
     }
 }

--- a/UI/Panels/Output/StepperPanel.cs
+++ b/UI/Panels/Output/StepperPanel.cs
@@ -12,9 +12,9 @@ namespace MobiFlight.UI.Panels
         public event EventHandler<StepperConfigChangedEventArgs> OnSetZeroTriggered;
         public event EventHandler<StepperConfigChangedEventArgs> OnStepperSelected;
 
-        private StepperProfilePreset stepperProfile;
+        protected StepperProfilePreset StepperProfile;
 
-        int[] stepValues = { -50, -10, -1, 1, 10, 50 };
+        int[] StepValues = { -50, -10, -1, 1, 10, 50 };
         ErrorProvider errorProvider = new ErrorProvider();
 
         public StepperPanel()
@@ -23,13 +23,13 @@ namespace MobiFlight.UI.Panels
             stepperAddressesComboBox.SelectedValueChanged += stepperAddressesComboBox_SelectedValueChanged;
         }
 
-        public void ShowManualCalibration(bool state)
+        public void ShowManualCalibration(Boolean state)
         {
             groupBox2.Enabled = state;
             trackBar1.Focus();
         }
 
-        internal void SyncFromConfig(OutputConfigItem config)
+        internal void syncFromConfig(OutputConfigItem config)
         {
             // stepper initialization
             if (!ComboBoxHelper.SetSelectedItem(stepperAddressesComboBox, config.Stepper.Address))
@@ -50,7 +50,7 @@ namespace MobiFlight.UI.Panels
             CompassModeCheckBox.Checked         = config.Stepper.CompassMode;
         }
 
-        internal OutputConfigItem SyncToConfig(OutputConfigItem config)
+        internal OutputConfigItem syncToConfig(OutputConfigItem config)
         {
             if (stepperAddressesComboBox.SelectedValue != null)
             {
@@ -92,7 +92,7 @@ namespace MobiFlight.UI.Panels
             var eventArgs = new ManualCalibrationTriggeredEventArgs
                 {
                     StepperAddress = stepperAddressesComboBox.SelectedValue.ToString(),
-                    Steps = stepValues[trackBar1.Value]
+                    Steps = StepValues[trackBar1.Value]
                 };
 
              OnManualCalibrationTriggered(this, eventArgs);
@@ -134,19 +134,19 @@ namespace MobiFlight.UI.Panels
         
         private void inputRevTextBox_Validating(object sender, CancelEventArgs e)
         {
-            if (!((Control)sender).Parent.Enabled) return;
+            if (!(sender as Control).Parent.Enabled) return;
 
-            var value = ((TextBox)sender).Text.Trim();
+            String value = ((TextBox)sender).Text.Trim();
 
             if (value == "") e.Cancel = true;
             if (e.Cancel)
             {
-                DisplayError((Control)sender, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustNonEmpty"));
+                displayError((Control)sender, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustNonEmpty"));
                 return;
             }
             else
             {
-                RemoveError((Control)sender);
+                removeError((Control)sender);
             }
 
             try
@@ -159,22 +159,22 @@ namespace MobiFlight.UI.Panels
             catch (Exception ex)
             {
                 e.Cancel = true;
-                DisplayError((Control)sender, i18n._tr("uiMessageValidationMustBeNumber"));
+                displayError((Control)sender, i18n._tr("uiMessageValidationMustBeNumber"));
                 return;
             }
 
             if (e.Cancel)
             {
-                DisplayError((Control)sender, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0"));
+                displayError((Control)sender, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0"));
                 return;
             }
             else
             {
-                RemoveError((Control)sender);
+                removeError((Control)sender);
             }
         }
 
-        private void DisplayError(Control control, string message)
+        private void displayError(Control control, String message)
         {
             errorProvider.SetError(
                     control,
@@ -182,7 +182,7 @@ namespace MobiFlight.UI.Panels
             MessageBox.Show(message, i18n._tr("Hint"));
         }
 
-        private void RemoveError(Control control)
+        private void removeError(Control control)
         {
             errorProvider.SetError(
                     control,
@@ -191,52 +191,52 @@ namespace MobiFlight.UI.Panels
 
         private void stepperAddressesComboBox_SelectedValueChanged(object sender, EventArgs e)
         {
-            if (((ComboBox)sender).Items.Count == 0) return;
+            if ((sender as ComboBox).Items.Count == 0) return;
             if (OnStepperSelected != null)
                 OnStepperSelected(sender, new StepperConfigChangedEventArgs() { StepperAddress = stepperAddressesComboBox.SelectedValue.ToString() });
 
             UpdateResetButtonVisibility();
         }
 
-        internal void SetStepperProfile(StepperProfilePreset profilePreset)
+        internal void setStepperProfile(StepperProfilePreset profilePreset)
         {
             // we assume that it is safe to update the values
             // when we have a different id
-            if (stepperProfile?.id != profilePreset.id)
+            if (StepperProfile?.id != profilePreset.id)
             {
                 outputRevTextBox.Text = profilePreset.StepsPerRevolution.ToString();
                 AccelerationTextBox.Text = profilePreset.Acceleration.ToString();
                 SpeedTextBox.Text = profilePreset.Speed.ToString();
             }
 
-            this.stepperProfile = profilePreset;
+            this.StepperProfile = profilePreset;
         }
 
         private void ResetButton_Click(object sender, EventArgs e)
         {
             if (sender == OutputRevResetButton)
             {
-                outputRevTextBox.Text = this.stepperProfile.StepsPerRevolution.ToString();
+                outputRevTextBox.Text = this.StepperProfile.StepsPerRevolution.ToString();
             }
             else if (sender == SpeedResetButton)
-                SpeedTextBox.Text = this.stepperProfile.Speed.ToString();
+                SpeedTextBox.Text = this.StepperProfile.Speed.ToString();
             else if (sender == AccelerationResetButton)
-                AccelerationTextBox.Text = this.stepperProfile.Acceleration.ToString();
+                AccelerationTextBox.Text = this.StepperProfile.Acceleration.ToString();
         }
 
         private void StepperSettingsTextBox_TextChanged(object sender, EventArgs e)
         {
-            if (stepperProfile == null) return;
+            if (StepperProfile == null) return;
             UpdateResetButtonVisibility();
         }
 
         private void UpdateResetButtonVisibility()
         {
-            if (stepperProfile == null) return;
+            if (StepperProfile == null) return;
 
-            OutputRevResetButton.Visible = outputRevTextBox.Text != this.stepperProfile.StepsPerRevolution.ToString();
-            AccelerationResetButton.Visible = AccelerationTextBox.Text != this.stepperProfile.Acceleration.ToString();
-            SpeedResetButton.Visible = SpeedTextBox.Text != this.stepperProfile.Speed.ToString();
+            OutputRevResetButton.Visible = outputRevTextBox.Text != this.StepperProfile.StepsPerRevolution.ToString();
+            AccelerationResetButton.Visible = AccelerationTextBox.Text != this.StepperProfile.Acceleration.ToString();
+            SpeedResetButton.Visible = SpeedTextBox.Text != this.StepperProfile.Speed.ToString();
         }
 
         
@@ -249,6 +249,6 @@ namespace MobiFlight.UI.Panels
 
     public class StepperConfigChangedEventArgs : EventArgs
     {
-        public string StepperAddress { get; set; }
+        public String StepperAddress { get; set; }
     }
 }

--- a/UI/Panels/Output/StepperPanel.cs
+++ b/UI/Panels/Output/StepperPanel.cs
@@ -11,10 +11,10 @@ namespace MobiFlight.UI.Panels
         public event EventHandler<ManualCalibrationTriggeredEventArgs> OnManualCalibrationTriggered;
         public event EventHandler<StepperConfigChangedEventArgs> OnSetZeroTriggered;
         public event EventHandler<StepperConfigChangedEventArgs> OnStepperSelected;
-        
-        protected StepperProfilePreset StepperProfile;
 
-        int[] StepValues = { -50, -10, -1, 1, 10, 50 };
+        private StepperProfilePreset stepperProfile;
+
+        int[] stepValues = { -50, -10, -1, 1, 10, 50 };
         ErrorProvider errorProvider = new ErrorProvider();
 
         public StepperPanel()
@@ -23,12 +23,13 @@ namespace MobiFlight.UI.Panels
             stepperAddressesComboBox.SelectedValueChanged += stepperAddressesComboBox_SelectedValueChanged;
         }
 
-        public void ShowManualCalibration(Boolean state)
+        public void ShowManualCalibration(bool state)
         {
             groupBox2.Enabled = state;
+            trackBar1.Focus();
         }
 
-        internal void syncFromConfig(OutputConfigItem config)
+        internal void SyncFromConfig(OutputConfigItem config)
         {
             // stepper initialization
             if (!ComboBoxHelper.SetSelectedItem(stepperAddressesComboBox, config.Stepper.Address))
@@ -37,8 +38,8 @@ namespace MobiFlight.UI.Panels
                 Log.Instance.log("Exception on selecting item in Stepper address ComboBox.", LogSeverity.Debug);
             }
 
-            inputRevTextBox.Text            = config.Stepper.InputRev.ToString();
-            outputRevTextBox.Text           = config.Stepper.OutputRev.ToString();
+            inputRevTextBox.Text                = config.Stepper.InputRev.ToString();
+            outputRevTextBox.Text               = config.Stepper.OutputRev.ToString();
 
             if (config.Stepper.Speed>0)
                 SpeedTextBox.Text               = config.Stepper.Speed.ToString();
@@ -46,10 +47,10 @@ namespace MobiFlight.UI.Panels
             if (config.Stepper.Acceleration>0)
                 AccelerationTextBox.Text        = config.Stepper.Acceleration.ToString();
 
-            CompassModeCheckBox.Checked     = config.Stepper.CompassMode;
+            CompassModeCheckBox.Checked         = config.Stepper.CompassMode;
         }
 
-        internal OutputConfigItem syncToConfig(OutputConfigItem config)
+        internal OutputConfigItem SyncToConfig(OutputConfigItem config)
         {
             if (stepperAddressesComboBox.SelectedValue != null)
             {
@@ -61,11 +62,6 @@ namespace MobiFlight.UI.Panels
                 config.Stepper.Speed        = Int16.Parse(SpeedTextBox.Text);
             }
             return config;
-        }
-
-        public void SetSelectedAddress(string value)
-        {
-            stepperAddressesComboBox.SelectedValue = value;
         }
 
         public void SetAddresses(List<ListItem> pins)
@@ -96,10 +92,11 @@ namespace MobiFlight.UI.Panels
             var eventArgs = new ManualCalibrationTriggeredEventArgs
                 {
                     StepperAddress = stepperAddressesComboBox.SelectedValue.ToString(),
-                    Steps = StepValues[trackBar1.Value]
+                    Steps = stepValues[trackBar1.Value]
                 };
 
              OnManualCalibrationTriggered(this, eventArgs);
+             button2.Enabled=true;
             
         }
         
@@ -115,6 +112,7 @@ namespace MobiFlight.UI.Panels
                 {
                     StepperAddress = stepperAddressesComboBox.SelectedValue.ToString()
                 });
+            button2.Enabled=false;
         }
         
         private void enter_KeyPress(object sender, KeyPressEventArgs e)
@@ -136,19 +134,19 @@ namespace MobiFlight.UI.Panels
         
         private void inputRevTextBox_Validating(object sender, CancelEventArgs e)
         {
-            if (!(sender as Control).Parent.Enabled) return;
+            if (!((Control)sender).Parent.Enabled) return;
 
-            String value = (sender as TextBox).Text.Trim();
+            var value = ((TextBox)sender).Text.Trim();
 
             if (value == "") e.Cancel = true;
             if (e.Cancel)
             {
-                displayError(sender as Control, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustNonEmpty"));
+                DisplayError((Control)sender, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustNonEmpty"));
                 return;
             }
             else
             {
-                removeError(sender as Control);
+                RemoveError((Control)sender);
             }
 
             try
@@ -161,22 +159,22 @@ namespace MobiFlight.UI.Panels
             catch (Exception ex)
             {
                 e.Cancel = true;
-                displayError(sender as Control, i18n._tr("uiMessageValidationMustBeNumber"));
+                DisplayError((Control)sender, i18n._tr("uiMessageValidationMustBeNumber"));
                 return;
             }
 
             if (e.Cancel)
             {
-                displayError(sender as Control, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0"));
+                DisplayError((Control)sender, i18n._tr("uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0"));
                 return;
             }
             else
             {
-                removeError(sender as Control);
+                RemoveError((Control)sender);
             }
         }
 
-        private void displayError(Control control, string message)
+        private void DisplayError(Control control, string message)
         {
             errorProvider.SetError(
                     control,
@@ -184,7 +182,7 @@ namespace MobiFlight.UI.Panels
             MessageBox.Show(message, i18n._tr("Hint"));
         }
 
-        private void removeError(Control control)
+        private void RemoveError(Control control)
         {
             errorProvider.SetError(
                     control,
@@ -204,42 +202,44 @@ namespace MobiFlight.UI.Panels
         {
             // we assume that it is safe to update the values
             // when we have a different id
-            if (StepperProfile?.id != profilePreset.id)
+            if (stepperProfile?.id != profilePreset.id)
             {
                 outputRevTextBox.Text = profilePreset.StepsPerRevolution.ToString();
                 AccelerationTextBox.Text = profilePreset.Acceleration.ToString();
                 SpeedTextBox.Text = profilePreset.Speed.ToString();
             }
 
-            this.StepperProfile = profilePreset;
+            this.stepperProfile = profilePreset;
         }
 
         private void ResetButton_Click(object sender, EventArgs e)
         {
             if (sender == OutputRevResetButton)
             {
-                outputRevTextBox.Text = this.StepperProfile.StepsPerRevolution.ToString();
+                outputRevTextBox.Text = this.stepperProfile.StepsPerRevolution.ToString();
             }
             else if (sender == SpeedResetButton)
-                SpeedTextBox.Text = this.StepperProfile.Speed.ToString();
+                SpeedTextBox.Text = this.stepperProfile.Speed.ToString();
             else if (sender == AccelerationResetButton)
-                AccelerationTextBox.Text = this.StepperProfile.Acceleration.ToString();
+                AccelerationTextBox.Text = this.stepperProfile.Acceleration.ToString();
         }
 
         private void StepperSettingsTextBox_TextChanged(object sender, EventArgs e)
         {
-            if (StepperProfile == null) return;
+            if (stepperProfile == null) return;
             UpdateResetButtonVisibility();
         }
 
         private void UpdateResetButtonVisibility()
         {
-            if (StepperProfile == null) return;
+            if (stepperProfile == null) return;
 
-            OutputRevResetButton.Visible = outputRevTextBox.Text != this.StepperProfile.StepsPerRevolution.ToString();
-            AccelerationResetButton.Visible = AccelerationTextBox.Text != this.StepperProfile.Acceleration.ToString();
-            SpeedResetButton.Visible = SpeedTextBox.Text != this.StepperProfile.Speed.ToString();
+            OutputRevResetButton.Visible = outputRevTextBox.Text != this.stepperProfile.StepsPerRevolution.ToString();
+            AccelerationResetButton.Visible = AccelerationTextBox.Text != this.stepperProfile.Acceleration.ToString();
+            SpeedResetButton.Visible = SpeedTextBox.Text != this.stepperProfile.Speed.ToString();
         }
+
+        
     }
 
     public class ManualCalibrationTriggeredEventArgs : StepperConfigChangedEventArgs

--- a/UI/Panels/Output/StepperPanel.resx
+++ b/UI/Panels/Output/StepperPanel.resx
@@ -417,6 +417,36 @@
   <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
     <value>3</value>
   </data>
+  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>110, 80</value>
+  </data>
+  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>320, 100</value>
+  </data>
+  <data name="label9.TabIndex" type="System.Int32, mscorlib">
+    <value>40</value>
+  </data>
+  <data name="label9.Text" xml:space="preserve">
+    <value>Keyboard Controls
+
+Use your keyboard by first clicking on the 'Move steps' track bar.
+
+ Left and Right arrow keys : Adjust the move steps size
+ Space bar : Move the motor
+ Enter or 0 : Sets the zero position</value>
+  </data>
+  <data name="&gt;&gt;label9.Name" xml:space="preserve">
+    <value>label9</value>
+  </data>
+  <data name="&gt;&gt;label9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
+    <value>groupBox2</value>
+  </data>
+  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
   <data name="button2.Location" type="System.Drawing.Point, System.Drawing">
     <value>355, 14</value>
   </data>
@@ -429,6 +459,9 @@
   <data name="button2.Text" xml:space="preserve">
     <value>Set Zero</value>
   </data>
+  <data name="button2.ToolTip" xml:space="preserve">
+    <value>Set the zero position</value>
+  </data>
   <data name="&gt;&gt;button2.Name" xml:space="preserve">
     <value>button2</value>
   </data>
@@ -439,7 +472,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;button2.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
     <value>274, 14</value>
@@ -453,6 +486,9 @@
   <data name="button1.Text" xml:space="preserve">
     <value>Move</value>
   </data>
+  <data name="button1.ToolTip" xml:space="preserve">
+    <value>Move the motor</value>
+  </data>
   <data name="&gt;&gt;button1.Name" xml:space="preserve">
     <value>button1</value>
   </data>
@@ -463,7 +499,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;button1.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -493,7 +529,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="label7.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -523,7 +559,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;label7.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -553,7 +589,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -583,7 +619,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="label4.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -613,7 +649,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -643,7 +679,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>8</value>
   </data>
   <data name="trackBar1.Location" type="System.Drawing.Point, System.Drawing">
     <value>110, 15</value>
@@ -664,7 +700,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;trackBar1.ZOrder" xml:space="preserve">
-    <value>8</value>
+    <value>9</value>
   </data>
   <data name="ManualCalibrateLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
@@ -694,7 +730,7 @@
     <value>groupBox2</value>
   </data>
   <data name="&gt;&gt;ManualCalibrateLabel.ZOrder" xml:space="preserve">
-    <value>9</value>
+    <value>10</value>
   </data>
   <data name="groupBox2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -703,7 +739,7 @@
     <value>0, 200</value>
   </data>
   <data name="groupBox2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 67</value>
+    <value>450, 200</value>
   </data>
   <data name="groupBox2.TabIndex" type="System.Int32, mscorlib">
     <value>24</value>
@@ -995,7 +1031,7 @@
     <value>450, 0</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>450, 267</value>
+    <value>450, 400</value>
   </data>
   <data name="&gt;&gt;toolTip1.Name" xml:space="preserve">
     <value>toolTip1</value>

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -588,7 +588,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
             servoPanel.SetAdresses(servos);
 
-            stepperPanel.SetAdresses(stepper);
+            stepperPanel.SetAddresses(stepper);
 
             displayShiftRegisterPanel.shiftRegistersComboBox.SelectedIndexChanged -= shiftRegistersComboBox_selectedIndexChanged;
             displayShiftRegisterPanel.shiftRegistersComboBox.SelectedIndexChanged += new EventHandler(shiftRegistersComboBox_selectedIndexChanged);

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -106,7 +106,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
             stepperPanel.OnSetZeroTriggered += stepperPanel_OnSetZeroTriggered;
             stepperPanel.OnStepperSelected += StepperPanel_OnStepperSelected;
             // set the default profile for steppers
-            stepperPanel.SetStepperProfile(MFStepperPanel.Profiles.Find(p => p.Value.id == 0).Value);
+            stepperPanel.setStepperProfile(MFStepperPanel.Profiles.Find(p => p.Value.id == 0).Value);
         }
 
         internal void syncFromConfig(OutputConfigItem cfg)
@@ -138,7 +138,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
                         break;
 
                     case MobiFlightStepper.TYPE:
-                        stepperPanel.SyncFromConfig(config);
+                        stepperPanel.syncFromConfig(config);
                         break;
 
                     case MobiFlightLedModule.TYPE:
@@ -210,7 +210,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
                     case MobiFlightStepper.TYPE:
                         // it is not nice but we haev to check what kind of stepper the stepper is
                         // to show or not show the manual calibration piece.
-                        stepperPanel.SyncToConfig(config);
+                        stepperPanel.syncToConfig(config);
                         break;
 
                     case MobiFlightLedModule.TYPE:
@@ -722,7 +722,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
 
                 MobiFlightStepper stepper = module.GetStepper(stepperAddress);
 
-                stepperPanel.SetStepperProfile(stepper.Profile);
+                stepperPanel.setStepperProfile(stepper.Profile);
                 stepperPanel.ShowManualCalibration(!stepper.HasAutoZero);
             }
             catch (IndexOutOfRangeException ex)
@@ -730,7 +730,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
                 // the module with that serial is currently not connected
                 // so we cannot lookup anything sensible
                 Log.Instance.log($"Trying to show stepper config but module {config.DisplaySerial} is not connected. Using default profile.", LogSeverity.Error);
-                stepperPanel.SetStepperProfile(MFStepperPanel.Profiles.Find(p=>p.Value.id == 0).Value);
+                stepperPanel.setStepperProfile(MFStepperPanel.Profiles.Find(p=>p.Value.id == 0).Value);
             }
         }
 

--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -138,7 +138,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
                         break;
 
                     case MobiFlightStepper.TYPE:
-                        stepperPanel.syncFromConfig(config);
+                        stepperPanel.SyncFromConfig(config);
                         break;
 
                     case MobiFlightLedModule.TYPE:
@@ -210,7 +210,7 @@ namespace MobiFlight.UI.Panels.OutputWizard
                     case MobiFlightStepper.TYPE:
                         // it is not nice but we haev to check what kind of stepper the stepper is
                         // to show or not show the manual calibration piece.
-                        stepperPanel.syncToConfig(config);
+                        stepperPanel.SyncToConfig(config);
                         break;
 
                     case MobiFlightLedModule.TYPE:


### PR DESCRIPTION
Enhancement Issue #1242
Use keyboard keys for stepper calibration.
Arrow keys already worked but user needs to click on the trackbar control for keyboard to work. 
Added extra keys:
Enter key or 0 keys will zero.
Space bar will move the stepper motor.
Fixed spelling mistakes.