### PR TITLE
Rearrange config via drag n drop

### DIFF
--- a/Base/DPIUtil.cs
+++ b/Base/DPIUtil.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Windows.Forms;
+
+namespace MobiFlight.Base
+{
+    public static class DPIUtil
+    {
+        [DllImport("gdi32.dll", CharSet = CharSet.Auto, SetLastError = true, ExactSpelling = true)]
+        public static extern int GetDeviceCaps(IntPtr hDC, int nIndex);
+
+        public enum DeviceCap
+        {
+            VERTRES = 10,
+            DESKTOPVERTRES = 117
+        }
+
+        public static double GetWindowsScreenScalingFactor(bool percentage = true)
+        {
+            //Create Graphics object from the current windows handle
+            Graphics GraphicsObject = Graphics.FromHwnd(IntPtr.Zero);
+            //Get Handle to the device context associated with this Graphics object
+            IntPtr DeviceContextHandle = GraphicsObject.GetHdc();
+            //Call GetDeviceCaps with the Handle to retrieve the Screen Height
+            int LogicalScreenHeight = GetDeviceCaps(DeviceContextHandle, (int)DeviceCap.VERTRES);
+            int PhysicalScreenHeight = GetDeviceCaps(DeviceContextHandle, (int)DeviceCap.DESKTOPVERTRES);
+            //Divide the Screen Heights to get the scaling factor and round it to two decimals
+            double ScreenScalingFactor = Math.Round((double)PhysicalScreenHeight / (double)LogicalScreenHeight, 2);
+            //If requested as percentage - convert it
+            if (percentage)
+            {
+                ScreenScalingFactor *= 100.0;
+            }
+            //Release the Handle and Dispose of the GraphicsObject object
+            GraphicsObject.ReleaseHdc(DeviceContextHandle);
+            GraphicsObject.Dispose();
+            //Return the Scaling Factor
+            return ScreenScalingFactor;
+        }
+    }
+}

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -232,6 +232,7 @@
     <Compile Include="Base\CacheInterface.cs" />
     <Compile Include="Base\ConfigRef.cs" />
     <Compile Include="Base\ConfigRefList.cs" />
+    <Compile Include="Base\DPIUtil.cs" />
     <Compile Include="Base\Extensions.cs" />
     <Compile Include="Base\FullCacheInterface.cs" />
     <Compile Include="Base\i18n.cs" />

--- a/UI/Panels/InputConfigPanel.Designer.cs
+++ b/UI/Panels/InputConfigPanel.Designer.cs
@@ -30,10 +30,10 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(InputConfigPanel));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle17 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle18 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle19 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle20 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
             this.inputsDataGridViewContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -200,6 +200,8 @@
             this.inputsDataGridView.DefaultValuesNeeded += new System.Windows.Forms.DataGridViewRowEventHandler(this.inputsDataGridViewConfig_DefaultValuesNeeded);
             this.inputsDataGridView.DragDrop += new System.Windows.Forms.DragEventHandler(this.inputsDataGridView_DragDrop);
             this.inputsDataGridView.DragOver += new System.Windows.Forms.DragEventHandler(this.inputsDataGridView_DragOver);
+            this.inputsDataGridView.GiveFeedback += new System.Windows.Forms.GiveFeedbackEventHandler(this.inputsDataGridView_GiveFeedback);
+            this.inputsDataGridView.QueryContinueDrag += new System.Windows.Forms.QueryContinueDragEventHandler(this.inputsDataGridView_QueryContinueDrag);
             this.inputsDataGridView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridViewConfig_KeyUp);
             this.inputsDataGridView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.inputsDataGridView_MouseDown);
             this.inputsDataGridView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.inputsDataGridView_MouseMove);
@@ -230,8 +232,8 @@
             // 
             this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.moduleSerial.DataPropertyName = "moduleSerial";
-            dataGridViewCellStyle17.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle17;
+            dataGridViewCellStyle9.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle9;
             this.moduleSerial.FillWeight = 150F;
             resources.ApplyResources(this.moduleSerial, "moduleSerial");
             this.moduleSerial.Name = "moduleSerial";
@@ -242,8 +244,8 @@
             // 
             this.inputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.inputName.DataPropertyName = "inputName";
-            dataGridViewCellStyle18.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.inputName.DefaultCellStyle = dataGridViewCellStyle18;
+            dataGridViewCellStyle10.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.inputName.DefaultCellStyle = dataGridViewCellStyle10;
             this.inputName.FillWeight = 150F;
             resources.ApplyResources(this.inputName, "inputName");
             this.inputName.Name = "inputName";
@@ -254,8 +256,8 @@
             // 
             this.inputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.inputType.DataPropertyName = "inputType";
-            dataGridViewCellStyle19.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.inputType.DefaultCellStyle = dataGridViewCellStyle19;
+            dataGridViewCellStyle11.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.inputType.DefaultCellStyle = dataGridViewCellStyle11;
             this.inputType.FillWeight = 150F;
             resources.ApplyResources(this.inputType, "inputType");
             this.inputType.Name = "inputType";
@@ -264,10 +266,10 @@
             // inputEditButtonColumn
             // 
             this.inputEditButtonColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle20.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle20.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle20.NullValue = "...";
-            this.inputEditButtonColumn.DefaultCellStyle = dataGridViewCellStyle20;
+            dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle12.NullValue = "...";
+            this.inputEditButtonColumn.DefaultCellStyle = dataGridViewCellStyle12;
             resources.ApplyResources(this.inputEditButtonColumn, "inputEditButtonColumn");
             this.inputEditButtonColumn.Name = "inputEditButtonColumn";
             this.inputEditButtonColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;

--- a/UI/Panels/InputConfigPanel.Designer.cs
+++ b/UI/Panels/InputConfigPanel.Designer.cs
@@ -30,10 +30,10 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(InputConfigPanel));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle17 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle18 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle19 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle20 = new System.Windows.Forms.DataGridViewCellStyle();
             this.inputsDataGridViewContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -65,7 +65,6 @@
             // 
             // inputsDataGridViewContextMenuStrip
             // 
-            resources.ApplyResources(this.inputsDataGridViewContextMenuStrip, "inputsDataGridViewContextMenuStrip");
             this.inputsDataGridViewContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyToolStripMenuItem,
             this.pasteToolStripMenuItem,
@@ -73,35 +72,36 @@
             this.duplicateInputsRowToolStripMenuItem,
             this.deleteInputsRowToolStripMenuItem});
             this.inputsDataGridViewContextMenuStrip.Name = "inputsDataGridViewContextMenuStrip";
+            resources.ApplyResources(this.inputsDataGridViewContextMenuStrip, "inputsDataGridViewContextMenuStrip");
             this.inputsDataGridViewContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.inputsDataGridViewContextMenuStrip_Opening);
             // 
             // copyToolStripMenuItem
             // 
-            resources.ApplyResources(this.copyToolStripMenuItem, "copyToolStripMenuItem");
             this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
+            resources.ApplyResources(this.copyToolStripMenuItem, "copyToolStripMenuItem");
             this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
             // 
             // pasteToolStripMenuItem
             // 
-            resources.ApplyResources(this.pasteToolStripMenuItem, "pasteToolStripMenuItem");
             this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
+            resources.ApplyResources(this.pasteToolStripMenuItem, "pasteToolStripMenuItem");
             this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
             // 
             // toolStripMenuItem1
             // 
-            resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
             // 
             // duplicateInputsRowToolStripMenuItem
             // 
-            resources.ApplyResources(this.duplicateInputsRowToolStripMenuItem, "duplicateInputsRowToolStripMenuItem");
             this.duplicateInputsRowToolStripMenuItem.Name = "duplicateInputsRowToolStripMenuItem";
+            resources.ApplyResources(this.duplicateInputsRowToolStripMenuItem, "duplicateInputsRowToolStripMenuItem");
             this.duplicateInputsRowToolStripMenuItem.Click += new System.EventHandler(this.duplicateInputsRowToolStripMenuItem_Click);
             // 
             // deleteInputsRowToolStripMenuItem
             // 
-            resources.ApplyResources(this.deleteInputsRowToolStripMenuItem, "deleteInputsRowToolStripMenuItem");
             this.deleteInputsRowToolStripMenuItem.Name = "deleteInputsRowToolStripMenuItem";
+            resources.ApplyResources(this.deleteInputsRowToolStripMenuItem, "deleteInputsRowToolStripMenuItem");
             this.deleteInputsRowToolStripMenuItem.Click += new System.EventHandler(this.deleteInputsRowToolStripMenuItem_Click);
             // 
             // dataSetInputs
@@ -166,11 +166,12 @@
             // 
             // inputsDataGridView
             // 
-            resources.ApplyResources(this.inputsDataGridView, "inputsDataGridView");
+            this.inputsDataGridView.AllowDrop = true;
             this.inputsDataGridView.AllowUserToResizeRows = false;
             this.inputsDataGridView.AutoGenerateColumns = false;
             this.inputsDataGridView.BackgroundColor = System.Drawing.SystemColors.Window;
             this.inputsDataGridView.ClipboardCopyMode = System.Windows.Forms.DataGridViewClipboardCopyMode.Disable;
+            resources.ApplyResources(this.inputsDataGridView, "inputsDataGridView");
             this.inputsDataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.DisableResizing;
             this.inputsDataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.inputActive,
@@ -197,7 +198,11 @@
             this.inputsDataGridView.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.inputsDataGridView_CellMouseDown);
             this.inputsDataGridView.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.inputsDataGridView_DataBindingComplete);
             this.inputsDataGridView.DefaultValuesNeeded += new System.Windows.Forms.DataGridViewRowEventHandler(this.inputsDataGridViewConfig_DefaultValuesNeeded);
+            this.inputsDataGridView.DragDrop += new System.Windows.Forms.DragEventHandler(this.inputsDataGridView_DragDrop);
+            this.inputsDataGridView.DragOver += new System.Windows.Forms.DragEventHandler(this.inputsDataGridView_DragOver);
             this.inputsDataGridView.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridViewConfig_KeyUp);
