### PR TITLE
Change download method for NSIS

### DIFF
--- a/Build/downgrade_nsis.ps1
+++ b/Build/downgrade_nsis.ps1
@@ -4,8 +4,14 @@
 ################################################################################
 
 $NsisVersion = "3.04"
-Install-Binary -Url "https://downloads.sourceforge.net/project/nsis/NSIS%203/${NsisVersion}/nsis-${NsisVersion}-setup.exe" -Name  "nsis-${NsisVersion}-setup.exe" -ArgumentList ('/S')
+Invoke-WebRequest "https://netcologne.dl.sourceforge.net/project/nsis/NSIS%203/${NsisVersion}/nsis-${NsisVersion}-setup.exe" -OutFile "C:\WINDOWS\Temp\nsis-${NsisVersion}-setup.exe"
+Start-Process -Wait -FilePath "C:\WINDOWS\Temp\nsis-${NsisVersion}-setup.exe" -ArgumentList "/S"
 
+# Add the newly installed version to the path.
 $NsisPath = "${env:ProgramFiles(x86)}\NSIS\"
 Add-MachinePathItem $NsisPath
 $env:Path = Get-MachinePath
+
+# Write out the version that's now on the path for confirmation of the installed version
+# in GitHub action logs.
+makensis.exe /VERSION


### PR DESCRIPTION
Fixes #1476

* Switch to using `invoke-webrequest` and `start-process` for the download and install
* Add a `makensis.exe /VERSION` step to output the version of makensis.exe that's on the path

I've confirmed this appears to install version 3.04:

![downgrade_version](https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/74782c64-152c-489a-8955-a1ef70d6a3f4)

However I do get a Windows Defender warning about the Mobiflight installer when I download and run it. 