### PR TITLE
Precondition "displayed" correctly

### DIFF
--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -84,14 +84,12 @@ namespace MobiFlight.UI.Dialogs
         protected void Init(ExecutionManager executionManager, OutputConfigItem cfg)
         {
             this._execManager = executionManager;
+            // create a clone so that we don't edit 
+            // the original item
             config = cfg.Clone() as OutputConfigItem;
 
-            // Until with have the preconditions completely refactored,
-            // add an empty precondition in case the current cfg doesn't have one
-            // we removed addEmptyNode but add an empty Precondition here
-            if (cfg.Preconditions.Count == 0) 
-                cfg.Preconditions.Add(new Precondition());
-
+            // this is only stored to be able
+            // to check for modifications
             originalConfig = cfg;
 
             InitializeComponent();

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -32,6 +32,8 @@ namespace MobiFlight.UI.Dialogs
         List<UserControl> displayPanels = new List<UserControl>();
 
         InputConfigItem config = null;
+        public InputConfigItem Config { get { return config; } }
+
         InputConfigItem originalConfig = null;
 
         ErrorProvider errorProvider = new ErrorProvider();
@@ -107,20 +109,17 @@ namespace MobiFlight.UI.Dialogs
         protected void Init(ExecutionManager mainForm, InputConfigItem cfg)
         {
             this._execManager = mainForm;
-            config = cfg;
+            // create a clone so that we don't edit 
+            // the original item
+            config = cfg.Clone() as InputConfigItem;
 
-            // Until with have the preconditions completely refactored,
-            // add an empty precondition in case the current cfg doesn't have one
-            // we removed addEmptyNode but add an empty Precondition here
-            if (cfg.Preconditions.Count == 0)
-                cfg.Preconditions.Add(new Precondition());
-
-            originalConfig = config.Clone() as InputConfigItem;
+            // this is only stored to be able
+            // to check for modifications
+            originalConfig = cfg;
 
             InitializeComponent();
 
-            ActivateCorrectTab(config);
-            
+            ActivateCorrectTab(config);            
 
             // PRECONDITION PANEL
             preconditionPanel.Init();

--- a/UI/Panels/Config/PreconditionPanel.cs
+++ b/UI/Panels/Config/PreconditionPanel.cs
@@ -178,6 +178,12 @@ namespace MobiFlight.UI.Panels.Config
 
         public bool syncFromConfig(IBaseConfigItem config)
         {
+            // Until with have the preconditions completely refactored,
+            // add an empty precondition in case the current cfg doesn't have one
+            // we removed addEmptyNode but add an empty Precondition here
+            if (config.Preconditions.Count == 0)
+                config.Preconditions.Add(new Precondition());
+
             preconditionListTreeView.Nodes.Clear();
             Preconditions = config.Preconditions.Clone() as PreconditionList;
 

--- a/UI/Panels/Config/PreconditionPanel.cs
+++ b/UI/Panels/Config/PreconditionPanel.cs
@@ -222,11 +222,13 @@ namespace MobiFlight.UI.Panels.Config
                 if (selected == "config")
                 {
                     preconditionConfigLabel.Text = i18n._tr("Label_Precondition_choose_config");
+                    preconditionConfigComboBox.DataSource = null;
                     preconditionConfigComboBox.DataSource = Configs;
                 }
                 else
                 {
                     preconditionConfigLabel.Text = i18n._tr("Label_Precondition_choose_variable");
+                    preconditionConfigComboBox.DataSource = null;
                     preconditionConfigComboBox.DataSource = Variables;
                 }
 
@@ -253,7 +255,7 @@ namespace MobiFlight.UI.Panels.Config
             {
                 case "variable":
                 case "config":
-                    if (sender == preconditionConfigComboBox)
+                    if (sender == preconditionConfigComboBox && preconditionConfigComboBox.SelectedValue != null)
                         c.PreconditionRef = preconditionConfigComboBox.SelectedValue.ToString();
                     if (sender == preconditionRefOperandComboBox)
                         c.PreconditionOperand = preconditionRefOperandComboBox.Text;

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -70,13 +70,13 @@ namespace MobiFlight.UI.Panels
             if (wizard.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {
                 if (dataRow == null) return;
-                // do something special
-                // Show used Button
-                // Show Type of Output
-                // Show last set value
-                // do something special
+
                 if (wizard.ConfigHasChanged())
                 {
+                    // we have to update the config
+                    // using the duplicated config 
+                    // that the user edited with the wizard
+                    dataRow["settings"] = wizard.Config;
                     SettingsChanged?.Invoke(cfg, null);
                     RestoreValuesInGridView();
                 }

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -505,10 +505,11 @@ namespace MobiFlight.UI.Panels
             {
                 if (dataRow == null) return;
 
-                // do something special
                 if (wizard.ConfigHasChanged()) {
-                    cfg = wizard.Config;
-                    dataRow["settings"] = cfg;
+                    // we have to update the config
+                    // using the duplicated config 
+                    // that the user edited with the wizard
+                    dataRow["settings"] = wizard.Config;
                     SettingsChanged?.Invoke(cfg, null);
                     RestoreValuesInGridView();
                 }


### PR DESCRIPTION
fixes #1428 
fixes #1164

- cfg.Clone logic is now the same for output and input
  - the wizard only modifies the cloned version, never the original instance
  - only on DialogResult.OK the modified config replaces the original one
- The dataSource is reset correctly so that the labels are generated properly