### PR TITLE
Add board type information to mfmc file

### DIFF
--- a/MobiFlight/Config/AnalogInput.cs
+++ b/MobiFlight/Config/AnalogInput.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/AnalogInput.cs
+++ b/MobiFlight/Config/AnalogInput.cs
@@ -58,7 +58,7 @@ namespace MobiFlight.Config
 
         public override string ToString()
         {
-            return Type + ":" + Name + " Pin:" + Pin + " Sensitivity:" + Sensitivity;
+            return $"{Type}:{Name} Pin:{Pin} Sensitivity:{Sensitivity}";
         }
     }
 }

--- a/MobiFlight/Config/BaseDevice.cs
+++ b/MobiFlight/Config/BaseDevice.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/Button.cs
+++ b/MobiFlight/Config/Button.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/Button.cs
+++ b/MobiFlight/Config/Button.cs
@@ -54,7 +54,7 @@ namespace MobiFlight.Config
 
         public override string ToString()
         {
-            return Type + ":" + Name + " Pin:" + Pin;
+            return $"{Type}:{Name} Pin:{Pin}";
         }
     }
 }

--- a/MobiFlight/Config/Config.cs
+++ b/MobiFlight/Config/Config.cs
@@ -7,7 +7,8 @@ namespace MobiFlight.Config
 {
     public class Config
     {
-        public String ModuleName = "";
+        public string ModuleType = "";
+        public string ModuleName = "";
         public int PowerSavingTime = 60 * 10; // => 10 Minutes Default
 
         [XmlElement(typeof(Button))]

--- a/MobiFlight/Config/Config.cs
+++ b/MobiFlight/Config/Config.cs
@@ -1,6 +1,8 @@
 ﻿using MobiFlight.Config.Compatibility;
 using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Windows.Forms;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config
@@ -216,6 +218,23 @@ namespace MobiFlight.Config
 
             }
             return this;
+        }
+
+        public static Config LoadFromFile(string fileName)
+        {
+            TextReader textReader = new StreamReader(fileName);
+            XmlSerializer serializer = new XmlSerializer(typeof(Config));
+            var config = (Config)serializer.Deserialize(textReader);
+            textReader.Close();
+            return config;
+        }
+
+        public void SaveToFile(string fileName)
+        {
+            XmlSerializer serializer = new XmlSerializer(typeof(MobiFlight.Config.Config));
+            TextWriter textWriter = new StreamWriter(fileName);
+            serializer.Serialize(textWriter, this);
+            textWriter.Close();
         }
     }
 }

--- a/MobiFlight/Config/Config.cs
+++ b/MobiFlight/Config/Config.cs
@@ -2,7 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Windows.Forms;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/CustomDevice.cs
+++ b/MobiFlight/Config/CustomDevice.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/Encoder.cs
+++ b/MobiFlight/Config/Encoder.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/Encoder.cs
+++ b/MobiFlight/Config/Encoder.cs
@@ -61,7 +61,7 @@ namespace MobiFlight.Config
 
         public override string ToString()
         {
-            return Type + ":" + Name + " PinLeft:" + PinLeft + " PinRight:" + PinRight + " EncoderType:" + EncoderType;
+            return $"{Type}:{Name} PinLeft:{PinLeft} PinRight:{PinRight} EncoderType:{EncoderType}";
         }
     }
 }

