### PR TITLE
Prevent exception on name change

### DIFF
--- a/UI/Panels/Device/MFEncoderPanel.cs
+++ b/UI/Panels/Device/MFEncoderPanel.cs
@@ -76,7 +76,8 @@ namespace MobiFlight.UI.Panels.Settings.Device
         private void value_Changed(object sender, EventArgs e)
         {
             if (!initialized) return;
-            ReassignFreePinsInDropDowns(sender as ComboBox);
+            if (sender is ComboBox)
+                ReassignFreePinsInDropDowns(sender as ComboBox);
             setNonPinValues();
             if (Changed != null)
                 Changed(encoder, new EventArgs());

--- a/UI/Panels/Device/MFInputMultiplexerPanel.cs
+++ b/UI/Panels/Device/MFInputMultiplexerPanel.cs
@@ -116,7 +116,8 @@ namespace MobiFlight.UI.Panels.Settings
         private void value_Changed(object sender, EventArgs e)
         {
             if (!initialized) return;
-            ReassignFreePinsInDropDowns(sender as ComboBox);
+            if (sender is ComboBox)
+                ReassignFreePinsInDropDowns(sender as ComboBox);
             setNonPinValues();
             if (Changed != null)
                 Changed(inputMultiplexer, new EventArgs());

--- a/UI/Panels/Device/MFInputShiftRegisterPanel.cs
+++ b/UI/Panels/Device/MFInputShiftRegisterPanel.cs
@@ -81,7 +81,8 @@ namespace MobiFlight.UI.Panels.Settings
         private void value_Changed(object sender, EventArgs e)
         {
             if (!initialized) return;
-            ReassignFreePinsInDropDowns(sender as ComboBox);
+            if (sender is ComboBox)
+                ReassignFreePinsInDropDowns(sender as ComboBox);
             setNonPinValues();
             if (Changed != null)
                 Changed(inputShiftRegister, new EventArgs());

--- a/UI/Panels/Device/MFMultiplexerDriverSubPanel.cs
+++ b/UI/Panels/Device/MFMultiplexerDriverSubPanel.cs
@@ -106,8 +106,10 @@ namespace MobiFlight.UI.Panels.Settings
         private void value_Changed(object sender, EventArgs e)
         {
             if (!initialized) return;
-            //setValues();
-            ReassignFreePinsInDropDowns(sender as ComboBox);
+            
+            if (sender is ComboBox)
+                ReassignFreePinsInDropDowns(sender as ComboBox);
+
             if (Changed != null)
                 Changed(multiplexerDriver, new EventArgs());
         }

--- a/UI/Panels/Device/MFShiftRegisterPanel.cs
+++ b/UI/Panels/Device/MFShiftRegisterPanel.cs
@@ -75,7 +75,8 @@ namespace MobiFlight.UI.Panels.Settings
         private void value_Changed(object sender, EventArgs e)
         {
             if (!initialized) return;
-            ReassignFreePinsInDropDowns(sender as ComboBox);
+            if (sender is ComboBox)
+                ReassignFreePinsInDropDowns(sender as ComboBox);
             setNonPinValues();
             if (Changed != null)
                 Changed(shiftRegister, new EventArgs());

--- a/UI/Panels/Device/MFStepperPanel.cs
+++ b/UI/Panels/Device/MFStepperPanel.cs
@@ -260,7 +260,8 @@ namespace MobiFlight.UI.Panels.Settings.Device
         {
             if (!initialized) return;
 
-            ReassignFreePinsInDropDowns(sender as ComboBox);
+            if (sender is ComboBox)
+                ReassignFreePinsInDropDowns(sender as ComboBox);
 
             SyncAutoHomeCorrectly();
 


### PR DESCRIPTION
fixes #1342 

## Changes 
Fix affected devices by adding a check `(sender is ComboBox)` before calling `ReassignFreePinsInDropDowns(sender as ComboBox);`
- [x] Stepper
- [x] Output Shift Register
- [x] Input Shift Register

## Note:
Applied same protection to all other devices even though they were not affected because they reference the comboboxes by name and not by `(sender as combobox)`