+            this.inputsDataGridView.MouseDown += new System.Windows.Forms.MouseEventHandler(this.inputsDataGridView_MouseDown);
+            this.inputsDataGridView.MouseMove += new System.Windows.Forms.MouseEventHandler(this.inputsDataGridView_MouseMove);
             // 
             // inputActive
             // 
@@ -225,8 +230,8 @@
             // 
             this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.moduleSerial.DataPropertyName = "moduleSerial";
-            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle5;
+            dataGridViewCellStyle17.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle17;
             this.moduleSerial.FillWeight = 150F;
             resources.ApplyResources(this.moduleSerial, "moduleSerial");
             this.moduleSerial.Name = "moduleSerial";
@@ -237,8 +242,8 @@
             // 
             this.inputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.inputName.DataPropertyName = "inputName";
-            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.inputName.DefaultCellStyle = dataGridViewCellStyle6;
+            dataGridViewCellStyle18.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.inputName.DefaultCellStyle = dataGridViewCellStyle18;
             this.inputName.FillWeight = 150F;
             resources.ApplyResources(this.inputName, "inputName");
             this.inputName.Name = "inputName";
@@ -249,8 +254,8 @@
             // 
             this.inputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.inputType.DataPropertyName = "inputType";
-            dataGridViewCellStyle7.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.inputType.DefaultCellStyle = dataGridViewCellStyle7;
+            dataGridViewCellStyle19.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.inputType.DefaultCellStyle = dataGridViewCellStyle19;
             this.inputType.FillWeight = 150F;
             resources.ApplyResources(this.inputType, "inputType");
             this.inputType.Name = "inputType";
@@ -259,10 +264,10 @@
             // inputEditButtonColumn
             // 
             this.inputEditButtonColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle8.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle8.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle8.NullValue = "...";
-            this.inputEditButtonColumn.DefaultCellStyle = dataGridViewCellStyle8;
+            dataGridViewCellStyle20.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle20.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle20.NullValue = "...";
+            this.inputEditButtonColumn.DefaultCellStyle = dataGridViewCellStyle20;
             resources.ApplyResources(this.inputEditButtonColumn, "inputEditButtonColumn");
             this.inputEditButtonColumn.Name = "inputEditButtonColumn";
             this.inputEditButtonColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -641,12 +641,13 @@ namespace MobiFlight.UI.Panels
 
         private void AddDragTargetHighlight(int rowIndex)
         {
-            ChangeRowBackgroundColor(rowIndex, Color.LightGray);
+            var color = Color.LightBlue;
+            ChangeRowBackgroundColor(rowIndex, color);
 
             if (rowIndex > 0 && rowIndex < (inputsDataGridView.Rows.Count - 1))
             {
                 int rowAdjust = rowIndex > RowIndexMouseDown ? 1 : -1;
-                ChangeRowBackgroundColor(rowIndex + rowAdjust, Color.LightGray);
+                ChangeRowBackgroundColor(rowIndex + rowAdjust, color);
             }
             RowCurrentDragHighlight = rowIndex;
         }

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -627,25 +627,39 @@ namespace MobiFlight.UI.Panels
             return result;
         }
 
+        private void ChangeRowBackgroundColor(int rowIndex, Color color)
+        {
+            if (rowIndex > -1)
+            {
+                foreach (DataGridViewCell cell in inputsDataGridView.Rows[rowIndex].Cells)
+                {
+                    cell.Style.BackColor = color;
+                    cell.Style.Padding = new Padding(0, 0, 0, 0);
+                }
+            }
+        }
 
         private void AddDragTargetHighlight(int rowIndex)
         {
-            foreach (DataGridViewCell cell in inputsDataGridView.Rows[rowIndex].Cells)
+            ChangeRowBackgroundColor(rowIndex, Color.LightGray);
+
+            if (rowIndex > 0 && rowIndex < (inputsDataGridView.Rows.Count - 1))
             {
-                cell.Style.BackColor = Color.LightGray;
+                int rowAdjust = rowIndex > RowIndexMouseDown ? 1 : -1;
+                ChangeRowBackgroundColor(rowIndex + rowAdjust, Color.LightGray);
             }
             RowCurrentDragHighlight = rowIndex;
         }
 
         private void RemoveDragTargetHighlight()
         {
-            if (RowCurrentDragHighlight > -1)
+            ChangeRowBackgroundColor(RowCurrentDragHighlight, Color.Empty);
+
+            if (RowCurrentDragHighlight > 0 && RowCurrentDragHighlight < (inputsDataGridView.Rows.Count - 1))
             {
-                foreach (DataGridViewCell cell in inputsDataGridView.Rows[RowCurrentDragHighlight].Cells)
-                {
-                    cell.Style.BackColor = Color.Empty;
-                }
-            }        
+                int rowAdjust = RowCurrentDragHighlight > RowIndexMouseDown ? 1 : -1;
+                ChangeRowBackgroundColor(RowCurrentDragHighlight + rowAdjust, Color.Empty);
+            }
         }
 
         private void inputsDataGridView_MouseDown(object sender, MouseEventArgs e)
@@ -728,10 +742,10 @@ namespace MobiFlight.UI.Panels
                 DataRow rowToRemove = (DataRow)e.Data.GetData(typeof(DataRow));
                 DataRow rowToInsert = inputsDataTable.NewRow();
                 rowToInsert.ItemArray = rowToRemove.ItemArray; // needs to be cloned
-                inputsDataGridView.ClearSelection();                            
-                inputsDataTable.Rows.InsertAt(rowToInsert, RowIndexDrop);
+                inputsDataGridView.ClearSelection();
                 EditedItem = null; // safety measure, otherwise on some circumstances exception can be provoked
                 inputsDataTable.Rows.Remove(rowToRemove);
+                inputsDataTable.Rows.InsertAt(rowToInsert, RowIndexDrop);
                 int newIndex = inputsDataTable.Rows.IndexOf(rowToInsert);                                      
                 inputsDataGridView.CurrentCell = inputsDataGridView.Rows[newIndex].Cells["inputDescription"];
             }           

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -822,7 +822,7 @@ namespace MobiFlight.UI.Panels
             using (Graphics g = Graphics.FromHwnd(handle))
             {
                 // Get the current display scaling factor.
-                return DPIUtil.GetWindowsScreenScalingFactor();
+                return DPIUtil.GetWindowsScreenScalingFactor(this);
             }
         }
 

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -796,7 +796,7 @@ namespace MobiFlight.UI.Panels
         {
             Size clientSize = inputsDataGridView.ClientSize;
             Rectangle rowRectangle = inputsDataGridView.GetRowDisplayRectangle(RowIndexMouseDown, true);
-            var scalingFactor = GetScalingFactor(this.Handle) / 100;
+            var scalingFactor = GetScalingFactor(this.Handle);
 
             using (Bitmap dataGridViewBmp = new Bitmap(clientSize.Width, clientSize.Height))
             using (Bitmap rowBmp = new Bitmap(rowRectangle.Width, rowRectangle.Height))
@@ -822,7 +822,7 @@ namespace MobiFlight.UI.Panels
             using (Graphics g = Graphics.FromHwnd(handle))
             {
                 // Get the current display scaling factor.
-                return DPIUtil.GetWindowsScreenScalingFactor(this);
+                return DPIUtil.GetWindowsScreenScalingFactor(this, false);
             }
         }
 

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -701,13 +701,16 @@ namespace MobiFlight.UI.Panels
                 AddDragTargetHighlight(currentRow); 
             }
 
-            // Autoscroll   
-            if ( (e.Y <= PointToScreen(DataGridTopLeftPoint).Y + 40) && (inputsDataGridView.FirstDisplayedScrollingRowIndex > 0))
+            // Autoscroll
+            int autoScrollMargin = 20;
+            int headerHeight = inputsDataGridView.ColumnHeadersHeight;
+            if ((e.Y <= PointToScreen(DataGridTopLeftPoint).Y + headerHeight + autoScrollMargin) &&
+                (inputsDataGridView.FirstDisplayedScrollingRowIndex > 0))             
             {
                 // Scroll up
                 inputsDataGridView.FirstDisplayedScrollingRowIndex -= 1;
             }