--- a/MobiFlight/Config/EncoderSingleDetent.cs
+++ b/MobiFlight/Config/EncoderSingleDetent.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/IBaseDevice.cs
+++ b/MobiFlight/Config/IBaseDevice.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing;
 
 namespace MobiFlight.Config
 {

--- a/MobiFlight/Config/IConfigItem.cs
+++ b/MobiFlight/Config/IConfigItem.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
 namespace MobiFlight.Config
 {

--- a/MobiFlight/Config/IConfigRefConfigItem.cs
+++ b/MobiFlight/Config/IConfigRefConfigItem.cs
@@ -1,9 +1,4 @@
 ﻿using MobiFlight.Base;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MobiFlight.Config
 {

--- a/MobiFlight/Config/InputMultiplexer.cs
+++ b/MobiFlight/Config/InputMultiplexer.cs
@@ -65,19 +65,27 @@ namespace MobiFlight.Config
             NumBytes    = paramList[6];
             Name        = paramList[7];
 
-            /* TO BE DELETED before PR is accepted:
-            // pass the MultiplexerDriver pins, but only if the multiplexerDriver wasn't already set
-            if (Selector == null || Selector.isInitialized()) return false;
-            value = ((int)DeviceType.MultiplexerDriver).ToString() + Separator + paramList[2] + Separator + paramList[3] + Separator + paramList[4] + Separator + paramList[5] + End;
-            Selector.FromInternal(value);
-            // The FromInternal() call takes care internally of the activation counter and the "initialized" flag
-            */
             return true;
+        }
+
+        public override bool Equals(object obj)
+        {
+            InputMultiplexer other = obj as InputMultiplexer;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return this.Name == other.Name
+                && this.DataPin == other.DataPin
+                && this.NumBytes == other.NumBytes
+                && this.Selector.Equals(other.Selector)
+                ;
         }
 
         public override string ToString()
         {
-            return $"{Type}:{Name}";
+            return $"{Type}:{Name} DataPin:{DataPin} NumBytes:{NumBytes} Selector:{this.Selector}";
         }
         
         public static String GetMultiplexerDriverConfig(String value)

--- a/MobiFlight/Config/InputShiftRegister.cs
+++ b/MobiFlight/Config/InputShiftRegister.cs
@@ -46,9 +46,25 @@ namespace MobiFlight.Config
             return true;
         }
 
+        public override bool Equals(object obj)
+        {
+            InputShiftRegister other = obj as InputShiftRegister;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return this.Name == other.Name
+                && this.LatchPin == other.LatchPin
+                && this.ClockPin == other.ClockPin
+                && this.DataPin == other.DataPin
+                && this.NumModules == other.NumModules
+                ;
+        }
+
         public override string ToString()
         {
-            return $"{Type}:{Name}";
+            return $"{Type}:{Name} LatchPin:{LatchPin} ClockPin:{ClockPin} DataPin:{DataPin} NumModules:{NumModules}";
         }
     }
 }

--- a/MobiFlight/Config/LCDDisplay.cs
+++ b/MobiFlight/Config/LCDDisplay.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/LCDDisplay.cs
+++ b/MobiFlight/Config/LCDDisplay.cs
@@ -61,7 +61,7 @@ namespace MobiFlight.Config
 
         public override string ToString()
         {
-            return Type + ":" + Name + " Cols:" + Cols + " Lines:" + Lines + " Address:" + Address;
+            return $"{Type}:{Name} Cols:{Cols} Lines:{Lines} Address:{Address}";
         }
     }
 }

--- a/MobiFlight/Config/LedModule.cs
+++ b/MobiFlight/Config/LedModule.cs
@@ -89,14 +89,7 @@ namespace MobiFlight.Config
 
         public override string ToString()
         {
-            return Type + ":" + Name
-                        + " TypeId:" + ModelType
-                        + " DinPin:" + DinPin
-                        + " ClsPin:" + ClsPin
-                        + " ClkPin:" + ClkPin
-                        + " Brightness:" + Brightness
-                        + " NumModules:" + NumModules;
-                        
+            return $"{Type}:{Name} TypeId:{ModelType} DinPin:{DinPin} ClsPin:{ClsPin} ClkPin:{ClkPin} Brightness:{Brightness} NumModules:{NumModules}";            
         }
     }
 }

--- a/MobiFlight/Config/MultiplexerDriver.cs
+++ b/MobiFlight/Config/MultiplexerDriver.cs
@@ -110,9 +110,25 @@ namespace MobiFlight.Config
             return res;
         }
 
+        public override bool Equals(object obj)
+        {
+            MultiplexerDriver other = obj as MultiplexerDriver;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return this.Name == other.Name
+                && this.PinSx[0] == other.PinSx[0]
+                && this.PinSx[1] == other.PinSx[1]
+                && this.PinSx[2] == other.PinSx[2]
+                && this.PinSx[3] == other.PinSx[3]
+                ;
+        }
+
         public override string ToString()
         {
-            return $"{Type}:{Name}";
+            return $"PinSx[0]:{PinSx[0]} PinSx[1]:{PinSx[1]} PinSx[2]:{PinSx[2]} PinSx[3]:{PinSx[3]}";
         }
     }
 

--- a/MobiFlight/Config/Output.cs
+++ b/MobiFlight/Config/Output.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/Output.cs
+++ b/MobiFlight/Config/Output.cs
@@ -51,8 +51,7 @@ namespace MobiFlight.Config
 
         public override string ToString()
         {
-            return Type + ":" + Name + " Pin:" + Pin;
+            return $"{Type}:{Name} Pin:{Pin}";
         }
