### PR TITLE
Adding log entry for skipped input configs.

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1421,7 +1421,11 @@ namespace MobiFlight
 
                 DataRow row = (tuple.Item2.DataBoundItem as DataRowView).Row;
 
-                if (!(bool)row["active"]) continue;
+                if (!(bool)row["active"])
+                {
+                    Log.Instance.log($"{msgEventLabel} => skipping \"{row["description"]}\", config not active.", LogSeverity.Warn);
+                    continue;
+                }
 
                 // if there are preconditions check and skip if necessary
                 if (tuple.Item1.Preconditions.Count > 0)


### PR DESCRIPTION
fixes #1199 

- [x] Log message for skipped inputs with level warn (like the other log messages in this context) 