### PR TITLE
Add schema validation to .board.json file loading

### DIFF
--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -1000,7 +1000,7 @@
     <None Include="Boards\mobiflight_genericI2C_mega.board.json.inactive">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Boards\RP2040.board.json">
+    <None Include="Boards\raspberrypi_pico.board.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Build\build-firmware.bat" />

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -165,6 +165,9 @@
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json.Schema, Version=3.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.Schema.3.0.15\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>
+    </Reference>
     <Reference Include="protobuf-net, Version=3.0.0.0, Culture=neutral, PublicKeyToken=257b51d87d2e4d67, processorArchitecture=MSIL">
       <HintPath>packages\protobuf-net.3.1.33\lib\net462\protobuf-net.dll</HintPath>
     </Reference>
@@ -997,7 +1000,7 @@
     <None Include="Boards\mobiflight_genericI2C_mega.board.json.inactive">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="Boards\raspberrypi_pico.board.json">
+    <None Include="Boards\RP2040.board.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Build\build-firmware.bat" />

--- a/UI/Dialogs/AboutForm.Designer.cs
+++ b/UI/Dialogs/AboutForm.Designer.cs
@@ -39,14 +39,15 @@
             this.label2 = new System.Windows.Forms.Label();
             this.linkLabel1 = new System.Windows.Forms.LinkLabel();
             this.panel2 = new System.Windows.Forms.Panel();
+            this.licenseReferenceControl6 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl5 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl2 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            this.licenseReferenceControl7 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl4 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl3 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl1 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.label5 = new System.Windows.Forms.Label();
             this.panel3 = new System.Windows.Forms.Panel();
-            this.licenseReferenceControl6 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panel3.SuspendLayout();
@@ -116,12 +117,22 @@
             this.panel2.Controls.Add(this.licenseReferenceControl6);
             this.panel2.Controls.Add(this.licenseReferenceControl5);
             this.panel2.Controls.Add(this.licenseReferenceControl2);
+            this.panel2.Controls.Add(this.licenseReferenceControl7);
             this.panel2.Controls.Add(this.licenseReferenceControl4);
             this.panel2.Controls.Add(this.licenseReferenceControl3);
             this.panel2.Controls.Add(this.licenseReferenceControl1);
             this.panel2.Controls.Add(this.label5);
             resources.ApplyResources(this.panel2, "panel2");
             this.panel2.Name = "panel2";
+            // 
+            // licenseReferenceControl6
+            // 
+            resources.ApplyResources(this.licenseReferenceControl6, "licenseReferenceControl6");
+            this.licenseReferenceControl6.Library = "MidiSlicer";
+            this.licenseReferenceControl6.LibraryLink = "https://github.com/codewitch-honey-crisis/MidiSlicer";
+            this.licenseReferenceControl6.LicenseLink = "https://www.codeproject.com/Articles/5272315/Midi-A-Windows-MIDI-Library-in-Cshar" +
+    "p";
+            this.licenseReferenceControl6.Name = "licenseReferenceControl6";
             // 
             // licenseReferenceControl5
             // 
@@ -139,10 +150,18 @@
             this.licenseReferenceControl2.LicenseLink = "http://sharpdx.org/License.txt";
             this.licenseReferenceControl2.Name = "licenseReferenceControl2";
             // 
+            // licenseReferenceControl7
+            // 
+            resources.ApplyResources(this.licenseReferenceControl7, "licenseReferenceControl7");
+            this.licenseReferenceControl7.Library = "NewtonSoft JSON.NET Schema";
+            this.licenseReferenceControl7.LibraryLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema";
+            this.licenseReferenceControl7.LicenseLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema/3.0.15/License";
+            this.licenseReferenceControl7.Name = "licenseReferenceControl7";
+            // 
             // licenseReferenceControl4
             // 
             resources.ApplyResources(this.licenseReferenceControl4, "licenseReferenceControl4");
-            this.licenseReferenceControl4.Library = "NewtonSoft JSON";
+            this.licenseReferenceControl4.Library = "NewtonSoft JSON.NET";
             this.licenseReferenceControl4.LibraryLink = "https://www.nuget.org/packages/Newtonsoft.Json/";
             this.licenseReferenceControl4.LicenseLink = "https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md";
             this.licenseReferenceControl4.Name = "licenseReferenceControl4";
@@ -173,15 +192,6 @@
             this.panel3.Controls.Add(this.button1);
             resources.ApplyResources(this.panel3, "panel3");
             this.panel3.Name = "panel3";
-            // 
-            // licenseReferenceControl6
-            // 
-            resources.ApplyResources(this.licenseReferenceControl6, "licenseReferenceControl6");
-            this.licenseReferenceControl6.Library = "MidiSlicer";
-            this.licenseReferenceControl6.LibraryLink = "https://github.com/codewitch-honey-crisis/MidiSlicer";
-            this.licenseReferenceControl6.LicenseLink = "https://www.codeproject.com/Articles/5272315/Midi-A-Windows-MIDI-Library-in-Cshar" +
-    "p";
-            this.licenseReferenceControl6.Name = "licenseReferenceControl6";
             // 
             // AboutForm
             // 
