### PR TITLE
Fix global test mode

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1278,21 +1278,29 @@ namespace MobiFlight
 
             switch (cfg.DisplayType)
             {
+                // the following execute displays assume that
+                //
+                // case 1) inside the config wizard, when we hit the test button
+                // we will have an actual connector value, we use it - even if it is the empty string.
+                //
+                // case 2) when we trigger the global test mode
+                // we won't have an actual connector value, and then
+                // we will use a static test string, that is specific to the device.
                 case MobiFlightStepper.TYPE:
-                    ExecuteDisplay(value.ToString() != "" ? value.ToString() : cfg.Stepper.TestValue.ToString(), cfg);
+                    ExecuteDisplay(value?.ToString() ?? cfg.Stepper.TestValue.ToString(), cfg);
                     break;
 
                 case MobiFlightServo.TYPE:
-                    ExecuteDisplay(value.ToString() != "" ? value.ToString() : cfg.Servo.Max, cfg);
+                    ExecuteDisplay(value?.ToString() ?? cfg.Servo.Max, cfg);
                     break;
 
                 case ArcazeLedDigit.TYPE:
                 case OutputConfig.LcdDisplay.Type:
-                    ExecuteDisplay(value.ToString() != "" ? value.ToString() : "1234567890", cfg);
+                    ExecuteDisplay(value?.ToString() ?? "1234567890", cfg);
                     break;
                 
                 case MobiFlightShiftRegister.TYPE:
-                    ExecuteDisplay(value.ToString() != "" ? value.ToString() : "1", cfg);
+                    ExecuteDisplay(value?.ToString() ?? "1", cfg);
                     break;
 
                 case "InputAction":
@@ -1300,7 +1308,7 @@ namespace MobiFlight
                     break;
 
                 default:
-                    ExecuteDisplay(value.ToString() != "" ? value.ToString() : "255", cfg);
+                    ExecuteDisplay(value?.ToString() ?? "255", cfg);
                     break;
             }
         }

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -147,10 +147,13 @@ namespace MobiFlight.UI.Dialogs
         private void TestTimer_Tick(object sender, EventArgs e)
         {
             var value = config.TestValue.Clone() as ConnectorValue;
+            if (value == null) value = new ConnectorValue();
+
             try
             {
-                if (value != null)
-                    config.Modifiers.Items.FindAll(x => x.Active).ForEach(y => value = y.Apply(value, new List<ConfigRefValue>()));
+                // Apply all modifiers to the test value
+                // so that the test value yields the final value
+                config.Modifiers.Items.FindAll(x => x.Active).ForEach(y => value = y.Apply(value, new List<ConfigRefValue>()));
             } catch (Exception ex)
             {
                 // ShowError? Or don't do anything?


### PR DESCRIPTION
fixes #1367 

When the global test mode is executed, 
* we don't have an actual test value and we want to use a device specific default-test value.
* the test value passed into the method is null, and is correctly handled now.