-            if (e.Y >= PointToScreen(DataGridBottomRightPoint).Y - 10)
+            if (e.Y >= PointToScreen(DataGridBottomRightPoint).Y - autoScrollMargin)
             {
                 // Scroll down
                 inputsDataGridView.FirstDisplayedScrollingRowIndex += 1;

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -657,6 +657,22 @@ namespace MobiFlight.UI.Panels
         private void inputsDataGridView_DragOver(object sender, DragEventArgs e)
         {
             e.Effect = DragDropEffects.Move;
+
+            // Autoscroll
+            Point topPoint = new Point(inputsDataGridView.Location.X, inputsDataGridView.Location.Y);
+            if ( (e.Y <= PointToScreen(topPoint).Y + 40) && (inputsDataGridView.FirstDisplayedScrollingRowIndex > 0))
+            {
+                // Scroll up
+                inputsDataGridView.FirstDisplayedScrollingRowIndex -= 1;
+            }
+
+            Point bottomPoint = new Point(inputsDataGridView.Location.X + inputsDataGridView.Width, 
+                                          inputsDataGridView.Location.Y + inputsDataGridView.Height);
+            if (e.Y >= PointToScreen(bottomPoint).Y - 10)
+            {
+                // Scroll down
+                inputsDataGridView.FirstDisplayedScrollingRowIndex += 1;
+            }
         }
 
         private void inputsDataGridView_DragDrop(object sender, DragEventArgs e)

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -632,7 +632,7 @@ namespace MobiFlight.UI.Panels
         {
             foreach (DataGridViewCell cell in inputsDataGridView.Rows[rowIndex].Cells)
             {
-                cell.Style.BackColor = Color.LightSkyBlue;
+                cell.Style.BackColor = Color.LightGray;
             }
             RowCurrentDragHighlight = rowIndex;
         }
@@ -683,6 +683,7 @@ namespace MobiFlight.UI.Panels
                     inputsDataGridView.ClearSelection();
                     inputsDataGridView.Rows[RowIndexMouseDown].Selected = true;
                     inputsDataGridView.CurrentCell = inputsDataGridView.Rows[RowIndexMouseDown].Cells["inputDescription"];
+                    // Start drag and drop
                     inputsDataGridView.DoDragDrop(inputsDataTable.Rows[RowIndexMouseDown], DragDropEffects.Move);           
                 }
             }

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -627,7 +627,9 @@ namespace MobiFlight.UI.Panels
         private void inputsDataGridView_MouseDown(object sender, MouseEventArgs e)
         {
             RowIndexMouseDown = inputsDataGridView.HitTest(e.X, e.Y).RowIndex;
-            if (RowIndexMouseDown != -1)
+
+            // Handle row "Double-click...." which has no underlying data
+            if (RowIndexMouseDown != -1 && (inputsDataTable.Rows.Count >= (RowIndexMouseDown + 1)))
             {
                 Size dragSize = SystemInformation.DragSize;
                 Point location = new Point(e.X - (dragSize.Width / 2), e.Y - (dragSize.Height / 2));

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -760,7 +760,7 @@ namespace MobiFlight.UI.Panels
                 // For performance reason we want to only
                 // calculate the bitmap for the cursor
                 // once when it changes from default
-                if (Cursor.Current == Cursors.Default)
+                if (Cursor.Current == Cursors.Default || Cursor.Current == Cursors.No)
                 {
                     int offsetX = CalculateCorrectCursorOffset();
 

--- a/UI/Panels/InputConfigPanel.resx
+++ b/UI/Panels/InputConfigPanel.resx
@@ -117,283 +117,289 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="inputsDataGridViewContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>136, 22</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="inputsDataGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>788, 519</value>
-  </data>
-  <data name="&gt;&gt;inputsDataTable.Type" xml:space="preserve">
-    <value>System.Data.DataTable, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="copyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 22</value>
-  </data>
-  <data name="&gt;&gt;inputsDescriptionDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="pasteToolStripMenuItem.Text" xml:space="preserve">
-    <value>Paste</value>
-  </data>
-  <data name="inputEditButtonColumn.ToolTipText" xml:space="preserve">
-    <value>...</value>
-  </data>
   <data name="inputsDataGridViewContextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
     <value>151, 98</value>
   </data>
-  <data name="inputsDataGridView.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 0</value>
-  </data>
-  <data name="inputDescription.ToolTipText" xml:space="preserve">
-    <value>The name or description of your config</value>
-  </data>
-  <data name="&gt;&gt;pasteToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;inputsActiveDataColumn.Name" xml:space="preserve">
-    <value>inputsActiveDataColumn</value>
-  </data>
-  <data name="&gt;&gt;inputName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;inputsDataGridViewContextMenuStrip.Name" xml:space="preserve">
+    <value>inputsDataGridViewContextMenuStrip</value>
   </data>
   <data name="&gt;&gt;inputsDataGridViewContextMenuStrip.Type" xml:space="preserve">
     <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;inputsGuidDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataSetInputs.Name" xml:space="preserve">
-    <value>dataSetInputs</value>
-  </data>
-  <data name="duplicateInputsRowToolStripMenuItem.Text" xml:space="preserve">
-    <value>Duplicate Row</value>
-  </data>
-  <data name="&gt;&gt;inputNameDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;moduleSerial.Name" xml:space="preserve">
-    <value>moduleSerial</value>
+  <data name="copyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 22</value>
   </data>
   <data name="copyToolStripMenuItem.Text" xml:space="preserve">
     <value>Copy</value>
   </data>
-  <data name="&gt;&gt;inputActive.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewCheckBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;inputsSettingsDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;inputType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="inputActive.Width" type="System.Int32, mscorlib">
-    <value>42</value>
-  </data>
-  <data name="&gt;&gt;moduleSerialDataColumn.Name" xml:space="preserve">
-    <value>moduleSerialDataColumn</value>
-  </data>
-  <data name="&gt;&gt;inputType.Name" xml:space="preserve">
-    <value>inputType</value>
-  </data>
-  <data name="&gt;&gt;inputTypeDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="inputName.ToolTipText" xml:space="preserve">
-    <value>The device used in the config</value>
-  </data>
-  <data name="inputDescription.HeaderText" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="&gt;&gt;inputsDataGridView.Name" xml:space="preserve">
-    <value>inputsDataGridView</value>
-  </data>
-  <data name="&gt;&gt;inputActive.Name" xml:space="preserve">
-    <value>inputActive</value>
-  </data>
-  <data name="inputsDataGridView.ColumnHeadersHeight" type="System.Int32, mscorlib">
-    <value>34</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="inputType.HeaderText" xml:space="preserve">
-    <value>Type</value>
-  </data>
-  <data name="&gt;&gt;inputsActiveDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;inputsGuidDataColumn.Name" xml:space="preserve">
-    <value>inputsGuidDataColumn</value>
-  </data>
-  <data name="&gt;&gt;deleteInputsRowToolStripMenuItem.Name" xml:space="preserve">
-    <value>deleteInputsRowToolStripMenuItem</value>
-  </data>
-  <data name="moduleSerial.ToolTipText" xml:space="preserve">
-    <value>The board used in the config</value>
-  </data>
-  <data name="duplicateInputsRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="pasteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>150, 22</value>
   </data>
-  <data name="moduleSerial.HeaderText" xml:space="preserve">
-    <value>Module</value>
+  <data name="pasteToolStripMenuItem.Text" xml:space="preserve">
+    <value>Paste</value>
   </data>
   <data name="toolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
     <value>147, 6</value>
   </data>
+  <data name="duplicateInputsRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 22</value>
+  </data>
+  <data name="duplicateInputsRowToolStripMenuItem.Text" xml:space="preserve">
+    <value>Duplicate Row</value>
+  </data>
+  <data name="deleteInputsRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>150, 22</value>
+  </data>
+  <data name="deleteInputsRowToolStripMenuItem.Text" xml:space="preserve">
+    <value>Delete Row</value>
+  </data>
+  <metadata name="dataSetInputs.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>431, 19</value>
+  </metadata>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="inputsDataGridView.ColumnHeadersHeight" type="System.Int32, mscorlib">
+    <value>34</value>
+  </data>
+  <data name="inputActive.HeaderText" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="inputActive.ToolTipText" xml:space="preserve">
+    <value>The device used in the config</value>
+  </data>
+  <data name="inputActive.Width" type="System.Int32, mscorlib">
+    <value>42</value>
+  </data>
+  <data name="inputDescription.HeaderText" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="inputDescription.ToolTipText" xml:space="preserve">
+    <value>The name or description of your config</value>
+  </data>
+  <metadata name="inputsGuid.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="inputsGuid.HeaderText" xml:space="preserve">
+    <value>guid</value>
+  </data>
+  <data name="inputsGuid.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <metadata name="moduleSerial.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="moduleSerial.HeaderText" xml:space="preserve">
+    <value>Module</value>
+  </data>
+  <data name="moduleSerial.ToolTipText" xml:space="preserve">
+    <value>The board used in the config</value>
+  </data>
+  <metadata name="inputName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <data name="inputName.HeaderText" xml:space="preserve">
     <value>Input</value>
   </data>
-  <data name="&gt;&gt;inputsGuid.Name" xml:space="preserve">
-    <value>inputsGuid</value>
+  <data name="inputName.ToolTipText" xml:space="preserve">
+    <value>The device used in the config</value>
+  </data>
+  <metadata name="inputType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="inputType.HeaderText" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="inputType.ToolTipText" xml:space="preserve">
+    <value>The type of device used in the config</value>
+  </data>
+  <metadata name="inputEditButtonColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="inputEditButtonColumn.HeaderText" xml:space="preserve">
+    <value>Edit</value>
   </data>
   <data name="inputEditButtonColumn.MinimumWidth" type="System.Int32, mscorlib">
     <value>55</value>
   </data>
+  <data name="inputEditButtonColumn.ToolTipText" xml:space="preserve">
+    <value>...</value>
+  </data>
   <data name="inputEditButtonColumn.Width" type="System.Int32, mscorlib">
     <value>55</value>
-  </data>
-  <data name="&gt;&gt;inputsDataGridView.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;dataSetInputs.Type" xml:space="preserve">
-    <value>System.Data.DataSet, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>788, 519</value>
-  </data>
-  <data name="&gt;&gt;duplicateInputsRowToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="inputsDataGridView.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
   </data>
-  <data name="&gt;&gt;moduleSerialDataColumn.Type" xml:space="preserve">
+  <data name="inputsDataGridView.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 0</value>
+  </data>
+  <data name="inputsDataGridView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="inputsDataGridView.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1182, 798</value>
+  </data>
+  <data name="inputsDataGridView.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;inputsDataGridView.Name" xml:space="preserve">
+    <value>inputsDataGridView</value>
+  </data>
+  <data name="&gt;&gt;inputsDataGridView.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputsDataGridView.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;inputsDataGridView.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>9, 20</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1182, 798</value>
+  </data>
+  <data name="&gt;&gt;copyToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pasteToolStripMenuItem.Name" xml:space="preserve">
+    <value>pasteToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;pasteToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
+    <value>toolStripMenuItem1</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;duplicateInputsRowToolStripMenuItem.Name" xml:space="preserve">
+    <value>duplicateInputsRowToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;duplicateInputsRowToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;deleteInputsRowToolStripMenuItem.Name" xml:space="preserve">
+    <value>deleteInputsRowToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;deleteInputsRowToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dataSetInputs.Name" xml:space="preserve">
+    <value>dataSetInputs</value>
+  </data>
+  <data name="&gt;&gt;dataSetInputs.Type" xml:space="preserve">
+    <value>System.Data.DataSet, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputsDataTable.Name" xml:space="preserve">
+    <value>inputsDataTable</value>
+  </data>
+  <data name="&gt;&gt;inputsDataTable.Type" xml:space="preserve">
+    <value>System.Data.DataTable, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputsActiveDataColumn.Name" xml:space="preserve">
+    <value>inputsActiveDataColumn</value>
+  </data>
+  <data name="&gt;&gt;inputsActiveDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputsDescriptionDataColumn.Name" xml:space="preserve">
+    <value>inputsDescriptionDataColumn</value>
+  </data>
+  <data name="&gt;&gt;inputsDescriptionDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputsGuidDataColumn.Name" xml:space="preserve">
+    <value>inputsGuidDataColumn</value>
+  </data>
+  <data name="&gt;&gt;inputsGuidDataColumn.Type" xml:space="preserve">
     <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;inputsSettingsDataColumn.Name" xml:space="preserve">
     <value>inputsSettingsDataColumn</value>
   </data>
-  <data name="inputsGuid.HeaderText" xml:space="preserve">
-    <value>guid</value>
-  </data>
-  <data name="inputsDataGridView.TabIndex" type="System.Int32, mscorlib">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;copyToolStripMenuItem.Name" xml:space="preserve">
-    <value>copyToolStripMenuItem</value>
-  </data>
-  <data name="&gt;&gt;inputName.Name" xml:space="preserve">
-    <value>inputName</value>
-  </data>
-  <data name="&gt;&gt;duplicateInputsRowToolStripMenuItem.Name" xml:space="preserve">
-    <value>duplicateInputsRowToolStripMenuItem</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="deleteInputsRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 22</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="&gt;&gt;inputsDataGridView.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;inputsGuid.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;inputEditButtonColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewButtonColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;inputsDescriptionDataColumn.Name" xml:space="preserve">
-    <value>inputsDescriptionDataColumn</value>
-  </data>
-  <data name="inputActive.HeaderText" xml:space="preserve">
-    <value>Active</value>
-  </data>
-  <data name="&gt;&gt;inputsDataTable.Name" xml:space="preserve">
-    <value>inputsDataTable</value>
+  <data name="&gt;&gt;inputsSettingsDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;inputNameDataColumn.Name" xml:space="preserve">
     <value>inputNameDataColumn</value>
   </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>InputConfigPanel</value>
-  </data>
-  <data name="&gt;&gt;moduleSerial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;pasteToolStripMenuItem.Name" xml:space="preserve">
-    <value>pasteToolStripMenuItem</value>
-  </data>
-  <data name="deleteInputsRowToolStripMenuItem.Text" xml:space="preserve">
-    <value>Delete Row</value>
-  </data>
-  <data name="&gt;&gt;copyToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;inputNameDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;inputTypeDataColumn.Name" xml:space="preserve">
     <value>inputTypeDataColumn</value>
   </data>
-  <data name="inputActive.ToolTipText" xml:space="preserve">
-    <value>The device used in the config</value>
+  <data name="&gt;&gt;inputTypeDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;inputEditButtonColumn.Name" xml:space="preserve">
-    <value>inputEditButtonColumn</value>
+  <data name="&gt;&gt;moduleSerialDataColumn.Name" xml:space="preserve">
+    <value>moduleSerialDataColumn</value>
   </data>
-  <data name="inputsGuid.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
+  <data name="&gt;&gt;moduleSerialDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
-    <value>toolStripMenuItem1</value>
+  <data name="&gt;&gt;inputActive.Name" xml:space="preserve">
+    <value>inputActive</value>
   </data>
-  <data name="pasteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>150, 22</value>
-  </data>
-  <data name="inputEditButtonColumn.HeaderText" xml:space="preserve">
-    <value>Edit</value>
-  </data>
-  <data name="inputType.ToolTipText" xml:space="preserve">
-    <value>The type of device used in the config</value>
-  </data>
-  <data name="&gt;&gt;inputsDataGridView.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;inputActive.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewCheckBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;inputDescription.Name" xml:space="preserve">
     <value>inputDescription</value>
   </data>
-  <data name="&gt;&gt;deleteInputsRowToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;inputsDataGridViewContextMenuStrip.Name" xml:space="preserve">
-    <value>inputsDataGridViewContextMenuStrip</value>
-  </data>
   <data name="&gt;&gt;inputDescription.Type" xml:space="preserve">
     <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <metadata name="inputsGuid.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="moduleSerial.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="inputEditButtonColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="inputsDataGridViewContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>136, 22</value>
-  </metadata>
-  <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dataSetInputs.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>431, 19</value>
-  </metadata>
-  <metadata name="inputName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="inputType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  <data name="&gt;&gt;inputsGuid.Name" xml:space="preserve">
+    <value>inputsGuid</value>
+  </data>
+  <data name="&gt;&gt;inputsGuid.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;moduleSerial.Name" xml:space="preserve">
+    <value>moduleSerial</value>
+  </data>
+  <data name="&gt;&gt;moduleSerial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputName.Name" xml:space="preserve">
+    <value>inputName</value>
+  </data>
+  <data name="&gt;&gt;inputName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputType.Name" xml:space="preserve">
+    <value>inputType</value>
+  </data>
+  <data name="&gt;&gt;inputType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;inputEditButtonColumn.Name" xml:space="preserve">
+    <value>inputEditButtonColumn</value>
+  </data>
+  <data name="&gt;&gt;inputEditButtonColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewButtonColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>InputConfigPanel</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>

--- a/UI/Panels/OutputConfigPanel.Designer.cs
+++ b/UI/Panels/OutputConfigPanel.Designer.cs
@@ -151,6 +151,8 @@
             this.dataGridViewConfig.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewConfig_EditingControlShowing);
             this.dataGridViewConfig.DragDrop += new System.Windows.Forms.DragEventHandler(this.dataGridViewConfig_DragDrop);
             this.dataGridViewConfig.DragOver += new System.Windows.Forms.DragEventHandler(this.dataGridViewConfig_DragOver);
+            this.dataGridViewConfig.GiveFeedback += new System.Windows.Forms.GiveFeedbackEventHandler(this.dataGridViewConfig_GiveFeedback);
+            this.dataGridViewConfig.QueryContinueDrag += new System.Windows.Forms.QueryContinueDragEventHandler(this.dataGridViewConfig_QueryContinueDrag);
             this.dataGridViewConfig.KeyDown += new System.Windows.Forms.KeyEventHandler(this.DataGridViewConfig_KeyUp);
             this.dataGridViewConfig.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridViewConfig_MouseDown);
             this.dataGridViewConfig.MouseMove += new System.Windows.Forms.MouseEventHandler(this.dataGridViewConfig_MouseMove);

--- a/UI/Panels/OutputConfigPanel.Designer.cs
+++ b/UI/Panels/OutputConfigPanel.Designer.cs
@@ -29,10 +29,10 @@
         private void InitializeComponent()
         {
             this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(OutputConfigPanel));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(OutputConfigPanel));
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
             System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
