### PR TITLE
Comparison modifier substitutes `$` correctly

### DIFF
--- a/MobiFlight/Modifier/Comparison.cs
+++ b/MobiFlight/Modifier/Comparison.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MobiFlight.Base;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -90,7 +91,7 @@ namespace MobiFlight.Modifier
 
             if (connectorValue.type == FSUIPCOffsetType.String)
             {
-                result.String = ExecuteStringComparison(connectorValue);
+                result.String = ExecuteStringComparison(connectorValue, configRefs);
                 return result;
             }
 
@@ -165,14 +166,21 @@ namespace MobiFlight.Modifier
 
             return result;
         }
-        private string ExecuteStringComparison(ConnectorValue connectorValue)
+        private string ExecuteStringComparison(ConnectorValue connectorValue, List<ConfigRefValue> configRefs)
         {
             string result = connectorValue.String;
             string value = connectorValue.String;
 
             string comparisonValue = Value;
-            string comparisonIfValue = IfValue;
-            string comparisonElseValue = ElseValue;
+            string comparisonIfValue = !String.IsNullOrEmpty(IfValue) ? IfValue : value;
+            string comparisonElseValue = !String.IsNullOrEmpty(ElseValue) ? ElseValue : value;
+
+            foreach (ConfigRefValue configRef in configRefs)
+            {
+                comparisonValue = comparisonValue.Replace(configRef.ConfigRef.Placeholder, configRef.Value);
+                comparisonIfValue = comparisonIfValue.Replace(configRef.ConfigRef.Placeholder, configRef.Value);
+                comparisonElseValue = comparisonElseValue.Replace(configRef.ConfigRef.Placeholder, configRef.Value);
+            }
 
             switch (Operand)
             {
@@ -183,6 +191,8 @@ namespace MobiFlight.Modifier
                     result = (value == comparisonValue) ? comparisonIfValue : comparisonElseValue;
                     break;
             }
+
+            result = result.Replace("$", value.ToString());
 
             return result;
         }

--- a/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
@@ -165,6 +165,19 @@ namespace MobiFlight.Modifier.Tests
             Assert.AreEqual(FSUIPCOffsetType.String, c.Apply(value, new List<ConfigRefValue>()).type);
             Assert.AreEqual("'works!'", c.Apply(value, new List<ConfigRefValue>()).String);
 
+            c.Active = true;
+            c.Operand = "=";
+            c.Value = "Hello";
+            c.IfValue = "$ world!";
+            c.ElseValue = "$ welt!";
+
+            value.type = FSUIPCOffsetType.String;
+            value.Float64 = 0;
+            value.String = "Hello";
+
+            Assert.AreEqual(FSUIPCOffsetType.String, c.Apply(value, new List<ConfigRefValue>()).type);
+            Assert.AreEqual("Hello world!", c.Apply(value, new List<ConfigRefValue>()).String);
+
         }
     }
 }


### PR DESCRIPTION
fixes #1531 

- [x] string processing for `ifValue`  and `elseValue` now replaces `$`
- [x] string processing for `ifValue`  and `elseValue` replace config references
- [x] fields can be left empty and will be substituted with the current value (similar to `$`)
- [x] unit tests

![image](https://github.com/MobiFlight/MobiFlight-Connector/assets/86157512/27255c09-4185-4453-8136-1e5a5df56cb6)
