### PR TITLE
Drag'nDrop improvements including reset sorting

### DIFF
--- a/ProjectMessages/ProjectMessages.Designer.cs
+++ b/ProjectMessages/ProjectMessages.Designer.cs
@@ -614,6 +614,15 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Drag and Drop is not available when list is sorted..
+        /// </summary>
+        internal static string uiMessageDragDropNotAllowed {
+            get {
+                return ResourceManager.GetString("uiMessageDragDropNotAllowed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to An error occurred on parsing your value formula. Please review and correct any errors..
         /// </summary>
         internal static string uiMessageErrorOnParsingExpression {

--- a/ProjectMessages/ProjectMessages.de.resx
+++ b/ProjectMessages/ProjectMessages.de.resx
@@ -634,4 +634,8 @@ That midiboard cannot be used until other application is terminated and MobiFlig
     <value>Doppelte x-Werte sind nicht gültig.</value>
     <comment>Duplicate x values are not valid</comment>
   </data>
+  <data name="uiMessageDragDropNotAllowed" xml:space="preserve">
+    <value>Drag and Drop ist nicht verfügbar, wenn die Liste sortiert ist.</value>
+    <comment>Drag and Drop is not available when list is sorted.</comment>
+  </data>
 </root>

--- a/ProjectMessages/ProjectMessages.resx
+++ b/ProjectMessages/ProjectMessages.resx
@@ -612,4 +612,7 @@ That midiboard cannot be used until other application is terminated and MobiFlig
   <data name="uiLabelInterpolationDuplicateXvalueNotAllowed" xml:space="preserve">
     <value>Duplicate x values are not valid</value>
   </data>
+  <data name="uiMessageDragDropNotAllowed" xml:space="preserve">
+    <value>Drag and Drop is not available when list is sorted.</value>
+  </data>
 </root>

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1852,6 +1852,10 @@ namespace MobiFlight.UI
                 execManager.Stop();
                 CurrentFileName = null;
                 _setFilenameInTitle(i18n._tr("DefaultFileName"));
+                // Reset sorting if active
+                if (outputConfigPanel.IsSortingActive()) outputConfigPanel.ResetSorting();
+                if (inputConfigPanel.IsSortingActive()) inputConfigPanel.ResetSorting();
+                // Clear data
                 outputConfigPanel.ConfigDataTable.Clear();
                 inputConfigPanel.ConfigDataTable.Clear();
             };

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1387,7 +1387,12 @@ namespace MobiFlight.UI
 
             execManager.Stop();
 
-            if (!merge) { 
+            // Reset sorting if active
+            if (outputConfigPanel.IsSortingActive()) outputConfigPanel.ResetSorting();
+            if (inputConfigPanel.IsSortingActive()) inputConfigPanel.ResetSorting();
+
+            if (!merge)
+            {
                 outputConfigPanel.DataSetConfig.Clear();
                 inputConfigPanel.InputDataSetConfig.Clear();
             }
@@ -1421,7 +1426,6 @@ namespace MobiFlight.UI
                 return;
             }
 
-
             // for backward compatibility 
             // we check if there are rows that need to
             // initialize our config item correctly
@@ -1438,7 +1442,8 @@ namespace MobiFlight.UI
                 // since due to initiliazing the dataSet
                 // it will automatically gets enabled
                 saveToolStripButton.Enabled = false;
-            } else
+            }
+            else
             {
                 // indicate that the merge changed
                 // the current config and that the user
@@ -1448,8 +1453,8 @@ namespace MobiFlight.UI
             // always put this after "normal" initialization
             // savetoolstripbutton may be set to "enabled"
             // if user has changed something
-            _checkForOrphanedSerials( false );
-            _checkForOrphanedJoysticks( false );
+            _checkForOrphanedSerials(false);
+            _checkForOrphanedJoysticks(false);
             _checkForOrphanedMidiBoards(false);
 
             // Track config loaded event
@@ -1458,6 +1463,7 @@ namespace MobiFlight.UI
             AppTelemetry.Instance.TrackSettings();
 
             ConfigLoaded?.Invoke(this, configFile);
+                 
         }
 
         private void _checkForOrphanedJoysticks(bool showNotNecessaryMessage)

--- a/UI/Panels/InputConfigPanel.Designer.cs
+++ b/UI/Panels/InputConfigPanel.Designer.cs
@@ -30,10 +30,10 @@
         {
             this.components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(InputConfigPanel));
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle9 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle10 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle11 = new System.Windows.Forms.DataGridViewCellStyle();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle12 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
             this.inputsDataGridViewContextMenuStrip = new System.Windows.Forms.ContextMenuStrip(this.components);
             this.copyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.pasteToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -198,6 +198,7 @@
             this.inputsDataGridView.CellMouseDown += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.inputsDataGridView_CellMouseDown);
             this.inputsDataGridView.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.inputsDataGridView_DataBindingComplete);
             this.inputsDataGridView.DefaultValuesNeeded += new System.Windows.Forms.DataGridViewRowEventHandler(this.inputsDataGridViewConfig_DefaultValuesNeeded);