@@ -85,7 +85,7 @@
             // 
             // dataGridViewConfig
             // 
-            resources.ApplyResources(this.dataGridViewConfig, "dataGridViewConfig");
+            this.dataGridViewConfig.AllowDrop = true;
             this.dataGridViewConfig.AllowUserToResizeRows = false;
             this.dataGridViewConfig.AutoGenerateColumns = false;
             this.dataGridViewConfig.BackgroundColor = System.Drawing.SystemColors.Window;
@@ -122,6 +122,7 @@
             dataGridViewCellStyle10.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
             dataGridViewCellStyle10.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
             this.dataGridViewConfig.DefaultCellStyle = dataGridViewCellStyle10;
+            resources.ApplyResources(this.dataGridViewConfig, "dataGridViewConfig");
             this.dataGridViewConfig.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnF2;
             this.dataGridViewConfig.Name = "dataGridViewConfig";
             dataGridViewCellStyle11.Alignment = System.Windows.Forms.DataGridViewContentAlignment.BottomCenter;
@@ -148,7 +149,11 @@
             this.dataGridViewConfig.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.dataGridViewConfig_DataBindingComplete);
             this.dataGridViewConfig.DefaultValuesNeeded += new System.Windows.Forms.DataGridViewRowEventHandler(this.DataGridViewConfig_DefaultValuesNeeded);
             this.dataGridViewConfig.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewConfig_EditingControlShowing);
+            this.dataGridViewConfig.DragDrop += new System.Windows.Forms.DragEventHandler(this.dataGridViewConfig_DragDrop);
+            this.dataGridViewConfig.DragOver += new System.Windows.Forms.DragEventHandler(this.dataGridViewConfig_DragOver);
             this.dataGridViewConfig.KeyDown += new System.Windows.Forms.KeyEventHandler(this.DataGridViewConfig_KeyUp);
+            this.dataGridViewConfig.MouseDown += new System.Windows.Forms.MouseEventHandler(this.dataGridViewConfig_MouseDown);
+            this.dataGridViewConfig.MouseMove += new System.Windows.Forms.MouseEventHandler(this.dataGridViewConfig_MouseMove);
             // 
             // active
             // 
@@ -253,7 +258,6 @@
             // 
             // dataGridViewContextMenuStrip
             // 
-            resources.ApplyResources(this.dataGridViewContextMenuStrip, "dataGridViewContextMenuStrip");
             this.dataGridViewContextMenuStrip.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.copyToolStripMenuItem,
             this.pasteToolStripMenuItem,
@@ -261,6 +265,7 @@
             this.duplicateRowToolStripMenuItem,
             this.deleteRowToolStripMenuItem});
             this.dataGridViewContextMenuStrip.Name = "dataGridViewContextMenuStrip";
