### PR TITLE
Update action versions in builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,38 +22,38 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
-      
-    - name: Add VSTest to Path
-      uses: darenm/Setup-VSTest@v1
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.3.1
 
-    - name: Restore NuGet packages
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+      - name: Add VSTest to Path
+        uses: darenm/Setup-VSTest@v1.2
 
-    - name: Replace version in AssemblyInfo.cs
-      run: (Get-Content "Properties/AssemblyInfo.cs") -replace '\("\d+\.\d+\.\d+(\.\d+)?"\)', '("${{ env.VERSION }}")' | Out-File "Properties/AssemblyInfo.cs"
-      shell: pwsh
-      
-    - name: Dump AssemblyInfo.cs
-      run: 'type Properties/AssemblyInfo.cs'
-      shell: pwsh
+      - name: Restore NuGet packages
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: nuget restore ${{env.SOLUTION_FILE_PATH}}
 
-    - name: Build
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /t:${{env.BUILD_PROJECT}} ${{env.SOLUTION_FILE_PATH}} 
-      
-    - name: Run Tests
-      run: vstest.console.exe MobiFlightUnitTests/bin/Release/MobiFlightUnitTests.dll
+      - name: Replace version in AssemblyInfo.cs
+        run: (Get-Content "Properties/AssemblyInfo.cs") -replace '\("\d+\.\d+\.\d+(\.\d+)?"\)', '("${{ env.VERSION }}")' | Out-File "Properties/AssemblyInfo.cs"
+        shell: pwsh
 
-    - name: store latest setup file
-      uses: actions/upload-artifact@v3
-      with:
-        name: MobiFlightConnector
-        path: |
-          Release/MobiFlightConnector-${{ env.VERSION }}.zip
+      - name: Dump AssemblyInfo.cs
+        run: "type Properties/AssemblyInfo.cs"
+        shell: pwsh
+
+      - name: Build
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        # Add additional options to the MSBuild command line here (like platform or verbosity level).
+        # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /t:${{env.BUILD_PROJECT}} ${{env.SOLUTION_FILE_PATH}}
+
+      - name: Run Tests
+        run: vstest.console.exe MobiFlightUnitTests/bin/Release/MobiFlightUnitTests.dll
+
+      - name: store latest setup file
+        uses: actions/upload-artifact@v3
+        with:
+          name: MobiFlightConnector
+          path: |
+            Release/MobiFlightConnector-${{ env.VERSION }}.zip

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,67 +21,67 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-    - name: Add MSBuild to PATH
-      uses: microsoft/setup-msbuild@v1.1.3
-      
-    - name: Add VSTest to Path
-      uses: darenm/Setup-VSTest@v1
+      - name: Add MSBuild to PATH
+        uses: microsoft/setup-msbuild@v1.3.1
 
-    - name: Downgrade NSIS
-      shell: pwsh
-      run: .\Build\downgrade_nsis.ps1
-      
-    - name: Replace version in AssemblyInfo.cs
-      run: (Get-Content "Properties/AssemblyInfo.cs") -replace '\("\d+\.\d+\.\d+(\.\d+)?"\)', '("${{ github.event.release.tag_name }}")' | Out-File "Properties/AssemblyInfo.cs"
-      shell: pwsh
-      
-    - name: Dump AssemblyInfo.cs
-      run: 'type Properties/AssemblyInfo.cs'
-      shell: pwsh
+      - name: Add VSTest to Path
+        uses: darenm/Setup-VSTest@v1.2
 
-    - name: Restore NuGet packages
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
-      
-    - name: Build Test
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /t:${{env.PROJECT_TEST}} ${{env.SOLUTION_FILE_PATH}}
-      
-    - name: Run Tests
-      run: vstest.console.exe ${{env.PROJECT_TEST}}/bin/Release/${{env.PROJECT_TEST}}.dll
+      - name: Downgrade NSIS
+        shell: pwsh
+        run: .\Build\downgrade_nsis.ps1
 
-    - name: Build Connector
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      # Add additional options to the MSBuild command line here (like platform or verbosity level).
-      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} /t:${{env.PROJECT_MAIN}}
-      
-    - name: Create Hash
-      run: (Get-FileHash Release/MobiFlightConnector-${{ github.event.release.tag_name }}.zip -Algorithm SHA1).Hash | Out-File Release/MobiFlightConnector-${{ github.event.release.tag_name }}.sha1 
-      shell: pwsh
-      
-    - name: Create latest setup exe
-      uses: joncloud/makensis-action@v4
-      with:
-        script-file: ./Build/setup.nsi
-        arguments: "/V3" 
-      
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        files: |
-          Release/*.zip
-          Release/*.sha1
+      - name: Replace version in AssemblyInfo.cs
+        run: (Get-Content "Properties/AssemblyInfo.cs") -replace '\("\d+\.\d+\.\d+(\.\d+)?"\)', '("${{ github.event.release.tag_name }}")' | Out-File "Properties/AssemblyInfo.cs"
+        shell: pwsh
 
-    - name: store latest setup file
-      uses: actions/upload-artifact@v3
-      with:
-        name: MobiFlight-Setup
-        path: |
-          Build/MobiFlight-Setup.exe
+      - name: Dump AssemblyInfo.cs
+        run: "type Properties/AssemblyInfo.cs"
+        shell: pwsh
+
+      - name: Restore NuGet packages
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+      - name: Build Test
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        # Add additional options to the MSBuild command line here (like platform or verbosity level).
+        # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /t:${{env.PROJECT_TEST}} ${{env.SOLUTION_FILE_PATH}}
+
+      - name: Run Tests
+        run: vstest.console.exe ${{env.PROJECT_TEST}}/bin/Release/${{env.PROJECT_TEST}}.dll
+
+      - name: Build Connector
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        # Add additional options to the MSBuild command line here (like platform or verbosity level).
+        # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+        run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} /t:${{env.PROJECT_MAIN}}
+
+      - name: Create Hash
+        run: (Get-FileHash Release/MobiFlightConnector-${{ github.event.release.tag_name }}.zip -Algorithm SHA1).Hash | Out-File Release/MobiFlightConnector-${{ github.event.release.tag_name }}.sha1
+        shell: pwsh
+
+      - name: Create latest setup exe
+        uses: joncloud/makensis-action@v4
+        with:
+          script-file: ./Build/setup.nsi
+          arguments: "/V3"
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: |
+            Release/*.zip
+            Release/*.sha1
+
+      - name: store latest setup file
+        uses: actions/upload-artifact@v3
+        with:
+          name: MobiFlight-Setup
+          path: |
+            Build/MobiFlight-Setup.exe


### PR DESCRIPTION
Fixes #1312

Updates the version of three actions used in our build process to remove warnings from the GitHub build process.

Before this change the following warnings are shown [after the action runs](https://github.com/MobiFlight/MobiFlight-Connector/actions/runs/6442356423):

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, microsoft/setup-msbuild@v1.0.2, darenm/Setup-VSTest@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

After this change [there are no warnings](https://github.com/MobiFlight/MobiFlight-Connector/actions/runs/6495578659).