### PR TITLE
Add setting to control minimize on autorun

### DIFF
--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MobiFlight.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.3.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.5.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -453,6 +453,18 @@ namespace MobiFlight.Properties {
             }
             set {
                 this["AutoRetrigger"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool MinimizeOnAutoRun {
+            get {
+                return ((bool)(this["MinimizeOnAutoRun"]));
+            }
+            set {
+                this["MinimizeOnAutoRun"] = value;
             }
         }
     }

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -111,5 +111,8 @@
     <Setting Name="AutoRetrigger" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="MinimizeOnAutoRun" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -832,7 +832,10 @@ namespace MobiFlight.UI
             if (Properties.Settings.Default.AutoRun || cmdLineParams.AutoRun)
             {
                 execManager.Start();
-                minimizeMainForm(true);
+                if (Properties.Settings.Default.MinimizeOnAutoRun)
+                {
+                    minimizeMainForm(true);
+                }
             }
         }
 

--- a/UI/Panels/Settings/GeneralPanel.Designer.cs
+++ b/UI/Panels/Settings/GeneralPanel.Designer.cs
@@ -57,6 +57,7 @@
             this.SpeedTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.autoRetriggerGoupBox = new System.Windows.Forms.GroupBox();
             this.autoRetriggerCheckBox = new System.Windows.Forms.CheckBox();
+            this.minimizeOnAutoRunCheckbox = new System.Windows.Forms.CheckBox();
             this.BetaUpdatesGroupBox.SuspendLayout();
             this.languageGroupBox.SuspendLayout();
             this.debugGroupBox.SuspendLayout();
@@ -251,6 +252,7 @@
             // 
             // autoRetriggerGoupBox
             // 
+            this.autoRetriggerGoupBox.Controls.Add(this.minimizeOnAutoRunCheckbox);
             this.autoRetriggerGoupBox.Controls.Add(this.autoRetriggerCheckBox);
             resources.ApplyResources(this.autoRetriggerGoupBox, "autoRetriggerGoupBox");
             this.autoRetriggerGoupBox.Name = "autoRetriggerGoupBox";
@@ -261,6 +263,12 @@
             resources.ApplyResources(this.autoRetriggerCheckBox, "autoRetriggerCheckBox");
             this.autoRetriggerCheckBox.Name = "autoRetriggerCheckBox";
             this.autoRetriggerCheckBox.UseVisualStyleBackColor = true;
+            // 
+            // minimizeOnAutoRunCheckbox
+            // 
+            resources.ApplyResources(this.minimizeOnAutoRunCheckbox, "minimizeOnAutoRunCheckbox");
+            this.minimizeOnAutoRunCheckbox.Name = "minimizeOnAutoRunCheckbox";
+            this.minimizeOnAutoRunCheckbox.UseVisualStyleBackColor = true;
             // 
             // GeneralPanel
             // 
@@ -325,5 +333,6 @@
         private System.Windows.Forms.TableLayoutPanel SpeedTableLayoutPanel;
         private System.Windows.Forms.GroupBox autoRetriggerGoupBox;
         private System.Windows.Forms.CheckBox autoRetriggerCheckBox;
+        private System.Windows.Forms.CheckBox minimizeOnAutoRunCheckbox;
     }
 }

--- a/UI/Panels/Settings/GeneralPanel.Designer.cs
+++ b/UI/Panels/Settings/GeneralPanel.Designer.cs
@@ -74,8 +74,8 @@
             // 
             // BetaUpdatesGroupBox
             // 
-            this.BetaUpdatesGroupBox.Controls.Add(this.BetaUpdateCheckBox);
             resources.ApplyResources(this.BetaUpdatesGroupBox, "BetaUpdatesGroupBox");
+            this.BetaUpdatesGroupBox.Controls.Add(this.BetaUpdateCheckBox);
             this.BetaUpdatesGroupBox.Name = "BetaUpdatesGroupBox";
             this.BetaUpdatesGroupBox.TabStop = false;
             // 
@@ -87,10 +87,10 @@
             // 
             // languageGroupBox
             // 
+            resources.ApplyResources(this.languageGroupBox, "languageGroupBox");
             this.languageGroupBox.Controls.Add(this.label9);
             this.languageGroupBox.Controls.Add(this.languageComboBox);
             this.languageGroupBox.Controls.Add(this.languageLabel);
-            resources.ApplyResources(this.languageGroupBox, "languageGroupBox");
             this.languageGroupBox.Name = "languageGroupBox";
             this.languageGroupBox.TabStop = false;
             // 
@@ -101,12 +101,12 @@
             // 
             // languageComboBox
             // 
+            resources.ApplyResources(this.languageComboBox, "languageComboBox");
             this.languageComboBox.FormattingEnabled = true;
             this.languageComboBox.Items.AddRange(new object[] {
             resources.GetString("languageComboBox.Items"),
             resources.GetString("languageComboBox.Items1"),
             resources.GetString("languageComboBox.Items2")});
-            resources.ApplyResources(this.languageComboBox, "languageComboBox");
             this.languageComboBox.Name = "languageComboBox";
             // 
             // languageLabel
@@ -116,11 +116,11 @@
             // 
             // debugGroupBox
             // 
+            resources.ApplyResources(this.debugGroupBox, "debugGroupBox");
             this.debugGroupBox.Controls.Add(this.LogJoystickAxisCheckBox);
             this.debugGroupBox.Controls.Add(this.logLevelComboBox);
             this.debugGroupBox.Controls.Add(this.logLevelLabel);
             this.debugGroupBox.Controls.Add(this.logLevelCheckBox);
-            resources.ApplyResources(this.debugGroupBox, "debugGroupBox");
             this.debugGroupBox.Name = "debugGroupBox";
             this.debugGroupBox.TabStop = false;
             // 
@@ -132,6 +132,7 @@
             // 
             // logLevelComboBox
             // 
+            resources.ApplyResources(this.logLevelComboBox, "logLevelComboBox");
             this.logLevelComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.logLevelComboBox.FormattingEnabled = true;
             this.logLevelComboBox.Items.AddRange(new object[] {
@@ -139,7 +140,6 @@
             resources.GetString("logLevelComboBox.Items1"),
             resources.GetString("logLevelComboBox.Items2"),
             resources.GetString("logLevelComboBox.Items3")});
-            resources.ApplyResources(this.logLevelComboBox, "logLevelComboBox");
             this.logLevelComboBox.Name = "logLevelComboBox";
             // 
             // logLevelLabel
@@ -155,10 +155,10 @@
             // 
             // testModeSpeedGroupBox
             // 
+            resources.ApplyResources(this.testModeSpeedGroupBox, "testModeSpeedGroupBox");
             this.testModeSpeedGroupBox.Controls.Add(this.label8);
             this.testModeSpeedGroupBox.Controls.Add(this.label6);
             this.testModeSpeedGroupBox.Controls.Add(this.testModeSpeedTrackBar);
-            resources.ApplyResources(this.testModeSpeedGroupBox, "testModeSpeedGroupBox");
             this.testModeSpeedGroupBox.Name = "testModeSpeedGroupBox";
             this.testModeSpeedGroupBox.TabStop = false;
             // 
@@ -180,16 +180,16 @@
             // 
             // recentFilesGroupBox
             // 
+            resources.ApplyResources(this.recentFilesGroupBox, "recentFilesGroupBox");
             this.recentFilesGroupBox.Controls.Add(this.label1);
             this.recentFilesGroupBox.Controls.Add(this.recentFilesNumericUpDown);
-            resources.ApplyResources(this.recentFilesGroupBox, "recentFilesGroupBox");
             this.recentFilesGroupBox.Name = "recentFilesGroupBox";
             this.recentFilesGroupBox.TabStop = false;
             // 
             // label1
             // 
-            this.label1.AutoEllipsis = true;
             resources.ApplyResources(this.label1, "label1");