+            resources.ApplyResources(this.dataGridViewContextMenuStrip, "dataGridViewContextMenuStrip");
             this.dataGridViewContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.DataGridViewContextMenuStrip_Opening);
             // 
             // copyToolStripMenuItem
@@ -277,21 +282,21 @@
             // 
             // toolStripMenuItem1
             // 
-            resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
             this.toolStripMenuItem1.Name = "toolStripMenuItem1";
+            resources.ApplyResources(this.toolStripMenuItem1, "toolStripMenuItem1");
             // 
             // duplicateRowToolStripMenuItem
             // 
-            resources.ApplyResources(this.duplicateRowToolStripMenuItem, "duplicateRowToolStripMenuItem");
             this.duplicateRowToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            resources.ApplyResources(this.duplicateRowToolStripMenuItem, "duplicateRowToolStripMenuItem");
             this.duplicateRowToolStripMenuItem.Image = global::MobiFlight.Properties.Resources.star_yellow_new;
             this.duplicateRowToolStripMenuItem.Name = "duplicateRowToolStripMenuItem";
             this.duplicateRowToolStripMenuItem.Click += new System.EventHandler(this.DuplicateRowToolStripMenuItem_Click);
             // 
             // deleteRowToolStripMenuItem
             // 
-            resources.ApplyResources(this.deleteRowToolStripMenuItem, "deleteRowToolStripMenuItem");
             this.deleteRowToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            resources.ApplyResources(this.deleteRowToolStripMenuItem, "deleteRowToolStripMenuItem");
             this.deleteRowToolStripMenuItem.Image = global::MobiFlight.Properties.Resources.delete2;
             this.deleteRowToolStripMenuItem.Name = "deleteRowToolStripMenuItem";
             this.deleteRowToolStripMenuItem.Click += new System.EventHandler(this.DeleteRowToolStripMenuItem_Click);

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -786,6 +786,22 @@ namespace MobiFlight.UI.Panels
         private void dataGridViewConfig_DragOver(object sender, DragEventArgs e)
         {
             e.Effect = DragDropEffects.Move;
+
+            // Autoscroll
+            Point topPoint = new Point(dataGridViewConfig.Location.X, dataGridViewConfig.Location.Y);
+            if ((e.Y <= PointToScreen(topPoint).Y + 40) && (dataGridViewConfig.FirstDisplayedScrollingRowIndex > 0))
+            {
+                // Scroll up
+                dataGridViewConfig.FirstDisplayedScrollingRowIndex -= 1;
+            }
+
+            Point bottomPoint = new Point(dataGridViewConfig.Location.X + dataGridViewConfig.Width,
+                                          dataGridViewConfig.Location.Y + dataGridViewConfig.Height);
+            if (e.Y >= PointToScreen(bottomPoint).Y - 10)
+            {
+                // Scroll down
+                dataGridViewConfig.FirstDisplayedScrollingRowIndex += 1;
+            }
         }
 
         private void dataGridViewConfig_DragDrop(object sender, DragEventArgs e)

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -891,7 +891,7 @@ namespace MobiFlight.UI.Panels
                 // once when it changes from default
                 if (Cursor.Current == Cursors.Default)
                 {
-                    int offsetX = CalculateCorrectCursorOffset(Cursor.Current);
+                    int offsetX = CalculateCorrectCursorOffset();
 
                     // This creates the bitmap of the row and creates assigns it as the new cursor
                     Cursor.Current = CreateCursor(dataGridViewConfig.Rows[RowIndexMouseDown]);
@@ -906,7 +906,7 @@ namespace MobiFlight.UI.Panels
                 Cursor.Current = Cursors.Default;
         }
 
-        private int CalculateCorrectCursorOffset(Cursor cursor)
+        private int CalculateCorrectCursorOffset()
         {
             // Transform cursor position from screen coords to control coords
             var localCoords = PointToClient(Cursor.Position);

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -771,12 +771,13 @@ namespace MobiFlight.UI.Panels
         
         private void AddDragTargetHighlight(int rowIndex)
         {
-            ChangeRowBackgroundColor(rowIndex, Color.LightSkyBlue);
+            var color = Color.LightBlue;
+            ChangeRowBackgroundColor(rowIndex, color);
 
             if (rowIndex > 0 && rowIndex < (dataGridViewConfig.Rows.Count - 1))
             {
                 int rowAdjust = rowIndex > RowIndexMouseDown ? 1 : -1;
-                ChangeRowBackgroundColor(rowIndex + rowAdjust, Color.LightSkyBlue);
+                ChangeRowBackgroundColor(rowIndex + rowAdjust, color);
             }
             RowCurrentDragHighlight = rowIndex;
         }
@@ -827,7 +828,7 @@ namespace MobiFlight.UI.Panels
                     dataGridViewConfig.Rows[RowIndexMouseDown].Selected = true;
                     dataGridViewConfig.CurrentCell = dataGridViewConfig.Rows[RowIndexMouseDown].Cells["description"];
                     // Start drag and drop               
-                    dataGridViewConfig.DoDragDrop(configDataTable.Rows[RowIndexMouseDown], DragDropEffects.Move);                    
+                    dataGridViewConfig.DoDragDrop(configDataTable.Rows[RowIndexMouseDown], DragDropEffects.Move);
                 }
             }
         }
@@ -900,7 +901,7 @@ namespace MobiFlight.UI.Panels
                     // This now corrects the position of the cursor using the offset,
                     // so that the cursor won't show displaced
                     Cursor.Position = new Point(Cursor.Position.X - offsetX, Cursor.Position.Y);
-                }
+                }                
             }
                 
             else

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -926,7 +926,7 @@ namespace MobiFlight.UI.Panels
         {
             Size clientSize = dataGridViewConfig.ClientSize;
             Rectangle rowRectangle = dataGridViewConfig.GetRowDisplayRectangle(RowIndexMouseDown, true);
-            var scalingFactor = GetScalingFactor(this.Handle) / 100;
+            var scalingFactor = GetScalingFactor(this.Handle);
             
             using (Bitmap dataGridViewBmp = new Bitmap(clientSize.Width, clientSize.Height))
             using (Bitmap rowBmp = new Bitmap(rowRectangle.Width, rowRectangle.Height))
@@ -952,7 +952,7 @@ namespace MobiFlight.UI.Panels
             using (Graphics g = Graphics.FromHwnd(handle))
             {
                 // Get the current display scaling factor.
-                return DPIUtil.GetWindowsScreenScalingFactor();
+                return DPIUtil.GetWindowsScreenScalingFactor(this, false);
             }
         }
 

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -756,7 +756,9 @@ namespace MobiFlight.UI.Panels
         private void dataGridViewConfig_MouseDown(object sender, MouseEventArgs e)
         {
             RowIndexMouseDown = dataGridViewConfig.HitTest(e.X, e.Y).RowIndex;
-            if (RowIndexMouseDown != -1)
+
+            // Handle row "Double-click...." which has no underlying data
+            if (RowIndexMouseDown != -1 && (configDataTable.Rows.Count >= (RowIndexMouseDown + 1)))
             {
                 Size dragSize = SystemInformation.DragSize;
                 Point location = new Point(e.X - (dragSize.Width / 2), e.Y - (dragSize.Height / 2));

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -771,12 +771,12 @@ namespace MobiFlight.UI.Panels
         
         private void AddDragTargetHighlight(int rowIndex)
         {
-            ChangeRowBackgroundColor(rowIndex, Color.LightGray);
+            ChangeRowBackgroundColor(rowIndex, Color.LightSkyBlue);
 
             if (rowIndex > 0 && rowIndex < (dataGridViewConfig.Rows.Count - 1))
             {
                 int rowAdjust = rowIndex > RowIndexMouseDown ? 1 : -1;
-                ChangeRowBackgroundColor(rowIndex + rowAdjust, Color.LightGray);
+                ChangeRowBackgroundColor(rowIndex + rowAdjust, Color.LightSkyBlue);
             }
             RowCurrentDragHighlight = rowIndex;
         }
@@ -889,7 +889,8 @@ namespace MobiFlight.UI.Panels
                 // For performance reason we want to only
                 // calculate the bitmap for the cursor
                 // once when it changes from default
-                if (Cursor.Current == Cursors.Default)
+                // or from No, which happens after leaving the client area and returning
+                if (Cursor.Current == Cursors.Default || Cursor.Current == Cursors.No)
                 {
                     int offsetX = CalculateCorrectCursorOffset();
 

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -756,60 +756,38 @@ namespace MobiFlight.UI.Panels
             return result;
         }
 
+        private void ChangeRowBackgroundColor(int rowIndex, Color color)
+        {
+            if (rowIndex > -1)
+            {
+                foreach (DataGridViewCell cell in dataGridViewConfig.Rows[rowIndex].Cells)
+                {
+                    cell.Style.BackColor = color;
+                }
+            }
+        }
+        
         private void AddDragTargetHighlight(int rowIndex)
         {
-            foreach (DataGridViewCell cell in dataGridViewConfig.Rows[rowIndex].Cells)
-            {
-                cell.Style.BackColor = Color.LightGray;
-            }
+            ChangeRowBackgroundColor(rowIndex, Color.LightGray);
 
             if (rowIndex > 0 && rowIndex < (dataGridViewConfig.Rows.Count - 1))
             {
-                if (rowIndex > RowIndexMouseDown)
-                {
-                    foreach (DataGridViewCell cell in dataGridViewConfig.Rows[rowIndex + 1].Cells)
-                    {
-                        cell.Style.BackColor = Color.LightGray;
-                    }
-                }
-                else
-                {
-                    foreach (DataGridViewCell cell in dataGridViewConfig.Rows[rowIndex - 1].Cells)
-                    {
-                        cell.Style.BackColor = Color.LightGray;
-                    }
-                }
+                int rowAdjust = rowIndex > RowIndexMouseDown ? 1 : -1;
+                ChangeRowBackgroundColor(rowIndex + rowAdjust, Color.LightGray);
             }
             RowCurrentDragHighlight = rowIndex;
         }
 
         private void RemoveDragTargetHighlight()
         {
-            if (RowCurrentDragHighlight > -1)
-            {
-                foreach (DataGridViewCell cell in dataGridViewConfig.Rows[RowCurrentDragHighlight].Cells)
-                {
-                    cell.Style.BackColor = Color.Empty;
-                }
+            ChangeRowBackgroundColor(RowCurrentDragHighlight, Color.Empty);
 
-                if (RowCurrentDragHighlight > 0 && RowCurrentDragHighlight < (dataGridViewConfig.Rows.Count - 1))
-                {
-                    if (RowCurrentDragHighlight > RowIndexMouseDown)
-                    {
-                        foreach (DataGridViewCell cell in dataGridViewConfig.Rows[RowCurrentDragHighlight + 1].Cells)
-                        {
-                            cell.Style.BackColor = Color.Empty;
-                        }
-                    }
-                    else
-                    {
-                        foreach (DataGridViewCell cell in dataGridViewConfig.Rows[RowCurrentDragHighlight - 1].Cells)
-                        {
-                            cell.Style.BackColor = Color.Empty;
-                        }
-                    }
-                }
-            }
+            if (RowCurrentDragHighlight > 0 && RowCurrentDragHighlight < (dataGridViewConfig.Rows.Count - 1))
+            {
+                int rowAdjust = RowCurrentDragHighlight > RowIndexMouseDown ? 1 : -1;
+                ChangeRowBackgroundColor(RowCurrentDragHighlight + rowAdjust, Color.Empty);
+            }            
         }
 
         private void dataGridViewConfig_MouseDown(object sender, MouseEventArgs e)
@@ -824,8 +802,7 @@ namespace MobiFlight.UI.Panels
                 dragSize.Height = dragSize.Height * 5;
                 Point location = new Point(e.X - (dragSize.Width / 2), e.Y - (dragSize.Height / 2));
                 RectangleMouseDown = new Rectangle(location, dragSize);
-                DataGridTopLeftPoint.X = dataGridViewConfig.Location.X;
-                DataGridTopLeftPoint.Y = dataGridViewConfig.Location.Y;
+                DataGridTopLeftPoint = dataGridViewConfig.Location;           
                 DataGridBottomRightPoint.X = dataGridViewConfig.Location.X + dataGridViewConfig.Width;
                 DataGridBottomRightPoint.Y = dataGridViewConfig.Location.Y + dataGridViewConfig.Height;                
             }
@@ -865,13 +842,16 @@ namespace MobiFlight.UI.Panels
                 AddDragTargetHighlight(currentRow);
             }
 
