### PR TITLE
Refactor Button Panel

### DIFF
--- a/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -10,6 +10,9 @@ namespace MobiFlight.InputConfig
         public InputAction onRelease;
         public InputAction onLongRelease;
 
+        private InputEventArgs PreviousInputEvent;
+        private const int DELAY_LONG_RELEASE = 350; //ms
+
         public object Clone()
         {
             ButtonInputConfig clone = new ButtonInputConfig();
@@ -122,21 +125,33 @@ namespace MobiFlight.InputConfig
             }
         }
 
-        private bool IsLongReleaseButOnlyReleaseDefined(MobiFlightButton.InputEvent inputEvent)
+        private void CheckAndAdaptForLongButtonRelease(InputEventArgs current, InputEventArgs previous)
         {
-            return (inputEvent == MobiFlightButton.InputEvent.LONG_RELEASE) && (onLongRelease == null) && (onRelease != null);
+            var inputEvent = (MobiFlightButton.InputEvent)current.Value;
+            TimeSpan timeSpanToPreviousInput = current.Time - previous.Time;
+
+            if (onLongRelease != null &&
+                inputEvent == MobiFlightButton.InputEvent.RELEASE &&
+                timeSpanToPreviousInput > TimeSpan.FromMilliseconds(DELAY_LONG_RELEASE))
+            {
+                current.Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE;
+                Log.Instance.log($"{current.Name} => {current.DeviceLabel}  => Execute as LONG_RELEASE", LogSeverity.Info);
+            }
         }
 
         internal void execute(CacheCollection cacheCollection, 
                               InputEventArgs args, 
                               List<ConfigRefValue> configRefs)
         {
+            if (PreviousInputEvent == null) PreviousInputEvent = args;
+            CheckAndAdaptForLongButtonRelease(args, PreviousInputEvent);
+
             var inputEvent = (MobiFlightButton.InputEvent)args.Value;
             if (inputEvent == MobiFlightButton.InputEvent.PRESS && onPress != null)
             {
                 onPress.execute(cacheCollection, args, configRefs);
             }
-            else if (inputEvent == MobiFlightButton.InputEvent.RELEASE && onRelease != null && IsLongReleaseButOnlyReleaseDefined(inputEvent))
+            else if (inputEvent == MobiFlightButton.InputEvent.RELEASE && onRelease != null)
             {
                 onRelease.execute(cacheCollection, args, configRefs);
             }
@@ -144,6 +159,7 @@ namespace MobiFlight.InputConfig
             {
                 onLongRelease.execute(cacheCollection, args, configRefs);             
             }
+            PreviousInputEvent = args;
         }
 
         public Dictionary<String, int> GetStatistics()

--- a/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -55,6 +55,37 @@ namespace MobiFlight.InputConfig
                 reader.Read();
         }
 
+        public void SetInputActionByName(string name, InputAction inputAction)
+        {
+            switch (name)
+            {
+                case "onPress":
+                    onPress = inputAction;
+                    break;
+                case "onRelease":
+                    onRelease = inputAction;
+                    break;                   
+                case "onLongRelease":
+                    onLongRelease = inputAction;
+                    break;                          
+            }
+        }
+
+        public InputAction GetInputActionByName(string name)
+        {
+            switch (name)
+            {
+                case "onPress":
+                    return onPress;
+                case "onRelease":
+                    return onRelease;
+                case "onLongRelease":
+                    return onLongRelease;
+                default:
+                    return null;
+            }        
+        }
+
         public List<InputAction> GetInputActionsByType(Type type)
         {
             List<InputAction> result = new List<InputAction>();

--- a/MobiFlight/InputConfigItem.cs
+++ b/MobiFlight/InputConfigItem.cs
@@ -36,9 +36,6 @@ namespace MobiFlight
         public PreconditionList Preconditions { get; set; }
         public ConfigRefList ConfigRefs { get; set; }
 
-        private InputEventArgs PreviousInputEvent;
-        private const int DELAY_LONG_RELEASE = 350; //ms
-
         public InputConfigItem()
         {
             Preconditions = new PreconditionList();
@@ -269,30 +266,15 @@ namespace MobiFlight
             return clone;
         }
 
-        private void CheckAndAdaptForLongButtonRelease(InputEventArgs current, InputEventArgs previous)
-        {
-            var inputEvent = (MobiFlightButton.InputEvent)current.Value;
-            TimeSpan timeSpanToPreviousInput = current.Time - previous.Time;
-
-            if (inputEvent == MobiFlightButton.InputEvent.RELEASE && 
-               (timeSpanToPreviousInput > TimeSpan.FromMilliseconds(DELAY_LONG_RELEASE)))
-            {
-                current.Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE;     
-                Log.Instance.log($"{current.Name} => {current.DeviceLabel}  => Execute as LONG_RELEASE", LogSeverity.Info);
-            }         
-        }
-
         internal void execute(
             CacheCollection cacheCollection,
             InputEventArgs e,
             List<ConfigRefValue> configRefs)
         {
-            if (PreviousInputEvent == null) PreviousInputEvent = e;
             switch (Type)
             {
                 case TYPE_BUTTON:
-                    if (button != null)
-                        CheckAndAdaptForLongButtonRelease(e, PreviousInputEvent);
+                    if (button != null)                
                         button.execute(cacheCollection, e, configRefs);
                     break;
                 case TYPE_ENCODER:
@@ -314,8 +296,7 @@ namespace MobiFlight
                     if (analog != null)
                         analog.execute(cacheCollection, e, configRefs);
                     break;
-            }
-            PreviousInputEvent = e;
+            }            
         }
 
         public Dictionary<String, int> GetStatistics()

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -442,6 +442,8 @@
     <Compile Include="UI\Panels\Config\HubHopPresetPanel.Designer.cs">
       <DependentUpon>HubHopPresetPanel.cs</DependentUpon>
     </Compile>
+    <Compile Include="UI\Panels\Config\InputActionMapping.cs" />
+    <Compile Include="UI\Panels\Config\IPanelConfigSync.cs" />
     <Compile Include="UI\Panels\Config\PreconditionPanel.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/UI/Panels/Action/EventIdInputPanel.cs
+++ b/UI/Panels/Action/EventIdInputPanel.cs
@@ -6,10 +6,12 @@ using System.Data;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using MobiFlight.UI.Panels.Config;
+using MobiFlight.InputConfig;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class EventIdInputPanel : UserControl
+    public partial class EventIdInputPanel : UserControl, IPanelConfigSync
     {
         public String PresetFile { get; set; }
         private DataTable Data;
@@ -79,9 +81,11 @@ namespace MobiFlight.UI.Panels.Action
             fsuipcPresetUseButton.Enabled = isLoaded;
         }
         