+            this.label1.AutoEllipsis = true;
             this.label1.Name = "label1";
             // 
             // recentFilesNumericUpDown
@@ -199,8 +199,8 @@
             // 
             // CommunityFeedbackGroupBox
             // 
-            this.CommunityFeedbackGroupBox.Controls.Add(this.CommunityFeedbackCheckBox);
             resources.ApplyResources(this.CommunityFeedbackGroupBox, "CommunityFeedbackGroupBox");
+            this.CommunityFeedbackGroupBox.Controls.Add(this.CommunityFeedbackCheckBox);
             this.CommunityFeedbackGroupBox.Name = "CommunityFeedbackGroupBox";
             this.CommunityFeedbackGroupBox.TabStop = false;
             // 
@@ -212,11 +212,11 @@
             // 
             // ConfigExecutionGroupBox
             // 
+            resources.ApplyResources(this.ConfigExecutionGroupBox, "ConfigExecutionGroupBox");
             this.ConfigExecutionGroupBox.Controls.Add(this.label3);
             this.ConfigExecutionGroupBox.Controls.Add(this.label2);
             this.ConfigExecutionGroupBox.Controls.Add(this.label5);
             this.ConfigExecutionGroupBox.Controls.Add(this.fsuipcPollIntervalTrackBar);
-            resources.ApplyResources(this.ConfigExecutionGroupBox, "ConfigExecutionGroupBox");
             this.ConfigExecutionGroupBox.Name = "ConfigExecutionGroupBox";
             this.ConfigExecutionGroupBox.TabStop = false;
             // 
@@ -252,9 +252,9 @@
             // 
             // autoRetriggerGoupBox
             // 
+            resources.ApplyResources(this.autoRetriggerGoupBox, "autoRetriggerGoupBox");
             this.autoRetriggerGoupBox.Controls.Add(this.minimizeOnAutoRunCheckbox);
             this.autoRetriggerGoupBox.Controls.Add(this.autoRetriggerCheckBox);
-            resources.ApplyResources(this.autoRetriggerGoupBox, "autoRetriggerGoupBox");
             this.autoRetriggerGoupBox.Name = "autoRetriggerGoupBox";
             this.autoRetriggerGoupBox.TabStop = false;
             // 

--- a/UI/Panels/Settings/GeneralPanel.Designer.cs
+++ b/UI/Panels/Settings/GeneralPanel.Designer.cs
@@ -56,8 +56,8 @@
             this.fsuipcPollIntervalTrackBar = new System.Windows.Forms.TrackBar();
             this.SpeedTableLayoutPanel = new System.Windows.Forms.TableLayoutPanel();
             this.autoRetriggerGoupBox = new System.Windows.Forms.GroupBox();
-            this.autoRetriggerCheckBox = new System.Windows.Forms.CheckBox();
             this.minimizeOnAutoRunCheckbox = new System.Windows.Forms.CheckBox();
+            this.autoRetriggerCheckBox = new System.Windows.Forms.CheckBox();
             this.BetaUpdatesGroupBox.SuspendLayout();
             this.languageGroupBox.SuspendLayout();
             this.debugGroupBox.SuspendLayout();
@@ -258,17 +258,17 @@
             this.autoRetriggerGoupBox.Name = "autoRetriggerGoupBox";
             this.autoRetriggerGoupBox.TabStop = false;
             // 
-            // autoRetriggerCheckBox
-            // 
-            resources.ApplyResources(this.autoRetriggerCheckBox, "autoRetriggerCheckBox");
-            this.autoRetriggerCheckBox.Name = "autoRetriggerCheckBox";
-            this.autoRetriggerCheckBox.UseVisualStyleBackColor = true;
-            // 
             // minimizeOnAutoRunCheckbox
             // 
             resources.ApplyResources(this.minimizeOnAutoRunCheckbox, "minimizeOnAutoRunCheckbox");
             this.minimizeOnAutoRunCheckbox.Name = "minimizeOnAutoRunCheckbox";
             this.minimizeOnAutoRunCheckbox.UseVisualStyleBackColor = true;
+            // 
+            // autoRetriggerCheckBox
+            // 
+            resources.ApplyResources(this.autoRetriggerCheckBox, "autoRetriggerCheckBox");
+            this.autoRetriggerCheckBox.Name = "autoRetriggerCheckBox";
+            this.autoRetriggerCheckBox.UseVisualStyleBackColor = true;
             // 
             // GeneralPanel
             // 

--- a/UI/Panels/Settings/GeneralPanel.cs
+++ b/UI/Panels/Settings/GeneralPanel.cs
@@ -88,8 +88,9 @@ namespace MobiFlight.UI.Panels.Settings
             // Community Feedback Program
             CommunityFeedbackCheckBox.Checked = Properties.Settings.Default.CommunityFeedback;
 
-            // Auto-retrigger
+            // Run options
             autoRetriggerCheckBox.Checked = Properties.Settings.Default.AutoRetrigger;
+            minimizeOnAutoRunCheckbox.Checked = Properties.Settings.Default.MinimizeOnAutoRun;
         }
 
         public void saveSettings()
@@ -124,8 +125,9 @@ namespace MobiFlight.UI.Panels.Settings
             // Community Feedback Program
             Properties.Settings.Default.CommunityFeedback = CommunityFeedbackCheckBox.Checked;
 
-            // Auto-retrigger
+            // Run options
             Properties.Settings.Default.AutoRetrigger = autoRetriggerCheckBox.Checked;
+            Properties.Settings.Default.MinimizeOnAutoRun = minimizeOnAutoRunCheckbox.Checked;
         }
     }
 }

--- a/UI/Panels/Settings/GeneralPanel.de.resx
+++ b/UI/Panels/Settings/GeneralPanel.de.resx
@@ -127,6 +127,9 @@
   <data name="BetaUpdatesGroupBox.Text" xml:space="preserve">
     <value>Beta Versionen</value>
   </data>
+  <data name="languageGroupBox.Text" xml:space="preserve">
+    <value>Sprache</value>
+  </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label9.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
     <value>Top, Left</value>
@@ -135,7 +138,7 @@
     <value>Bottom</value>
   </data>
   <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 56</value>
+    <value>3, 52</value>
   </data>
   <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
     <value>449, 22</value>
@@ -146,14 +149,14 @@
   <data name="languageLabel.Text" xml:space="preserve">
     <value>Sprache von UI ändern:</value>
   </data>
-  <data name="languageGroupBox.Text" xml:space="preserve">
-    <value>Sprache</value>
-  </data>
   <data name="logLevelCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>63, 17</value>
   </data>
   <data name="logLevelCheckBox.Text" xml:space="preserve">
     <value>aktiviert</value>
+  </data>
+  <data name="testModeSpeedGroupBox.Text" xml:space="preserve">
+    <value>Test Mode Geschwindigkeit</value>
   </data>
   <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
     <value>205, 54</value>
@@ -173,17 +176,17 @@
   <data name="label6.Text" xml:space="preserve">
     <value>Langsam</value>
   </data>
-  <data name="testModeSpeedGroupBox.Text" xml:space="preserve">
-    <value>Test Mode Geschwindigkeit</value>
+  <data name="recentFilesGroupBox.Text" xml:space="preserve">
+    <value>Zuletzt verwendete Dateien</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>Anzahl der angezeigten Dateien in der Liste</value>
   </data>
-  <data name="recentFilesGroupBox.Text" xml:space="preserve">
-    <value>Zuletzt verwendete Dateien</value>
-  </data>
   <data name="CommunityFeedbackCheckBox.Text" xml:space="preserve">
     <value>Ja, ich möchte am Community Feedback Programm teilnehmen und helfen MobiFlight zu verbessern.</value>
+  </data>
+  <data name="ConfigExecutionGroupBox.Text" xml:space="preserve">
+    <value>Config Ausführung Speed</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
     <value>222, 63</value>