-            // Autoscroll   
-            if ((e.Y <= PointToScreen(DataGridTopLeftPoint).Y + 40) && (dataGridViewConfig.FirstDisplayedScrollingRowIndex > 0))
+            // Autoscroll
+            int autoScrollMargin = 20;
+            int headerHeight = dataGridViewConfig.ColumnHeadersHeight;
+            if ((e.Y <= PointToScreen(DataGridTopLeftPoint).Y + headerHeight + autoScrollMargin) && 
+                (dataGridViewConfig.FirstDisplayedScrollingRowIndex > 0))
             {
                 // Scroll up
                 dataGridViewConfig.FirstDisplayedScrollingRowIndex -= 1;
             }
-            if (e.Y >= PointToScreen(DataGridBottomRightPoint).Y - 10)
+            if (e.Y >= PointToScreen(DataGridBottomRightPoint).Y - autoScrollMargin)
             {
                 // Scroll down
                 dataGridViewConfig.FirstDisplayedScrollingRowIndex += 1;
@@ -903,7 +883,7 @@ namespace MobiFlight.UI.Panels
             // Sets the custom cursor based upon the effect.
             e.UseDefaultCursors = false;
             if ((e.Effect & DragDropEffects.Move) == DragDropEffects.Move)
-                Cursor.Current = Cursors.Hand;
+                Cursor.Current = Cursors.HSplit;
             else
                 Cursor.Current = Cursors.Default;
         }

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -760,7 +760,25 @@ namespace MobiFlight.UI.Panels
         {
             foreach (DataGridViewCell cell in dataGridViewConfig.Rows[rowIndex].Cells)
             {
-                cell.Style.BackColor = Color.LightSkyBlue;
+                cell.Style.BackColor = Color.LightGray;
+            }
+
+            if (rowIndex > 0 && rowIndex < (dataGridViewConfig.Rows.Count - 1))
+            {
+                if (rowIndex > RowIndexMouseDown)
+                {
+                    foreach (DataGridViewCell cell in dataGridViewConfig.Rows[rowIndex + 1].Cells)
+                    {
+                        cell.Style.BackColor = Color.LightGray;
+                    }
+                }
+                else
+                {
+                    foreach (DataGridViewCell cell in dataGridViewConfig.Rows[rowIndex - 1].Cells)
+                    {
+                        cell.Style.BackColor = Color.LightGray;
+                    }
+                }
             }
             RowCurrentDragHighlight = rowIndex;
         }
@@ -772,6 +790,24 @@ namespace MobiFlight.UI.Panels
                 foreach (DataGridViewCell cell in dataGridViewConfig.Rows[RowCurrentDragHighlight].Cells)
                 {
                     cell.Style.BackColor = Color.Empty;
+                }
+
+                if (RowCurrentDragHighlight > 0 && RowCurrentDragHighlight < (dataGridViewConfig.Rows.Count - 1))
+                {
+                    if (RowCurrentDragHighlight > RowIndexMouseDown)
+                    {
+                        foreach (DataGridViewCell cell in dataGridViewConfig.Rows[RowCurrentDragHighlight + 1].Cells)
+                        {
+                            cell.Style.BackColor = Color.Empty;
+                        }
+                    }
+                    else
+                    {
+                        foreach (DataGridViewCell cell in dataGridViewConfig.Rows[RowCurrentDragHighlight - 1].Cells)
+                        {
+                            cell.Style.BackColor = Color.Empty;
+                        }
+                    }
                 }
             }
         }
@@ -811,7 +847,7 @@ namespace MobiFlight.UI.Panels
                     dataGridViewConfig.ClearSelection();
                     dataGridViewConfig.Rows[RowIndexMouseDown].Selected = true;
                     dataGridViewConfig.CurrentCell = dataGridViewConfig.Rows[RowIndexMouseDown].Cells["description"];
-                    // Start drag and drop
+                    // Start drag and drop               
                     dataGridViewConfig.DoDragDrop(configDataTable.Rows[RowIndexMouseDown], DragDropEffects.Move);                    
                 }
             }

--- a/UI/Panels/OutputConfigPanel.resx
+++ b/UI/Panels/OutputConfigPanel.resx
@@ -117,430 +117,436 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="active.HeaderText" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="active.Width" type="System.Int32, mscorlib">
+    <value>43</value>
+  </data>
+  <metadata name="guid.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="guid.HeaderText" xml:space="preserve">
+    <value>guid</value>
+  </data>
+  <data name="guid.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="Description.HeaderText" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="Description.MinimumWidth" type="System.Int32, mscorlib">
+    <value>100</value>
+  </data>
+  <data name="Description.ToolTipText" xml:space="preserve">
+    <value>The name or description of your config</value>
+  </data>
+  <metadata name="moduleSerial.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="moduleSerial.HeaderText" xml:space="preserve">
+    <value>Module</value>
+  </data>
+  <data name="moduleSerial.MinimumWidth" type="System.Int32, mscorlib">
+    <value>90</value>
+  </data>
+  <data name="moduleSerial.ToolTipText" xml:space="preserve">
+    <value>The board used in the config</value>
+  </data>
+  <metadata name="OutputName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <data name="OutputName.HeaderText" xml:space="preserve">
     <value>Output</value>
   </data>
-  <data name="&gt;&gt;converterDataColumn.Name" xml:space="preserve">
-    <value>converterDataColumn</value>
+  <data name="OutputName.MinimumWidth" type="System.Int32, mscorlib">
+    <value>90</value>
   </data>
-  <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="OutputName.ToolTipText" xml:space="preserve">
+    <value>The device used in the config</value>
+  </data>
+  <metadata name="OutputType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="OutputType.HeaderText" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="OutputType.ToolTipText" xml:space="preserve">
+    <value>The type of device used in the config</value>
+  </data>
+  <metadata name="FsuipcOffset.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="FsuipcOffset.HeaderText" xml:space="preserve">
+    <value>FSUIPC Offset</value>
+  </data>
   <data name="FsuipcOffset.MinimumWidth" type="System.Int32, mscorlib">
     <value>65</value>
   </data>
-  <data name="&gt;&gt;maskDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="FsuipcOffset.ToolTipText" xml:space="preserve">
+    <value>Der FSUIPC Offset laut Dokumentation</value>
+  </data>
+  <data name="FsuipcOffset.Visible" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="FsuipcOffset.Width" type="System.Int32, mscorlib">
+    <value>65</value>
+  </data>
+  <metadata name="fsuipcValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="fsuipcValueColumn.HeaderText" xml:space="preserve">
+    <value>Flight Sim Value</value>
+  </data>
+  <data name="fsuipcValueColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>65</value>
+  </data>
+  <data name="fsuipcValueColumn.ToolTipText" xml:space="preserve">
+    <value>The value read from the sim / variable</value>
+  </data>
+  <data name="fsuipcValueColumn.Width" type="System.Int32, mscorlib">
+    <value>65</value>
+  </data>
+  <metadata name="arcazeValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="arcazeValueColumn.HeaderText" xml:space="preserve">
+    <value>Output Value</value>
+  </data>
+  <data name="arcazeValueColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>40</value>
+  </data>
+  <data name="arcazeValueColumn.ToolTipText" xml:space="preserve">
+    <value>The final value used for output</value>
+  </data>
+  <data name="arcazeValueColumn.Width" type="System.Int32, mscorlib">
+    <value>65</value>
+  </data>
+  <metadata name="EditButtonColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <data name="EditButtonColumn.HeaderText" xml:space="preserve">
+    <value>Edit</value>
+  </data>
+  <data name="EditButtonColumn.MinimumWidth" type="System.Int32, mscorlib">
+    <value>55</value>
+  </data>
+  <data name="EditButtonColumn.Width" type="System.Int32, mscorlib">
+    <value>55</value>
+  </data>
+  <metadata name="dataGridViewContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>591, 56</value>
+  </metadata>
+  <data name="copyToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="copyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>147, 22</value>
   </data>
