### PR TITLE
fixes problem with XMLReader

### DIFF
--- a/MobiFlight/Modifier/ModifierList.cs
+++ b/MobiFlight/Modifier/ModifierList.cs
@@ -126,6 +126,14 @@ namespace MobiFlight.Modifier
                         break;
                 }
             } while (reader.LocalName != "modifiers");
+
+            // are still on the closing tag
+            if (reader.LocalName == "modifiers" && reader.NodeType == XmlNodeType.EndElement)
+            {
+                // advance to the next node
+                reader.Read();
+                return;
+            }
         }
 
         public void WriteXml(XmlWriter writer)

--- a/MobiFlight/OutputConfigItem.cs
+++ b/MobiFlight/OutputConfigItem.cs
@@ -187,9 +187,10 @@ namespace MobiFlight
                 // backward compatibility when we have comparison
                 // as a single node instead of modifiers
                 Modifiers.Comparison.ReadXml(reader);
+                reader.Read();
             }
 
-            if (reader.ReadToNextSibling("display"))
+            if (reader.LocalName == "display")
             {
                 DisplayType = reader["type"];
 


### PR DESCRIPTION
Fixes a problem with the `xmlRead()` when reading a config with old `comparison` or `modifers`, this was reported by @Koseng 

- [x] All existing unit tests are passing
- [x] Advanced the reader to the next node when reading modifiers