@@ -209,8 +212,14 @@
   <data name="label5.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>BottomLeft</value>
   </data>
-  <data name="ConfigExecutionGroupBox.Text" xml:space="preserve">
-    <value>Config Ausführung Speed</value>
+  <data name="autoRetriggerGoupBox.Text" xml:space="preserve">
+    <value>"Run" Optionen</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>207, 17</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.Text" xml:space="preserve">
+    <value>Bei AutoRun in Task Leiste minimieren</value>
   </data>
   <data name="autoRetriggerCheckBox.Size" type="System.Drawing.Size, System.Drawing">
     <value>284, 17</value>

--- a/UI/Panels/Settings/GeneralPanel.resx
+++ b/UI/Panels/Settings/GeneralPanel.resx
@@ -117,137 +117,425 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="&gt;&gt;testModeSpeedTrackBar.Parent" xml:space="preserve">
+    <value>testModeSpeedGroupBox</value>
+  </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="BetaUpdateCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="label2.TabIndex" type="System.Int32, mscorlib">
+    <value>8</value>
+  </data>
+  <data name="&gt;&gt;recentFilesGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>ConfigExecutionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;CommunityFeedbackCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;autoRetriggerCheckBox.Parent" xml:space="preserve">
+    <value>autoRetriggerGoupBox</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="BetaUpdateCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="logLevelCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="BetaUpdateCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 17</value>
+  <data name="languageGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 77</value>
   </data>
-  <data name="BetaUpdateCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>258, 17</value>
+  <data name="fsuipcPollIntervalTrackBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
   </data>
-  <data name="BetaUpdateCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="&gt;&gt;fsuipcPollIntervalTrackBar.Parent" xml:space="preserve">
+    <value>ConfigExecutionGroupBox</value>
   </data>
-  <data name="BetaUpdateCheckBox.Text" xml:space="preserve">
-    <value>Yes, I would like to receive beta version updates.</value>
+  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 13</value>
   </data>
-  <data name="&gt;&gt;BetaUpdateCheckBox.Name" xml:space="preserve">
-    <value>BetaUpdateCheckBox</value>
-  </data>
-  <data name="&gt;&gt;BetaUpdateCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;BetaUpdateCheckBox.Parent" xml:space="preserve">
-    <value>BetaUpdatesGroupBox</value>
-  </data>
-  <data name="&gt;&gt;BetaUpdateCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="BetaUpdatesGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="BetaUpdatesGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 108</value>
-  </data>
-  <data name="BetaUpdatesGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 53</value>
-  </data>
-  <data name="BetaUpdatesGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="BetaUpdatesGroupBox.Text" xml:space="preserve">
-    <value>Beta Versions</value>
-  </data>
-  <data name="&gt;&gt;BetaUpdatesGroupBox.Name" xml:space="preserve">
-    <value>BetaUpdatesGroupBox</value>
-  </data>
-  <data name="&gt;&gt;BetaUpdatesGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;BetaUpdatesGroupBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;BetaUpdatesGroupBox.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="label9.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Left, Right</value>
-  </data>
-  <data name="label9.Font" type="System.Drawing.Font, System.Drawing">
-    <value>Microsoft Sans Serif, 8pt</value>
-  </data>
-  <data name="label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
-    <value>96, 49</value>
-  </data>
-  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
-    <value>267, 16</value>
-  </data>
-  <data name="label9.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="label9.Text" xml:space="preserve">
-    <value>It requires a restart of MobiFlight if you change the language.</value>
-  </data>
-  <data name="&gt;&gt;label9.Name" xml:space="preserve">
-    <value>label9</value>
-  </data>
-  <data name="&gt;&gt;label9.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
-    <value>languageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="languageComboBox.Items" xml:space="preserve">
-    <value>System Default</value>
-  </data>
-  <data name="languageComboBox.Items1" xml:space="preserve">
-    <value>English</value>
-  </data>
-  <data name="languageComboBox.Items2" xml:space="preserve">
-    <value>Deutsch</value>
+  <data name="label1.Text" xml:space="preserve">
+    <value>Set the number of files shown in the list to</value>
   </data>
   <data name="languageComboBox.Location" type="System.Drawing.Point, System.Drawing">
     <value>173, 22</value>
   </data>
-  <data name="languageComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 21</value>
+  <data name="&gt;&gt;languageLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="testModeSpeedGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>230, 3</value>
+  </data>
+  <data name="LogJoystickAxisCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>341, 20</value>
+  </data>
+  <data name="&gt;&gt;label9.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;autoRetriggerGoupBox.Name" xml:space="preserve">
+    <value>autoRetriggerGoupBox</value>
+  </data>
+  <data name="autoRetriggerCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
   </data>
   <data name="languageComboBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;languageComboBox.Name" xml:space="preserve">
-    <value>languageComboBox</value>
+  <data name="&gt;&gt;languageGroupBox.Name" xml:space="preserve">
+    <value>languageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;logLevelCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="autoRetriggerGoupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 67</value>
+  </data>
+  <data name="testModeSpeedGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>222, 123</value>
+  </data>
+  <data name="recentFilesGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 51</value>
+  </data>
+  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
+    <value>6, 41</value>
+  </data>
+  <data name="&gt;&gt;logLevelLabel.Parent" xml:space="preserve">
+    <value>debugGroupBox</value>
+  </data>
+  <data name="&gt;&gt;SpeedTableLayoutPanel.Name" xml:space="preserve">
+    <value>SpeedTableLayoutPanel</value>
+  </data>
+  <data name="testModeSpeedGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label8.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;languageGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="fsuipcPollIntervalTrackBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;logLevelComboBox.Name" xml:space="preserve">
+    <value>logLevelComboBox</value>
+  </data>
+  <data name="languageGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 285</value>
+  </data>
+  <data name="logLevelComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>88, 21</value>
+  </data>
+  <data name="LogJoystickAxisCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 42</value>
+  </data>
+  <data name="languageComboBox.Items2" xml:space="preserve">
+    <value>Deutsch</value>
+  </data>
+  <data name="languageComboBox.Items1" xml:space="preserve">
+    <value>English</value>
+  </data>
+  <data name="label8.Text" xml:space="preserve">
+    <value>Very Fast</value>
+  </data>
+  <data name="autoRetriggerGoupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="testModeSpeedTrackBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;label1.Name" xml:space="preserve">
+    <value>label1</value>
+  </data>
+  <data name="BetaUpdateCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="BetaUpdateCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 17</value>
+  </data>
+  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>99, 41</value>
+  </data>
+  <data name="languageComboBox.Items" xml:space="preserve">
+    <value>System Default</value>
+  </data>
+  <data name="&gt;&gt;recentFilesGroupBox.Name" xml:space="preserve">
+    <value>recentFilesGroupBox</value>
+  </data>
+  <data name="LogJoystickAxisCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
+    <value>testModeSpeedGroupBox</value>
+  </data>
+  <data name="SpeedTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="logLevelComboBox.Items2" xml:space="preserve">
+    <value>Warn</value>
+  </data>
+  <data name="&gt;&gt;recentFilesGroupBox.ZOrder" xml:space="preserve">
+    <value>6</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 491</value>
+  </data>
+  <data name="&gt;&gt;recentFilesNumericUpDown.Type" xml:space="preserve">
+    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label8.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="logLevelCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="languageGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>5</value>
+  </data>
+  <data name="ConfigExecutionGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;testModeSpeedGroupBox.Name" xml:space="preserve">
+    <value>testModeSpeedGroupBox</value>
+  </data>
+  <data name="logLevelLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;logLevelLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="ConfigExecutionGroupBox.Text" xml:space="preserve">
+    <value>Config Execution Speed</value>
+  </data>
+  <data name="testModeSpeedTrackBar.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="CommunityFeedbackCheckBox.CheckAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopLeft</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>GeneralPanel</value>
+  </data>
+  <data name="LogJoystickAxisCheckBox.Text" xml:space="preserve">
+    <value>Log Joystick Axis</value>
+  </data>
+  <data name="BetaUpdateCheckBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;logLevelComboBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="recentFilesNumericUpDown.Location" type="System.Drawing.Point, System.Drawing">
+    <value>271, 23</value>
+  </data>
+  <data name="&gt;&gt;ConfigExecutionGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;CommunityFeedbackGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CommunityFeedbackGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 57</value>
+  </data>
+  <data name="label6.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>96, 49</value>
+  </data>
+  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="fsuipcPollIntervalTrackBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>215, 45</value>
+  </data>
+  <data name="&gt;&gt;languageLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;LogJoystickAxisCheckBox.Parent" xml:space="preserve">
+    <value>debugGroupBox</value>
+  </data>
+  <data name="autoRetriggerCheckBox.Text" xml:space="preserve">
+    <value>Automatically perform retrigger-action with "run"-mode</value>
+  </data>
+  <data name="BetaUpdatesGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 53</value>
+  </data>
+  <data name="&gt;&gt;logLevelLabel.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="logLevelLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopRight</value>
+  </data>
+  <data name="&gt;&gt;recentFilesNumericUpDown.Parent" xml:space="preserve">
+    <value>recentFilesGroupBox</value>
+  </data>
+  <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label3.Text" xml:space="preserve">
+    <value>Very Fast</value>
+  </data>
+  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Parent" xml:space="preserve">
+    <value>autoRetriggerGoupBox</value>
+  </data>
+  <data name="recentFilesGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="&gt;&gt;testModeSpeedTrackBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.Text" xml:space="preserve">
+    <value>Minimize to system tray on AutoRun</value>
   </data>
   <data name="&gt;&gt;languageComboBox.Type" xml:space="preserve">
     <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;languageComboBox.Parent" xml:space="preserve">
