### PR TITLE
Use multiclient wasm interface

### DIFF
--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -307,6 +307,7 @@
     <Compile Include="SimConnectMSFS\SimConnectCacheInterface.cs" />
     <Compile Include="SimConnectMSFS\WasmModuleClient.cs" />
     <Compile Include="SimConnectMSFS\SimConnectDefinitions.cs" />
+    <Compile Include="SimConnectMSFS\WasmModuleClientData.cs" />
     <Compile Include="SimConnectMSFS\WasmModuleUpdater.cs" />
     <Compile Include="UI\Dialogs\AboutForm.cs">
       <SubType>Form</SubType>

--- a/SimConnectMSFS/SimConnectDefinitions.cs
+++ b/SimConnectMSFS/SimConnectDefinitions.cs
@@ -44,9 +44,12 @@ namespace MobiFlight.SimConnectMSFS
 
     public enum SIMCONNECT_CLIENT_DATA_ID
     {
-        MOBIFLIGHT_LVARS,
-        MOBIFLIGHT_CMD,
-        MOBIFLIGHT_RESPONSE
+        MOBIFLIGHT_LVARS = 0,
+        MOBIFLIGHT_CMD = 1,
+        MOBIFLIGHT_RESPONSE = 2,
+        RUNTIME_LVARS = 3,
+        RUNTIME_CMD = 4,
+        RUNTIME_RESPONSE = 5
     }
 
     public enum SIMCONNECT_REQUEST_ID

--- a/SimConnectMSFS/WasmModuleClient.cs
+++ b/SimConnectMSFS/WasmModuleClient.cs
@@ -10,54 +10,74 @@ namespace MobiFlight.SimConnectMSFS
 
     static class WasmModuleClient
     {
-        public static void Ping(SimConnect simConnect)
+        public static void Ping(SimConnect simConnect, WasmModuleClientData clientData)
         {
             if (simConnect == null) return;
 
-            SendWasmCmd(simConnect, "MF.Ping");
-            DummyCommand(simConnect);
+            SendWasmCmd(simConnect, "MF.Ping", clientData);
+            DummyCommand(simConnect, clientData);
         }
 
-        public static void Stop(SimConnect simConnect)
+        public static void Stop(SimConnect simConnect, WasmModuleClientData clientData)
         {
             if (simConnect == null) return;
                
-            SendWasmCmd(simConnect, "MF.SimVars.Clear");
+            SendWasmCmd(simConnect, "MF.SimVars.Clear", clientData);
         }
 
-        public static void GetLVarList(SimConnect simConnect)
+        public static void GetLVarList(SimConnect simConnect, WasmModuleClientData clientData)
         {
             if (simConnect == null) return;
 
-            SendWasmCmd(simConnect, "MF.LVars.List");
-            DummyCommand(simConnect);
+            SendWasmCmd(simConnect, "MF.LVars.List", clientData);
+            DummyCommand(simConnect, clientData);
         }
 
-        public static void DummyCommand(SimConnect simConnect)
+        public static void DummyCommand(SimConnect simConnect, WasmModuleClientData clientData)
         {
             if (simConnect == null) return;
 
-            SendWasmCmd(simConnect, "MF.DummyCmd");
+            SendWasmCmd(simConnect, "MF.DummyCmd", clientData);
         }
 
-        public static void SendWasmCmd(SimConnect simConnect, String command)
+        public static void SendWasmCmd(SimConnect simConnect, String command, WasmModuleClientData clientData)
         {
             if (simConnect == null) return;
 
             simConnect.SetClientData(
-                SIMCONNECT_CLIENT_DATA_ID.MOBIFLIGHT_CMD,
-               (SIMCONNECT_CLIENT_DATA_ID)0,
-               SIMCONNECT_CLIENT_DATA_SET_FLAG.DEFAULT, 0,
+               clientData.AREA_COMMAND_ID,
+               (SIMCONNECT_DEFINE_ID)clientData.DATA_DEFINITION_ID,
+               SIMCONNECT_CLIENT_DATA_SET_FLAG.DEFAULT,
+               0,
                new ClientDataString(command)
             );
         }
 
-        public static void SetConfig(SimConnect simConnect, String ConfigName, String ConfigValue)
+        public static void SetConfig(SimConnect simConnect, String ConfigName, String ConfigValue, WasmModuleClientData clientData)
         {
             if (simConnect == null) return;
 
-            SendWasmCmd(simConnect, $"MF.Config.{ConfigName}.Set.{ConfigValue}");
-            DummyCommand(simConnect);
+            SendWasmCmd(simConnect, $"MF.Config.{ConfigName}.Set.{ConfigValue}", clientData);
+            DummyCommand(simConnect, clientData);
         }
+
+        public static void AddAdditionalClient(SimConnect simConnect, String clientName, WasmModuleClientData clientData)
+        {
+            WasmModuleClient.DummyCommand(simConnect, clientData);
+            WasmModuleClient.SendWasmCmd(simConnect, $"MF.Clients.Add.{clientName}", clientData);
+        }
+
+        public static void SetSimVar(SimConnect simConnect, String SimVarCode, WasmModuleClientData clientData)
+        {
+            WasmModuleClient.SendWasmCmd(simConnect, "MF.SimVars.Set." + SimVarCode, clientData);
+            WasmModuleClient.DummyCommand(simConnect, clientData);
+        }
+
+        public static void AddSimVar(SimConnect simConnect, String SimVarName, WasmModuleClientData clientData)
+        {
+            WasmModuleClient.SendWasmCmd(simConnect, "MF.SimVars.Add." + SimVarName, clientData);
+        }
+
+
     }
 }

--- a/SimConnectMSFS/WasmModuleClientData.cs
+++ b/SimConnectMSFS/WasmModuleClientData.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace MobiFlight.SimConnectMSFS
+{
+    public class WasmModuleClientData
+    {
+        public string NAME;
+        public Enum AREA_SIMVAR_ID;
+        public Enum AREA_COMMAND_ID;
+        public Enum AREA_RESPONSE_ID;
+        public uint DATA_DEFINITION_ID;
+        public uint RESPONSE_OFFSET;
+    }
+}


### PR DESCRIPTION
Resolves: #1305 
Two wasm client configurations are introduced.

- InitClient +
- RuntimeClient

InitClient is only used to establish the first connection and register the RuntimeClient. Then RuntimeClient is used for all operations.

So far the code is still under the assumption, that the simconnect connection might be available before the wasm was initialized. 
I doubt that can happen, in the devmode console logging wasm is initialized long before first simconnect operations. 

To clarify I opened the ticket:
https://devsupport.flightsimulator.com/t/is-standalone-wasm-initialized-before-external-simconnect-becomes-available/6535