### PR TITLE
Fixed reverse logic for 7-segment displays

### DIFF
--- a/Base/Extensions.cs
+++ b/Base/Extensions.cs
@@ -42,5 +42,19 @@ namespace MobiFlight.Base
             }
             return (byte) result;
         }
+
+
+        public static byte HammingWeight(this byte value)
+        {
+            byte sum = 0;
+
+            while (value > 0)
+            {
+                sum += (byte)(value & 0x01);
+                value >>= 1;
+            }
+
+            return sum;
+        }
     }
 }

--- a/MobiFlight/MobiFlightLedModule.cs
+++ b/MobiFlight/MobiFlightLedModule.cs
@@ -78,7 +78,8 @@ namespace MobiFlight
             }
 
             // clamp and reverse the string
-            if (value.Length > 8) value = value.Substring(0, 8);
+            var maxLength = Math.Min(mask.HammingWeight(), (byte) 8);
+            if (value.Length > maxLength) value = value.Substring(0, maxLength);
 
             if (reverse)
             {

--- a/MobiFlightUnitTests/MobiFlight/MobiFlightLedModuleTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/MobiFlightLedModuleTests.cs
@@ -99,11 +99,12 @@ namespace MobiFlight.Tests
 
             mask = 254;
             value = "12345608";
+            var expectedValue = "1234560";
             mockTransport.Clear();
             module.Display(0, value, points, mask);
             WaitForQueueUpdate();
 
-            DataExpected = $"{CommandId},{ModuleIndex},{SubModuleIndex},{value},{points},{mask};";
+            DataExpected = $"{CommandId},{ModuleIndex},{SubModuleIndex},{expectedValue},{points},{mask};";
             Assert.AreEqual(DataExpected, mockTransport.DataWrite, $"Sending same mask, and value changed in masked area. Mask in Mock should be \"{mask}\"");
 
             // #
@@ -241,6 +242,28 @@ namespace MobiFlight.Tests
             module.Display(0, value, points, mask);
             WaitForQueueUpdate();
             DataExpected = $"{CommandId},{ModuleIndex},{SubModuleIndex},11880500,32,{mask};";
+            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Decimal point not set correctly");
+
+
+            value = "1234";
+            points = 0;
+            mask = 8 + 4 + 2 + 1;
+            var reverseMask = 128 + 64 + 32 + 16;
+            mockTransport.Clear();
+            module.Display(0, value, points, mask, true);
+            WaitForQueueUpdate();
+            DataExpected = $"{CommandId},{ModuleIndex},{SubModuleIndex},4321,0,{reverseMask};";
+            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Decimal point not set correctly");
+
+            module.ClearState();
+            value = "123456";
+            points = 0;
+            mask = 8 + 4 + 2 + 1;
+            reverseMask = 128 + 64 + 32 + 16;
+            mockTransport.Clear();
+            module.Display(0, value, points, mask, true);
+            WaitForQueueUpdate();
+            DataExpected = $"{CommandId},{ModuleIndex},{SubModuleIndex},4321,0,{reverseMask};";
             Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Decimal point not set correctly");
         }
 


### PR DESCRIPTION
fixes #1251 

- [x] reverse logic works correctly
- [x] unit tests added


**Note:** 
The problem occurred when the string was longer than the amount of active digits. This was always the case with the test mode because it used `12345678` - so reversing the string gave `87654321` which displayed `5678` on the displays. Now the reversed string will first be shortened based on the activated digits (ex 4 digits) -> `12345678` -> `1234` -> reverse -> `4321` 