### PR TITLE
Added string SimVars

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -698,8 +698,7 @@ namespace MobiFlight
             }
             else
             {
-                result.type = FSUIPCOffsetType.Float;
-                result.Float64 = simConnectCache.GetSimVar(cfg.SimConnectValue.Value);
+                result.type = simConnectCache.GetSimVar(cfg.SimConnectValue.Value, out result.String, out result.Float64);
             }
 
             return result;

--- a/SimConnectMSFS/SimConnectDefinitions.cs
+++ b/SimConnectMSFS/SimConnectDefinitions.cs
@@ -13,6 +13,12 @@ namespace MobiFlight.SimConnectMSFS
         public float data;
     }
 
+    public struct ClientDataStringValue
+    {
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public String data;
+    }
+
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct ClientDataString
     {
@@ -42,14 +48,23 @@ namespace MobiFlight.SimConnectMSFS
 
     }
 
+    public class StringSimVar
+    {
+        public UInt32 ID { get; set; }
+        public String Name { get; set; }
+        public String Data { get; set; }
+    }
+
     public enum SIMCONNECT_CLIENT_DATA_ID
     {
-        MOBIFLIGHT_LVARS = 0,
-        MOBIFLIGHT_CMD = 1,
-        MOBIFLIGHT_RESPONSE = 2,
-        RUNTIME_LVARS = 3,
-        RUNTIME_CMD = 4,
-        RUNTIME_RESPONSE = 5
+        MOBIFLIGHT_LVARS,
+        MOBIFLIGHT_CMD,
+        MOBIFLIGHT_RESPONSE,
+        MOBIFLIGHT_STRINGVAR,
+        RUNTIME_LVARS,
+        RUNTIME_CMD,
+        RUNTIME_RESPONSE,
+        RUNTIME_STRINGVAR
     }
 
     public enum SIMCONNECT_REQUEST_ID

--- a/SimConnectMSFS/WasmModuleClient.cs
+++ b/SimConnectMSFS/WasmModuleClient.cs
@@ -78,6 +78,11 @@ namespace MobiFlight.SimConnectMSFS
             WasmModuleClient.SendWasmCmd(simConnect, "MF.SimVars.Add." + SimVarName, clientData);
         }
 
+        public static void AddStringSimVar(SimConnect simConnect, String SimVarName, WasmModuleClientData clientData)
+        {
+            WasmModuleClient.SendWasmCmd(simConnect, "MF.SimVars.AddString." + SimVarName, clientData);
+        }
+
 
     }
 }

--- a/SimConnectMSFS/WasmModuleClientData.cs
+++ b/SimConnectMSFS/WasmModuleClientData.cs
@@ -8,6 +8,7 @@ namespace MobiFlight.SimConnectMSFS
         public Enum AREA_SIMVAR_ID;
         public Enum AREA_COMMAND_ID;
         public Enum AREA_RESPONSE_ID;
+        public Enum AREA_STRINGSIMVAR_ID;
         public SIMCONNECT_DEFINE_ID DATA_DEFINITION_ID;
         public uint RESPONSE_OFFSET;
     }


### PR DESCRIPTION
* Added client data area for string SimVars
* Added separate StringSimVars list
* Register on string SimVars
* Assume that a string shall be used when RPN-Code contains "String"

Handling as discussed with @DocMoebiuz 

In conjunction with https://github.com/MobiFlight/MobiFlight-WASM-Module/pull/19