### PR TITLE
Use mono-space in code text fields

### DIFF
--- a/UI/Panels/Config/HubHopPresetPanel.Designer.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.Designer.cs
@@ -30,6 +30,9 @@
         {
             this.FilterGroupBox = new System.Windows.Forms.GroupBox();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.TextFilterPanel = new System.Windows.Forms.Panel();
+            this.FilterTextBox = new System.Windows.Forms.TextBox();
+            this.FilterLabel = new System.Windows.Forms.Label();
             this.FilterVendorPanel = new System.Windows.Forms.Panel();
             this.VendorComboBox = new System.Windows.Forms.ComboBox();
             this.VendorLabel = new System.Windows.Forms.Label();
@@ -39,9 +42,6 @@
             this.SystemFilterPanel = new System.Windows.Forms.Panel();
             this.SystemComboBox = new System.Windows.Forms.ComboBox();
             this.SystemLabel = new System.Windows.Forms.Label();
-            this.TextFilterPanel = new System.Windows.Forms.Panel();
-            this.FilterTextBox = new System.Windows.Forms.TextBox();
-            this.FilterLabel = new System.Windows.Forms.Label();
             this.ResetButton = new System.Windows.Forms.Button();
             this.PresetGroupBox = new System.Windows.Forms.GroupBox();
             this.ExpertSettingsPanel = new System.Windows.Forms.Panel();
@@ -73,10 +73,10 @@
             this.ShowExpertSettingsCheckBox = new System.Windows.Forms.CheckBox();
             this.FilterGroupBox.SuspendLayout();
             this.flowLayoutPanel1.SuspendLayout();
+            this.TextFilterPanel.SuspendLayout();
             this.FilterVendorPanel.SuspendLayout();
             this.AircraftFilterPanel.SuspendLayout();
             this.SystemFilterPanel.SuspendLayout();
-            this.TextFilterPanel.SuspendLayout();
             this.PresetGroupBox.SuspendLayout();
             this.ExpertSettingsPanel.SuspendLayout();
             this.Msfs2020Panel.SuspendLayout();
@@ -119,6 +119,36 @@
             this.flowLayoutPanel1.Padding = new System.Windows.Forms.Padding(70, 0, 0, 0);
             this.flowLayoutPanel1.Size = new System.Drawing.Size(594, 46);
             this.flowLayoutPanel1.TabIndex = 16;
+            // 
+            // TextFilterPanel
+            // 
+            this.TextFilterPanel.Controls.Add(this.FilterTextBox);
+            this.TextFilterPanel.Controls.Add(this.FilterLabel);
+            this.TextFilterPanel.Location = new System.Drawing.Point(72, 2);
+            this.TextFilterPanel.Margin = new System.Windows.Forms.Padding(2);
+            this.TextFilterPanel.Name = "TextFilterPanel";
+            this.TextFilterPanel.Size = new System.Drawing.Size(113, 40);
+            this.TextFilterPanel.TabIndex = 20;
+            // 
+            // FilterTextBox
+            // 
+            this.FilterTextBox.Dock = System.Windows.Forms.DockStyle.Top;
+            this.FilterTextBox.Location = new System.Drawing.Point(0, 13);
+            this.FilterTextBox.Name = "FilterTextBox";
+            this.FilterTextBox.Size = new System.Drawing.Size(113, 20);
+            this.FilterTextBox.TabIndex = 9;
+            // 
+            // FilterLabel
+            // 
+            this.FilterLabel.AutoSize = true;
+            this.FilterLabel.Dock = System.Windows.Forms.DockStyle.Top;
+            this.FilterLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            this.FilterLabel.Location = new System.Drawing.Point(0, 0);
+            this.FilterLabel.Name = "FilterLabel";
+            this.FilterLabel.Size = new System.Drawing.Size(41, 13);
+            this.FilterLabel.TabIndex = 10;
+            this.FilterLabel.Text = "Search";
+            this.FilterLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // FilterVendorPanel
             // 
@@ -218,36 +248,6 @@
             this.SystemLabel.TabIndex = 4;
             this.SystemLabel.Text = "System";
             this.SystemLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // TextFilterPanel
-            // 
-            this.TextFilterPanel.Controls.Add(this.FilterTextBox);
-            this.TextFilterPanel.Controls.Add(this.FilterLabel);
-            this.TextFilterPanel.Location = new System.Drawing.Point(72, 2);
-            this.TextFilterPanel.Margin = new System.Windows.Forms.Padding(2);
-            this.TextFilterPanel.Name = "TextFilterPanel";
-            this.TextFilterPanel.Size = new System.Drawing.Size(113, 40);
-            this.TextFilterPanel.TabIndex = 20;
-            // 
-            // FilterTextBox
-            // 
-            this.FilterTextBox.Dock = System.Windows.Forms.DockStyle.Top;
-            this.FilterTextBox.Location = new System.Drawing.Point(0, 13);
-            this.FilterTextBox.Name = "FilterTextBox";
-            this.FilterTextBox.Size = new System.Drawing.Size(113, 20);
-            this.FilterTextBox.TabIndex = 9;
-            // 
-            // FilterLabel
-            // 
-            this.FilterLabel.AutoSize = true;
-            this.FilterLabel.Dock = System.Windows.Forms.DockStyle.Top;
-            this.FilterLabel.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.FilterLabel.Location = new System.Drawing.Point(0, 0);
-            this.FilterLabel.Name = "FilterLabel";
-            this.FilterLabel.Size = new System.Drawing.Size(41, 13);
-            this.FilterLabel.TabIndex = 10;
-            this.FilterLabel.Text = "Search";
-            this.FilterLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // ResetButton
             // 
@@ -472,6 +472,7 @@
             // 
             this.SimVarNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.SimVarNameTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.SimVarNameTextBox.Location = new System.Drawing.Point(75, 3);
             this.SimVarNameTextBox.MaxLength = 1024;
             this.SimVarNameTextBox.Multiline = true;
@@ -596,14 +597,14 @@
             this.FilterGroupBox.ResumeLayout(false);
             this.FilterGroupBox.PerformLayout();
             this.flowLayoutPanel1.ResumeLayout(false);
+            this.TextFilterPanel.ResumeLayout(false);
+            this.TextFilterPanel.PerformLayout();
             this.FilterVendorPanel.ResumeLayout(false);
             this.FilterVendorPanel.PerformLayout();
             this.AircraftFilterPanel.ResumeLayout(false);
             this.AircraftFilterPanel.PerformLayout();
             this.SystemFilterPanel.ResumeLayout(false);
             this.SystemFilterPanel.PerformLayout();
-            this.TextFilterPanel.ResumeLayout(false);
-            this.TextFilterPanel.PerformLayout();
             this.PresetGroupBox.ResumeLayout(false);
             this.PresetGroupBox.PerformLayout();
             this.ExpertSettingsPanel.ResumeLayout(false);

--- a/UI/Panels/Config/HubHopPresetPanel.Designer.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.Designer.cs
@@ -472,7 +472,7 @@
             // 
             this.SimVarNameTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.SimVarNameTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.SimVarNameTextBox.Font = new System.Drawing.Font("Cascadia Mono", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.SimVarNameTextBox.Location = new System.Drawing.Point(75, 3);
             this.SimVarNameTextBox.MaxLength = 1024;
             this.SimVarNameTextBox.Multiline = true;

--- a/UI/Panels/Modifier/ComparisonModifierPanel.Designer.cs
+++ b/UI/Panels/Modifier/ComparisonModifierPanel.Designer.cs
@@ -82,7 +82,7 @@
             // 
             // comparisonValueTextBox
             // 
-            this.comparisonValueTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.comparisonValueTextBox.Font = new System.Drawing.Font("Cascadia Mono", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comparisonValueTextBox.Location = new System.Drawing.Point(51, 19);
             this.comparisonValueTextBox.Name = "comparisonValueTextBox";
             this.comparisonValueTextBox.Size = new System.Drawing.Size(100, 20);
@@ -90,7 +90,7 @@
             // 
             // comparisonElseValueTextBox
             // 
-            this.comparisonElseValueTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.comparisonElseValueTextBox.Font = new System.Drawing.Font("Cascadia Mono", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comparisonElseValueTextBox.Location = new System.Drawing.Point(286, 19);
             this.comparisonElseValueTextBox.Name = "comparisonElseValueTextBox";
             this.comparisonElseValueTextBox.Size = new System.Drawing.Size(100, 20);
@@ -109,7 +109,7 @@
             // 
             // comparisonIfValueTextBox
             // 
-            this.comparisonIfValueTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.comparisonIfValueTextBox.Font = new System.Drawing.Font("Cascadia Mono", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comparisonIfValueTextBox.Location = new System.Drawing.Point(169, 19);
             this.comparisonIfValueTextBox.Name = "comparisonIfValueTextBox";
             this.comparisonIfValueTextBox.Size = new System.Drawing.Size(100, 20);

--- a/UI/Panels/Modifier/ComparisonModifierPanel.Designer.cs
+++ b/UI/Panels/Modifier/ComparisonModifierPanel.Designer.cs
@@ -82,6 +82,7 @@
             // 
             // comparisonValueTextBox
             // 
+            this.comparisonValueTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comparisonValueTextBox.Location = new System.Drawing.Point(51, 19);
             this.comparisonValueTextBox.Name = "comparisonValueTextBox";
             this.comparisonValueTextBox.Size = new System.Drawing.Size(100, 20);
@@ -89,6 +90,7 @@
             // 
             // comparisonElseValueTextBox
             // 
+            this.comparisonElseValueTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comparisonElseValueTextBox.Location = new System.Drawing.Point(286, 19);
             this.comparisonElseValueTextBox.Name = "comparisonElseValueTextBox";
             this.comparisonElseValueTextBox.Size = new System.Drawing.Size(100, 20);
@@ -107,6 +109,7 @@
             // 
             // comparisonIfValueTextBox
             // 
+            this.comparisonIfValueTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.comparisonIfValueTextBox.Location = new System.Drawing.Point(169, 19);
             this.comparisonIfValueTextBox.Name = "comparisonIfValueTextBox";
             this.comparisonIfValueTextBox.Size = new System.Drawing.Size(100, 20);

--- a/UI/Panels/Modifier/TransformModifierPanel.Designer.cs
+++ b/UI/Panels/Modifier/TransformModifierPanel.Designer.cs
@@ -50,7 +50,7 @@
             // 
             this.expressionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.expressionTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.expressionTextBox.Font = new System.Drawing.Font("Cascadia Mono", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.expressionTextBox.Location = new System.Drawing.Point(3, 4);
             this.expressionTextBox.Name = "expressionTextBox";
             this.expressionTextBox.Size = new System.Drawing.Size(394, 20);

--- a/UI/Panels/Modifier/TransformModifierPanel.Designer.cs
+++ b/UI/Panels/Modifier/TransformModifierPanel.Designer.cs
@@ -50,6 +50,7 @@
             // 
             this.expressionTextBox.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.expressionTextBox.Font = new System.Drawing.Font("Cascadia Code", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.expressionTextBox.Location = new System.Drawing.Point(3, 4);
             this.expressionTextBox.Name = "expressionTextBox";
             this.expressionTextBox.Size = new System.Drawing.Size(394, 20);


### PR DESCRIPTION
fixes #1231 

- [x] use Cascadia Code as font - great readability while rather narrow and less space consuming.
- [x] Output Configs - MSFS2020 / X-Plane
- [x] Input Configs - MSFS2020 / X-Plane
- [x] Modifiers - Transformation, Comparison


Other options:
* courier new, lucida console - both don't look as nice, I am not 100% sure if Cascadia Code will work on Win7 - I hope it falls back to some Arial or whatever font is default on the system. 