### PR TITLE
Skip update check on pull request builds

### DIFF
--- a/Base/AutoUpdateChecker.cs
+++ b/Base/AutoUpdateChecker.cs
@@ -17,8 +17,16 @@ namespace MobiFlight.UpdateChecker
             if (Properties.Settings.Default.CacheId == "0") Properties.Settings.Default.CacheId = Guid.NewGuid().ToString();
             String trackingParams = hash + "-" + Properties.Settings.Default.CacheId + "-" + Properties.Settings.Default.Started;
 
-            string CurVersion = Assembly.GetExecutingAssembly().GetName().Version.ToString();
-            string CommandToSend = "/check /version " + CurVersion + " /cacheId " + trackingParams;
+            var CurVersion = Assembly.GetExecutingAssembly().GetName().Version;
+            string CommandToSend = "/check /version " + CurVersion.ToString() + " /cacheId " + trackingParams;
+
+            // Issue 1365: Don't check for updates if the build came from a pull request. These builds are
+            // identified by the major version being 0.
+            if (CurVersion.Major == 0)
+            {
+                Log.Instance.log("Skipping update check since this is an unreleased build.", LogSeverity.Info);
+                return;
+            }
 
             if (Properties.Settings.Default.BetaUpdates)
             {

--- a/Base/AutoUpdateChecker.cs
+++ b/Base/AutoUpdateChecker.cs
@@ -15,7 +15,7 @@ namespace MobiFlight.UpdateChecker
         {
             String hash = (Environment.UserName + Environment.MachineName).GetHashCode().ToString();
             if (Properties.Settings.Default.CacheId == "0") Properties.Settings.Default.CacheId = Guid.NewGuid().ToString();
-            String trackingParams = hash + "-" + Properties.Settings.Default.CacheId + "-" + Properties.Settings.Default.Started;
+            var trackingParams = $"{hash}-{Properties.Settings.Default.CacheId}-{Properties.Settings.Default.Started}";
 
             var CurVersion = Assembly.GetExecutingAssembly().GetName().Version;
             var CommandToSend = $"/check /version {CurVersion} /cacheId {trackingParams}";

--- a/Base/AutoUpdateChecker.cs
+++ b/Base/AutoUpdateChecker.cs
@@ -9,9 +9,9 @@ namespace MobiFlight.UpdateChecker
 {
     static class AutoUpdateChecker
     {
-        static string mobiFlightInstaller = "MobiFlight-Installer.exe";
-        static int UpdateCheckTimeoutInMs = 5000;
-        public static void CheckForUpdate(bool force = false, bool silent = false)
+        static readonly string mobiFlightInstaller = "MobiFlight-Installer.exe";
+        static readonly int UpdateCheckTimeoutInMs = 5000;
+        public static void CheckForUpdate(bool silent = false)
         {
             String hash = (Environment.UserName + Environment.MachineName).GetHashCode().ToString();
             if (Properties.Settings.Default.CacheId == "0") Properties.Settings.Default.CacheId = Guid.NewGuid().ToString();

--- a/Base/AutoUpdateChecker.cs
+++ b/Base/AutoUpdateChecker.cs
@@ -18,7 +18,7 @@ namespace MobiFlight.UpdateChecker
             String trackingParams = hash + "-" + Properties.Settings.Default.CacheId + "-" + Properties.Settings.Default.Started;
 
             var CurVersion = Assembly.GetExecutingAssembly().GetName().Version;
-            string CommandToSend = "/check /version " + CurVersion.ToString() + " /cacheId " + trackingParams;
+            var CommandToSend = $"/check /version {CurVersion} /cacheId {trackingParams}";
 
             // Issue 1365: Don't check for updates if the build came from a pull request. These builds are
             // identified by the major version being 0.

--- a/Base/AutoUpdateChecker.cs
+++ b/Base/AutoUpdateChecker.cs
@@ -18,7 +18,6 @@ namespace MobiFlight.UpdateChecker
             var trackingParams = $"{hash}-{Properties.Settings.Default.CacheId}-{Properties.Settings.Default.Started}";
 
             var CurVersion = Assembly.GetExecutingAssembly().GetName().Version;
-            var CommandToSend = $"/check /version {CurVersion} /cacheId {trackingParams}";
 
             // Issue 1365: Don't check for updates if the build came from a pull request. These builds are
             // identified by the major version being 0.
@@ -27,6 +26,8 @@ namespace MobiFlight.UpdateChecker
                 Log.Instance.log("Skipping update check since this is an unreleased build.", LogSeverity.Info);
                 return;
             }
+
+            var CommandToSend = $"/check /version {CurVersion} /cacheId {trackingParams}";
 
             if (Properties.Settings.Default.BetaUpdates)
             {

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -148,7 +148,7 @@ namespace MobiFlight.UI
         {
             // Check for updates before loading anything else
 #if (!DEBUG)
-            AutoUpdateChecker.CheckForUpdate(false, true);
+            AutoUpdateChecker.CheckForUpdate(true);
 #endif
 
             if (Properties.Settings.Default.Started == 0)

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -592,7 +592,7 @@ namespace MobiFlight.UI
 
         private void checkForUpdateToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AutoUpdateChecker.CheckForUpdate(true);
+            AutoUpdateChecker.CheckForUpdate();
         }
 
         private void startAutoConnectThreadSafe()


### PR DESCRIPTION
Fixes #1365

Checks to see if the major version of the build is `0` and if so skips the update check.

```
Info	10/28/2023 12:38:24	Skipping update check since this is an unreleased build.
```

Since I was touching the lines close by anyway I also converted two old-style strings to new style string interpolation.