### PR TITLE
Remove analog pin labels from Pro Micro board

### DIFF
--- a/Boards/arduino_micro.board.json
+++ b/Boards/arduino_micro.board.json
@@ -74,8 +74,7 @@
       "isAnalog": true,
       "isI2C": false,
       "isPWM": false,
-      "Pin": 4,
-      "Name": "A6"
+      "Pin": 4
     },
     {
       "isAnalog": false,
@@ -87,8 +86,7 @@
       "isAnalog": true,
       "isI2C": false,
       "isPWM": true,
-      "Pin": 6,
-      "Name": "A7"
+      "Pin": 6
     },
     {
       "isAnalog": false,
@@ -100,22 +98,19 @@
       "isAnalog": true,
       "isI2C": false,
       "isPWM": false,
-      "Pin": 8,
-      "Name": "A8"
+      "Pin": 8
     },
     {
       "isAnalog": true,
       "isI2C": false,
       "isPWM": true,
-      "Pin": 9,
-      "Name": "A9"
+      "Pin": 9
     },
     {
       "isAnalog": true,
       "isI2C": false,
       "isPWM": true,
-      "Pin": 10,
-      "Name": "A10"
+      "Pin": 10
     },
     {
       "isAnalog": false,


### PR DESCRIPTION
Fixes #1522

Remove the analog pin labels that shouldn't have been added in #1236. Dropdown now looks like this:

<img width="116" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/b35e31f5-df35-425a-9290-9c1ca200b1b9">
