### PR TITLE
Fix Blink exception with empty values

### DIFF
--- a/UI/Panels/Modifier/BlinkModifierPanel.cs
+++ b/UI/Panels/Modifier/BlinkModifierPanel.cs
@@ -80,6 +80,8 @@ namespace MobiFlight.UI.Panels.Modifier
             for (var i=0; i!= panelSequences.Controls.Count; i++)
             {
                 var sequence = (panelSequences.Controls[i] as BlinkSequencePanel).toConfig();
+                if (sequence == null) continue;
+
                 onOffSequence.Add(sequence.Item1);
                 onOffSequence.Add(sequence.Item2);
             }


### PR DESCRIPTION
fixes #1508 

- [x] add a test for null 

### Notes
related to: https://github.com/MobiFlight/MobiFlight-Connector/issues/1498 - this will proper value validation and show it to the user.