### PR TITLE
Green checkmark updated correctly after plane switch with no linked config

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -275,6 +275,12 @@ namespace MobiFlight.UI
 
             if (!AutoLoadConfigs.ContainsKey(key)) return;
 
+            if (!AutoLoadConfigs.ContainsKey(key))
+            {
+                UpdateAutoLoadMenu();
+                return;
+            }
+
             var filename = AutoLoadConfigs[key];
 
             if (CurrentFileName == filename)


### PR DESCRIPTION
fixes #1355

Call UpdateAutoLoadMenu at the right time.