+            this.inputsDataGridView.Sorted += new System.EventHandler(this.inputsDataGridView_Sorted);
             this.inputsDataGridView.DragDrop += new System.Windows.Forms.DragEventHandler(this.inputsDataGridView_DragDrop);
             this.inputsDataGridView.DragOver += new System.Windows.Forms.DragEventHandler(this.inputsDataGridView_DragOver);
             this.inputsDataGridView.GiveFeedback += new System.Windows.Forms.GiveFeedbackEventHandler(this.inputsDataGridView_GiveFeedback);
@@ -232,8 +233,8 @@
             // 
             this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.moduleSerial.DataPropertyName = "moduleSerial";
-            dataGridViewCellStyle9.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle9;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle1;
             this.moduleSerial.FillWeight = 150F;
             resources.ApplyResources(this.moduleSerial, "moduleSerial");
             this.moduleSerial.Name = "moduleSerial";
@@ -244,8 +245,8 @@
             // 
             this.inputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.inputName.DataPropertyName = "inputName";
-            dataGridViewCellStyle10.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.inputName.DefaultCellStyle = dataGridViewCellStyle10;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.inputName.DefaultCellStyle = dataGridViewCellStyle2;
             this.inputName.FillWeight = 150F;
             resources.ApplyResources(this.inputName, "inputName");
             this.inputName.Name = "inputName";
@@ -256,8 +257,8 @@
             // 
             this.inputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.inputType.DataPropertyName = "inputType";
-            dataGridViewCellStyle11.BackColor = System.Drawing.SystemColors.ControlLight;
-            this.inputType.DefaultCellStyle = dataGridViewCellStyle11;
+            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.inputType.DefaultCellStyle = dataGridViewCellStyle3;
             this.inputType.FillWeight = 150F;
             resources.ApplyResources(this.inputType, "inputType");
             this.inputType.Name = "inputType";
@@ -266,10 +267,10 @@
             // inputEditButtonColumn
             // 
             this.inputEditButtonColumn.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            dataGridViewCellStyle12.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
-            dataGridViewCellStyle12.BackColor = System.Drawing.SystemColors.ControlLight;
-            dataGridViewCellStyle12.NullValue = "...";
-            this.inputEditButtonColumn.DefaultCellStyle = dataGridViewCellStyle12;
+            dataGridViewCellStyle4.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleCenter;
+            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.ControlLight;
+            dataGridViewCellStyle4.NullValue = "...";
+            this.inputEditButtonColumn.DefaultCellStyle = dataGridViewCellStyle4;
             resources.ApplyResources(this.inputEditButtonColumn, "inputEditButtonColumn");
             this.inputEditButtonColumn.Name = "inputEditButtonColumn";
             this.inputEditButtonColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -253,10 +253,23 @@ namespace MobiFlight.UI.Panels
                 row.Selected = false;
             }
         }
-
-        private bool IsSortingActive()
+        
+        /// <summary>
+        /// Is sorting in DataGridView active.
+        /// </summary>        
+        public bool IsSortingActive()
         {
             return inputsDataGridView.SortOrder != SortOrder.None;
+        }
+
+        /// <summary>
+        /// Reset sorting in DataGridView
+        /// </summary>
+        public void ResetSorting()
+        {
+            LastSortingColumnName = string.Empty;
+            LastSortingOrder = SortOrder.None;
+            inputsDataTable.DefaultView.Sort = string.Empty;
         }
 
         private void inputsDataGridView_Sorted(object sender, EventArgs e)
