### PR TITLE
Add row description to config window titles

### DIFF
--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -43,7 +43,8 @@ namespace MobiFlight.UI.Dialogs
                              Dictionary<string, ArcazeModuleSettings> moduleSettings, 
 #endif
                              DataSet dataSetConfig, 
-                             String filterGuid)
+                             String filterGuid,
+                             String description)
         {
             Init(mainForm, cfg);
 #if ARCAZE
@@ -63,7 +64,13 @@ namespace MobiFlight.UI.Dialogs
 
             preconditionPanel.SetAvailableConfigs(list);
             preconditionPanel.SetAvailableVariables(mainForm.GetAvailableVariables());
-            initConfigRefDropDowns(_dataSetConfig, filterGuid);   
+            initConfigRefDropDowns(_dataSetConfig, filterGuid);
+
+            // Append the row description to the window title if one was provided.
+            if (!String.IsNullOrEmpty(description))
+            {
+                this.Text = $"{this.Text} - {description}";
+            }
         }
 
         private void initConfigRefDropDowns(DataSet dataSetConfig, string filterGuid)

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -61,7 +61,8 @@ namespace MobiFlight.UI.Dialogs
                              Dictionary<string, ArcazeModuleSettings> moduleSettings,
 #endif
                              DataSet dataSetConfig,
-                             String filterGuid)
+                             String filterGuid,
+                             String description)
         {
             Init(mainForm, cfg);
 #if ARCAZE
@@ -85,6 +86,12 @@ namespace MobiFlight.UI.Dialogs
             ScanForInputButtonDefaultStyle.BackColor = ScanForInputButton.BackColor;
             ScanForInputButtonDefaultStyle.ForeColor = ScanForInputButton.ForeColor;
             ScanForInputButtonDefaultStyle.BorderColor = ScanForInputButton.FlatAppearance.BorderColor;
+
+            // Append the row description to the window title if one was provided.
+            if (!String.IsNullOrEmpty(description))
+            {
+                this.Text = $"{this.Text} - {description}";
+            }
         }
 
         private void initConfigRefDropDowns(DataSet dataSetConfig, string filterGuid)

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -72,9 +72,13 @@ namespace MobiFlight.UI.Panels
                                 ExecutionManager.getModuleCache().GetArcazeModuleSettings(),
 #endif
                                 OutputDataSetConfig,
-                                dataRow["guid"].ToString()
-                                );
-            wizard.StartPosition = FormStartPosition.CenterParent;
+                                dataRow["guid"].ToString(),
+                                dataRow["description"].ToString()
+                                )
+            {
+                StartPosition = FormStartPosition.CenterParent
+            };
+
             wizard.SettingsDialogRequested += new EventHandler(wizard_SettingsDialogRequested);
             if (wizard.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             {

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -504,10 +504,12 @@ namespace MobiFlight.UI.Panels
                                             ExecutionManager.getModuleCache().GetArcazeModuleSettings(),
 #endif
                                             dataSetConfig,
-                                            dataRow["guid"].ToString()
-                                          );
-
-            wizard.StartPosition = FormStartPosition.CenterParent;
+                                            dataRow["guid"].ToString(),
+                                            dataRow["description"].ToString()
+                                          )
+            {
+                StartPosition = FormStartPosition.CenterParent
+            };
             wizard.SettingsDialogRequested += new EventHandler(wizard_SettingsDialogRequested);
 
             if (wizard.ShowDialog() == System.Windows.Forms.DialogResult.OK)


### PR DESCRIPTION
Fixes #1458

Adds the row description to the title of the input and output config wizard windows. Also cleaned up a Visual Studio suggested style change.

Change the base window title to be "Output" and "Input" instead of "ConfigWizard" and "InputConfigWizard".

<img width="182" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/262d93b3-ef3d-4c2f-82cd-b1fe528973bb">

<img width="179" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/42131bf5-21aa-45c8-b801-aade28cf7810">

