### PR TITLE
All boards - Increase max number of devices for all types

### DIFF
--- a/Boards/arduino_mega.board.json
+++ b/Boards/arduino_mega.board.json
@@ -44,17 +44,17 @@
   },
   "ModuleLimits": {
     "MaxAnalogInputs": 16,
-    "MaxInputShifters": 4,
+    "MaxInputShifters": 6,
     "MaxButtons": 68,
     "MaxEncoders": 20,
     "MaxLcdI2C": 2,
-    "MaxLedSegments": 4,
-    "MaxOutputs": 40,
-    "MaxServos": 10,
-    "MaxShifters": 4,
+    "MaxLedSegments": 6,
+    "MaxOutputs": 68,
+    "MaxServos": 12,
+    "MaxShifters": 6,
     "MaxSteppers": 10,
-    "MaxInputMultiplexer": 4,
-    "MaxCustomDevices" : 5
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices" : 0
   },
   "Pins": [
     {

--- a/Boards/arduino_micro.board.json
+++ b/Boards/arduino_micro.board.json
@@ -35,14 +35,15 @@
     "MaxAnalogInputs": 9,
     "MaxButtons": 18,
     "MaxEncoders": 9,
-    "MaxInputShifters": 2,
+    "MaxInputShifters": 6,
     "MaxLcdI2C": 2,
-    "MaxLedSegments": 1,
+    "MaxLedSegments": 6,
     "MaxOutputs": 18,
-    "MaxServos": 3,
-    "MaxShifters": 2,
-    "MaxSteppers": 3,
-    "MaxInputMultiplexer": 3
+    "MaxServos": 8,
+    "MaxShifters": 6,
+    "MaxSteppers": 4,
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices": 0
   },
   "Pins": [
     {

--- a/Boards/arduino_nano.board.json
+++ b/Boards/arduino_nano.board.json
@@ -41,14 +41,15 @@
     "MaxAnalogInputs": 8,
     "MaxButtons": 18,
     "MaxEncoders": 9,
-    "MaxInputShifters": 2,
+    "MaxInputShifters": 6,
     "MaxLcdI2C": 2,
-    "MaxLedSegments": 1,
+    "MaxLedSegments": 6,
     "MaxOutputs": 18,
-    "MaxServos": 2,
-    "MaxShifters": 2,
-    "MaxSteppers": 2,
-    "MaxInputMultiplexer": 3
+    "MaxServos": 8,
+    "MaxShifters": 6,
+    "MaxSteppers": 4,
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices": 0
   },
   "Pins": [
     {

--- a/Boards/arduino_uno.board.json
+++ b/Boards/arduino_uno.board.json
@@ -40,14 +40,15 @@
     "MaxAnalogInputs": 6,
     "MaxButtons": 18,
     "MaxEncoders": 9,
-    "MaxInputShifters": 2,
+    "MaxInputShifters": 6,
     "MaxLcdI2C": 2,
-    "MaxLedSegments": 1,
+    "MaxLedSegments": 6,
     "MaxOutputs": 18,
-    "MaxServos": 2,
-    "MaxShifters": 2,
-    "MaxSteppers": 2,
-    "MaxInputMultiplexer": 3
+    "MaxServos": 8,
+    "MaxShifters": 6,
+    "MaxSteppers": 4,
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices": 0
   },
   "Pins": [
     {

--- a/Boards/kav_mega.board.json.inactive
+++ b/Boards/kav_mega.board.json.inactive
@@ -48,16 +48,16 @@
   },
   "ModuleLimits": {
     "MaxAnalogInputs": 16,
-    "MaxInputShifters": 4,
+    "MaxInputShifters": 6,
     "MaxButtons": 68,
     "MaxEncoders": 20,
     "MaxLcdI2C": 2,
-    "MaxLedSegments": 4,
-    "MaxOutputs": 40,
-    "MaxServos": 10,
-    "MaxShifters": 4,
+    "MaxLedSegments": 6,
+    "MaxOutputs": 68,
+    "MaxServos": 12,
+    "MaxShifters": 6,
     "MaxSteppers": 10,
-    "MaxInputMultiplexer": 4,
+    "MaxInputMultiplexer": 6,
     "MaxCustomDevices": 5
   },
   "Pins": [

--- a/Boards/mobiflight_genericI2C_mega.board.json.inactive
+++ b/Boards/mobiflight_genericI2C_mega.board.json.inactive
@@ -47,16 +47,16 @@
     },
     "ModuleLimits": {
       "MaxAnalogInputs": 16,
-      "MaxInputShifters": 4,
+      "MaxInputShifters": 6,
       "MaxButtons": 68,
       "MaxEncoders": 20,
       "MaxLcdI2C": 2,
-      "MaxLedSegments": 4,
-      "MaxOutputs": 40,
-      "MaxServos": 10,
-      "MaxShifters": 4,
+      "MaxLedSegments": 6,
+      "MaxOutputs": 68,
+      "MaxServos": 12,
+      "MaxShifters": 6,
       "MaxSteppers": 10,
-      "MaxInputMultiplexer": 4,
+      "MaxInputMultiplexer": 6,
       "MaxCustomDevices": 5
     },
     "Pins": [

--- a/Boards/raspberrypi_pico.board.json
+++ b/Boards/raspberrypi_pico.board.json
@@ -26,16 +26,17 @@
   },
   "ModuleLimits": {
     "MaxAnalogInputs": 3,
-    "MaxInputShifters": 4,
+    "MaxInputShifters": 6,
     "MaxButtons": 26,
-    "MaxEncoders": 8,
+    "MaxEncoders": 13,
     "MaxLcdI2C": 2,
-    "MaxLedSegments": 4,
+    "MaxLedSegments": 6,
     "MaxOutputs": 26,
     "MaxServos": 8,
-    "MaxShifters": 4,
+    "MaxShifters": 6,
     "MaxSteppers": 6,
-    "MaxInputMultiplexer": 4
+    "MaxInputMultiplexer": 6,
+    "MaxCustomDevices": 0
   },
   "Pins": [
     {


### PR DESCRIPTION
In all board.json files the max. number of devices per type are increased to either max. available pins, limitations from a used library (e.g. servos) or to existing experiences.

Fixes #1502 