-    <value>languageGroupBox</value>
+  <data name="logLevelCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>64, 17</value>
   </data>
-  <data name="&gt;&gt;languageComboBox.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;logLevelComboBox.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="languageLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="logLevelComboBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>222, 18</value>
+  </data>
+  <data name="&gt;&gt;logLevelCheckBox.Name" xml:space="preserve">
+    <value>logLevelCheckBox</value>
+  </data>
+  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 24</value>
+  </data>
+  <data name="&gt;&gt;debugGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="logLevelLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>134, 13</value>
+  </data>
+  <data name="debugGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;logLevelCheckBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="CommunityFeedbackGroupBox.Text" xml:space="preserve">
+    <value>Community Feedback Program</value>
+  </data>
+  <data name="&gt;&gt;CommunityFeedbackCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>220, 18</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;languageLabel.Name" xml:space="preserve">
+    <value>languageLabel</value>
+  </data>
+  <data name="&gt;&gt;recentFilesNumericUpDown.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="LogJoystickAxisCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
+  </data>
+  <data name="&gt;&gt;label6.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
   </data>
   <data name="languageLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>5, 24</value>
   </data>
-  <data name="languageLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>162, 13</value>
+  <data name="&gt;&gt;BetaUpdateCheckBox.Name" xml:space="preserve">
+    <value>BetaUpdateCheckBox</value>
+  </data>
+  <data name="&gt;&gt;BetaUpdatesGroupBox.Name" xml:space="preserve">
+    <value>BetaUpdatesGroupBox</value>
+  </data>
+  <data name="&gt;&gt;ConfigExecutionGroupBox.Parent" xml:space="preserve">
+    <value>SpeedTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;testModeSpeedGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label3.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;debugGroupBox.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
+    <value>ConfigExecutionGroupBox</value>
+  </data>
+  <data name="testModeSpeedTrackBar.Size" type="System.Drawing.Size, System.Drawing">
+    <value>216, 45</value>
+  </data>
+  <data name="SpeedTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 129</value>
+  </data>
+  <data name="autoRetriggerGoupBox.Text" xml:space="preserve">
+    <value>Run options</value>
+  </data>
+  <data name="&gt;&gt;debugGroupBox.Name" xml:space="preserve">
+    <value>debugGroupBox</value>
+  </data>
+  <data name="&gt;&gt;BetaUpdatesGroupBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="logLevelComboBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;logLevelCheckBox.Parent" xml:space="preserve">
+    <value>debugGroupBox</value>
+  </data>
+  <data name="&gt;&gt;label8.Name" xml:space="preserve">
+    <value>label8</value>
+  </data>
+  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="CommunityFeedbackCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 19</value>
+  </data>
+  <data name="ConfigExecutionGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 3</value>
+  </data>
+  <data name="testModeSpeedTrackBar.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 16</value>
+  </data>
+  <data name="label8.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopRight</value>
+  </data>
+  <data name="label8.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>ConfigExecutionGroupBox</value>
+  </data>
+  <data name="ConfigExecutionGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>221, 123</value>
+  </data>
+  <data name="logLevelComboBox.Items1" xml:space="preserve">
+    <value>Info</value>
+  </data>
+  <data name="CommunityFeedbackCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="debugGroupBox.Text" xml:space="preserve">
+    <value>Logging</value>
+  </data>
+  <data name="&gt;&gt;testModeSpeedTrackBar.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="languageLabel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -255,401 +543,335 @@
   <data name="languageLabel.Text" xml:space="preserve">
     <value>Change the language of the UI:</value>
   </data>
-  <data name="languageLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>TopRight</value>
-  </data>
-  <data name="&gt;&gt;languageLabel.Name" xml:space="preserve">
-    <value>languageLabel</value>
-  </data>
-  <data name="&gt;&gt;languageLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;languageLabel.Parent" xml:space="preserve">
-    <value>languageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;languageLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="languageGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="languageGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 285</value>
+  <data name="SpeedTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>2, 2, 2, 2</value>
   </data>
-  <data name="languageGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 77</value>
+  <data name="fsuipcPollIntervalTrackBar.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
   </data>
-  <data name="languageGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+  <data name="BetaUpdatesGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 108</value>
   </data>
-  <data name="languageGroupBox.Text" xml:space="preserve">
-    <value>Language</value>
-  </data>
-  <data name="&gt;&gt;languageGroupBox.Name" xml:space="preserve">
-    <value>languageGroupBox</value>
-  </data>
-  <data name="&gt;&gt;languageGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;languageGroupBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;languageGroupBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="LogJoystickAxisCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="LogJoystickAxisCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="LogJoystickAxisCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>341, 20</value>
-  </data>
-  <data name="LogJoystickAxisCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>107, 17</value>
-  </data>
-  <data name="LogJoystickAxisCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="LogJoystickAxisCheckBox.Text" xml:space="preserve">
-    <value>Log Joystick Axis</value>
-  </data>
-  <data name="&gt;&gt;LogJoystickAxisCheckBox.Name" xml:space="preserve">
-    <value>LogJoystickAxisCheckBox</value>
-  </data>
-  <data name="&gt;&gt;LogJoystickAxisCheckBox.Type" xml:space="preserve">
+  <data name="&gt;&gt;autoRetriggerCheckBox.Type" xml:space="preserve">
     <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;LogJoystickAxisCheckBox.Parent" xml:space="preserve">
