### PR TITLE
Add check for bad CH340 chips

### DIFF
--- a/MobiFlight/Monitors/SerialPortMonitor.cs
+++ b/MobiFlight/Monitors/SerialPortMonitor.cs
@@ -8,6 +8,70 @@ namespace MobiFlight.Monitors
 {
     public class SerialPortMonitor : DeviceMonitor
     {
+        /// <summary>
+        /// Uses WMI to retrieve property data from a ManagementObject.
+        /// </summary>
+        /// <param name="managementObject">The object to retrieve the property from</param>
+        /// <param name="propertyName">The name of the property to retrieve</param>
+        /// <returns>The value of the property or an empty string if the property doesn't exist</returns>
+        private static string GetDeviceProperty(ManagementObject managementObject, string propertyName)
+        {
+            // The GetDeviceProperties method is a method of Win32_PnPEntity objects, but that's not
+            // a type that's exposed via System.Management. To call the method we need to use
+            // InvokeMethod() instead.
+            // The method takes two parameters, a string array of property names and an out parameter
+            // that will contain an array of ManagementBaseObjects.
+            var args = new object[] { new string[] { propertyName }, null };
+            managementObject.InvokeMethod("GetDeviceProperties", args);
+
+            // Grab the properties that were returned by the method.
+            var returnedProperties = (ManagementBaseObject[])args[1];
+
+            // It's possible that the property doesn't exist. If so just return an empty string.
+            if (returnedProperties.Length == 0) return "";
+
+            // Attempt to read the data from the returned property. Not all properties will have data so FirstOrDefault()()
+            // is used to handle the case of no data being returned.
+            var data = returnedProperties[0].Properties.OfType<PropertyData>().FirstOrDefault(p => p.Name == "Data");
+
+            // Return the data or an empty string if there was no data.
+            return (string)data?.Value ?? "";
+        }
+
+        /// <summary>
+        /// Many Arduinos (mostly Nanos, but also some Megas) have a bad CH340 chip that
+        /// doesn't work properly with Windows 11 drivers after Feburary, 2023. This method
+        /// checks the name returned from the chip to see if it is the garbled name
+        /// from the bad chip and returns true if it is.
+        /// </summary>
+        /// <param name="managementObject">A management object for the detected board</param>
+        /// <returns>True if the chip is a bad CH340 chip</returns>
+        private static bool IsBadCH340(ManagementObject managementObject)
+        {
+            var deviceName = GetDeviceProperty(managementObject, "DEVPKEY_Device_BusReportedDeviceDesc");
+
+            // First check is for the bad name. If it doesn't match then it's not a problem board and
+            // just return false.
+            if (deviceName != "USB2.0-Ser!")
+            {
+                return false;
+            }
+
+            // Second test is the version number of the driver. Anything after 3.5.2019.1 is bad.
+            var rawDriverVersion = GetDeviceProperty(managementObject, "DEVPKEY_Device_DriverVersion");
+
+            try
+            {
+                var versionInfo = new Version(rawDriverVersion);
+                var goodDriverVersion = new Version("3.5.2019.1");
+
+                return versionInfo > goodDriverVersion;
+            }
+            catch
+            {
+                return false;
+            }
+        }
         override protected void Scan()
         {
             var portNameRegEx = "\\(.*\\)";
@@ -16,7 +80,7 @@ namespace MobiFlight.Monitors
 
             // Code from https://stackoverflow.com/questions/45165299/wmi-get-list-of-all-serial-com-ports-including-virtual-ports
             ManagementObjectSearcher searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_PnPEntity WHERE ClassGuid=\"{4d36e978-e325-11ce-bfc1-08002be10318}\"");
-            foreach (ManagementObject queryObj in searcher.Get())
+            foreach (ManagementObject queryObj in searcher.Get().Cast<ManagementObject>())
             {
                 // At this point we have a list of possibly valid connected devices. Since everything at this point
                 // depends on the VID/PID extract that to start. USB devices seem to consistently have two hardwareID
@@ -76,6 +140,12 @@ namespace MobiFlight.Monitors
                 {
                     //Log.Instance.log($"Duplicate entry for port: {board.Info.FriendlyName} {portName}.", LogSeverity.Error);
                     continue;
+                }
+
+                // If the device has a bad CH340 chip then log a warning.
+                if (IsBadCH340(queryObj))
+                {
+                    Log.Instance.log($"The device on port {portName} has a CH340 chip that will not work with the installed CH340 driver version. Install driver version 3.5.2019.1 or earlier, otherwise the board will not work with MobiFlight.", LogSeverity.Error);
                 }
 
                 result.Add(new PortDetails


### PR DESCRIPTION
Fixes #1410 

Add a test against the garbled device name that is returned by bad CH340 chips and use that to log an error if a bad chip is detected.