### PR TITLE
Pico firmware upload works correctly on start up

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -493,8 +493,6 @@ namespace MobiFlight.UI
                 }
             }
 
-            // Connected USB devices that are in bootsel mode get added to the firmware flashing list
-            modulesForFlashing.AddRange(MobiFlightCache.FindConnectedUsbDevices());
 
             if (Properties.Settings.Default.FwAutoUpdateCheck && (modulesForFlashing.Count > 0 || modulesForUpdate.Count > 0))
             {


### PR DESCRIPTION
fixes #1464

- [x] removed `modulesForFlashing.AddRange` which is redundant and just from the old code, but not needed anymore