-    <value>debugGroupBox</value>
-  </data>
-  <data name="&gt;&gt;LogJoystickAxisCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="logLevelComboBox.Items" xml:space="preserve">
-    <value>Debug</value>
-  </data>
-  <data name="logLevelComboBox.Items1" xml:space="preserve">
-    <value>Info</value>
-  </data>
-  <data name="logLevelComboBox.Items2" xml:space="preserve">
-    <value>Warn</value>
-  </data>
-  <data name="logLevelComboBox.Items3" xml:space="preserve">
-    <value>Error</value>
-  </data>
-  <data name="logLevelComboBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>222, 18</value>
-  </data>
-  <data name="logLevelComboBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>88, 21</value>
-  </data>
-  <data name="logLevelComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;logLevelComboBox.Name" xml:space="preserve">
-    <value>logLevelComboBox</value>
-  </data>
-  <data name="&gt;&gt;logLevelComboBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ComboBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;logLevelComboBox.Parent" xml:space="preserve">
-    <value>debugGroupBox</value>
-  </data>
-  <data name="&gt;&gt;logLevelComboBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="logLevelLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="logLevelLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>82, 21</value>
-  </data>
-  <data name="logLevelLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>134, 13</value>
-  </data>
-  <data name="logLevelLabel.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="logLevelLabel.Text" xml:space="preserve">
-    <value>Log Level</value>
-  </data>
-  <data name="logLevelLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>TopRight</value>
-  </data>
-  <data name="&gt;&gt;logLevelLabel.Name" xml:space="preserve">
-    <value>logLevelLabel</value>
-  </data>
-  <data name="&gt;&gt;logLevelLabel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;logLevelLabel.Parent" xml:space="preserve">
-    <value>debugGroupBox</value>
-  </data>
-  <data name="&gt;&gt;logLevelLabel.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="label9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>267, 16</value>
   </data>
   <data name="logLevelCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
-  <data name="logLevelCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="&gt;&gt;languageComboBox.Parent" xml:space="preserve">
+    <value>languageGroupBox</value>
+  </data>
+  <data name="SpeedTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="languageLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
-  </data>
-  <data name="logLevelCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 20</value>
-  </data>
-  <data name="logLevelCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>64, 17</value>
-  </data>
-  <data name="logLevelCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="logLevelCheckBox.Text" xml:space="preserve">
-    <value>enabled</value>
-  </data>
-  <data name="&gt;&gt;logLevelCheckBox.Name" xml:space="preserve">
-    <value>logLevelCheckBox</value>
-  </data>
-  <data name="&gt;&gt;logLevelCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;logLevelCheckBox.Parent" xml:space="preserve">
-    <value>debugGroupBox</value>
-  </data>
-  <data name="&gt;&gt;logLevelCheckBox.ZOrder" xml:space="preserve">
-    <value>3</value>
   </data>
   <data name="debugGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="debugGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 51</value>
-  </data>
-  <data name="debugGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 57</value>
-  </data>
-  <data name="debugGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="debugGroupBox.Text" xml:space="preserve">
-    <value>Logging</value>
-  </data>
-  <data name="&gt;&gt;debugGroupBox.Name" xml:space="preserve">
-    <value>debugGroupBox</value>
-  </data>
-  <data name="&gt;&gt;debugGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;debugGroupBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;debugGroupBox.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="label8.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>99, 41</value>
-  </data>
-  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 13</value>
-  </data>
-  <data name="label8.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="label8.Text" xml:space="preserve">
-    <value>Very Fast</value>
-  </data>
-  <data name="label8.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>TopRight</value>
-  </data>
-  <data name="&gt;&gt;label8.Name" xml:space="preserve">
-    <value>label8</value>
-  </data>
-  <data name="&gt;&gt;label8.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label8.Parent" xml:space="preserve">
-    <value>testModeSpeedGroupBox</value>
-  </data>
-  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 41</value>
-  </data>
-  <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>117, 13</value>
-  </data>
-  <data name="label6.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="label6.Text" xml:space="preserve">
-    <value>Slow</value>
-  </data>
-  <data name="&gt;&gt;label6.Name" xml:space="preserve">
-    <value>label6</value>
-  </data>
-  <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
-    <value>testModeSpeedGroupBox</value>
-  </data>
-  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="testModeSpeedTrackBar.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="testModeSpeedTrackBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="testModeSpeedTrackBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
-  </data>
-  <data name="testModeSpeedTrackBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>216, 45</value>
-  </data>
-  <data name="testModeSpeedTrackBar.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;testModeSpeedTrackBar.Name" xml:space="preserve">
-    <value>testModeSpeedTrackBar</value>
-  </data>
-  <data name="&gt;&gt;testModeSpeedTrackBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;testModeSpeedTrackBar.Parent" xml:space="preserve">
-    <value>testModeSpeedGroupBox</value>
-  </data>
-  <data name="&gt;&gt;testModeSpeedTrackBar.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="testModeSpeedGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="testModeSpeedGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>230, 3</value>
-  </data>
-  <data name="testModeSpeedGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 123</value>
-  </data>
-  <data name="testModeSpeedGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="&gt;&gt;languageComboBox.Name" xml:space="preserve">
+    <value>languageComboBox</value>
   </data>
   <data name="testModeSpeedGroupBox.Text" xml:space="preserve">
     <value>Test mode speed</value>
   </data>
-  <data name="&gt;&gt;testModeSpeedGroupBox.Name" xml:space="preserve">
-    <value>testModeSpeedGroupBox</value>
-  </data>
-  <data name="&gt;&gt;testModeSpeedGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;testModeSpeedGroupBox.Parent" xml:space="preserve">
-    <value>SpeedTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;testModeSpeedGroupBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 24</value>
-  </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>220, 18</value>
-  </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Set the number of files shown in the list to</value>
+  <data name="debugGroupBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>455, 57</value>
   </data>
   <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>TopRight</value>
   </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
+  <data name="SpeedTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 362</value>
   </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>recentFilesGroupBox</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="recentFilesNumericUpDown.Location" type="System.Drawing.Point, System.Drawing">
-    <value>271, 23</value>
+  <data name="logLevelLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>82, 21</value>
   </data>
   <data name="recentFilesNumericUpDown.Size" type="System.Drawing.Size, System.Drawing">
     <value>38, 20</value>
   </data>
-  <data name="recentFilesNumericUpDown.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+  <data name="autoRetriggerCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
-  <data name="&gt;&gt;recentFilesNumericUpDown.Name" xml:space="preserve">
-    <value>recentFilesNumericUpDown</value>
+  <data name="minimizeOnAutoRunCheckbox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 17</value>
   </data>
-  <data name="&gt;&gt;recentFilesNumericUpDown.Type" xml:space="preserve">
-    <value>System.Windows.Forms.NumericUpDown, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;recentFilesNumericUpDown.Parent" xml:space="preserve">
+  <data name="autoRetriggerCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 19</value>
+  </data>
+  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;languageLabel.Parent" xml:space="preserve">
+    <value>languageGroupBox</value>
+  </data>
+  <data name="languageLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>162, 13</value>
+  </data>
+  <data name="label9.Font" type="System.Drawing.Font, System.Drawing">
+    <value>Microsoft Sans Serif, 8pt</value>
+  </data>
+  <data name="logLevelLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="CommunityFeedbackGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 161</value>
+  </data>
+  <data name="&gt;&gt;label9.Parent" xml:space="preserve">
+    <value>languageGroupBox</value>
+  </data>
+  <data name="&gt;&gt;label5.Name" xml:space="preserve">
+    <value>label5</value>
+  </data>
+  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
+    <value>59, 13</value>
+  </data>
+  <data name="&gt;&gt;ConfigExecutionGroupBox.Name" xml:space="preserve">
+    <value>ConfigExecutionGroupBox</value>
+  </data>
+  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;CommunityFeedbackGroupBox.Name" xml:space="preserve">
+    <value>CommunityFeedbackGroupBox</value>
+  </data>
+  <data name="BetaUpdateCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>258, 17</value>
+  </data>
+  <data name="&gt;&gt;LogJoystickAxisCheckBox.Name" xml:space="preserve">
+    <value>LogJoystickAxisCheckBox</value>
+  </data>
+  <data name="&gt;&gt;testModeSpeedGroupBox.Parent" xml:space="preserve">
+    <value>SpeedTableLayoutPanel</value>
+  </data>
+  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>recentFilesGroupBox</value>
   </data>
