### PR TITLE
remove MobiFlight-Admin from ignore section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,8 +2,6 @@ changelog:
   exclude:
     labels:
       - ignore-for-release-notes
-    authors:
-      - MobiFlight-Admin
   categories:
     - title: New Feature 🎉
       labels:


### PR DESCRIPTION
Trying to find out if https://github.com/MobiFlight/MobiFlight-Connector/pull/1281 is not displayed on the Release notes because it was originally created by MobiFlight-Admin