### PR TITLE
Fix input config error log message 

### DIFF
--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -286,7 +286,7 @@ namespace MobiFlight.UI.Dialogs
             }
 
             // second tab
-            if (!ComboBoxHelper.SetSelectedItemByValue(inputTypeComboBox, config.Name))
+            if (config.Name!=null && !ComboBoxHelper.SetSelectedItem(inputTypeComboBox, config.Name))
             {
                 // TODO: provide error message
                 Log.Instance.log($"Exception on selecting item in input type ComboBox. {config.Name}", LogSeverity.Error);
@@ -516,7 +516,7 @@ namespace MobiFlight.UI.Dialogs
                 }
 
                 // third tab
-                if (!ComboBoxHelper.SetSelectedItem(inputTypeComboBox, config.Name))
+                if (config.Name != null && !ComboBoxHelper.SetSelectedItem(inputTypeComboBox, config.Name))
                 {
                     Log.Instance.log($"Problem setting input type ComboBox. {config.Name}", LogSeverity.Error);
                 }

--- a/UI/Panels/Output/DisplayShiftRegisterPanel.cs
+++ b/UI/Panels/Output/DisplayShiftRegisterPanel.cs
@@ -29,9 +29,9 @@ namespace MobiFlight.UI.Panels
             // pre-select display stuff
             if (config.ShiftRegister != null && config.ShiftRegister.Address != null)
             {
-                if (!ComboBoxHelper.SetSelectedItem(shiftRegistersComboBox, config.ShiftRegister.Address.ToString()))
+                if (!ComboBoxHelper.SetSelectedItem(shiftRegistersComboBox, config.ShiftRegister.Address))
                 {
-                    Log.Instance.log("Exception on selecting item in Shift Register ComboBox.", LogSeverity.Error);
+                    Log.Instance.log($"Exception on selecting item {config.ShiftRegister.Address} in Shift Register ComboBox.", LogSeverity.Error);
                 }
             }
 

--- a/UI/Panels/Output/LCDDisplayPanel.cs
+++ b/UI/Panels/Output/LCDDisplayPanel.cs
@@ -40,10 +40,10 @@ namespace MobiFlight.UI.Panels
             // preselect display stuff
             if (config.LcdDisplay.Address != null)
             {
-                if (!ComboBoxHelper.SetSelectedItem(DisplayComboBox, config.LcdDisplay.Address.ToString()))
+                if (!ComboBoxHelper.SetSelectedItem(DisplayComboBox, config.LcdDisplay.Address))
                 {
                     // TODO: provide error message
-                    Log.Instance.log("Exception on selecting item in LCD address ComboBox.", LogSeverity.Error);
+                    Log.Instance.log($"Exception on selecting item {config.LcdDisplay.Address} in LCD address ComboBox.", LogSeverity.Error);
                 }
             }
             if (config.LcdDisplay.Lines.Count > 0)

--- a/UI/Panels/Output/ServoPanel.cs
+++ b/UI/Panels/Output/ServoPanel.cs
@@ -48,7 +48,7 @@ namespace MobiFlight.UI.Panels
             if (!ComboBoxHelper.SetSelectedItem(servoAddressesComboBox, config.Servo.Address))
             {
                 // TODO: provide error message
-                Log.Instance.log("Exception on selecting item in Servo address ComboBox.", LogSeverity.Error);
+                Log.Instance.log($"Exception on selecting item {config.Servo.Address} in Servo address ComboBox.", LogSeverity.Error);
             }
 
             if (config.Servo.Min != null) minValueTextBox.Text = config.Servo.Min;

--- a/UI/Panels/Output/StepperPanel.cs
+++ b/UI/Panels/Output/StepperPanel.cs
@@ -33,7 +33,7 @@ namespace MobiFlight.UI.Panels
             if (!ComboBoxHelper.SetSelectedItem(stepperAddressesComboBox, config.Stepper.Address))
             {
                 // TODO: provide error message
-                Log.Instance.log("Exception on selecting item in Stepper address ComboBox.", LogSeverity.Debug);
+                Log.Instance.log($"Exception on selecting item {config.Stepper.Address} in Stepper address ComboBox.", LogSeverity.Debug);
             }
 
             inputRevTextBox.Text            = config.Stepper.InputRev.ToString();


### PR DESCRIPTION
fixes #1219 

- [x] Use ComboBoxHelper.SetSelectedItem
- [x] Use device names consistently in error messages