### PR TITLE
Resolve crash with custom device statistics

### DIFF
--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -1083,7 +1083,16 @@ namespace MobiFlight
 
             foreach(var device in customDevices.Values)
             {
-                var customDeviceType = device.CustomDevice.Info.Type;
+                // Issue 1423: Handle the case where an Arduino with custom
+                // devices in the config is connected, but the corresponding
+                // custom device and board json files are missing on the desktop.
+                var customDeviceType = device.CustomDevice?.Info.Type;
+
+                if (String.IsNullOrEmpty(customDeviceType))
+                {
+                    continue;
+                }
+
                 var statisticsKey = $"CustomDevice.{customDeviceType}";
                 if (!result.ContainsKey(statisticsKey))
                     result[statisticsKey] = 0;


### PR DESCRIPTION
Fixes #1423

Add a null coalescing operator and test for null or empty string.