### PR TITLE
Prevent `IsReady` from blocking too long

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -276,6 +276,7 @@ namespace MobiFlight
         /// Returns a list of connected USB drives that are supported with MobiFlight and are in flash mode already,
         /// as opposed to being connected as COM port.
         /// </summary>
+        /// <param name="WaitInMilliseconds">Time for the UsbDeviceMonitor to perform a port scan</param>
         /// <returns>The list of connected USB drives supported by MobiFlight.</returns>
         public static List<MobiFlightModuleInfo> FindConnectedUsbDevices(double WaitInMilliseconds = 500)
         {
@@ -287,7 +288,10 @@ namespace MobiFlight
             {
                 usbDeviceMonitor.Start();
                 var task = Task
-                    // we need to wait for the timer to trigger
+                    // we need to give the usbDeviceMonitor the chance
+                    // to do the USB drive scan and return a valid list
+                    // of Detected Ports.
+                    // This might take a few moments to complete.
                     .Delay(TimeSpan.FromMilliseconds(WaitInMilliseconds))
                     .ContinueWith(_ => usbDeviceMonitor.DetectedPorts
                         .ForEach(p =>

--- a/MobiFlight/Monitors/DeviceMonitor.cs
+++ b/MobiFlight/Monitors/DeviceMonitor.cs
@@ -4,15 +4,20 @@ using System.Timers;
 
 namespace MobiFlight.Monitors
 {
-    public class DeviceMonitor
+    public class DeviceMonitor : IDisposable
     {
+        protected bool isScanning = false;
         public event EventHandler<PortDetails> PortAvailable;
         public event EventHandler<PortDetails> PortUnavailable;
         public List<PortDetails> DetectedPorts { get; set; } = new List<PortDetails>();
-        private Timer timer = new Timer();
+
+        // initial timer interval will be 10 
+        // so it will execute Timer_Elapsed immediately
+        private readonly Timer timer = new Timer(10);
+
+        const double TimerIntervalInMs = 1000;
 
         public DeviceMonitor() {
-            timer.Interval = 1000;
             timer.Elapsed += Timer_Elapsed;
         }
         public void Start()
@@ -20,10 +25,17 @@ namespace MobiFlight.Monitors
             timer.Start();
         }
 
-        public void Stop() { timer.Stop(); }
+        public void Stop() 
+        { 
+            timer.Stop(); 
+        }
 
         private void Timer_Elapsed(object sender, ElapsedEventArgs e)
         {
+            // we initialize the timer with default 0
+            // and on first timer_elapsed we set it to the
+            // regular interval `TimerIntervalInMs`
+            timer.Interval = TimerIntervalInMs;
             Scan();
         }
 
@@ -33,29 +45,37 @@ namespace MobiFlight.Monitors
 
         protected void UpdatePorts(List<PortDetails> ports)
         {
-            ports.ForEach(p =>
+            lock(DetectedPorts)
             {
-                if (DetectedPorts.FindIndex(port => port.Name == p.Name) == -1)
+                ports.ForEach(p =>
                 {
-                    // new port found!
-                    DetectedPorts.Add(p);
-                    PortAvailable?.Invoke(this, p);
-                }
-            });
+                    if (DetectedPorts.FindIndex(port => port.Name == p.Name) == -1)
+                    {
+                        // new port found!
+                        DetectedPorts.Add(p);
+                        PortAvailable?.Invoke(this, p);
+                    }
+                });
 
-            var stalePorts = new List<PortDetails>();
+                var stalePorts = new List<PortDetails>();
 
-            DetectedPorts.ForEach(p =>
-            {
-                if (ports.FindIndex(port => port.Name == p.Name) == -1)
+                DetectedPorts.ForEach(p =>
                 {
-                    // stale port found!
-                    stalePorts.Add(p);
-                    PortUnavailable?.Invoke(this, p);
-                }
-            });
+                    if (ports.FindIndex(port => port.Name == p.Name) == -1)
+                    {
+                        // stale port found!
+                        stalePorts.Add(p);
+                        PortUnavailable?.Invoke(this, p);
+                    }
+                });
 
-            stalePorts.ForEach(p => DetectedPorts.Remove(p));
+                stalePorts.ForEach(p => DetectedPorts.Remove(p));
+            }
+        }
+
+        public void Dispose()
+        {
+            ((IDisposable)timer).Dispose();
         }
     }
 }

--- a/MobiFlight/Monitors/DeviceMonitor.cs
+++ b/MobiFlight/Monitors/DeviceMonitor.cs
@@ -32,7 +32,7 @@ namespace MobiFlight.Monitors
 
         private void Timer_Elapsed(object sender, ElapsedEventArgs e)
         {
-            // we initialize the timer with default 0
+            // we initialize the timer with default 10ms
             // and on first timer_elapsed we set it to the
             // regular interval `TimerIntervalInMs`
             timer.Interval = TimerIntervalInMs;
@@ -45,6 +45,10 @@ namespace MobiFlight.Monitors
 
         protected void UpdatePorts(List<PortDetails> ports)
         {
+            // prevent concurrent modification of our DetectedPorts.
+            // this could be theoretically possible because:
+            // - scan events are triggered by a timer 
+            // - a scan event could take longer than the timer interval
             lock(DetectedPorts)
             {
                 ports.ForEach(p =>

--- a/MobiFlight/Monitors/UsbDeviceMonitor.cs
+++ b/MobiFlight/Monitors/UsbDeviceMonitor.cs
@@ -19,6 +19,8 @@ namespace MobiFlight.Monitors
         {
             // Issue 1074: Failing to check for IsReady caused an IOException on certain machines
             // when trying to read the volume label when the drive wasn't actually ready.
+            // Issue 1437: IsReady takes forever to timeout when called on USB card readers that have no
+            // cards in them. Wrap the test in a task so we limit the damage to only 100ms.
             var task = Task.Run(() =>
             {
                 return drive.IsReady;

--- a/MobiFlight/Monitors/UsbDeviceMonitor.cs
+++ b/MobiFlight/Monitors/UsbDeviceMonitor.cs
@@ -9,6 +9,12 @@ namespace MobiFlight.Monitors
 {
     public class UsbDeviceMonitor : DeviceMonitor
     {
+        /// <summary>
+        /// Returns the IsReady value of the DriveInfo but also
+        /// applies a timeout to not wait for it too long.
+        /// </summary>
+        /// <param name="drive"></param>
+        /// <returns>Actual `IsReady` value, or false if timed out</returns>
         async Task<bool> DriveIsReady(DriveInfo drive)
         {
             // Issue 1074: Failing to check for IsReady caused an IOException on certain machines


### PR DESCRIPTION
fixes #1437 

This change makes sure that

- There is a timeout of 100ms for the `DriveInfo.isReady` check
- There can be no parallel execution of a `Scan` for the UsbDeviceMonitor
- A lock was added to prevent concurrent access to `DetectedPorts`
- `FindConnectedUsbDevices` timeout is reduced significantly which will make the firmware reset faster.
