### PR TITLE
Use a combination of PR number and run count for the connector version.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ env:
   BUILD_CONFIGURATION: Release
   BUILD_PLATFORM: x86
   BUILD_PROJECT: MobiFlightUnitTests
+  VERSION: "0.0.${{ github.event.number }}.${{ github.run_number }}"
 
 jobs:
   build:
@@ -34,7 +35,7 @@ jobs:
       run: nuget restore ${{env.SOLUTION_FILE_PATH}}
 
     - name: Replace version in AssemblyInfo.cs
-      run: (Get-Content "Properties/AssemblyInfo.cs") -replace '\("\d+\.\d+\.\d+(\.\d+)?"\)', '("0.0.0.${{ github.run_number }}")' | Out-File "Properties/AssemblyInfo.cs"
+      run: (Get-Content "Properties/AssemblyInfo.cs") -replace '\("\d+\.\d+\.\d+(\.\d+)?"\)', '("${{ env.VERSION }}")' | Out-File "Properties/AssemblyInfo.cs"
       shell: pwsh
       
     - name: Dump AssemblyInfo.cs
@@ -55,4 +56,4 @@ jobs:
       with:
         name: MobiFlightConnector
         path: |
-          Release/MobiFlightConnector-*.zip
+          Release/MobiFlightConnector-${{ env.VERSION }}.zip

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -1690,7 +1690,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if "$(ConfigurationName)" == "Release" ($(ProjectDir)Build\release.bat $(TargetDir) $(SolutionDir) 7.1.4)</PostBuildEvent>
+    <PostBuildEvent>if "$(ConfigurationName)" == "Release" ($(ProjectDir)Build\release.bat $(TargetDir) $(SolutionDir))</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>xcopy /R /Y "$(ProjectDir)Lib\vJoyInterface.dll" "$(TargetDir)"


### PR DESCRIPTION
Fixes #1294 

* Updates the build version to a combination of the PR number and the run number (which increments on every PR run). The build version winds up being `0.0.<prnumber>.<runnumber>`.
* Change the artifact upload to only upload that specific zip file, instead of a wildcard of everything in the release folder.
* Update the checkout action to use v3 to get rid of a warning

There doesn't seem to be a way to tell the artifact uploader to only upload a single file instead of zipping all the artifacts, so no way to avoid the zip-inside-a-zip problem.