### PR TITLE
Log a success message when firmware update completes

### DIFF
--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -98,6 +98,7 @@ namespace MobiFlight
                     System.Threading.Thread.Sleep(module.Board.Connection.DelayAfterFirmwareUpdate);
                 }
 
+                Log.Instance.log($"Firmware update for {module.Board.Info.MobiFlightType} ({module.Port}) completed successfully", LogSeverity.Info);
                 result = true;
             }
             catch


### PR DESCRIPTION
Fixes #1216 

Add a log message after the firmware update succeeds:

```
Info	11/09/2023 09:39:15	Firmware update for MobiFlight Micro (COM6) completed successfully
```