### PR TITLE
Change MessageType to int

### DIFF
--- a/MobiFlight/CustomDevices/CustomDevice.cs
+++ b/MobiFlight/CustomDevices/CustomDevice.cs
@@ -96,7 +96,7 @@ namespace MobiFlight.CustomDevices
         /// <summary>
         /// The identifier for the message type. Unique in the scope of the device.
         /// </summary>
-        public string Id;
+        public int Id;
 
         /// <summary>
         /// The label for the message type which is used in the config wizard UI.

--- a/MobiFlight/MobiFlightCustomDevice.cs
+++ b/MobiFlight/MobiFlightCustomDevice.cs
@@ -24,7 +24,7 @@ namespace MobiFlight
         public int DeviceNumber { get; set; }
         public CustomDevices.CustomDevice CustomDevice { get; set; }
 
-        public void Display(string MessageType, string value)
+        public void Display(int MessageType, string value)
         {
             var command = new SendCommand((int)MobiFlightModule.Command.SetCustomDevice);
 

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -885,9 +885,9 @@ namespace MobiFlight
             return true;
         }
 
-        internal bool setCustomDevice(string deviceName, string messageType, string value)
+        internal bool setCustomDevice(string deviceName, int messageType, string value)
         {
-            String key = "CustomDevice_" + deviceName + messageType;
+            String key = $"CustomDevice_{deviceName}{messageType}";
             String cachedValue = value;
 
             if (lastValue.ContainsKey(key) &&

--- a/MobiFlight/OutputConfig/CustomDevice.cs
+++ b/MobiFlight/OutputConfig/CustomDevice.cs
@@ -13,7 +13,7 @@ namespace MobiFlight.OutputConfig
         public const string Type = "CustomDevice";
         public String CustomType { get; set; }
         public String CustomName { get; set; }
-        public String MessageType { get; set; }
+        public int MessageType { get; set; }
         public String Value { get; set; }
 
         public CustomDevice()
@@ -61,7 +61,10 @@ namespace MobiFlight.OutputConfig
 
             if (reader["messageType"] != null && reader["messageType"] != "")
             {
-                MessageType = reader["messageType"].ToString();
+                if (Int32.TryParse(reader["messageType"], out int convertedMessageType))
+                {
+                    MessageType = convertedMessageType;
+                }
             }
 
             if (reader["value"] != null && reader["value"] != "")
@@ -74,7 +77,7 @@ namespace MobiFlight.OutputConfig
         {
             writer.WriteAttributeString("customType", CustomType);
             writer.WriteAttributeString("customName", CustomName);
-            writer.WriteAttributeString("messageType", MessageType);
+            writer.WriteAttributeString("messageType", MessageType.ToString());
             writer.WriteAttributeString("value", Value);
         }
     }

--- a/MobiFlightUnitTests/MobiFlight/MobiFlightCustomDeviceTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/MobiFlightCustomDeviceTests.cs
@@ -28,7 +28,7 @@ namespace MobiFlight.Tests
         {
             byte CommandId = (byte)MobiFlightModule.Command.SetCustomDevice;
             string value = "12345678";
-            var messageType = "3";
+            var messageType = 3;
 
             var module = new MobiFlightCustomDevice()
             {

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/CustomDeviceTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/CustomDeviceTests.cs
@@ -21,7 +21,7 @@ namespace MobiFlight.OutputConfig.Tests
             Assert.AreEqual(null, o.CustomName);
             Assert.AreEqual(null, o.CustomType);
             Assert.AreEqual(null, o.Value);
-            Assert.AreEqual(null, o.MessageType);
+            Assert.AreEqual(0, o.MessageType);
         }
 
         [TestMethod()]
@@ -88,7 +88,7 @@ namespace MobiFlight.OutputConfig.Tests
             Assert.AreEqual("TM1637 Display", o.CustomName);
             Assert.AreEqual("TM1637", o.CustomType);
             Assert.AreEqual("$+2", o.Value);
-            Assert.AreEqual("3", o.MessageType);
+            Assert.AreEqual(3, o.MessageType);
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/CustomDeviceTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/CustomDeviceTests.cs
@@ -34,24 +34,26 @@ namespace MobiFlight.OutputConfig.Tests
             o1.CustomName = "DisplayPin";
             o1.CustomType = "CustomType";
             o1.Value = "Value";
-            o1.MessageType = "MessageType";
+            o1.MessageType = 1;
             Assert.IsFalse(o1.Equals(o2));
 
             o2.CustomName = "DisplayPin";
             o2.CustomType = "CustomType";
             o2.Value = "Value";
-            o2.MessageType = "MessageType";
+            o2.MessageType = 1;
             Assert.IsTrue(o1.Equals(o2));
         }
 
         [TestMethod()]
         public void CloneTest()
         {
-            var o1 = new CustomDevice();
-            o1.CustomName = "DisplayPin";
-            o1.CustomType = "CustomType";
-            o1.Value = "Value";
-            o1.MessageType = "MessageType";
+            var o1 = new CustomDevice
+            {
+                CustomName = "DisplayPin",
+                CustomType = "CustomType",
+                Value = "Value",
+                MessageType = 1
+            };
             var clone = (CustomDevice)o1.Clone();
 
             Assert.AreEqual(o1.CustomName, clone.CustomName);
@@ -103,7 +105,7 @@ namespace MobiFlight.OutputConfig.Tests
             o.CustomName = "TM1637 Display";
             o.CustomType = "TM1637";
             o.Value = "$+2";
-            o.MessageType = "3";
+            o.MessageType = 3;
 
             xmlWriter.WriteStartElement("display");
             xmlWriter.WriteAttributeString("type", CustomDevice.Type);

--- a/UI/Panels/Output/CustomDevicePanel.cs
+++ b/UI/Panels/Output/CustomDevicePanel.cs
@@ -38,7 +38,7 @@ namespace MobiFlight.UI.Panels
                 Log.Instance.log("Exception on selecting item in Custom Device Name ComboBox.", LogSeverity.Error);
             }
 
-            if (!ComboBoxHelper.SetSelectedItemByValue(MessageTypeComboBox, config.CustomDevice.MessageType))
+            if (!ComboBoxHelper.SetSelectedItemByValue(MessageTypeComboBox, config.CustomDevice.MessageType.ToString()))
             {
                 Log.Instance.log("Exception on selecting item in Custom Device Name ComboBox.", LogSeverity.Error);
             }


### PR DESCRIPTION
Fixes #1433

Change the type of the message id in the custom device definition object to `int`, then ripple that change through all the rest of the code.

This does NOT need to ship with 10.0.

This is not a breaking change. The schema already defined this property as an int, it's just that the code internally was calling it a string and that happened to magically work.