-  <data name="&gt;&gt;OutputType.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewConfig.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="pasteToolStripMenuItem.Text" xml:space="preserve">
-    <value>Paste</value>
-  </data>
-  <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;guidDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="deleteRowToolStripMenuItem.ToolTipText" xml:space="preserve">
-    <value>Delete selected row(s)</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="guid.Visible" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="FsuipcOffset.ToolTipText" xml:space="preserve">
-    <value>Der FSUIPC Offset laut Dokumentation</value>
-  </data>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="dataGridViewConfig.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Fill</value>
-  </data>
-  <data name="&gt;&gt;arcazeSerialDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;configDataTable.Name" xml:space="preserve">
-    <value>configDataTable</value>
-  </data>
-  <data name="&gt;&gt;pasteToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="Description.HeaderText" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="&gt;&gt;fsuipcValueColumn.Name" xml:space="preserve">
-    <value>fsuipcValueColumn</value>
-  </data>
-  <data name="Description.MinimumWidth" type="System.Int32, mscorlib">
-    <value>100</value>
-  </data>
-  <data name="fsuipcValueColumn.Width" type="System.Int32, mscorlib">
-    <value>65</value>
-  </data>
-  <data name="&gt;&gt;triggerDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;descriptionDataColumn.Name" xml:space="preserve">
-    <value>descriptionDataColumn</value>
-  </data>
-  <data name="&gt;&gt;activeDataColumn.Name" xml:space="preserve">
-    <value>activeDataColumn</value>
-  </data>
-  <data name="deleteRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 22</value>
-  </data>
-  <data name="OutputType.HeaderText" xml:space="preserve">
-    <value>Type</value>
-  </data>
-  <data name="&gt;&gt;activeDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fsuipcSizeDataColumn.Name" xml:space="preserve">
-    <value>fsuipcSizeDataColumn</value>
-  </data>
-  <data name="&gt;&gt;fsuipcOffsetDataColumn.Name" xml:space="preserve">
-    <value>fsuipcOffsetDataColumn</value>
-  </data>
-  <data name="&gt;&gt;arcazeValueColumn.Name" xml:space="preserve">
-    <value>arcazeValueColumn</value>
-  </data>
-  <data name="&gt;&gt;Description.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="fsuipcValueColumn.HeaderText" xml:space="preserve">
-    <value>Flight Sim Value</value>
-  </data>
   <data name="copyToolStripMenuItem.Text" xml:space="preserve">
     <value>Copy</value>
-  </data>
-  <data name="OutputName.MinimumWidth" type="System.Int32, mscorlib">
-    <value>90</value>
-  </data>
-  <data name="&gt;&gt;deleteRowToolStripMenuItem.Name" xml:space="preserve">
-    <value>deleteRowToolStripMenuItem</value>
-  </data>
-  <data name="fsuipcValueColumn.ToolTipText" xml:space="preserve">
-    <value>The value read from the sim / variable</value>
-  </data>
-  <data name="EditButtonColumn.Width" type="System.Int32, mscorlib">
-    <value>55</value>
-  </data>
-  <data name="&gt;&gt;settingsColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="dataGridViewConfig.Size" type="System.Drawing.Size, System.Drawing">
-    <value>929, 629</value>
-  </data>
-  <data name="&gt;&gt;FsuipcOffset.Name" xml:space="preserve">
-    <value>FsuipcOffset</value>
-  </data>
-  <data name="&gt;&gt;EditButtonColumn.Name" xml:space="preserve">
-    <value>EditButtonColumn</value>
-  </data>
-  <data name="active.HeaderText" xml:space="preserve">
-    <value>Active</value>
   </data>
   <data name="pasteToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="deleteRowToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="copyToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;fsuipcOffsetDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewContextMenuStrip.Name" xml:space="preserve">
-    <value>dataGridViewContextMenuStrip</value>
-  </data>
-  <data name="&gt;&gt;usbArcazePinDataColumn.Name" xml:space="preserve">
-    <value>usbArcazePinDataColumn</value>
-  </data>
-  <data name="&gt;&gt;FsuipcOffset.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OutputName.Name" xml:space="preserve">
-    <value>OutputName</value>
-  </data>
-  <data name="EditButtonColumn.HeaderText" xml:space="preserve">
-    <value>Edit</value>
-  </data>
-  <data name="duplicateRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="pasteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>147, 22</value>
   </data>
-  <data name="OutputName.ToolTipText" xml:space="preserve">
-    <value>The device used in the config</value>
-  </data>
-  <data name="guid.HeaderText" xml:space="preserve">
-    <value>guid</value>
-  </data>
-  <data name="&gt;&gt;outputDataColumn.Name" xml:space="preserve">
-    <value>outputDataColumn</value>
-  </data>
-  <data name="&gt;&gt;comparisonDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="active.Width" type="System.Int32, mscorlib">
-    <value>43</value>
-  </data>
-  <data name="FsuipcOffset.HeaderText" xml:space="preserve">
-    <value>FSUIPC Offset</value>
-  </data>
-  <data name="moduleSerial.ToolTipText" xml:space="preserve">
-    <value>The board used in the config</value>
-  </data>
-  <data name="moduleSerial.HeaderText" xml:space="preserve">
-    <value>Module</value>
+  <data name="pasteToolStripMenuItem.Text" xml:space="preserve">
+    <value>Paste</value>
   </data>
   <data name="toolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
     <value>144, 6</value>
   </data>
-  <data name="moduleSerial.MinimumWidth" type="System.Int32, mscorlib">
-    <value>90</value>
+  <data name="duplicateRowToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
-  <data name="&gt;&gt;dataGridViewConfig.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;comparisonValueDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;duplicateRowToolStripMenuItem.Name" xml:space="preserve">
-    <value>duplicateRowToolStripMenuItem</value>
-  </data>
-  <data name="&gt;&gt;dataSetConfig.Type" xml:space="preserve">
-    <value>System.Data.DataSet, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;guid.Name" xml:space="preserve">
-    <value>guid</value>
-  </data>
-  <data name="&gt;&gt;outputDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;Description.Name" xml:space="preserve">
-    <value>Description</value>
-  </data>
-  <data name="arcazeValueColumn.Width" type="System.Int32, mscorlib">
-    <value>65</value>
-  </data>
-  <data name="arcazeValueColumn.HeaderText" xml:space="preserve">
-    <value>Output Value</value>
+  <data name="duplicateRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 22</value>
   </data>
   <data name="duplicateRowToolStripMenuItem.Text" xml:space="preserve">
     <value>Duplicate row</value>
   </data>
-  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>929, 629</value>
-  </data>
-  <data name="&gt;&gt;arcazeValueColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;converterDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;configDataTable.Type" xml:space="preserve">
-    <value>System.Data.DataTable, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="FsuipcOffset.Visible" type="System.Boolean, mscorlib">
+  <data name="deleteRowToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
-  <data name="EditButtonColumn.MinimumWidth" type="System.Int32, mscorlib">
-    <value>55</value>
-  </data>
-  <data name="&gt;&gt;outputTypeDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonDataColumn.Name" xml:space="preserve">
-    <value>comparisonDataColumn</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewContextMenuStrip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="dataGridViewConfig.TabIndex" type="System.Int32, mscorlib">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;copyToolStripMenuItem.Name" xml:space="preserve">
-    <value>copyToolStripMenuItem</value>
-  </data>
-  <data name="&gt;&gt;maskDataColumn.Name" xml:space="preserve">
-    <value>maskDataColumn</value>
-  </data>
-  <data name="&gt;&gt;typeDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="FsuipcOffset.Width" type="System.Int32, mscorlib">
-    <value>65</value>
-  </data>
-  <data name="&gt;&gt;durationDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
-  </data>
-  <data name="Description.ToolTipText" xml:space="preserve">
-    <value>The name or description of your config</value>
-  </data>
-  <data name="&gt;&gt;active.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewCheckBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;descriptionDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;typeDataColumn.Name" xml:space="preserve">
-    <value>typeDataColumn</value>
-  </data>
-  <data name="&gt;&gt;OutputName.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="dataGridViewContextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 98</value>
-  </data>
-  <data name="OutputType.ToolTipText" xml:space="preserve">
-    <value>The type of device used in the config</value>
-  </data>
-  <data name="&gt;&gt;OutputType.Name" xml:space="preserve">
-    <value>OutputType</value>
+  <data name="deleteRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>147, 22</value>
   </data>
   <data name="deleteRowToolStripMenuItem.Text" xml:space="preserve">
     <value>Delete row(s)</value>
   </data>
-  <data name="&gt;&gt;$this.Name" xml:space="preserve">
-    <value>OutputConfigPanel</value>
+  <data name="deleteRowToolStripMenuItem.ToolTipText" xml:space="preserve">
+    <value>Delete selected row(s)</value>
   </data>
-  <data name="&gt;&gt;duplicateRowToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="dataGridViewContextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>148, 98</value>
   </data>
-  <data name="&gt;&gt;outputTypeDataColumn.Name" xml:space="preserve">
-    <value>outputTypeDataColumn</value>
+  <data name="&gt;&gt;dataGridViewContextMenuStrip.Name" xml:space="preserve">
+    <value>dataGridViewContextMenuStrip</value>
   </data>