-  <data name="&gt;&gt;recentFilesNumericUpDown.ZOrder" xml:space="preserve">
-    <value>1</value>
+  <data name="logLevelCheckBox.Text" xml:space="preserve">
+    <value>enabled</value>
   </data>
-  <data name="recentFilesGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="recentFilesGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="recentFilesGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 51</value>
-  </data>
-  <data name="recentFilesGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
+  <data name="&gt;&gt;BetaUpdatesGroupBox.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
   <data name="recentFilesGroupBox.Text" xml:space="preserve">
     <value>Recent files</value>
   </data>
-  <data name="&gt;&gt;recentFilesGroupBox.Name" xml:space="preserve">
-    <value>recentFilesGroupBox</value>
+  <data name="&gt;&gt;fsuipcPollIntervalTrackBar.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;recentFilesGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;recentFilesGroupBox.Parent" xml:space="preserve">
+  <data name="&gt;&gt;languageGroupBox.Parent" xml:space="preserve">
     <value>$this</value>
   </data>
-  <data name="&gt;&gt;recentFilesGroupBox.ZOrder" xml:space="preserve">
-    <value>6</value>
+  <data name="&gt;&gt;label6.Parent" xml:space="preserve">
+    <value>testModeSpeedGroupBox</value>
   </data>
-  <data name="CommunityFeedbackCheckBox.CheckAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+  <data name="recentFilesGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;CommunityFeedbackCheckBox.Name" xml:space="preserve">
+    <value>CommunityFeedbackCheckBox</value>
+  </data>
+  <data name="&gt;&gt;debugGroupBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="ConfigExecutionGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="label2.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleLeft</value>
+  </data>
+  <data name="logLevelComboBox.Items" xml:space="preserve">
+    <value>Debug</value>
+  </data>
+  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>30, 13</value>
+  </data>
+  <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="LogJoystickAxisCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>107, 17</value>
+  </data>
+  <data name="&gt;&gt;autoRetriggerCheckBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="CommunityFeedbackGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="SpeedTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="BetaUpdatesGroupBox.Text" xml:space="preserve">
+    <value>Beta Versions</value>
+  </data>
+  <data name="&gt;&gt;BetaUpdateCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="CommunityFeedbackCheckBox.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
     <value>TopLeft</value>
   </data>
-  <data name="CommunityFeedbackCheckBox.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="&gt;&gt;SpeedTableLayoutPanel.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="testModeSpeedTrackBar.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="testModeSpeedGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
+    <value>9, 41</value>
+  </data>
+  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 61</value>
+  </data>
+  <data name="&gt;&gt;label3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;BetaUpdatesGroupBox.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;autoRetriggerGoupBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="recentFilesNumericUpDown.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;languageGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="BetaUpdatesGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="label3.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleRight</value>
+  </data>
+  <data name="label9.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Left, Right</value>
+  </data>
+  <data name="&gt;&gt;testModeSpeedGroupBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="logLevelComboBox.Items3" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="&gt;&gt;ConfigExecutionGroupBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
+    <value>152, 41</value>
+  </data>
+  <data name="CommunityFeedbackGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="&gt;&gt;label8.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;SpeedTableLayoutPanel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label6.Name" xml:space="preserve">
+    <value>label6</value>
+  </data>
+  <data name="label2.Text" xml:space="preserve">
+    <value>Slow</value>
+  </data>
+  <data name="BetaUpdatesGroupBox.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="autoRetriggerCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>278, 17</value>
+  </data>
+  <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="CommunityFeedbackCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 19</value>
+  <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="CommunityFeedbackCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>467, 31</value>
+  <data name="SpeedTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
+    <value>6</value>
+  </data>
+  <data name="label9.Text" xml:space="preserve">
+    <value>It requires a restart of MobiFlight if you change the language.</value>
+  </data>
+  <data name="&gt;&gt;CommunityFeedbackGroupBox.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;label9.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>6, 13</value>
+  </data>
+  <data name="languageGroupBox.Text" xml:space="preserve">
+    <value>Language</value>
+  </data>
+  <data name="label9.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="label6.Text" xml:space="preserve">
+    <value>Slow</value>
+  </data>
+  <data name="&gt;&gt;languageComboBox.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;fsuipcPollIntervalTrackBar.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;LogJoystickAxisCheckBox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="BetaUpdateCheckBox.Text" xml:space="preserve">
+    <value>Yes, I would like to receive beta version updates.</value>
+  </data>
+  <data name="logLevelCheckBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 20</value>
+  </data>
+  <data name="&gt;&gt;BetaUpdateCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="logLevelLabel.Text" xml:space="preserve">
+    <value>Log Level</value>
+  </data>
+  <data name="autoRetriggerGoupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
+    <value>215, 59</value>
+  </data>
+  <data name="autoRetriggerGoupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 218</value>
+  </data>
+  <data name="SpeedTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
+    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="testModeSpeedGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ConfigExecutionGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="Percent,50,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="&gt;&gt;BetaUpdateCheckBox.Parent" xml:space="preserve">
+    <value>BetaUpdatesGroupBox</value>
+  </data>
+  <data name="&gt;&gt;fsuipcPollIntervalTrackBar.Name" xml:space="preserve">
+    <value>fsuipcPollIntervalTrackBar</value>
+  </data>
+  <data name="&gt;&gt;label5.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="BetaUpdateCheckBox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
   </data>
   <data name="CommunityFeedbackCheckBox.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -658,331 +880,109 @@
     <value>Yes, I want to participate in Community Feedback Program and help to improve MobiFlight.
 </value>
   </data>
-  <data name="CommunityFeedbackCheckBox.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>TopLeft</value>
-  </data>
-  <data name="&gt;&gt;CommunityFeedbackCheckBox.Name" xml:space="preserve">
-    <value>CommunityFeedbackCheckBox</value>
-  </data>
-  <data name="&gt;&gt;CommunityFeedbackCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CommunityFeedbackCheckBox.Parent" xml:space="preserve">
-    <value>CommunityFeedbackGroupBox</value>
-  </data>
-  <data name="&gt;&gt;CommunityFeedbackCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="CommunityFeedbackGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="CommunityFeedbackGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 161</value>
-  </data>
-  <data name="CommunityFeedbackGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 57</value>
-  </data>
-  <data name="CommunityFeedbackGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="CommunityFeedbackGroupBox.Text" xml:space="preserve">
-    <value>Community Feedback Program</value>
-  </data>
-  <data name="&gt;&gt;CommunityFeedbackGroupBox.Name" xml:space="preserve">
-    <value>CommunityFeedbackGroupBox</value>
-  </data>
-  <data name="&gt;&gt;CommunityFeedbackGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;CommunityFeedbackGroupBox.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;CommunityFeedbackGroupBox.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="label3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
-  </data>
-  <data name="label3.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>152, 41</value>
-  </data>
-  <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>59, 13</value>
-  </data>
-  <data name="label3.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
-  </data>
-  <data name="label3.Text" xml:space="preserve">
-    <value>Very Fast</value>
-  </data>
-  <data name="label3.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
-  </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>ConfigExecutionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="label2.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="label2.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>9, 41</value>
-  </data>
-  <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>30, 13</value>
-  </data>
-  <data name="label2.TabIndex" type="System.Int32, mscorlib">
-    <value>8</value>
-  </data>
-  <data name="label2.Text" xml:space="preserve">
-    <value>Slow</value>
-  </data>
-  <data name="label2.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleLeft</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>ConfigExecutionGroupBox</value>
+  <data name="CommunityFeedbackCheckBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>467, 31</value>
   </data>
   <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
+  <data name="&gt;&gt;autoRetriggerGoupBox.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
-  <data name="label5.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="&gt;&gt;recentFilesGroupBox.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 61</value>
+  <data name="&gt;&gt;testModeSpeedTrackBar.Name" xml:space="preserve">
+    <value>testModeSpeedTrackBar</value>
   </data>
