### PR TITLE
Remove duplicate code block due to earlier wrong merge

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -279,12 +279,6 @@ namespace MobiFlight.UI
                 return;
             }
 
-            if (!AutoLoadConfigs.ContainsKey(key))
-            {
-                UpdateAutoLoadMenu();
-                return;
-            }
-
             var filename = AutoLoadConfigs[key];
 
             if (CurrentFileName == filename)


### PR DESCRIPTION
I should pay more attention... I wanted to break up some commits into individual PRs and then I accidentally merged a branch twice. Since it is a Squash Merge, Github duplicated parts of the code.

My bad... TIL...