-  <data name="&gt;&gt;pasteToolStripMenuItem.Name" xml:space="preserve">
-    <value>pasteToolStripMenuItem</value>
+  <data name="&gt;&gt;dataGridViewContextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;EditButtonColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewButtonColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;copyToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fsuipcValueColumn.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;guid.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;fsuipcSizeDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;durationDataColumn.Name" xml:space="preserve">
-    <value>durationDataColumn</value>
-  </data>
-  <data name="&gt;&gt;settingsColumn.Name" xml:space="preserve">
-    <value>settingsColumn</value>
-  </data>
-  <data name="arcazeValueColumn.ToolTipText" xml:space="preserve">
-    <value>The final value used for output</value>
-  </data>
-  <data name="duplicateRowToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
-    <value>False</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewConfig.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;dataSetConfig.Name" xml:space="preserve">
-    <value>dataSetConfig</value>
-  </data>
-  <data name="&gt;&gt;dataGridViewConfig.Name" xml:space="preserve">
-    <value>dataGridViewConfig</value>
-  </data>
-  <data name="arcazeValueColumn.MinimumWidth" type="System.Int32, mscorlib">
-    <value>40</value>
-  </data>
-  <data name="&gt;&gt;deleteRowToolStripMenuItem.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
-    <value>toolStripMenuItem1</value>
-  </data>
-  <data name="&gt;&gt;guidDataColumn.Name" xml:space="preserve">
-    <value>guidDataColumn</value>
-  </data>
-  <data name="pasteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 22</value>
-  </data>
-  <data name="&gt;&gt;usbArcazePinDataColumn.Type" xml:space="preserve">
-    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;comparisonValueDataColumn.Name" xml:space="preserve">
-    <value>comparisonValueDataColumn</value>
-  </data>
-  <data name="&gt;&gt;moduleSerial.Name" xml:space="preserve">
-    <value>moduleSerial</value>
-  </data>
-  <data name="fsuipcValueColumn.MinimumWidth" type="System.Int32, mscorlib">
-    <value>65</value>
-  </data>
-  <data name="&gt;&gt;triggerDataColumn.Name" xml:space="preserve">
-    <value>triggerDataColumn</value>
+  <metadata name="dataSetConfig.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>815, 56</value>
+  </metadata>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="dataGridViewConfig.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
   <data name="dataGridViewConfig.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="&gt;&gt;arcazeSerialDataColumn.Name" xml:space="preserve">
-    <value>arcazeSerialDataColumn</value>
+  <data name="dataGridViewConfig.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
-  <data name="&gt;&gt;active.Name" xml:space="preserve">
-    <value>active</value>
+  <data name="dataGridViewConfig.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1394, 968</value>
   </data>
-  <data name="&gt;&gt;moduleSerial.Type" xml:space="preserve">
-    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="dataGridViewConfig.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
   </data>
-  <metadata name="guid.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="arcazeValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="OutputName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="moduleSerial.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="FsuipcOffset.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  <data name="&gt;&gt;dataGridViewConfig.Name" xml:space="preserve">
+    <value>dataGridViewConfig</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewConfig.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridView, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewConfig.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;dataGridViewConfig.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <metadata name="$this.Localizable" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>280</value>
   </metadata>
-  <metadata name="dataGridViewContextMenuStrip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>591, 56</value>
-  </metadata>
-  <metadata name="fsuipcValueColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="EditButtonColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="Description.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
-  <metadata name="dataSetConfig.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>815, 56</value>
-  </metadata>
-  <metadata name="OutputType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
+  <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
+    <value>9, 20</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1394, 968</value>
+  </data>
+  <data name="&gt;&gt;active.Name" xml:space="preserve">
+    <value>active</value>
+  </data>
+  <data name="&gt;&gt;active.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewCheckBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;guid.Name" xml:space="preserve">
+    <value>guid</value>
+  </data>
+  <data name="&gt;&gt;guid.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;Description.Name" xml:space="preserve">
+    <value>Description</value>
+  </data>
+  <data name="&gt;&gt;Description.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;moduleSerial.Name" xml:space="preserve">
+    <value>moduleSerial</value>
+  </data>
+  <data name="&gt;&gt;moduleSerial.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OutputName.Name" xml:space="preserve">
+    <value>OutputName</value>
+  </data>
+  <data name="&gt;&gt;OutputName.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OutputType.Name" xml:space="preserve">
+    <value>OutputType</value>
+  </data>
+  <data name="&gt;&gt;OutputType.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;FsuipcOffset.Name" xml:space="preserve">
+    <value>FsuipcOffset</value>
+  </data>
+  <data name="&gt;&gt;FsuipcOffset.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fsuipcValueColumn.Name" xml:space="preserve">
+    <value>fsuipcValueColumn</value>
+  </data>
+  <data name="&gt;&gt;fsuipcValueColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;arcazeValueColumn.Name" xml:space="preserve">
+    <value>arcazeValueColumn</value>
+  </data>
+  <data name="&gt;&gt;arcazeValueColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewTextBoxColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;EditButtonColumn.Name" xml:space="preserve">
+    <value>EditButtonColumn</value>
+  </data>
+  <data name="&gt;&gt;EditButtonColumn.Type" xml:space="preserve">
+    <value>System.Windows.Forms.DataGridViewButtonColumn, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;copyToolStripMenuItem.Name" xml:space="preserve">
+    <value>copyToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;copyToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;pasteToolStripMenuItem.Name" xml:space="preserve">
+    <value>pasteToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;pasteToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Name" xml:space="preserve">
+    <value>toolStripMenuItem1</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;duplicateRowToolStripMenuItem.Name" xml:space="preserve">
+    <value>duplicateRowToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;duplicateRowToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;deleteRowToolStripMenuItem.Name" xml:space="preserve">
+    <value>deleteRowToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;deleteRowToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dataSetConfig.Name" xml:space="preserve">
+    <value>dataSetConfig</value>
+  </data>
+  <data name="&gt;&gt;dataSetConfig.Type" xml:space="preserve">
+    <value>System.Data.DataSet, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;configDataTable.Name" xml:space="preserve">
+    <value>configDataTable</value>
+  </data>
+  <data name="&gt;&gt;configDataTable.Type" xml:space="preserve">
+    <value>System.Data.DataTable, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;activeDataColumn.Name" xml:space="preserve">
+    <value>activeDataColumn</value>
+  </data>
+  <data name="&gt;&gt;activeDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fsuipcOffsetDataColumn.Name" xml:space="preserve">
+    <value>fsuipcOffsetDataColumn</value>
+  </data>
+  <data name="&gt;&gt;fsuipcOffsetDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;converterDataColumn.Name" xml:space="preserve">
+    <value>converterDataColumn</value>
+  </data>
+  <data name="&gt;&gt;converterDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;maskDataColumn.Name" xml:space="preserve">
+    <value>maskDataColumn</value>
+  </data>
+  <data name="&gt;&gt;maskDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;usbArcazePinDataColumn.Name" xml:space="preserve">
+    <value>usbArcazePinDataColumn</value>
+  </data>
+  <data name="&gt;&gt;usbArcazePinDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;typeDataColumn.Name" xml:space="preserve">
+    <value>typeDataColumn</value>
+  </data>
+  <data name="&gt;&gt;typeDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;durationDataColumn.Name" xml:space="preserve">
+    <value>durationDataColumn</value>
+  </data>
+  <data name="&gt;&gt;durationDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonDataColumn.Name" xml:space="preserve">
+    <value>comparisonDataColumn</value>
+  </data>
+  <data name="&gt;&gt;comparisonDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;comparisonValueDataColumn.Name" xml:space="preserve">
+    <value>comparisonValueDataColumn</value>
+  </data>
+  <data name="&gt;&gt;comparisonValueDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;descriptionDataColumn.Name" xml:space="preserve">
+    <value>descriptionDataColumn</value>
+  </data>
+  <data name="&gt;&gt;descriptionDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;fsuipcSizeDataColumn.Name" xml:space="preserve">
+    <value>fsuipcSizeDataColumn</value>
+  </data>
+  <data name="&gt;&gt;fsuipcSizeDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;triggerDataColumn.Name" xml:space="preserve">
+    <value>triggerDataColumn</value>
+  </data>
+  <data name="&gt;&gt;triggerDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;arcazeSerialDataColumn.Name" xml:space="preserve">
+    <value>arcazeSerialDataColumn</value>
+  </data>
+  <data name="&gt;&gt;arcazeSerialDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;settingsColumn.Name" xml:space="preserve">
+    <value>settingsColumn</value>
+  </data>
+  <data name="&gt;&gt;settingsColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;guidDataColumn.Name" xml:space="preserve">
+    <value>guidDataColumn</value>
+  </data>
+  <data name="&gt;&gt;guidDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;outputDataColumn.Name" xml:space="preserve">
+    <value>outputDataColumn</value>
+  </data>
+  <data name="&gt;&gt;outputDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;outputTypeDataColumn.Name" xml:space="preserve">
+    <value>outputTypeDataColumn</value>
+  </data>
+  <data name="&gt;&gt;outputTypeDataColumn.Type" xml:space="preserve">
+    <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;$this.Name" xml:space="preserve">
+    <value>OutputConfigPanel</value>
+  </data>
+  <data name="&gt;&gt;$this.Type" xml:space="preserve">
+    <value>System.Windows.Forms.UserControl, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
 </root>


### PR DESCRIPTION
fixes #251 

builds on top of the great ground work of https://github.com/MobiFlight/MobiFlight-Connector/pull/1394 by 
adds the current row as bitmap cursor so that it looks like the row is dragged.

- [x] Autoscroll implemented
- [x] Changed cursor more prominently on drag
- [x] Highlight current drop target 
- [x] Decide drop behavior. - Two lines are highlighted.