@@ -220,5 +230,6 @@
         private System.Windows.Forms.Label label5;
         private System.Windows.Forms.Panel panel3;
         private Panels.About.LicenseReferenceControl licenseReferenceControl6;
+        private Panels.About.LicenseReferenceControl licenseReferenceControl7;
     }
 }

--- a/UI/Dialogs/AboutForm.resx
+++ b/UI/Dialogs/AboutForm.resx
@@ -188,102 +188,6 @@ Copyright 2014-2022 - Sebastian Moebius</value>
   <data name="&gt;&gt;button1.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
-  <data name="&gt;&gt;linkLabel3.Name" xml:space="preserve">
-    <value>linkLabel3</value>
-  </data>
-  <data name="&gt;&gt;linkLabel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;linkLabel3.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;linkLabel3.ZOrder" xml:space="preserve">
-    <value>0</value>
-  </data>
-  <data name="&gt;&gt;label4.Name" xml:space="preserve">
-    <value>label4</value>
-  </data>
-  <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="&gt;&gt;linkLabel2.Name" xml:space="preserve">
-    <value>linkLabel2</value>
-  </data>
-  <data name="&gt;&gt;linkLabel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;linkLabel2.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;linkLabel2.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="&gt;&gt;label3.Name" xml:space="preserve">
-    <value>label3</value>
-  </data>
-  <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="&gt;&gt;label2.Name" xml:space="preserve">
-    <value>label2</value>
-  </data>
-  <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
-    <value>4</value>
-  </data>
-  <data name="&gt;&gt;linkLabel1.Name" xml:space="preserve">
-    <value>linkLabel1</value>
-  </data>
-  <data name="&gt;&gt;linkLabel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;linkLabel1.Parent" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
-    <value>5</value>
-  </data>
-  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 88</value>
-  </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>321, 75</value>
-  </data>
-  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="linkLabel3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
@@ -473,11 +377,35 @@ Copyright 2014-2022 - Sebastian Moebius</value>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
+  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 88</value>
+  </data>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>321, 75</value>
+  </data>
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
   <data name="licenseReferenceControl6.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 161</value>
+    <value>3, 185</value>
   </data>
   <data name="licenseReferenceControl6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
@@ -504,7 +432,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 137</value>
+    <value>3, 161</value>
   </data>
   <data name="licenseReferenceControl5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
@@ -531,7 +459,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 113</value>
+    <value>3, 137</value>
   </data>
   <data name="licenseReferenceControl2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
@@ -553,6 +481,33 @@ Copyright 2014-2022 - Sebastian Moebius</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl2.ZOrder" xml:space="preserve">
     <value>2</value>
+  </data>
+  <data name="licenseReferenceControl7.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="licenseReferenceControl7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 113</value>
+  </data>
+  <data name="licenseReferenceControl7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 10, 3</value>
+  </data>
+  <data name="licenseReferenceControl7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>315, 24</value>
+  </data>
+  <data name="licenseReferenceControl7.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl7.Name" xml:space="preserve">
+    <value>licenseReferenceControl7</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl7.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl7.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl7.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="licenseReferenceControl4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -579,7 +534,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl4.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
   </data>
   <data name="licenseReferenceControl3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -606,7 +561,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl3.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>5</value>
   </data>
   <data name="licenseReferenceControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -633,7 +588,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl1.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>6</value>
   </data>
   <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -666,7 +621,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>7</value>
   </data>
   <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -678,7 +633,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>3, 0, 3, 0</value>
   </data>
   <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>321, 218</value>
+    <value>321, 273</value>
   </data>
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -699,7 +654,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>Bottom</value>
   </data>
   <data name="panel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 352</value>
+    <value>0, 407</value>
   </data>
   <data name="panel3.Size" type="System.Drawing.Size, System.Drawing">
     <value>321, 29</value>
@@ -726,7 +681,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>321, 381</value>
+    <value>321, 436</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/packages.config
+++ b/packages.config
@@ -6,6 +6,7 @@
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.21.0" targetFramework="net48" />
   <package id="Microsoft.Web.WebView2" version="1.0.1518.46" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
+  <package id="Newtonsoft.Json.Schema" version="3.0.15" targetFramework="net48" />
   <package id="protobuf-net" version="3.1.33" targetFramework="net48" />
   <package id="protobuf-net.Core" version="3.1.33" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />


### PR DESCRIPTION
Fixes #1417 

Adds schema validation for .board.json files when attempting to load them from disk. Any .board.json files that are invalid (fail schema validation) are skipped, with appropriate error messages logged that specify what the errors in the file are.

This adds the Newtonsoft.Json.Schema nuget package to our product. License dialog updated appropriately.

<img width="244" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/ae1eb379-abcb-45b2-ac51-e3cfe346c772">

Please please please do not merge this and ship it in the upcoming release 😅. There is no reason to. This bug only happened because one person had one custom .board.json file that was all messed up.