-        internal void syncFromConfig(InputConfig.EventIdInputAction eventIdInputAction)
+        public void syncFromConfig(object config)
         {
+            EventIdInputAction eventIdInputAction = config as EventIdInputAction;
             if (eventIdInputAction == null) return;
+            
             eventIdTextBox.Text = eventIdInputAction.EventId.ToString();
             paramTextBox.Text = eventIdInputAction.Param.ToString();
 
@@ -95,9 +99,9 @@ namespace MobiFlight.UI.Panels.Action
             }
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputConfig.InputAction ToConfig()
         {
-            MobiFlight.InputConfig.EventIdInputAction result = new InputConfig.EventIdInputAction();
+            EventIdInputAction result = new EventIdInputAction();
             result.EventId = Int32.Parse(eventIdTextBox.Text);
             result.Param = paramTextBox.Text;
             return result;
@@ -105,7 +109,7 @@ namespace MobiFlight.UI.Panels.Action
 
         private void testButton_Click(object sender, EventArgs e)
         {
-            MobiFlight.InputConfig.InputAction tmp = ToConfig();
+            InputAction tmp = ToConfig();
             tmp.execute(null, null, null);
         }
 

--- a/UI/Panels/Action/JeehellInputPanel.cs
+++ b/UI/Panels/Action/JeehellInputPanel.cs
@@ -6,10 +6,12 @@ using System.Data;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using MobiFlight.UI.Panels.Config;
+using MobiFlight.InputConfig;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class JeehellInputPanel : UserControl
+    public partial class JeehellInputPanel : UserControl, IPanelConfigSync
     {
         public String PresetFile { get; set; }
         private DataTable Data;
@@ -102,9 +104,11 @@ namespace MobiFlight.UI.Panels.Action
             }
         }
 