@@ -268,9 +281,7 @@ namespace MobiFlight.UI.Panels
                 // Reset sorting after previous Descending
                 if (LastSortingColumnName == name && LastSortingOrder == SortOrder.Descending)
                 {
-                    LastSortingColumnName = string.Empty;
-                    LastSortingOrder = SortOrder.None;
-                    inputsDataTable.DefaultView.Sort = string.Empty;
+                    ResetSorting();
                 }
                 else
                 {
@@ -285,6 +296,7 @@ namespace MobiFlight.UI.Panels
         { 
             if (e.ListChangedType == ListChangedType.Reset)
             {
+                inputsDataGridView.ClearSelection(); // necessary because on sorting reset, callback is called twice
                 foreach (DataGridViewRow row in (sender as DataGridView).Rows)
                 {                   
                     if (row.DataBoundItem as DataRowView == null) continue;

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -731,9 +731,11 @@ namespace MobiFlight.UI.Panels
         private void inputsDataGridView_MouseMove(object sender, MouseEventArgs e)
         {
             if (MouseButtons.Left == (e.Button & MouseButtons.Left))
-            {                
+            {
                 // When mouse leaves the rectangle, start drag and drop
-                if (RectangleMouseDown != Rectangle.Empty && !RectangleMouseDown.Contains(e.X, e.Y))
+                if (RectangleMouseDown != Rectangle.Empty &&
+                    !RectangleMouseDown.Contains(e.X, e.Y) &&
+                    !IsSortingActive())                   
                 {
                     // Only select Row which is to be moved, needed because of active multiselect
                     inputsDataGridView.ClearSelection();

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -45,9 +45,9 @@ namespace MobiFlight.UI.Panels
         public DataGridView InputsDataGridView { get { return inputsDataGridView; } }
 
         void Init()
-        {      
-            inputsDataGridView.DataSource = inputsDataTable;
+        {
             inputsDataGridView.DataMember = null;
+            inputsDataGridView.DataSource = inputsDataTable;            
             Helper.DoubleBufferedDGV(inputsDataGridView, true);
 
             inputsDataTable.RowChanged += new DataRowChangeEventHandler(configDataTable_RowChanged);

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -24,6 +24,8 @@ namespace MobiFlight.UI.Panels
         private int RowCurrentDragHighlight = 0;
         private int RowNeighbourDragHighlight = 0;
         private bool IsInCurrentRowTopHalf;
+        private System.Windows.Forms.Timer DropTimer = new Timer();
+        private Bitmap CurrentCursorBitmap;
 
         private object[] EditedItem = null;
         public ExecutionManager ExecutionManager { get; set; }
@@ -50,6 +52,9 @@ namespace MobiFlight.UI.Panels
 
             inputsDataGridView.Columns["inputDescription"].DefaultCellStyle.NullValue = i18n._tr("uiLabelDoubleClickToAddConfig");
             inputsDataGridView.Columns["inputEditButtonColumn"].DefaultCellStyle.NullValue = "...";
+
+            DropTimer.Interval = 400;
+            DropTimer.Tick += DropTimer_Tick;
         }
 
         private void _editConfigWithInputWizard(DataRow dataRow, InputConfigItem cfg, bool create)
@@ -767,6 +772,11 @@ namespace MobiFlight.UI.Panels
                 inputsDataTable.Rows.Remove(rowToRemove);
                 int newIndex = inputsDataTable.Rows.IndexOf(rowToInsert);
                 inputsDataGridView.CurrentCell = inputsDataGridView.Rows[newIndex].Cells["inputDescription"];
+                // Used to keep the two rows colored for a short period of time after drop
+                if (newIndex > 0)
+                    RowNeighbourDragHighlight = newIndex - 1;
+                if (newIndex < (inputsDataGridView.Rows.Count - 1))
+                    RowCurrentDragHighlight = newIndex + 1;
             }
         }
 
@@ -791,7 +801,6 @@ namespace MobiFlight.UI.Panels
                     Cursor.Position = new Point(Cursor.Position.X - offsetX, Cursor.Position.Y);
                 }
             }
-
             else
                 Cursor.Current = Cursors.Default;
         }
@@ -802,7 +811,7 @@ namespace MobiFlight.UI.Panels
             var localCoords = PointToClient(Cursor.Position);
 
             // Get the size of the row which is equivalent to the cursor bitmap
-            Rectangle rowRectangle = inputsDataGridView.GetRowDisplayRectangle(RowIndexMouseDown, true);
+            Rectangle rowRectangle = inputsDataGridView.GetRowDisplayRectangle(RowCurrentDragHighlight, true);
 
             double cursorWidth = rowRectangle.Width;
             // if we grab the row exactly in the center, then the offset is 0
@@ -813,28 +822,30 @@ namespace MobiFlight.UI.Panels
 
         private Cursor CreateCursor(DataGridViewRow row)
         {
-            Size clientSize = inputsDataGridView.ClientSize;
-            Rectangle rowRectangle = inputsDataGridView.GetRowDisplayRectangle(RowIndexMouseDown, true);
-            var scalingFactor = GetScalingFactor(this.Handle);
-
-            using (Bitmap dataGridViewBmp = new Bitmap(clientSize.Width, clientSize.Height))
-            using (Bitmap rowBmp = new Bitmap(rowRectangle.Width, rowRectangle.Height))
+            if (CurrentCursorBitmap == null)
             {
-                inputsDataGridView.DrawToBitmap(dataGridViewBmp, new Rectangle(Point.Empty, clientSize));
-                using (Graphics G = Graphics.FromImage(rowBmp))
-                {
-                    G.DrawImage(dataGridViewBmp, new Rectangle(Point.Empty, rowRectangle.Size), rowRectangle, GraphicsUnit.Pixel);
-                }
+                Size clientSize = inputsDataGridView.ClientSize;
+                Rectangle rowRectangle = inputsDataGridView.GetRowDisplayRectangle(RowIndexMouseDown, true);
+                var scalingFactor = GetScalingFactor(this.Handle);
 
-                var scaledX = (int)Math.Round(rowRectangle.Width * scalingFactor, 0);
-                var scaledY = (int)Math.Round(rowRectangle.Height * scalingFactor, 0);
-
-                using (var scaledRowBmp = new Bitmap(rowBmp, new Size(scaledX, scaledY)))
+                using (Bitmap dataGridViewBmp = new Bitmap(clientSize.Width, clientSize.Height))
+                using (Bitmap rowBmp = new Bitmap(rowRectangle.Width, rowRectangle.Height))
                 {
-                    return new Cursor(scaledRowBmp.GetHicon());
+                    inputsDataGridView.DrawToBitmap(dataGridViewBmp, new Rectangle(Point.Empty, clientSize));
+                    using (Graphics G = Graphics.FromImage(rowBmp))
+                    {
+                        G.DrawImage(dataGridViewBmp, new Rectangle(Point.Empty, rowRectangle.Size), rowRectangle, GraphicsUnit.Pixel);
+                    }
+
+                    var scaledX = (int)Math.Round(rowRectangle.Width * scalingFactor, 0);
+                    var scaledY = (int)Math.Round(rowRectangle.Height * scalingFactor, 0);
+
+                    CurrentCursorBitmap = new Bitmap(rowBmp, new Size(scaledX, scaledY));
                 }
             }
+            return new Cursor(CurrentCursorBitmap.GetHicon());
         }
+
 
         private double GetScalingFactor(IntPtr handle)
         {
@@ -848,9 +859,20 @@ namespace MobiFlight.UI.Panels
         private void inputsDataGridView_QueryContinueDrag(object sender, QueryContinueDragEventArgs e)
         {
             if (e.Action == DragAction.Cancel || e.Action == DragAction.Drop) 
-            {         
-                RemoveDragTargetHighlight();               
+            {               
+                if (CurrentCursorBitmap != null)
+                {
+                    CurrentCursorBitmap.Dispose();
+                    CurrentCursorBitmap = null;
+                }
+                DropTimer.Start();                             
             }                   
+        }
+
+        private void DropTimer_Tick(object sender, EventArgs e)
+        {
+            DropTimer.Stop();
+            RemoveDragTargetHighlight();
         }
     }
 }

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -47,7 +47,7 @@ namespace MobiFlight.UI.Panels
         void Init()
         {
             inputsDataGridView.DataMember = null;
-            inputsDataGridView.DataSource = inputsDataTable;            
+            inputsDataGridView.DataSource = inputsDataTable;
             Helper.DoubleBufferedDGV(inputsDataGridView, true);
 
             inputsDataTable.RowChanged += new DataRowChangeEventHandler(configDataTable_RowChanged);
@@ -259,6 +259,27 @@ namespace MobiFlight.UI.Panels
             return inputsDataGridView.SortOrder != SortOrder.None;
         }
 
+        private void inputsDataGridView_Sorted(object sender, EventArgs e)
+        {
+            if (IsSortingActive())
+            {
+                string name = inputsDataGridView.SortedColumn.Name;
+                // It is always (Ascending) -> (Descending) -> (Ascending)
+                // Reset sorting after previous Descending
+                if (LastSortingColumnName == name && LastSortingOrder == SortOrder.Descending)
+                {
+                    LastSortingColumnName = string.Empty;
+                    LastSortingOrder = SortOrder.None;
+                    inputsDataTable.DefaultView.Sort = string.Empty;
+                }
+                else
+                {
+                    // Store current sorting
+                    LastSortingColumnName = name;
+                    LastSortingOrder = InputsDataGridView.SortOrder;
+                }
+            }
+        }
 
         private void inputsDataGridView_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
         { 
@@ -273,25 +294,6 @@ namespace MobiFlight.UI.Panels
 
                     if (SelectedGuids.Contains(guid))
                         row.Selected = true;
-                }
-
-                if (IsSortingActive())
-                {
-                    string name = inputsDataGridView.SortedColumn.Name;
-                    // It is always (Ascending) -> (Descending) -> (Ascending)
-                    // Reset sorting after previous Descending
-                    if (LastSortingColumnName == name && LastSortingOrder == SortOrder.Descending)
-                    {                        
-                        LastSortingColumnName = string.Empty;
-                        LastSortingOrder = SortOrder.None;
-                        inputsDataTable.DefaultView.Sort = string.Empty;
-                    }
-                    else
-                    {
-                        // Store current sorting
-                        LastSortingColumnName = name;
-                        LastSortingOrder = InputsDataGridView.SortOrder;
-                    }
                 }
             }
         }

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -746,17 +746,22 @@ namespace MobiFlight.UI.Panels
         {
             if (MouseButtons.Left == (e.Button & MouseButtons.Left))
             {
-                // When mouse leaves the rectangle, start drag and drop
-                if (RectangleMouseDown != Rectangle.Empty &&
-                    !RectangleMouseDown.Contains(e.X, e.Y) &&
-                    !IsSortingActive())                   
-                {
+                // When mouse did not leave rectangle return, otherwise start drag and drop
+                if (RectangleMouseDown == Rectangle.Empty || RectangleMouseDown.Contains(e.X, e.Y)) return;
+
+                if (!IsSortingActive())
+                {                    
                     // Only select Row which is to be moved, needed because of active multiselect
                     inputsDataGridView.ClearSelection();
                     inputsDataGridView.Rows[RowIndexMouseDown].Selected = true;
                     inputsDataGridView.CurrentCell = inputsDataGridView.Rows[RowIndexMouseDown].Cells["inputDescription"];
                     // Start drag and drop
                     inputsDataGridView.DoDragDrop(inputsDataTable.Rows[RowIndexMouseDown], DragDropEffects.Move);           
+                }
+                else
+                {
+                    // Show message box no drag and drop on sorted list
+                    MessageBox.Show(i18n._tr("uiMessageDragDropNotAllowed"), i18n._tr("Hint"));
                 }
             }
         }

--- a/UI/Panels/InputConfigPanel.resx
+++ b/UI/Panels/InputConfigPanel.resx
@@ -121,15 +121,6 @@
     <value>136, 22</value>
   </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-  <data name="inputsDataGridViewContextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>151, 98</value>
-  </data>
-  <data name="&gt;&gt;inputsDataGridViewContextMenuStrip.Name" xml:space="preserve">
-    <value>inputsDataGridViewContextMenuStrip</value>
-  </data>
-  <data name="&gt;&gt;inputsDataGridViewContextMenuStrip.Type" xml:space="preserve">
-    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
   <data name="copyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>150, 22</value>
   </data>
@@ -156,6 +147,15 @@
   </data>
   <data name="deleteInputsRowToolStripMenuItem.Text" xml:space="preserve">
     <value>Delete Row</value>
+  </data>
+  <data name="inputsDataGridViewContextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
+    <value>151, 98</value>
+  </data>
+  <data name="&gt;&gt;inputsDataGridViewContextMenuStrip.Name" xml:space="preserve">
+    <value>inputsDataGridViewContextMenuStrip</value>
+  </data>
+  <data name="&gt;&gt;inputsDataGridViewContextMenuStrip.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ContextMenuStrip, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <metadata name="dataSetInputs.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>431, 19</value>

--- a/UI/Panels/OutputConfigPanel.Designer.cs
+++ b/UI/Panels/OutputConfigPanel.Designer.cs
@@ -149,6 +149,7 @@
             this.dataGridViewConfig.DataBindingComplete += new System.Windows.Forms.DataGridViewBindingCompleteEventHandler(this.dataGridViewConfig_DataBindingComplete);
             this.dataGridViewConfig.DefaultValuesNeeded += new System.Windows.Forms.DataGridViewRowEventHandler(this.DataGridViewConfig_DefaultValuesNeeded);
             this.dataGridViewConfig.EditingControlShowing += new System.Windows.Forms.DataGridViewEditingControlShowingEventHandler(this.dataGridViewConfig_EditingControlShowing);
+            this.dataGridViewConfig.Sorted += new System.EventHandler(this.dataGridViewConfig_Sorted);
             this.dataGridViewConfig.DragDrop += new System.Windows.Forms.DragEventHandler(this.dataGridViewConfig_DragDrop);
             this.dataGridViewConfig.DragOver += new System.Windows.Forms.DragEventHandler(this.dataGridViewConfig_DragOver);
             this.dataGridViewConfig.GiveFeedback += new System.Windows.Forms.GiveFeedbackEventHandler(this.dataGridViewConfig_GiveFeedback);

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -41,7 +41,7 @@ namespace MobiFlight.UI.Panels
         private void Init()
         {
             dataGridViewConfig.DataMember = null;
-            dataGridViewConfig.DataSource = configDataTable;            
+            dataGridViewConfig.DataSource = configDataTable;
             dataGridViewConfig.Columns["Description"].DefaultCellStyle.NullValue = i18n._tr("uiLabelDoubleClickToAddConfig");
             dataGridViewConfig.Columns["EditButtonColumn"].DefaultCellStyle.NullValue = "...";
 
@@ -742,6 +742,28 @@ namespace MobiFlight.UI.Panels
             return dataGridViewConfig.SortOrder != SortOrder.None;
         }
 
+        private void dataGridViewConfig_Sorted(object sender, EventArgs e)
+        {
+            if (IsSortingActive())
+            {
+                string name = dataGridViewConfig.SortedColumn.Name;
+                // It is always (Ascending) -> (Descending) -> (Ascending)
+                // Reset sorting after previous Descending
+                if (LastSortingColumnName == name && LastSortingOrder == SortOrder.Descending)
+                {
+                    LastSortingColumnName = string.Empty;
+                    LastSortingOrder = SortOrder.None;
+                    configDataTable.DefaultView.Sort = string.Empty;
+                }
+                else
+                {
+                    // Store current sorting
+                    LastSortingColumnName = name;
+                    LastSortingOrder = dataGridViewConfig.SortOrder;
+                }
+            }
+        }
+
         private void dataGridViewConfig_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
         {
             if (e.ListChangedType == ListChangedType.Reset)
@@ -755,25 +777,6 @@ namespace MobiFlight.UI.Panels
 
                     if (SelectedGuids.Contains(guid))
                         row.Selected = true;
-                }
-
-                if (IsSortingActive())
-                {                    
-                    string name = dataGridViewConfig.SortedColumn.Name;
-                    // It is always (Ascending) -> (Descending) -> (Ascending)
-                    // Reset sorting after previous Descending
-                    if (LastSortingColumnName == name && LastSortingOrder == SortOrder.Descending)
-                    {
-                        LastSortingColumnName = string.Empty;
-                        LastSortingOrder = SortOrder.None;
-                        configDataTable.DefaultView.Sort = string.Empty;
-                    }
-                    else
-                    {
-                        // Store current sorting
-                        LastSortingColumnName = name;
-                        LastSortingOrder = dataGridViewConfig.SortOrder;
-                    }
                 }
             }
         }

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -737,9 +737,22 @@ namespace MobiFlight.UI.Panels
             }
         }
 