-  <data name="label5.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 0</value>
+  <data name="languageLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>TopRight</value>
   </data>
-  <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>215, 59</value>
+  <data name="&gt;&gt;LogJoystickAxisCheckBox.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
-  <data name="label5.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+  <data name="debugGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 51</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
     <value>You can control the execution speed, e.g., if you experience some lag in your input. Very fast settings might impact performance.</value>
   </data>
-  <data name="&gt;&gt;label5.Name" xml:space="preserve">
-    <value>label5</value>
+  <data name="label5.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
   </data>
-  <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label5.Parent" xml:space="preserve">
-    <value>ConfigExecutionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
+  <data name="label9.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
-  </data>
-  <data name="fsuipcPollIntervalTrackBar.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="fsuipcPollIntervalTrackBar.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="fsuipcPollIntervalTrackBar.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 16</value>
-  </data>
-  <data name="fsuipcPollIntervalTrackBar.Size" type="System.Drawing.Size, System.Drawing">
-    <value>215, 45</value>
   </data>
   <data name="fsuipcPollIntervalTrackBar.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;fsuipcPollIntervalTrackBar.Name" xml:space="preserve">
-    <value>fsuipcPollIntervalTrackBar</value>
+  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="&gt;&gt;fsuipcPollIntervalTrackBar.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TrackBar, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
   </data>
-  <data name="&gt;&gt;fsuipcPollIntervalTrackBar.Parent" xml:space="preserve">
-    <value>ConfigExecutionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;fsuipcPollIntervalTrackBar.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="ConfigExecutionGroupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="ConfigExecutionGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 3</value>
-  </data>
-  <data name="ConfigExecutionGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>221, 123</value>
-  </data>
-  <data name="ConfigExecutionGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="ConfigExecutionGroupBox.Text" xml:space="preserve">
-    <value>Config Execution Speed</value>
-  </data>
-  <data name="&gt;&gt;ConfigExecutionGroupBox.Name" xml:space="preserve">
-    <value>ConfigExecutionGroupBox</value>
-  </data>
-  <data name="&gt;&gt;ConfigExecutionGroupBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;ConfigExecutionGroupBox.Parent" xml:space="preserve">
-    <value>SpeedTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;ConfigExecutionGroupBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="SpeedTableLayoutPanel.ColumnCount" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="SpeedTableLayoutPanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="SpeedTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 362</value>
-  </data>
-  <data name="SpeedTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 2, 2, 2</value>
-  </data>
-  <data name="SpeedTableLayoutPanel.RowCount" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="SpeedTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 129</value>
-  </data>
-  <data name="SpeedTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>6</value>
-  </data>
-  <data name="&gt;&gt;SpeedTableLayoutPanel.Name" xml:space="preserve">
-    <value>SpeedTableLayoutPanel</value>
-  </data>
-  <data name="&gt;&gt;SpeedTableLayoutPanel.Type" xml:space="preserve">
-    <value>System.Windows.Forms.TableLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;SpeedTableLayoutPanel.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;SpeedTableLayoutPanel.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="SpeedTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
-    <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="testModeSpeedGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ConfigExecutionGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="Percent,50,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
-  </data>
-  <data name="minimizeOnAutoRunCheckbox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="minimizeOnAutoRunCheckbox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 42</value>
-  </data>
-  <data name="minimizeOnAutoRunCheckbox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>193, 17</value>
-  </data>
-  <data name="minimizeOnAutoRunCheckbox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="minimizeOnAutoRunCheckbox.Text" xml:space="preserve">
-    <value>Minimize to system tray on AutoRun</value>
+  <data name="label3.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
+    <value>Top, Right</value>
   </data>
   <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Name" xml:space="preserve">
     <value>minimizeOnAutoRunCheckbox</value>
   </data>
-  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;SpeedTableLayoutPanel.Parent" xml:space="preserve">
+    <value>$this</value>
   </data>
-  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Parent" xml:space="preserve">
-    <value>autoRetriggerGoupBox</value>
-  </data>
-  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="autoRetriggerCheckBox.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="autoRetriggerCheckBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>12, 19</value>
-  </data>
-  <data name="autoRetriggerCheckBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>278, 17</value>
-  </data>
-  <data name="autoRetriggerCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="autoRetriggerCheckBox.Text" xml:space="preserve">
-    <value>Automatically perform retrigger-action with "run"-mode</value>
-  </data>
-  <data name="&gt;&gt;autoRetriggerCheckBox.Name" xml:space="preserve">
-    <value>autoRetriggerCheckBox</value>
-  </data>
-  <data name="&gt;&gt;autoRetriggerCheckBox.Type" xml:space="preserve">
-    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;autoRetriggerCheckBox.Parent" xml:space="preserve">
-    <value>autoRetriggerGoupBox</value>
-  </data>
-  <data name="&gt;&gt;autoRetriggerCheckBox.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="autoRetriggerGoupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="autoRetriggerGoupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 218</value>
-  </data>
-  <data name="autoRetriggerGoupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 67</value>
-  </data>
-  <data name="autoRetriggerGoupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>4</value>
-  </data>
-  <data name="autoRetriggerGoupBox.Text" xml:space="preserve">
-    <value>Run options</value>
-  </data>
-  <data name="&gt;&gt;autoRetriggerGoupBox.Name" xml:space="preserve">
-    <value>autoRetriggerGoupBox</value>
+  <data name="&gt;&gt;logLevelLabel.Name" xml:space="preserve">
+    <value>logLevelLabel</value>
   </data>
   <data name="&gt;&gt;autoRetriggerGoupBox.Type" xml:space="preserve">
     <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;autoRetriggerGoupBox.Parent" xml:space="preserve">
-    <value>$this</value>
+  <data name="&gt;&gt;recentFilesNumericUpDown.Name" xml:space="preserve">
+    <value>recentFilesNumericUpDown</value>
   </data>
-  <data name="&gt;&gt;autoRetriggerGoupBox.ZOrder" xml:space="preserve">
-    <value>2</value>
+  <data name="label1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;CommunityFeedbackGroupBox.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="label5.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 3, 0, 0</value>
+  </data>
+  <data name="&gt;&gt;logLevelComboBox.Parent" xml:space="preserve">
+    <value>debugGroupBox</value>
+  </data>
+  <data name="&gt;&gt;autoRetriggerCheckBox.Name" xml:space="preserve">
+    <value>autoRetriggerCheckBox</value>
+  </data>
+  <data name="&gt;&gt;label9.Name" xml:space="preserve">
+    <value>label9</value>
+  </data>
+  <data name="label8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>117, 13</value>
+  </data>
+  <data name="&gt;&gt;label1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="label8.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="recentFilesGroupBox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="&gt;&gt;CommunityFeedbackCheckBox.Parent" xml:space="preserve">
+    <value>CommunityFeedbackGroupBox</value>
+  </data>
+  <data name="languageComboBox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 21</value>
   </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 491</value>
-  </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>GeneralPanel</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
 </root>

--- a/UI/Panels/Settings/GeneralPanel.resx
+++ b/UI/Panels/Settings/GeneralPanel.resx
@@ -160,7 +160,7 @@
     <value>455, 53</value>
   </data>
   <data name="BetaUpdatesGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
+    <value>2</value>
   </data>
   <data name="BetaUpdatesGroupBox.Text" xml:space="preserve">
     <value>Beta Versions</value>
@@ -226,7 +226,7 @@
     <value>147, 21</value>
   </data>
   <data name="languageComboBox.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;languageComboBox.Name" xml:space="preserve">
     <value>languageComboBox</value>
@@ -280,7 +280,7 @@
     <value>455, 77</value>
   </data>
   <data name="languageGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+    <value>5</value>
   </data>
   <data name="languageGroupBox.Text" xml:space="preserve">
     <value>Language</value>