-
     }
 }

--- a/MobiFlight/Config/Servo.cs
+++ b/MobiFlight/Config/Servo.cs
@@ -1,7 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Xml.Serialization;
 
 namespace MobiFlight.Config

--- a/MobiFlight/Config/Servo.cs
+++ b/MobiFlight/Config/Servo.cs
@@ -51,7 +51,7 @@ namespace MobiFlight.Config
 
         public override string ToString()
         {
-            return Type + ":" + Name + " DataPin:" + DataPin;
+            return $"{Type}:{Name} DataPin:{DataPin}";
         }
     }
 }

--- a/MobiFlight/Config/ShiftRegister.cs
+++ b/MobiFlight/Config/ShiftRegister.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MobiFlight.OutputConfig;
+using System;
 using System.Linq;
 using System.Xml.Serialization;
 
@@ -44,6 +45,26 @@ namespace MobiFlight.Config
             Name = paramList[5];
 
             return true;
+        }
+
+        public override bool Equals(object obj)
+        {
+            ShiftRegister other = obj as ShiftRegister;
+            if (other == null)
+            {
+                return false;
+            }
+
+            return this.Name == other.Name
+                && this.LatchPin == other.LatchPin
+                && this.ClockPin == other.ClockPin
+                && this.DataPin == other.DataPin
+                && this.NumModules == other.NumModules
+                ;
+        }
+        public override string ToString()
+        {
+            return $"{Type}:{Name} LatchPin:{LatchPin} ClockPin:{ClockPin} DataPin:{DataPin} NumModules:{NumModules}";
         }
     }
 }

--- a/MobiFlight/Config/ShiftRegister.cs
+++ b/MobiFlight/Config/ShiftRegister.cs
@@ -1,5 +1,4 @@
-﻿using MobiFlight.OutputConfig;
-using System;
+﻿using System;
 using System.Linq;
 using System.Xml.Serialization;
 

--- a/MobiFlightUnitTests/MobiFlight/Config/ConfigTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Config/ConfigTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using MobiFlight.Config;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.Config.Compatibility;
 using System;
 using System.Collections.Generic;
@@ -573,6 +574,35 @@ namespace MobiFlight.Config.Tests
             Assert.AreEqual("7.0.1.2.Device7:", actual.ElementAt(6));
             Assert.AreEqual("8.0.1.2.Device8:", actual.ElementAt(7));
             Assert.AreEqual("15.0.1.2.3.4.0.0.0.0.Device9:", actual.ElementAt(8));
+        }
+
+        [TestMethod()]
+        public void LoadFromFileTest()
+        {
+            const string fileName = @"assets/MobiFlight/Config/Config/UnitTest.mfmc";
+            var config = Config.LoadFromFile(fileName);
+
+            Assert.AreEqual("UnitTest", config.ModuleName);
+            Assert.AreEqual("MobiFlight Mega", config.ModuleType);
+            Assert.AreEqual(11, config.Items.Count);
+        }
+
+        [TestMethod()]
+        public void SaveToFileTest()
+        {
+            const string fileName = @"assets/MobiFlight/Config/Config/UnitTest.mfmc";
+            var config = Config.LoadFromFile(fileName);
+            const string tmpFileName = @"assets/MobiFlight/Config/Config/UnitTest.tmp.mfmc";
+
+            config.SaveToFile(tmpFileName);
+            var savedConfig = Config.LoadFromFile(tmpFileName);
+            Assert.AreEqual(config.ModuleName, savedConfig.ModuleName);
+            Assert.AreEqual(config.ModuleType, savedConfig.ModuleType);
+            Assert.AreEqual(config.Items.Count, savedConfig.Items.Count);  
+            for(var i = 0; i < config.Items.Count; i++)
+            {
+                Assert.IsTrue(config.Items[i].Equals(savedConfig.Items[i]));
+            }
         }
     }
 }

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -469,6 +469,9 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <None Include="assets\MobiFlight\Config\Config\UnitTest.mfmc">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/MobiFlightUnitTests/assets/MobiFlight/Config/Config/UnitTest.mfmc
+++ b/MobiFlightUnitTests/assets/MobiFlight/Config/Config/UnitTest.mfmc
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <ModuleType>MobiFlight Mega</ModuleType>
+  <ModuleName>UnitTest</ModuleName>
+  <PowerSavingTime>600</PowerSavingTime>
+  <Output Name="Output" Pin="2" />
+  <LedModule Name="LedModule" ModelType="0" DinPin="3" ClsPin="5" ClkPin="4" Brightness="15" NumModules="1" />
+  <Servo Name="Servo" DataPin="6" />
+  <Stepper Name="Stepper" Pin1="7" Pin2="8" Pin3="9" Pin4="10" BtnPin="0" Mode="0" Backlash="0" Deactivate="false" Profile="0" />
+  <LcdDisplay Name="LcdDisplay" Address="39" Cols="16" Lines="2" />
+  <ShiftRegister Name="ShiftRegister" LatchPin="13" ClockPin="12" DataPin="11" NumModules="1" />
+  <Button Name="Button" Pin="14" />
+  <Encoder Name="Encoder" PinLeft="15" PinRight="16" EncoderType="0" />
+  <AnalogInput Name="Analog Input" Pin="54" Sensitivity="5" />
+  <InputShiftRegister Name="InputShifter" LatchPin="19" ClockPin="18" DataPin="17" NumModules="1" />
+  <InputMultiplexer Name="Multiplexer" DataPin="26" NumBytes="2">
+    <Selector Name="MultiplexerDriver" PinSx="22 23 24 25" />
+  </InputMultiplexer>
+</Config>

