### PR TITLE
Remove unneeded slash from board definition directory specification

### DIFF
--- a/MobiFlight/BoardDefinitions.cs
+++ b/MobiFlight/BoardDefinitions.cs
@@ -87,7 +87,7 @@ namespace MobiFlight
         public static void LoadDefinitions()
         {
             var files = new List<String>(Directory.GetFiles("Boards", "*.board.json"));
-            files.AddRange(Directory.GetFiles("Community/", "*.board.json", SearchOption.AllDirectories));
+            files.AddRange(Directory.GetFiles("Community", "*.board.json", SearchOption.AllDirectories));
             boards = JsonBackedObject.LoadDefinitions<Board>(files.ToArray(), "Boards/mfboard.schema.json",
                 onSuccess: (board, definitionFile) => {
                     Log.Instance.log($"Loaded board definition for {board.Info.MobiFlightType} ({board.Info.FriendlyName})", LogSeverity.Info);


### PR DESCRIPTION
Fixes #1518 

* Remove the slash from the `Community` path given to `Directory.GetFiles()`

Before this change:

```
Error	12/21/2023 20:22:13	Community/Neil\boards\CJ4 autopilot.board.json isn't valid:
```

After this change:

```
Error	12/21/2023 20:21:37	Community\Neil\boards\CJ4 autopilot.board.json isn't valid:
```