### PR TITLE
Perform installation when zip file already available

### DIFF
--- a/MobiFlight-Installer/MobiFlight-Installer/Properties/AssemblyInfo.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.5.0")]
-[assembly: AssemblyFileVersion("1.5.0")]
+[assembly: AssemblyVersion("1.5.1")]
+[assembly: AssemblyFileVersion("1.5.1")]

--- a/MobiFlight-Installer/MobiFlight-Installer/UI/UpdaterMainForm.cs
+++ b/MobiFlight-Installer/MobiFlight-Installer/UI/UpdaterMainForm.cs
@@ -45,12 +45,8 @@ namespace MobiFlightInstaller.UI
             UpdaterCurrentTask.Text = "Download finished.";
             if (MobiFlightUpdaterModel.CheckIfFileIsHere(CurrentFileName, _downloadChecksum)) //compare checksum if download is correct
             {
-                UpdaterCurrentTask.Text = "Extracting files...";
-                Log.Instance.log("DOWNLOAD is OK, start extracting ...", LogSeverity.Debug);
-                MobiFlightUpdaterModel.CloseMobiFlightAndWait();
-                MobiFlightUpdaterModel.GoExtractToDirectory(CurrentFileName, Directory.GetCurrentDirectory());
-                UpdaterCurrentTask.Text = "Start MobiFlight";
-                MobiFlightUpdaterModel.StartProcessAndClose(MobiFlightHelperMethods.ProcessName);
+                Log.Instance.log("DOWNLOAD is OK.", LogSeverity.Debug);
+                ExtractAndInstall(CurrentFileName);
             }
             else
             {
@@ -58,6 +54,15 @@ namespace MobiFlightInstaller.UI
                 MessageBox.Show("Download failed, installation aborted! Please run installer again or unzip manually.");
             }
             _webClient.Dispose();
+        }
+
+        private void ExtractAndInstall(string currentFileName)
+        {
+            UpdaterCurrentTask.Text = "Extracting files...";
+            MobiFlightUpdaterModel.CloseMobiFlightAndWait();
+            MobiFlightUpdaterModel.GoExtractToDirectory(currentFileName, Directory.GetCurrentDirectory());
+            UpdaterCurrentTask.Text = "Start MobiFlight";
+            MobiFlightUpdaterModel.StartProcessAndClose(MobiFlightHelperMethods.ProcessName);
         }
 
         private void ManualUpgradeFromCommandLine(string Version)
@@ -79,7 +84,13 @@ namespace MobiFlightInstaller.UI
                     _webClient.DownloadProgressChanged += new DownloadProgressChangedEventHandler(OnDownloadProgressChanged);
                     _webClient.DownloadFileCompleted += new AsyncCompletedEventHandler(OnDownloadComplete);
                     _webClient.DownloadFileAsync(uri, CurrentFileName); // Download the file
+
+                    // Extract and install is done in the OnDownloadFinished
+                    // 
+                    return;
                 }
+                UpdaterCurrentTask.Text = $"MobiFlight file {Version} already available. No download needed.";
+                ExtractAndInstall(CurrentFileName);
             }
             else
             {


### PR DESCRIPTION
fixes #1377 

- [x] Added case so that installer runs if zip-file with correct version is already downloaded.