--- a/ProjectMessages/ProjectMessages.Designer.cs
+++ b/ProjectMessages/ProjectMessages.Designer.cs
@@ -1093,7 +1093,7 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Incompatible config.
+        ///   Looks up a localized string similar to Board type warning.
         /// </summary>
         internal static string uiMessageOpenConfigIncompatibleTypeHint {
             get {
@@ -1102,9 +1102,9 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The config was created for a &quot;{0}&quot; board type. Your board type is &quot;{1}&quot;. The config might be incompatible.
+        ///   Looks up a localized string similar to The config was created for a &quot;{0}&quot; board. Your selected board is a &quot;{1}&quot;. The config may be incompatible, check before uploading.
         ///
-        ///Do you want to open it?.
+        ///Open anyway?.
         /// </summary>
         internal static string uiMessageOpenConfigIncompatibleTypeText {
             get {
@@ -1113,9 +1113,11 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The config doesn&apos;t contain any board type information. Your board type is &quot;{0}&quot;.
+        ///   Looks up a localized string similar to This config doesn&apos;t specify a board type and may not be compatible with your &quot;{0}&quot;.
         ///
-        ///Do you want to open it?.
+        ///Open anyway?
+        ///
+        ///Tip: Save the file after opening to update the associated board for future use..
         /// </summary>
         internal static string uiMessageOpenConfigUnspecificTypeText {
             get {

--- a/ProjectMessages/ProjectMessages.Designer.cs
+++ b/ProjectMessages/ProjectMessages.Designer.cs
@@ -1093,6 +1093,37 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Incompatible config.
+        /// </summary>
+        internal static string uiMessageOpenConfigIncompatibleTypeHint {
+            get {
+                return ResourceManager.GetString("uiMessageOpenConfigIncompatibleTypeHint", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The config was created for a &quot;{0}&quot; board type. Your board type is &quot;{1}&quot;. The config might be incompatible.
+        ///
+        ///Do you want to open it?.
+        /// </summary>
+        internal static string uiMessageOpenConfigIncompatibleTypeText {
+            get {
+                return ResourceManager.GetString("uiMessageOpenConfigIncompatibleTypeText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The config doesn&apos;t contain any board type information. Your board type is &quot;{0}&quot;.
+        ///
+        ///Do you want to open it?.
+        /// </summary>
+        internal static string uiMessageOpenConfigUnspecificTypeText {
+            get {
+                return ResourceManager.GetString("uiMessageOpenConfigUnspecificTypeText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value must be a number and greater than 0..
         /// </summary>
         internal static string uiMessagePanelsStepperInputRevolutionsMustBeGreaterThan0 {

--- a/ProjectMessages/ProjectMessages.de.resx
+++ b/ProjectMessages/ProjectMessages.de.resx
@@ -648,4 +648,23 @@ Möchtest Du sie aktualisieren?</value>
     <value>HubHop Preset Update</value>
     <comment>HubHop Preset Update</comment>
   </data>
+  <data name="uiMessageOpenConfigIncompatibleTypeHint" xml:space="preserve">
+    <value>Inkompatible Konfiguration</value>
+  </data>
+  <data name="uiMessageOpenConfigIncompatibleTypeText" xml:space="preserve">
+    <value>Die Config wurde für ein Board von Typ "{0}" gemacht. Dein Board ist Typ "{1}". Die Config ist vielleicht inkompatibel.
+
+Willst Du sie öffnen?</value>
+    <comment>The config was created for a "{0}" board type. Your board type is "{1}". The config might be incompatible.
+
+Do you want to open it?</comment>
+  </data>
+  <data name="uiMessageOpenConfigUnspecificTypeText" xml:space="preserve">
+    <value>Die Config enthält keine Information zu Board-Typ. Dein Board ist Typ "{1}".  Die Config ist vielleicht inkompatibel.
+
+Bist du sicher, dass du sie für Dein Board ({1}) laden willst? </value>
+    <comment>The config doesn't contain any board type information. Your board type is "{0}".
+
+Do you want to open it?</comment>
+  </data>
 </root>

--- a/ProjectMessages/ProjectMessages.resx
+++ b/ProjectMessages/ProjectMessages.resx
@@ -624,16 +624,18 @@ Would you like to update?</value>
     <value>Drag and Drop is not available when list is sorted.</value>
   </data>
   <data name="uiMessageOpenConfigIncompatibleTypeHint" xml:space="preserve">
-    <value>Incompatible config</value>
+    <value>Board type warning</value>
   </data>
   <data name="uiMessageOpenConfigIncompatibleTypeText" xml:space="preserve">
-    <value>The config was created for a "{0}" board type. Your board type is "{1}". The config might be incompatible.
+    <value>The config was created for a "{0}" board. Your selected board is a "{1}". The config may be incompatible, check before uploading.
 
-Do you want to open it?</value>
+Open anyway?</value>
   </data>
   <data name="uiMessageOpenConfigUnspecificTypeText" xml:space="preserve">
-    <value>The config doesn't contain any board type information. Your board type is "{0}".
+    <value>This config doesn't specify a board type and may not be compatible with your "{0}".
 
-Do you want to open it?</value>
+Open anyway?
+
+Tip: Save the file after opening to update the associated board for future use.</value>
   </data>
 </root>

--- a/ProjectMessages/ProjectMessages.resx
+++ b/ProjectMessages/ProjectMessages.resx
@@ -623,4 +623,17 @@ Would you like to update?</value>
   <data name="uiMessageDragDropNotAllowed" xml:space="preserve">
     <value>Drag and Drop is not available when list is sorted.</value>
   </data>
+  <data name="uiMessageOpenConfigIncompatibleTypeHint" xml:space="preserve">
+    <value>Incompatible config</value>
+  </data>
+  <data name="uiMessageOpenConfigIncompatibleTypeText" xml:space="preserve">
+    <value>The config was created for a "{0}" board type. Your board type is "{1}". The config might be incompatible.
+
+Do you want to open it?</value>
+  </data>
+  <data name="uiMessageOpenConfigUnspecificTypeText" xml:space="preserve">
+    <value>The config doesn't contain any board type information. Your board type is "{0}".
+
+Do you want to open it?</value>
+  </data>
 </root>

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -1038,6 +1038,7 @@ namespace MobiFlight.UI.Panels.Settings
             MobiFlightModule module = moduleNode.Tag as MobiFlightModule;
 
             MobiFlight.Config.Config newConfig = new MobiFlight.Config.Config();
+            newConfig.ModuleType = module.Type;
             newConfig.ModuleName = module.Name;
 
             foreach (TreeNode node in moduleNode.Nodes)
@@ -1061,8 +1062,6 @@ namespace MobiFlight.UI.Panels.Settings
         private void openToolStripButton_Click(object sender, EventArgs e)
         {
             TreeNode moduleNode = getModuleNode();
-            MobiFlightModule module = moduleNode.Tag as MobiFlightModule;
-
             OpenFileDialog fd = new OpenFileDialog();
             fd.Filter = "Mobiflight Module Config (*.mfmc)|*.mfmc";
 
@@ -1079,10 +1078,32 @@ namespace MobiFlight.UI.Panels.Settings
             MobiFlight.Config.Config newConfig;
             newConfig = (MobiFlight.Config.Config)serializer.Deserialize(textReader);
             textReader.Close();
+            var module = (moduleNode.Tag as MobiFlightModule);
+
+            if (newConfig?.ModuleType != module.Type)
+            {
+                // Old configs don't contain a specified type 
+                // In this case newConfig.ModuleType == "" 
+                var message = string.Format(i18n._tr("uiMessageOpenConfigUnspecificTypeText"), module.Type);
+
+                // New configs have a specific type other than ""
+                if ((newConfig?.ModuleType ?? "") != "")
+                {
+                    message = string.Format(i18n._tr("uiMessageOpenConfigIncompatibleTypeText"), newConfig.ModuleType, module.Type);
+                }
+                
+                if (MessageBox.Show(message,
+                                    i18n._tr("uiMessageOpenConfigIncompatibleTypeHint"),
+                                    MessageBoxButtons.YesNo) != System.Windows.Forms.DialogResult.Yes)
+                {
+                    // User aborted using the incompatible file
+                    return;
+                }
+            }
 
             if (newConfig.ModuleName != null && newConfig.ModuleName != "")
             {
-                moduleNode.Text = (moduleNode.Tag as MobiFlightModule).Name = newConfig.ModuleName;
+                moduleNode.Text = module.Name = newConfig.ModuleName;
 
             }
 

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -1072,15 +1072,16 @@ namespace MobiFlight.UI.Panels.Settings
         {
             var newConfig = MobiFlight.Config.Config.LoadFromFile(fileName);
             var module = (moduleNode.Tag as MobiFlightModule);
+            var moduleType = newConfig?.ModuleType;
 
-            if (newConfig?.ModuleType != module.Type)
+            if (module.Type != moduleType)
             {
                 // Old configs don't contain a specified type 
                 // In this case newConfig.ModuleType == "" 
                 var message = string.Format(i18n._tr("uiMessageOpenConfigUnspecificTypeText"), module.Type);
 
                 // New configs have a specific type other than ""
-                if ((newConfig?.ModuleType ?? "") != "")
+                if (!String.IsNullOrEmpty(moduleType))
                 {
                     message = string.Format(i18n._tr("uiMessageOpenConfigIncompatibleTypeText"), newConfig.ModuleType, module.Type);
                 }

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -1052,10 +1052,7 @@ namespace MobiFlight.UI.Panels.Settings
 
             if (DialogResult.OK == fd.ShowDialog())
             {
-                XmlSerializer serializer = new XmlSerializer(typeof(MobiFlight.Config.Config));
-                TextWriter textWriter = new StreamWriter(fd.FileName);
-                serializer.Serialize(textWriter, newConfig);
-                textWriter.Close();
+                newConfig.SaveToFile(fd.FileName);
             }
         }
 
@@ -1073,11 +1070,7 @@ namespace MobiFlight.UI.Panels.Settings
 
         private void OpenFile(TreeNode moduleNode, string fileName)
         {
-            TextReader textReader = new StreamReader(fileName);
-            XmlSerializer serializer = new XmlSerializer(typeof(MobiFlight.Config.Config));
-            MobiFlight.Config.Config newConfig;
-            newConfig = (MobiFlight.Config.Config)serializer.Deserialize(textReader);
-            textReader.Close();
+            var newConfig = MobiFlight.Config.Config.LoadFromFile(fileName);
             var module = (moduleNode.Tag as MobiFlightModule);
 
             if (newConfig?.ModuleType != module.Type)


### PR DESCRIPTION
fixes #1521 

- [x] On opening - Message popping up to inform when no board type is contained in file.
  ![image](https://github.com/MobiFlight/MobiFlight-Connector/assets/86157512/95356a3e-391f-4d5d-9b00-3491c63d40fb)
- [x] On opening - Message popping up to inform that there is a board type mismatch.
  ![image](https://github.com/MobiFlight/MobiFlight-Connector/assets/86157512/0c5ccb5e-6790-416a-a73f-90f608b65cfb)
- [x] On opening - In both cases user can continue with "Yes" or stop opening with "No"
- [x] On saving - board type is saved as new property
- [ ] Documentation - Add info to https://github.com/MobiFlight/MobiFlight-Connector/wiki/Mobiflight-Connector-Main-Window#mobiflight-modules---tab
- [x] i18n
- [x] unit tests
  - [x] extract methods for open and save logic
  - [x] add unit tests for open and save
  - [x] add missing `equals` implementations in various classes
  - [x] added ToString implementations in various classes
  - [x] refactored ToString method to new style
- [x] remove all unnecessary usings in config namespace