@@ -430,7 +430,7 @@
     <value>455, 57</value>
   </data>
   <data name="debugGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>12</value>
+    <value>1</value>
   </data>
   <data name="debugGroupBox.Text" xml:space="preserve">
     <value>Logging</value>
@@ -544,7 +544,7 @@
     <value>222, 123</value>
   </data>
   <data name="testModeSpeedGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>11</value>
+    <value>1</value>
   </data>
   <data name="testModeSpeedGroupBox.Text" xml:space="preserve">
     <value>Test mode speed</value>
@@ -571,7 +571,7 @@
     <value>220, 18</value>
   </data>
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>0</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>Set the number of files shown in the list to</value>
@@ -598,7 +598,7 @@
     <value>38, 20</value>
   </data>
   <data name="recentFilesNumericUpDown.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>1</value>
   </data>
   <data name="&gt;&gt;recentFilesNumericUpDown.Name" xml:space="preserve">
     <value>recentFilesNumericUpDown</value>
@@ -622,7 +622,7 @@
     <value>455, 51</value>
   </data>
   <data name="recentFilesGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>10</value>
+    <value>0</value>
   </data>
   <data name="recentFilesGroupBox.Text" xml:space="preserve">
     <value>Recent files</value>
@@ -652,7 +652,7 @@
     <value>467, 31</value>
   </data>
   <data name="CommunityFeedbackCheckBox.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
+    <value>0</value>
   </data>
   <data name="CommunityFeedbackCheckBox.Text" xml:space="preserve">
     <value>Yes, I want to participate in Community Feedback Program and help to improve MobiFlight.
@@ -683,7 +683,7 @@
     <value>455, 57</value>
   </data>
   <data name="CommunityFeedbackGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
+    <value>3</value>
   </data>
   <data name="CommunityFeedbackGroupBox.Text" xml:space="preserve">
     <value>Community Feedback Program</value>
@@ -812,7 +812,7 @@
     <value>215, 45</value>
   </data>
   <data name="fsuipcPollIntervalTrackBar.TabIndex" type="System.Int32, mscorlib">
-    <value>5</value>
+    <value>0</value>
   </data>
   <data name="&gt;&gt;fsuipcPollIntervalTrackBar.Name" xml:space="preserve">
     <value>fsuipcPollIntervalTrackBar</value>
@@ -836,7 +836,7 @@
     <value>221, 123</value>
   </data>
   <data name="ConfigExecutionGroupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
+    <value>0</value>
   </data>
   <data name="ConfigExecutionGroupBox.Text" xml:space="preserve">
     <value>Config Execution Speed</value>
@@ -872,7 +872,7 @@
     <value>455, 129</value>
   </data>
   <data name="SpeedTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>6</value>
   </data>
   <data name="&gt;&gt;SpeedTableLayoutPanel.Name" xml:space="preserve">
     <value>SpeedTableLayoutPanel</value>
@@ -953,7 +953,7 @@
     <value>455, 67</value>
   </data>
   <data name="autoRetriggerGoupBox.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="autoRetriggerGoupBox.Text" xml:space="preserve">
     <value>Run options</value>

--- a/UI/Panels/Settings/GeneralPanel.resx
+++ b/UI/Panels/Settings/GeneralPanel.resx
@@ -274,10 +274,10 @@
     <value>Top</value>
   </data>
   <data name="languageGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 269</value>
+    <value>0, 285</value>
   </data>
   <data name="languageGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 81</value>
+    <value>455, 77</value>
   </data>
   <data name="languageGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>14</value>
@@ -541,7 +541,7 @@
     <value>230, 3</value>
   </data>
   <data name="testModeSpeedGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>222, 160</value>
+    <value>222, 123</value>
   </data>
   <data name="testModeSpeedGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -779,7 +779,7 @@
     <value>0, 3, 0, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>215, 96</value>
+    <value>215, 59</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>11</value>
@@ -833,7 +833,7 @@
     <value>3, 3</value>
   </data>
   <data name="ConfigExecutionGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>221, 160</value>
+    <value>221, 123</value>
   </data>
   <data name="ConfigExecutionGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -860,7 +860,7 @@
     <value>Fill</value>
   </data>
   <data name="SpeedTableLayoutPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 350</value>
+    <value>0, 362</value>
   </data>
   <data name="SpeedTableLayoutPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>2, 2, 2, 2</value>
@@ -869,7 +869,7 @@
     <value>1</value>
   </data>
   <data name="SpeedTableLayoutPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 166</value>
+    <value>455, 129</value>
   </data>
   <data name="SpeedTableLayoutPanel.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -888,6 +888,33 @@
   </data>
   <data name="SpeedTableLayoutPanel.LayoutSettings" type="System.Windows.Forms.TableLayoutSettings, System.Windows.Forms">
     <value>&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;TableLayoutSettings&gt;&lt;Controls&gt;&lt;Control Name="testModeSpeedGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;Control Name="ConfigExecutionGroupBox" Row="0" RowSpan="1" Column="0" ColumnSpan="1" /&gt;&lt;/Controls&gt;&lt;Columns Styles="Percent,50,Percent,50" /&gt;&lt;Rows Styles="Percent,50,Percent,50" /&gt;&lt;/TableLayoutSettings&gt;</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.Location" type="System.Drawing.Point, System.Drawing">
+    <value>12, 42</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.Size" type="System.Drawing.Size, System.Drawing">
+    <value>193, 17</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
+  </data>
+  <data name="minimizeOnAutoRunCheckbox.Text" xml:space="preserve">
+    <value>Minimize to system tray on AutoRun</value>
+  </data>
+  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Name" xml:space="preserve">
+    <value>minimizeOnAutoRunCheckbox</value>
+  </data>
+  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Type" xml:space="preserve">
+    <value>System.Windows.Forms.CheckBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Parent" xml:space="preserve">
+    <value>autoRetriggerGoupBox</value>
+  </data>
+  <data name="&gt;&gt;minimizeOnAutoRunCheckbox.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="autoRetriggerCheckBox.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -914,7 +941,7 @@
     <value>autoRetriggerGoupBox</value>
   </data>
   <data name="&gt;&gt;autoRetriggerCheckBox.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="autoRetriggerGoupBox.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -923,13 +950,13 @@
     <value>0, 218</value>
   </data>
   <data name="autoRetriggerGoupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 51</value>
+    <value>455, 67</value>
   </data>
   <data name="autoRetriggerGoupBox.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
   </data>
   <data name="autoRetriggerGoupBox.Text" xml:space="preserve">
-    <value>Auto-Retrigger</value>
+    <value>Run options</value>
   </data>
   <data name="&gt;&gt;autoRetriggerGoupBox.Name" xml:space="preserve">
     <value>autoRetriggerGoupBox</value>
@@ -950,7 +977,7 @@
     <value>6, 13</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>455, 516</value>
+    <value>455, 491</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>GeneralPanel</value>

--- a/app.config
+++ b/app.config
@@ -136,6 +136,9 @@
       <setting name="AutoRetrigger" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="MinimizeOnAutoRun" serializeAs="String">
+        <value>True</value>
+      </setting>
     </MobiFlight.Properties.Settings>
     <ArcazeUSB.Properties.Settings>
       <setting name="RecentFiles" serializeAs="Xml">


### PR DESCRIPTION
Fixes #1317 

* Rename an existing section of the general settings dialog to "Run options" so I don't have to add another section with a single setting in it
* Add a general setting "Minimize to system tray on AutoRun", which defaults to true to maintain existing behaviour by default
* Check that setting before attempting to minimize the app

<img width="160" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/e6a4e8a1-d40b-4597-bf3c-f6b663cc073b">

@DocMoebiuz If you give me the German translation for that string I can add it to the string resources for the dialog