-        internal void syncFromConfig(InputConfig.JeehellInputAction jeehellInputAction)
+        public void syncFromConfig(object config)
         {
+            JeehellInputAction jeehellInputAction = config as JeehellInputAction;
             if (jeehellInputAction == null) return;
+            
             DataRow[] rows = Data.Select("EventId = '" + jeehellInputAction.EventId.ToString() + "'");
             if (rows.Length > 0)
             {
@@ -115,9 +119,9 @@ namespace MobiFlight.UI.Panels.Action
             }
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputConfig.InputAction ToConfig()
         {
-            MobiFlight.InputConfig.JeehellInputAction result = new InputConfig.JeehellInputAction();
+            JeehellInputAction result = new JeehellInputAction();
             if (currentRow != null)
             {
                 result.EventId = Byte.Parse(currentRow["EventId"].ToString());

--- a/UI/Panels/Action/KeyboardInputPanel.cs
+++ b/UI/Panels/Action/KeyboardInputPanel.cs
@@ -6,10 +6,12 @@ using System.Data;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using MobiFlight.UI.Panels.Config;
+using MobiFlight.InputConfig;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class KeyboardInputPanel : UserControl
+    public partial class KeyboardInputPanel : UserControl, IPanelConfigSync
     {
         int isRecording = 0;
         bool CtrlPressed = false;
@@ -60,10 +62,11 @@ namespace MobiFlight.UI.Panels.Action
         {
         }
 
-        internal void syncFromConfig(InputConfig.KeyInputAction keyInputAction)
+        public void syncFromConfig(object config)
         {
+            KeyInputAction keyInputAction = config as KeyInputAction;
             if (keyInputAction == null) return;
-
+            
             KeysConverter kc = new KeysConverter();
             CurrentKey = keyInputAction.Key;
             CtrlPressed = keyInputAction.Control;
@@ -72,9 +75,9 @@ namespace MobiFlight.UI.Panels.Action
             UpdateTextBox();
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputConfig.InputAction ToConfig()
         {
-            MobiFlight.InputConfig.KeyInputAction config = new InputConfig.KeyInputAction();
+            KeyInputAction config = new KeyInputAction();
             config.Key = CurrentKey;
             config.Shift = ShiftPressed;
             config.Control = CtrlPressed;

--- a/UI/Panels/Action/LuaMacroInputPanel.cs
+++ b/UI/Panels/Action/LuaMacroInputPanel.cs
@@ -7,10 +7,12 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using MobiFlight.UI.Panels.Config;
+using MobiFlight.InputConfig;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class LuaMacroInputPanel : UserControl
+    public partial class LuaMacroInputPanel : UserControl, IPanelConfigSync
     {
         public LuaMacroInputPanel()
         {
@@ -22,17 +24,18 @@ namespace MobiFlight.UI.Panels.Action
             bool isLoaded = true;
         }
         
-        internal void syncFromConfig(InputConfig.LuaMacroInputAction inputAction)
+        public void syncFromConfig(object config)
         {
+            LuaMacroInputAction inputAction = config as LuaMacroInputAction;
             if (inputAction == null) return;
+            
             MacroNameTextBox.Text = inputAction.MacroName;
             MacroValueTextBox.Text = inputAction.MacroValue.ToString();
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputConfig.InputAction ToConfig()
         {
-
-            MobiFlight.InputConfig.LuaMacroInputAction result = new InputConfig.LuaMacroInputAction();
+            LuaMacroInputAction result = new LuaMacroInputAction();
             result.MacroName = MacroNameTextBox.Text.Trim();
             result.MacroValue = MacroValueTextBox.Text;
             return result;

--- a/UI/Panels/Action/MSFS2020CustomInputPanel.cs
+++ b/UI/Panels/Action/MSFS2020CustomInputPanel.cs
@@ -8,10 +8,11 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using MobiFlight.InputConfig;
+using MobiFlight.UI.Panels.Config;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class MSFS2020CustomInputPanel : UserControl
+    public partial class MSFS2020CustomInputPanel : UserControl, IPanelConfigSync
     {
         ErrorProvider errorProvider = new ErrorProvider();
 
@@ -24,19 +25,21 @@ namespace MobiFlight.UI.Panels.Action
             Disposed += (sender, args) => { hubHopPresetPanel1.Dispose(); };
         }       
 
-        internal void syncFromConfig(InputConfig.MSFS2020CustomInputAction inputAction)
-        {
-            hubHopPresetPanel1.syncFromConfig(inputAction);
-        }
-
-        internal InputConfig.InputAction ToConfig()
+        public InputConfig.InputAction ToConfig()
         {
             return hubHopPresetPanel1.ToConfig();            
         }
 
-        internal void syncFromConfig(MSFS2020EventIdInputAction inputAction)
+        public void syncFromConfig(object config)
         {
-            hubHopPresetPanel1.syncFromConfig(inputAction);
+            if (config is MSFS2020CustomInputAction)
+            {
+                hubHopPresetPanel1.syncFromConfig(config as MSFS2020CustomInputAction);
+            }
+            else if (config is MSFS2020EventIdInputAction)
+            {
+                hubHopPresetPanel1.syncFromConfig(config as MSFS2020EventIdInputAction);
+            }            
         }
     }
 }

--- a/UI/Panels/Action/PmdgEventIdInputPanel.cs
+++ b/UI/Panels/Action/PmdgEventIdInputPanel.cs
@@ -7,10 +7,11 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using MobiFlight.InputConfig;
+using MobiFlight.UI.Panels.Config;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class PmdgEventIdInputPanel : UserControl
+    public partial class PmdgEventIdInputPanel : UserControl, IPanelConfigSync
     {
         static PmdgEventIdInputAction.PmdgAircraftType lastUsedType = PmdgEventIdInputAction.PmdgAircraftType.B737;
         public String PresetFile { get; set; }
@@ -126,9 +127,11 @@ namespace MobiFlight.UI.Panels.Action
             fsuipcPresetUseButton.Enabled = isLoaded;
         }
         
-        internal void syncFromConfig(InputConfig.PmdgEventIdInputAction eventIdInputAction)
+        public void syncFromConfig(object config)
         {
+            PmdgEventIdInputAction eventIdInputAction = config as PmdgEventIdInputAction;
             if (eventIdInputAction == null) return;
+            
             eventIdTextBox.Text = eventIdInputAction.EventId.ToString();
 
             if (lastUsedType!=eventIdInputAction.AircraftType)
@@ -157,9 +160,9 @@ namespace MobiFlight.UI.Panels.Action
             }
         }
 
-        internal InputConfig.PmdgEventIdInputAction ToConfig()
+        public InputConfig.InputAction ToConfig()
         {
-            MobiFlight.InputConfig.PmdgEventIdInputAction result = new InputConfig.PmdgEventIdInputAction();
+            PmdgEventIdInputAction result = new PmdgEventIdInputAction();
             result.EventId = Int32.Parse(eventIdTextBox.Text);
             result.Param = customParamTextBox.Text;
             result.AircraftType = lastUsedType;

--- a/UI/Panels/Action/RetriggerInputPanel.cs
+++ b/UI/Panels/Action/RetriggerInputPanel.cs
@@ -6,10 +6,12 @@ using System.Data;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
+using MobiFlight.UI.Panels.Config;
+using MobiFlight.InputConfig;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class RetriggerInputPanel : UserControl
+    public partial class RetriggerInputPanel : UserControl, IPanelConfigSync
     {
         public RetriggerInputPanel()
         {
@@ -21,14 +23,15 @@ namespace MobiFlight.UI.Panels.Action
             bool isLoaded = true;
         }
         
-        internal void syncFromConfig(InputConfig.RetriggerInputAction inputAction)
+        public void syncFromConfig(object config)
         {
+            RetriggerInputAction inputAction = config as RetriggerInputAction;
             if (inputAction == null) return;
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputConfig.InputAction ToConfig()
         {
-            MobiFlight.InputConfig.RetriggerInputAction result = new InputConfig.RetriggerInputAction();
+            RetriggerInputAction result = new RetriggerInputAction();
             return result;
         }
 

--- a/UI/Panels/Action/VJoyInputPanel.cs
+++ b/UI/Panels/Action/VJoyInputPanel.cs
@@ -7,10 +7,12 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using MobiFlight.VJoy;
+using MobiFlight.UI.Panels.Config;
+using MobiFlight.InputConfig;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class VJoyInputPanel : UserControl
+    public partial class VJoyInputPanel : UserControl, IPanelConfigSync
     {
         public VJoyInputPanel()
         {
@@ -52,10 +54,11 @@ namespace MobiFlight.UI.Panels.Action
             comboBoxButtonNr.Enabled = false;
         }
 
-        internal void syncFromConfig(InputConfig.VJoyInputAction vJoyInputAction)
+        public void syncFromConfig(object config)
         {
+            VJoyInputAction vJoyInputAction = config as VJoyInputAction;
             if (vJoyInputAction == null) return;
-
+            
             ComboBoxID.SelectedItem = vJoyInputAction.vJoyID;
             try
             {
@@ -88,11 +91,11 @@ namespace MobiFlight.UI.Panels.Action
             setInputEnabledState(-1);
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputAction ToConfig()
         {
             if (ComboBoxID.SelectedItem != null)
             {
-                InputConfig.VJoyInputAction vJoyInputAction = new InputConfig.VJoyInputAction();
+                VJoyInputAction vJoyInputAction = new VJoyInputAction();
                 vJoyInputAction.vJoyID = UInt16.Parse(ComboBoxID.SelectedItem.ToString());
                 if (comboBoxButtonNr.SelectedItem.ToString() != "--")
                 {

--- a/UI/Panels/Action/VariableInputPanel.cs
+++ b/UI/Panels/Action/VariableInputPanel.cs
@@ -7,10 +7,11 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using MobiFlight.InputConfig;
+using MobiFlight.UI.Panels.Config;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class VariableInputPanel : UserControl
+    public partial class VariableInputPanel : UserControl, IPanelConfigSync
     {
         ErrorProvider errorProvider = new ErrorProvider();
         Dictionary<String, MobiFlightVariable> Variables = new Dictionary<String, MobiFlightVariable>();
@@ -67,9 +68,10 @@ namespace MobiFlight.UI.Panels.Action
             ValueTextBox.Text = Variable.Expression;
         }
 
-        internal void syncFromConfig(InputConfig.VariableInputAction inputAction)
+        public void syncFromConfig(object config)
         {
-            if (inputAction == null) inputAction = new InputConfig.VariableInputAction();
+            VariableInputAction inputAction = config as VariableInputAction;
+            if (inputAction == null) inputAction = new VariableInputAction();
 
             // this can happen when we are 
             // copy & paste an input actions
@@ -93,9 +95,9 @@ namespace MobiFlight.UI.Panels.Action
             ValueTextBox.Text = inputAction.Variable.Expression;
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputAction ToConfig()
         {
-            MobiFlight.InputConfig.VariableInputAction result = new InputConfig.VariableInputAction();
+            VariableInputAction result = new VariableInputAction();
             result.Variable.TYPE = TypeComboBox.SelectedValue.ToString();
             result.Variable.Name = NameTextBox.Text;
             result.Variable.Expression = ValueTextBox.Text;

--- a/UI/Panels/Action/XplaneInputPanel.cs
+++ b/UI/Panels/Action/XplaneInputPanel.cs
@@ -1,4 +1,5 @@
 ﻿using MobiFlight.InputConfig;
+using MobiFlight.UI.Panels.Config;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -11,7 +12,7 @@ using System.Windows.Forms;
 
 namespace MobiFlight.UI.Panels.Action
 {
-    public partial class XplaneInputPanel : UserControl
+    public partial class XplaneInputPanel : UserControl, IPanelConfigSync
     {
         public XplaneInputPanel()
         {
@@ -22,12 +23,13 @@ namespace MobiFlight.UI.Panels.Action
             hubHopPresetPanel1.LoadPresets();
             Disposed += (sender, args) => { hubHopPresetPanel1.Dispose(); };
         }
-        internal void syncFromConfig(InputConfig.XplaneInputAction inputAction)
+        public void syncFromConfig(object config)
         {
+            XplaneInputAction inputAction = config as XplaneInputAction;
             hubHopPresetPanel1.syncFromConfig(inputAction);
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputAction ToConfig()
         {
             return hubHopPresetPanel1.ToConfig();
         }

--- a/UI/Panels/Config/FsuipcConfigPanel.cs
+++ b/UI/Panels/Config/FsuipcConfigPanel.cs
@@ -13,7 +13,7 @@ using MobiFlight.Modifier;
 
 namespace MobiFlight.UI.Panels.Config
 {
-    public partial class FsuipcConfigPanel : UserControl
+    public partial class FsuipcConfigPanel : UserControl, IPanelConfigSync
     {
         public event EventHandler ModifyTabLink;
         public event EventHandler ModifierChanged;
@@ -226,20 +226,21 @@ namespace MobiFlight.UI.Panels.Config
             }
         }
 
-        internal void syncFromConfig(IFsuipcConfigItem config)
+        public void syncFromConfig(object config)
         {
-            if (config == null)
+            IFsuipcConfigItem conf = config as IFsuipcConfigItem;
+            if (conf == null)
             {
                 // this happens when casting badly
                 return;
             }
             // first tab                        
-            fsuipcOffsetTextBox.Text = "0x" + config.FSUIPC.Offset.ToString("X4");
+            fsuipcOffsetTextBox.Text = "0x" + conf.FSUIPC.Offset.ToString("X4");
 
             // preselect fsuipc offset type
             try
             {
-                fsuipcOffsetTypeComboBox.SelectedValue = config.FSUIPC.OffsetType.ToString();
+                fsuipcOffsetTypeComboBox.SelectedValue = conf.FSUIPC.OffsetType.ToString();
             }
             catch (Exception ex)
             {
@@ -247,7 +248,7 @@ namespace MobiFlight.UI.Panels.Config
                 Log.Instance.log($"Exception on FSUIPCOffsetType.ToString: {ex.Message}", LogSeverity.Error);
             }
 
-            if (!ComboBoxHelper.SetSelectedItem(fsuipcSizeComboBox, config.FSUIPC.Size.ToString()))
+            if (!ComboBoxHelper.SetSelectedItem(fsuipcSizeComboBox, conf.FSUIPC.Size.ToString()))
             {
                 // TODO: provide error message
                 Log.Instance.log("Exception on selecting item in ComboBox.", LogSeverity.Error);
@@ -255,12 +256,12 @@ namespace MobiFlight.UI.Panels.Config
 
             // mask
             fsuipcMaskTextBox.Text = "0xFF";
-            if (config.FSUIPC.OffsetType != FSUIPCOffsetType.String)
-                fsuipcMaskTextBox.Text = "0x" + config.FSUIPC.Mask.ToString("X" + config.FSUIPC.Size.ToString());
+            if (conf.FSUIPC.OffsetType != FSUIPCOffsetType.String)
+                fsuipcMaskTextBox.Text = "0x" + conf.FSUIPC.Mask.ToString("X" + conf.FSUIPC.Size.ToString());
             
-            fsuipcBcdModeCheckBox.Checked = config.FSUIPC.BcdMode;
+            fsuipcBcdModeCheckBox.Checked = conf.FSUIPC.BcdMode;
 
-            transformOptionsGroup1.syncFromConfig(config);
+            transformOptionsGroup1.syncFromConfig(conf);
 
             /*if (config.Modifiers.Items.Count > 0 && config.Modifiers.Transformation != null)
             {
@@ -269,11 +270,11 @@ namespace MobiFlight.UI.Panels.Config
 
             foreach (DataRow row in presetDataTable.Rows)
             {
-                if ((row["settings"] as IFsuipcConfigItem).FSUIPC.Offset == config.FSUIPC.Offset &&
-                    (row["settings"] as IFsuipcConfigItem).FSUIPC.OffsetType == config.FSUIPC.OffsetType &&
-                    (row["settings"] as IFsuipcConfigItem).FSUIPC.Size == config.FSUIPC.Size &&
-                    (row["settings"] as IFsuipcConfigItem).FSUIPC.Mask == config.FSUIPC.Mask &&
-                    (row["settings"] as IFsuipcConfigItem).FSUIPC.BcdMode == config.FSUIPC.BcdMode
+                if ((row["settings"] as IFsuipcConfigItem).FSUIPC.Offset == conf.FSUIPC.Offset &&
+                    (row["settings"] as IFsuipcConfigItem).FSUIPC.OffsetType == conf.FSUIPC.OffsetType &&
+                    (row["settings"] as IFsuipcConfigItem).FSUIPC.Size == conf.FSUIPC.Size &&
+                    (row["settings"] as IFsuipcConfigItem).FSUIPC.Mask == conf.FSUIPC.Mask &&
+                    (row["settings"] as IFsuipcConfigItem).FSUIPC.BcdMode == conf.FSUIPC.BcdMode
                     ) {
                     fsuipcPresetComboBox.Text = row["description"].ToString();
                     break;
@@ -310,9 +311,9 @@ namespace MobiFlight.UI.Panels.Config
             }*/
         }
 
-        internal InputConfig.InputAction ToConfig()
+        public InputConfig.InputAction ToConfig()
         {
-            MobiFlight.InputConfig.FsuipcOffsetInputAction config = new FsuipcOffsetInputAction();
+            FsuipcOffsetInputAction config = new FsuipcOffsetInputAction();
             syncToConfig(config);
 
             return config;

--- a/UI/Panels/Config/IPanelConfigSync.cs
+++ b/UI/Panels/Config/IPanelConfigSync.cs
@@ -1,0 +1,10 @@
+﻿using MobiFlight.InputConfig;
+
+namespace MobiFlight.UI.Panels.Config
+{
+    internal interface IPanelConfigSync
+    {
+        InputAction ToConfig();
+        void syncFromConfig(object config);
+    }
+}

--- a/UI/Panels/Config/InputActionMapping.cs
+++ b/UI/Panels/Config/InputActionMapping.cs
@@ -1,0 +1,42 @@
+﻿using MobiFlight.InputConfig;
+using MobiFlight.UI.Panels.Action;
+using System;
+using System.Collections.Generic;
+
+namespace MobiFlight.UI.Panels.Config
+{
+    internal class InputActionMapping
+    {
+        public static Dictionary<Type, string> InputActionTypesToInputLabels = new Dictionary<Type, string>
+        {
+            { typeof(FsuipcOffsetInputAction), FsuipcOffsetInputAction.Label },
+            { typeof(KeyInputAction), KeyInputAction.Label },
+            { typeof(EventIdInputAction), EventIdInputAction.Label },
+            { typeof(PmdgEventIdInputAction), PmdgEventIdInputAction.Label },
+            { typeof(JeehellInputAction), JeehellInputAction.Label },
+            { typeof(VJoyInputAction), VJoyInputAction.Label },
+            { typeof(LuaMacroInputAction), LuaMacroInputAction.Label },
+            { typeof(RetriggerInputAction), RetriggerInputAction.Label },
+            { typeof(MSFS2020EventIdInputAction), MSFS2020EventIdInputAction.Label },
+            { typeof(MSFS2020CustomInputAction), MSFS2020CustomInputAction.Label },
+            { typeof(VariableInputAction), VariableInputAction.Label },
+            { typeof(XplaneInputAction), XplaneInputAction.Label }
+        };
+
+        public static Dictionary<string, Type> InputLabelsToConfigPanelTypes = new Dictionary<string, Type>
+        {
+            { FsuipcOffsetInputAction.Label, typeof(FsuipcConfigPanel) },
+            { KeyInputAction.Label, typeof(KeyboardInputPanel) },
+            { EventIdInputAction.Label, typeof(EventIdInputPanel) },
+            { PmdgEventIdInputAction.Label, typeof(PmdgEventIdInputPanel) },
+            { JeehellInputAction.Label, typeof(JeehellInputPanel) },
+            { VJoyInputAction.Label, typeof(VJoyInputPanel) },
+            { LuaMacroInputAction.Label, typeof(LuaMacroInputPanel) },
+            { RetriggerInputAction.Label, typeof(RetriggerInputPanel) },
+            { MSFS2020EventIdInputAction.Label, typeof(MSFS2020CustomInputPanel) },
+            { MSFS2020CustomInputAction.Label, typeof(MSFS2020CustomInputPanel) },
+            { VariableInputAction.Label, typeof(VariableInputPanel) },
+            { XplaneInputAction.Label, typeof(XplaneInputPanel) }
+        };
+    }
+}

--- a/UI/Panels/Input/ButtonPanel.cs
+++ b/UI/Panels/Input/ButtonPanel.cs
@@ -1,16 +1,11 @@
-﻿using System;
+﻿using MobiFlight.InputConfig;
+using MobiFlight.UI.Panels.Action;
+using MobiFlight.UI.Panels.Config;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
-using System.Data;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using MobiFlight;
-using MobiFlight.InputConfig;
-using MobiFlight.UI.Panels.Config;
-using System.Windows.Forms.DataVisualization.Charting;
-using MobiFlight.UI.Panels.Action;
 
 namespace MobiFlight.UI.Panels.Input
 {
@@ -18,41 +13,47 @@ namespace MobiFlight.UI.Panels.Input
     {
         public event EventHandler<EventArgs> OnPanelChanged;
         Dictionary<String, MobiFlightVariable> Variables = new Dictionary<String, MobiFlightVariable>();
-        InputConfig.ButtonInputConfig _config;
+        ButtonInputConfig _config;
+
+        Dictionary<ActionTypePanel, string> ActionTypePanelsToActionNames = new Dictionary<ActionTypePanel, string>();
+        Dictionary<ActionTypePanel, Panel> ActionTypePanelsToOwnerPanels = new Dictionary<ActionTypePanel, Panel>();
 
         private void clipBoardActionChanged(InputAction action)
         {
-            onPressActionTypePanel.OnClipBoardChanged(action);
-            onReleaseActionTypePanel.OnClipBoardChanged(action);
-            onLongReleaseActionTypePanel.OnClipBoardChanged(action);
+            foreach (ActionTypePanel panel in ActionTypePanelsToActionNames.Keys)
+            {
+                panel.OnClipBoardChanged(action);
+            }
         }
 
         public new bool Enabled {
             get { return onPressActionConfigPanel.Enabled;  }
-            set { 
-                onReleaseActionTypePanel.Enabled = value;
-                onLongReleaseActionTypePanel.Enabled = value;
-                onPressActionTypePanel.Enabled = value;
-                onPressActionConfigPanel.Enabled = value; 
-                onReleaseActionConfigPanel.Enabled = value;    
-                onLongRelActionConfigPanel.Enabled = value;
+            set 
+            {
+                foreach (var actionTypePanel in ActionTypePanelsToOwnerPanels.Keys)
+                {
+                    actionTypePanel.Enabled = value;
+                    ActionTypePanelsToOwnerPanels[actionTypePanel].Enabled = value;
+                }
             }
         }
         public ButtonPanel()
         {
             InitializeComponent();
-            onPressActionTypePanel.ActionTypeChanged += new MobiFlight.UI.Panels.Config.ActionTypePanel.ActionTypePanelSelectHandler(onPressActionTypePanel_ActionTypeChanged);
-            onReleaseActionTypePanel.ActionTypeChanged += new MobiFlight.UI.Panels.Config.ActionTypePanel.ActionTypePanelSelectHandler(onPressActionTypePanel_ActionTypeChanged);
-            onLongReleaseActionTypePanel.ActionTypeChanged += new MobiFlight.UI.Panels.Config.ActionTypePanel.ActionTypePanelSelectHandler(onPressActionTypePanel_ActionTypeChanged);
+            ActionTypePanelsToActionNames.Add(onPressActionTypePanel, "onPress");
+            ActionTypePanelsToActionNames.Add(onReleaseActionTypePanel, "onRelease");
+            ActionTypePanelsToActionNames.Add(onLongReleaseActionTypePanel, "onLongRelease");
 
-            List<ActionTypePanel> panels = new List<ActionTypePanel>() { 
-                onPressActionTypePanel, onReleaseActionTypePanel, onLongReleaseActionTypePanel
-            };
-            panels.ForEach(action =>
+            ActionTypePanelsToOwnerPanels.Add(onPressActionTypePanel, onPressActionConfigPanel);
+            ActionTypePanelsToOwnerPanels.Add(onReleaseActionTypePanel, onReleaseActionConfigPanel);
+            ActionTypePanelsToOwnerPanels.Add(onLongReleaseActionTypePanel, onLongRelActionConfigPanel);      
+
+            foreach (ActionTypePanel panel in ActionTypePanelsToActionNames.Keys)
             {
-                action.CopyButtonPressed += Action_CopyButtonPressed;
-                action.PasteButtonPressed += Action_PasteButtonPressed;
-            });
+                panel.ActionTypeChanged += onPressActionTypePanel_ActionTypeChanged;
+                panel.CopyButtonPressed += Action_CopyButtonPressed;
+                panel.PasteButtonPressed += Action_PasteButtonPressed;
+            }
 
             Clipboard.Instance.PropertyChanged += (object sender, PropertyChangedEventArgs e) =>
             {
@@ -71,222 +72,73 @@ namespace MobiFlight.UI.Panels.Input
 
         private void Action_CopyButtonPressed(object sender, EventArgs e)
         {
-            InputConfig.ButtonInputConfig config = new ButtonInputConfig();
+            ButtonInputConfig config = new ButtonInputConfig();
             ToConfig(config);
-            if ((sender as ActionTypePanel) == onPressActionTypePanel) { 
-                Clipboard.Instance.InputAction = config.onPress;
-            }
-            if ((sender as ActionTypePanel) == onReleaseActionTypePanel)
-            {
-                Clipboard.Instance.InputAction = config.onRelease;
-            }
-            if ((sender as ActionTypePanel) == onLongReleaseActionTypePanel)
-            {
-                Clipboard.Instance.InputAction = config.onLongRelease;
-            }
+            string inputActionName = ActionTypePanelsToActionNames[(ActionTypePanel)sender];
+            Clipboard.Instance.InputAction = config.GetInputActionByName(inputActionName);
         }
 
         private void Action_PasteButtonPressed(object sender, EventArgs e)
-        {
-            Panel owner = null;
+        {            
+            ActionTypePanel actionTypePanel = (ActionTypePanel)sender;
+            Panel owner = ActionTypePanelsToOwnerPanels[actionTypePanel];            
 
-            (sender as ActionTypePanel).syncFromConfig(Clipboard.Instance.InputAction);
+            // Set the selected item from config
+            actionTypePanel.syncFromConfig(Clipboard.Instance.InputAction);            
 
-            bool isPress = (sender as ActionTypePanel) == onPressActionTypePanel;
-            bool isRelease = (sender as ActionTypePanel) == onReleaseActionTypePanel;
-
-            InputConfig.ButtonInputConfig config = new ButtonInputConfig();
-            if (isPress)
-            {
-                owner = onPressActionConfigPanel; 
-                config.onPress = Clipboard.Instance.InputAction;
-            }
-            else if (isRelease)
-            {
-                owner = onReleaseActionConfigPanel;
-                config.onRelease = Clipboard.Instance.InputAction;
-            }
-            else
-            {
-                owner = onLongRelActionConfigPanel;
-                config.onLongRelease = Clipboard.Instance.InputAction;
-            }
-
-            String value = null;
-            String type = Clipboard.Instance.InputAction.GetType().ToString();
-
-            if (type == "MobiFlight.InputConfig.FsuipcOffsetInputAction") value = MobiFlight.InputConfig.FsuipcOffsetInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.KeyInputAction") value = MobiFlight.InputConfig.KeyInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.EventIdInputAction") value = MobiFlight.InputConfig.EventIdInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.PmdgEventIdInputAction") value = MobiFlight.InputConfig.PmdgEventIdInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.JeehellInputAction") value = MobiFlight.InputConfig.JeehellInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.VJoyInputAction") value = MobiFlight.InputConfig.VJoyInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.LuaMacroInputAction") value = MobiFlight.InputConfig.LuaMacroInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.RetriggerInputAction") value = MobiFlight.InputConfig.RetriggerInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.MSFS2020EventIdInputAction") value = MobiFlight.InputConfig.MSFS2020CustomInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.MSFS2020CustomInputAction") value = MobiFlight.InputConfig.MSFS2020CustomInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.VariableInputAction") value = MobiFlight.InputConfig.VariableInputAction.Label;
-            else if (type == "MobiFlight.InputConfig.XplaneInputAction") value = MobiFlight.InputConfig.XplaneInputAction.Label;
-
-            UpdatePanelWithAction(owner, config, value, isPress, isRelease);
+            // Create new button config
+            ButtonInputConfig config = new ButtonInputConfig();
+            string inputActionName = ActionTypePanelsToActionNames[actionTypePanel];
+            config.SetInputActionByName(inputActionName, Clipboard.Instance.InputAction);
+            
+            // Create the right config panel and fill with data
+            Type inputActionType = Clipboard.Instance.InputAction.GetType();          
+            String inputLabel = InputActionMapping.InputActionTypesToInputLabels[inputActionType];
+            UpdatePanelWithAction(owner, config, inputLabel, inputActionName);
         }
 
-        private void UpdatePanelWithAction(Panel owner, ButtonInputConfig config, string value, bool isOnPress, bool isOnRelease)
+
+        private void UpdatePanelWithAction(Panel owner, ButtonInputConfig config, string inputLabel, string inputActionName)
         {
-            this.SuspendLayout();
-            Control panel = null;
-            owner.Controls.Clear();
-            switch (value)
+            this.SuspendLayout();            
+            owner.Controls.Clear();  
+
+            // In case "None" is selected, then key is not in dictionary
+            if (InputActionMapping.InputLabelsToConfigPanelTypes.ContainsKey(inputLabel))
             {
-                case MobiFlight.InputConfig.FsuipcOffsetInputAction.Label:
-                    panel = new Panels.Config.FsuipcConfigPanel();
-                    (panel as Panels.Config.FsuipcConfigPanel).setMode(false);
+                Type configPanelType = InputActionMapping.InputLabelsToConfigPanelTypes[inputLabel];
 
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as Panels.Config.FsuipcConfigPanel).syncFromConfig(config.onPress as FsuipcOffsetInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as Panels.Config.FsuipcConfigPanel).syncFromConfig(config.onRelease as FsuipcOffsetInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as Panels.Config.FsuipcConfigPanel).syncFromConfig(config.onLongRelease as FsuipcOffsetInputAction);
+                // Create config panel
+                Control panel = (Control)Activator.CreateInstance(configPanelType);
 
-                    break;
+                // Special cases
+                if (inputLabel == FsuipcOffsetInputAction.Label)
+                {
+                    ((FsuipcConfigPanel)panel).setMode(false);
+                }
+                else if (inputLabel == VariableInputAction.Label)
+                {
+                    ((VariableInputPanel)panel).SetVariableReferences(Variables);
+                }
 
-                case InputConfig.KeyInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.KeyboardInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.KeyboardInputPanel).syncFromConfig(config.onPress as KeyInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.KeyboardInputPanel).syncFromConfig(config.onRelease as KeyInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.KeyboardInputPanel).syncFromConfig(config.onLongRelease as KeyInputAction);
+                // Sync data from config for inputAction
+                InputAction inputAction = config.GetInputActionByName(inputActionName);
+                if (config != null && inputAction != null)
+                {
+                    // Here always the current active inputAction is given as an argument.
+                    // When switching, the inputAction probably is of wrong type. That case is handled in each InputPanel.
+                    ((IPanelConfigSync)panel).syncFromConfig(inputAction);
+                }
 
-                    break;
-
-                case MobiFlight.InputConfig.EventIdInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.EventIdInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.EventIdInputPanel).syncFromConfig(config.onPress as EventIdInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.EventIdInputPanel).syncFromConfig(config.onRelease as EventIdInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.EventIdInputPanel).syncFromConfig(config.onLongRelease as EventIdInputAction);
-
-                    break;
-
-
-                case MobiFlight.InputConfig.PmdgEventIdInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.PmdgEventIdInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.PmdgEventIdInputPanel).syncFromConfig(config.onPress as PmdgEventIdInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.PmdgEventIdInputPanel).syncFromConfig(config.onRelease as PmdgEventIdInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.PmdgEventIdInputPanel).syncFromConfig(config.onLongRelease as PmdgEventIdInputAction);
-
-                    break;
-
-                case InputConfig.JeehellInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.JeehellInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.JeehellInputPanel).syncFromConfig(config.onPress as JeehellInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.JeehellInputPanel).syncFromConfig(config.onRelease as JeehellInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.JeehellInputPanel).syncFromConfig(config.onLongRelease as JeehellInputAction);
-
-                    break;
-
-                case InputConfig.VJoyInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.VJoyInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.VJoyInputPanel).syncFromConfig(config.onPress as VJoyInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.VJoyInputPanel).syncFromConfig(config.onRelease as VJoyInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.VJoyInputPanel).syncFromConfig(config.onLongRelease as VJoyInputAction);
-                    break;
-
-                case MobiFlight.InputConfig.LuaMacroInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.LuaMacroInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.LuaMacroInputPanel).syncFromConfig(config.onPress as LuaMacroInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.LuaMacroInputPanel).syncFromConfig(config.onRelease as LuaMacroInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.LuaMacroInputPanel).syncFromConfig(config.onLongRelease as LuaMacroInputAction);
-
-                    break;
-
-                case MobiFlight.InputConfig.RetriggerInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.RetriggerInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.RetriggerInputPanel).syncFromConfig(config.onPress as RetriggerInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.RetriggerInputPanel).syncFromConfig(config.onRelease as RetriggerInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.RetriggerInputPanel).syncFromConfig(config.onLongRelease as RetriggerInputAction);
-
-                    break;
-
-                case MobiFlight.InputConfig.VariableInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.VariableInputPanel();
-                    (panel as MobiFlight.UI.Panels.Action.VariableInputPanel).SetVariableReferences(Variables);
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.VariableInputPanel).syncFromConfig(config.onPress as VariableInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.VariableInputPanel).syncFromConfig(config.onRelease as VariableInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.VariableInputPanel).syncFromConfig(config.onLongRelease as VariableInputAction);
-
-                    break;
-
-                // For backward compatibility this is now combined and MSFS2020EventIdInputAction was removed
-                case MobiFlight.InputConfig.MSFS2020CustomInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                    {
-                        if (config.onPress is MSFS2020CustomInputAction)
-                            (panel as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).syncFromConfig(config.onPress as MSFS2020CustomInputAction);
-                        else if (config.onPress is MSFS2020EventIdInputAction)
-                            (panel as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).syncFromConfig(config.onPress as MSFS2020EventIdInputAction);
-                    }
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                    {
-                        if (config.onRelease is MSFS2020CustomInputAction)
-                            (panel as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).syncFromConfig(config.onRelease as MSFS2020CustomInputAction);
-                        else if (config.onRelease is MSFS2020EventIdInputAction)
-                            (panel as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).syncFromConfig(config.onRelease as MSFS2020EventIdInputAction);
-                    }
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                    {
-                        if (config.onLongRelease is MSFS2020CustomInputAction)
-                            (panel as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).syncFromConfig(config.onLongRelease as MSFS2020CustomInputAction);
-                        else if (config.onLongRelease is MSFS2020EventIdInputAction)
-                            (panel as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).syncFromConfig(config.onLongRelease as MSFS2020EventIdInputAction);
-                    }
-
-                    break;
-
-                case MobiFlight.InputConfig.XplaneInputAction.Label:
-                    panel = new MobiFlight.UI.Panels.Action.XplaneInputPanel();
-                    if (isOnPress && config != null && config.onPress != null)
-                        (panel as MobiFlight.UI.Panels.Action.XplaneInputPanel).syncFromConfig(config.onPress as XplaneInputAction);
-                    else if (isOnRelease && config != null && config.onRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.XplaneInputPanel).syncFromConfig(config.onRelease as XplaneInputAction);
-                    else if (!isOnRelease && config != null && config.onLongRelease != null)
-                        (panel as MobiFlight.UI.Panels.Action.XplaneInputPanel).syncFromConfig(config.onLongRelease as XplaneInputAction);
-
-                    break;
-            }
-
-            if (panel != null)
-            {
                 panel.Padding = new Padding(2, 0, 2, 0);
                 panel.Dock = DockStyle.Top;
+
+                // Add config panel to owner panel
                 owner.Controls.Add(panel);
                 owner.Dock = DockStyle.Top;
                 OnPanelChanged?.Invoke(panel, EventArgs.Empty);
             }
+                       
             this.ResumeLayout(true);
         }
 
@@ -298,222 +150,47 @@ namespace MobiFlight.UI.Panels.Input
         // On Press Action
         private void onPressActionTypePanel_ActionTypeChanged(object sender, String value)
         {
-            Panel owner = onPressActionConfigPanel;
-            bool isOnPress = (sender as MobiFlight.UI.Panels.Config.ActionTypePanel) == onPressActionTypePanel;
-            bool isOnRelease = (sender as MobiFlight.UI.Panels.Config.ActionTypePanel) == onReleaseActionTypePanel;
-            if (isOnPress)
-            {
-                owner = onPressActionConfigPanel;
-            }
-            else if (isOnRelease)
-            {
-                owner = onReleaseActionConfigPanel;
-            }
-            else
-            {
-                owner = onLongRelActionConfigPanel;
-            }
-
-            UpdatePanelWithAction(owner, _config, value, isOnPress, isOnRelease);
+            string inputLabel = value;
+            ActionTypePanel actionTypePanel = (ActionTypePanel)sender;
+            Panel owner = ActionTypePanelsToOwnerPanels[actionTypePanel];            
+            string inputActionName = ActionTypePanelsToActionNames[actionTypePanel];
+            UpdatePanelWithAction(owner, _config, inputLabel, inputActionName);
         }
 
-        public void syncFromConfig(InputConfig.ButtonInputConfig config)
+        public void syncFromConfig(ButtonInputConfig config)
         {
             if (config == null) return;
 
             _config = config;
 
-            if (_config.onPress != null)
+            // Iterate through all ActionTypePanels and read config
+            foreach (var actionTypePanel in ActionTypePanelsToOwnerPanels.Keys)
             {
-                onPressActionTypePanel.syncFromConfig(_config.onPress);
-            }
-            
-            if (_config.onRelease != null)
-            {
-                onReleaseActionTypePanel.syncFromConfig(_config.onRelease);
-            }
-
-            if (_config.onLongRelease != null)
-            {
-                onLongReleaseActionTypePanel.syncFromConfig(_config.onLongRelease);
+                string inputActionName = ActionTypePanelsToActionNames[actionTypePanel];
+                InputAction inputAction = config.GetInputActionByName(inputActionName);
+                if (inputAction != null)
+                {
+                    actionTypePanel.syncFromConfig(inputAction);
+                }
             }
         }
 
-        public void ToConfig(InputConfig.ButtonInputConfig config)
+        public void ToConfig(ButtonInputConfig config)
         {
-            // for on press check the action type
-            if (onPressActionTypePanel.ActionTypeComboBox.SelectedItem != null)
+           // Iterate through all ActionTypePanels and set config
+            foreach (var actionTypePanel in ActionTypePanelsToOwnerPanels.Keys)
             {
-                switch (onPressActionTypePanel.ActionTypeComboBox.SelectedItem.ToString())
+                if (actionTypePanel.ActionTypeComboBox.SelectedItem != null)
                 {
-                    case MobiFlight.InputConfig.FsuipcOffsetInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Config.FsuipcConfigPanel).ToConfig();
-                        break;
+                    var ownerPanel = ActionTypePanelsToOwnerPanels[actionTypePanel];
 
-                    case InputConfig.KeyInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.KeyboardInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.EventIdInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.EventIdInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.PmdgEventIdInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.PmdgEventIdInputPanel).ToConfig();
-                        break;
-
-                    case InputConfig.JeehellInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.JeehellInputPanel).ToConfig();
-                        break;
-
-                    case InputConfig.VJoyInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.VJoyInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.LuaMacroInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.LuaMacroInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.RetriggerInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.RetriggerInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.MSFS2020EventIdInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.MSFS2020InputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.MSFS2020CustomInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.VariableInputAction.Label:                        
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.VariableInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.XplaneInputAction.Label:
-                        config.onPress = (onPressActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.XplaneInputPanel).ToConfig();
-                        break;
-
-                    default:
-                        config.onPress = null;
-                        break;
-                }
-            }
-
-            if (onReleaseActionTypePanel.ActionTypeComboBox.SelectedItem != null)
-            {
-                switch (onReleaseActionTypePanel.ActionTypeComboBox.SelectedItem.ToString())
-                {
-                    case MobiFlight.InputConfig.FsuipcOffsetInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Config.FsuipcConfigPanel).ToConfig();
-                        break;
-
-                    case InputConfig.KeyInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.KeyboardInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.EventIdInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.EventIdInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.PmdgEventIdInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.PmdgEventIdInputPanel).ToConfig();
-                        break;
-
-                    case InputConfig.JeehellInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.JeehellInputPanel).ToConfig();
-                        break;
-
-                    case InputConfig.VJoyInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.VJoyInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.LuaMacroInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.LuaMacroInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.RetriggerInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.RetriggerInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.MSFS2020EventIdInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.MSFS2020InputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.MSFS2020CustomInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.VariableInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.VariableInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.XplaneInputAction.Label:
-                        config.onRelease = (onReleaseActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.XplaneInputPanel).ToConfig();
-                        break;
-
-                    default:
-                        config.onRelease = null;
-                        break;
-                }
-            }
-            
-            if (onLongReleaseActionTypePanel.ActionTypeComboBox.SelectedItem != null)
-            {
-                switch (onLongReleaseActionTypePanel.ActionTypeComboBox.SelectedItem.ToString())
-                {
-                    
-                    case MobiFlight.InputConfig.FsuipcOffsetInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Config.FsuipcConfigPanel).ToConfig();
-                        break;
-
-                    case InputConfig.KeyInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.KeyboardInputPanel).ToConfig();
-                        break;
-                      
-                    case MobiFlight.InputConfig.EventIdInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.EventIdInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.PmdgEventIdInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.PmdgEventIdInputPanel).ToConfig();
-                        break;
-
-                    case InputConfig.JeehellInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.JeehellInputPanel).ToConfig();
-                        break;
-
-                    case InputConfig.VJoyInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.VJoyInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.LuaMacroInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.LuaMacroInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.RetriggerInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.RetriggerInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.MSFS2020EventIdInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.MSFS2020InputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.MSFS2020CustomInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.MSFS2020CustomInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.VariableInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.VariableInputPanel).ToConfig();
-                        break;
-
-                    case MobiFlight.InputConfig.XplaneInputAction.Label:
-                        config.onLongRelease = (onLongRelActionConfigPanel.Controls[0] as MobiFlight.UI.Panels.Action.XplaneInputPanel).ToConfig();
-                        break;
-
-                    default:
-                        config.onLongRelease = null;
-                        break;
+                    // Does the ownerPanel contain an action config panel?
+                    if (ownerPanel.Controls.Count > 0)
+                    {
+                        InputAction inputAction = ((IPanelConfigSync)ownerPanel.Controls[0]).ToConfig();
+                        string inputActionName = ActionTypePanelsToActionNames[actionTypePanel];
+                        config.SetInputActionByName(inputActionName, inputAction);
+                    }
                 }
             }
         }

--- a/UI/Panels/Input/ButtonPanel.cs
+++ b/UI/Panels/Input/ButtonPanel.cs
@@ -177,19 +177,24 @@ namespace MobiFlight.UI.Panels.Input
 
         public void ToConfig(ButtonInputConfig config)
         {
-           // Iterate through all ActionTypePanels and set config
+            // Iterate through all ActionTypePanels and set config
             foreach (var actionTypePanel in ActionTypePanelsToOwnerPanels.Keys)
             {
                 if (actionTypePanel.ActionTypeComboBox.SelectedItem != null)
                 {
                     var ownerPanel = ActionTypePanelsToOwnerPanels[actionTypePanel];
+                    string inputActionName = ActionTypePanelsToActionNames[actionTypePanel];
 
                     // Does the ownerPanel contain an action config panel?
                     if (ownerPanel.Controls.Count > 0)
                     {
                         InputAction inputAction = ((IPanelConfigSync)ownerPanel.Controls[0]).ToConfig();
-                        string inputActionName = ActionTypePanelsToActionNames[actionTypePanel];
                         config.SetInputActionByName(inputActionName, inputAction);
+                    }
+                    // case "None", reset to Null
+                    else
+                    {
+                        config.SetInputActionByName(inputActionName, null);
                     }
                 }
             }


### PR DESCRIPTION
Refactor `ButtonPanel` and remove all the long copy and paste switch cases. `ButtonPanel` is shrinked from 520 to 200 lines.

- All input panels now share the same interface `IPanelConfigSync`
- Input actions are mapped to input panels in `InputActionMapping.cs`
- In `ButtonInputConfig` two new methods are introduced:
   - `SetInputActionByName`
   - `GetInputActionByName`

If the refactoring is approved, it can also be applied to the other panels like `AnalogPanel` or `EncoderPanel`.

-> Now introducing a new tab or a new input panel is just a couple lines of code.

- [x] Resolve Issue of Setting Input Action back to "None".