-        private bool IsSortingActive()
+        /// <summary>
+        /// Is sorting in DataGridView active.
+        /// </summary>        
+        public bool IsSortingActive()
         {
             return dataGridViewConfig.SortOrder != SortOrder.None;
+        }
+
+        /// <summary>
+        /// Reset sorting in DataGridView
+        /// </summary>
+        public void ResetSorting()
+        {
+            LastSortingColumnName = string.Empty;
+            LastSortingOrder = SortOrder.None;
+            configDataTable.DefaultView.Sort = string.Empty;
         }
 
         private void dataGridViewConfig_Sorted(object sender, EventArgs e)
@@ -751,9 +764,7 @@ namespace MobiFlight.UI.Panels
                 // Reset sorting after previous Descending
                 if (LastSortingColumnName == name && LastSortingOrder == SortOrder.Descending)
                 {
-                    LastSortingColumnName = string.Empty;
-                    LastSortingOrder = SortOrder.None;
-                    configDataTable.DefaultView.Sort = string.Empty;
+                    ResetSorting();
                 }
                 else
                 {
@@ -768,6 +779,7 @@ namespace MobiFlight.UI.Panels
         {
             if (e.ListChangedType == ListChangedType.Reset)
             {
+                dataGridViewConfig.ClearSelection(); // necessary because on sorting reset, callback is called twice
                 foreach (DataGridViewRow row in (sender as DataGridView).Rows)
                 {
                     if (row.DataBoundItem as DataRowView == null) continue;

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -40,8 +40,8 @@ namespace MobiFlight.UI.Panels
 
         private void Init()
         {
-            dataGridViewConfig.DataSource = configDataTable;
             dataGridViewConfig.DataMember = null;
+            dataGridViewConfig.DataSource = configDataTable;            
             dataGridViewConfig.Columns["Description"].DefaultCellStyle.NullValue = i18n._tr("uiLabelDoubleClickToAddConfig");
             dataGridViewConfig.Columns["EditButtonColumn"].DefaultCellStyle.NullValue = "...";
 

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -876,17 +876,22 @@ namespace MobiFlight.UI.Panels
         {
             if (MouseButtons.Left == (e.Button & MouseButtons.Left))
             {
-                // When mouse leaves the rectangle, start drag and drop
-                if (RectangleMouseDown != Rectangle.Empty && 
-                    !RectangleMouseDown.Contains(e.X, e.Y) &&
-                    !IsSortingActive())
+                // When mouse did not leave rectangle return, otherwise start drag and drop
+                if (RectangleMouseDown == Rectangle.Empty || RectangleMouseDown.Contains(e.X, e.Y)) return;
+
+                if (!IsSortingActive())
                 {
                     // Only select Row which is to be moved, needed because of active multiselect
                     dataGridViewConfig.ClearSelection();
                     dataGridViewConfig.Rows[RowIndexMouseDown].Selected = true;
                     dataGridViewConfig.CurrentCell = dataGridViewConfig.Rows[RowIndexMouseDown].Cells["description"];
-                    // Start drag and drop               
+                    // Start drag and drop
                     dataGridViewConfig.DoDragDrop(configDataTable.Rows[RowIndexMouseDown], DragDropEffects.Move);
+                }
+                else
+                {
+                    // Show message box no drag and drop on sorted list
+                    MessageBox.Show(i18n._tr("uiMessageDragDropNotAllowed"), i18n._tr("Hint"));
                 }
             }
         }

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -800,7 +800,7 @@ namespace MobiFlight.UI.Panels
                     cell.Style.BackColor = color;
                     cell.Style.Padding = new Padding(0,0,0,0);
                 }
-            }
+            }            
         }
 
         private void AdjustDragTargetHighlight(int rowIndex)
@@ -862,7 +862,9 @@ namespace MobiFlight.UI.Panels
             if (MouseButtons.Left == (e.Button & MouseButtons.Left))
             {
                 // When mouse leaves the rectangle, start drag and drop
-                if (RectangleMouseDown != Rectangle.Empty && !RectangleMouseDown.Contains(e.X, e.Y))
+                if (RectangleMouseDown != Rectangle.Empty && 
+                    !RectangleMouseDown.Contains(e.X, e.Y) &&
+                    !IsSortingActive())
                 {
                     // Only select Row which is to be moved, needed because of active multiselect
                     dataGridViewConfig.ClearSelection();

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -27,6 +27,8 @@ namespace MobiFlight.UI.Panels
         private int RowCurrentDragHighlight = 0;
         private int RowNeighbourDragHighlight = 0;
         private bool IsInCurrentRowTopHalf;
+        private System.Windows.Forms.Timer DropTimer = new Timer();
+        private Bitmap CurrentCursorBitmap;
 
         public OutputConfigPanel()
         {
@@ -46,6 +48,9 @@ namespace MobiFlight.UI.Panels
             configDataTable.TableCleared += new DataTableClearEventHandler((o,a)=> { SettingsChanged?.Invoke(this, null); });
 
             Helper.DoubleBufferedDGV(dataGridViewConfig, true);
+
+            DropTimer.Interval = 400;
+            DropTimer.Tick += DropTimer_Tick;
         }
 
         public ExecutionManager ExecutionManager { get; set; }
@@ -896,6 +901,11 @@ namespace MobiFlight.UI.Panels
                 configDataTable.Rows.Remove(rowToRemove);
                 int newIndex = configDataTable.Rows.IndexOf(rowToInsert);
                 dataGridViewConfig.CurrentCell = dataGridViewConfig.Rows[newIndex].Cells["description"];
+                // Used to keep the two rows colored for a short period of time after drop
+                if (newIndex > 0)
+                    RowNeighbourDragHighlight = newIndex - 1;
+                if (newIndex < (dataGridViewConfig.Rows.Count - 1))
+                    RowCurrentDragHighlight = newIndex + 1;
             }
         }
 
@@ -932,7 +942,7 @@ namespace MobiFlight.UI.Panels
             var localCoords = PointToClient(Cursor.Position);
 
             // Get the size of the row which is equivalent to the cursor bitmap
-            Rectangle rowRectangle = dataGridViewConfig.GetRowDisplayRectangle(RowIndexMouseDown, true);
+            Rectangle rowRectangle = dataGridViewConfig.GetRowDisplayRectangle(RowCurrentDragHighlight, true);
 
             double cursorWidth = rowRectangle.Width;
             // if we grab the row exactly in the center, then the offset is 0
@@ -943,27 +953,28 @@ namespace MobiFlight.UI.Panels
 
         private Cursor CreateCursor(DataGridViewRow row)
         {
-            Size clientSize = dataGridViewConfig.ClientSize;
-            Rectangle rowRectangle = dataGridViewConfig.GetRowDisplayRectangle(RowIndexMouseDown, true);
-            var scalingFactor = GetScalingFactor(this.Handle);
-            
-            using (Bitmap dataGridViewBmp = new Bitmap(clientSize.Width, clientSize.Height))
-            using (Bitmap rowBmp = new Bitmap(rowRectangle.Width, rowRectangle.Height))
+            if (CurrentCursorBitmap == null)
             {
-                dataGridViewConfig.DrawToBitmap(dataGridViewBmp, new Rectangle(Point.Empty, clientSize));
-                using (Graphics G = Graphics.FromImage(rowBmp))
+                Size clientSize = dataGridViewConfig.ClientSize;
+                Rectangle rowRectangle = dataGridViewConfig.GetRowDisplayRectangle(RowIndexMouseDown, true);
+                var scalingFactor = GetScalingFactor(this.Handle);
+
+                using (Bitmap dataGridViewBmp = new Bitmap(clientSize.Width, clientSize.Height))
+                using (Bitmap rowBmp = new Bitmap(rowRectangle.Width, rowRectangle.Height))
                 {
-                    G.DrawImage(dataGridViewBmp, new Rectangle(Point.Empty, rowRectangle.Size), rowRectangle, GraphicsUnit.Pixel);
+                    dataGridViewConfig.DrawToBitmap(dataGridViewBmp, new Rectangle(Point.Empty, clientSize));
+                    using (Graphics G = Graphics.FromImage(rowBmp))
+                    {
+                        G.DrawImage(dataGridViewBmp, new Rectangle(Point.Empty, rowRectangle.Size), rowRectangle, GraphicsUnit.Pixel);
+                    }
+
+                    var scaledX = (int)Math.Round(rowRectangle.Width * scalingFactor, 0);
+                    var scaledY = (int)Math.Round(rowRectangle.Height * scalingFactor, 0);
+
+                    CurrentCursorBitmap = new Bitmap(rowBmp, new Size(scaledX, scaledY));
                 }
-
-                var scaledX = (int)Math.Round(rowRectangle.Width * scalingFactor, 0);
-                var scaledY = (int)Math.Round(rowRectangle.Height * scalingFactor, 0);
-
-                using (var scaledRowBmp = new Bitmap(rowBmp, new Size(scaledX, scaledY)))
-                {
-                    return new Cursor(scaledRowBmp.GetHicon());
-                }                
             }
+            return new Cursor(CurrentCursorBitmap.GetHicon());
         }
 
         private double GetScalingFactor(IntPtr handle)
@@ -979,8 +990,19 @@ namespace MobiFlight.UI.Panels
         {
             if (e.Action == DragAction.Cancel || e.Action == DragAction.Drop)
             {
-                RemoveDragTargetHighlight();                
+                if (CurrentCursorBitmap != null)
+                {
+                    CurrentCursorBitmap.Dispose();
+                    CurrentCursorBitmap = null;
+                }
+                DropTimer.Start();
             }
+        }
+
+        private void DropTimer_Tick(object sender, EventArgs e)
+        {
+            DropTimer.Stop();
+            RemoveDragTargetHighlight();
         }
     }
 }


### PR DESCRIPTION
- [x] Short row highlight on drop 
- [x] Bitmap fix when leaving window and dragged row is not visible anymore
- [x] Reset Sorting on third header column click.
- [x] Drag and Drop shall not be possible on sorted list 
- [x] MessageBox when drag and drop is not allowed
- [x] Reset sorting on file open and file new 
- [x] i18n
- [x] ~~unit tests~~ - does not apply here
- [ ] documentation

related to #251 
improves #1405