### PR TITLE
Interpolation supports float values

### DIFF
--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -397,6 +397,7 @@ namespace MobiFlight.UI.Dialogs
             try {
                 if (!ValidateChildren())
                 {
+                    Log.Instance.log("The dialog cannot be closed. There are invalid values on some tab.", LogSeverity.Error);
                     return;
                 }
             } catch (System.InvalidOperationException ex)

--- a/UI/Panels/Modifier/InterpolationModifier/InterpolationMappingPanel.cs
+++ b/UI/Panels/Modifier/InterpolationModifier/InterpolationMappingPanel.cs
@@ -42,11 +42,11 @@ namespace MobiFlight.UI.Panels.Modifier.InterpolationModifier
 
         public Tuple<double, double> toConfig()
         {
-            if (!int.TryParse(textBoxFromValue.Text, out int on) || 
-                !int.TryParse(textBoxToValue.Text, out int off)) 
+            if (!double.TryParse(textBoxFromValue.Text, out double from) || 
+                !double.TryParse(textBoxToValue.Text, out double to)) 
                 return null;
 
-            return new Tuple<double, double>(on, off);
+            return new Tuple<double, double>(from, to);
         }
 
         private void Button1_Click(object sender, EventArgs e)


### PR DESCRIPTION
fixes #1481 

The UI now supports floats again. The result is still an integer. This behaves like before.

- [x] Add a log entry if form validation failed - in some cases the validation errors are not displayed because they are on a different tab
- [x] The UI Form fields are parsed as `double`