### PR TITLE
Auto width for Module, Input, Output and Type

### DIFF
--- a/UI/Panels/InputConfigPanel.Designer.cs
+++ b/UI/Panels/InputConfigPanel.Designer.cs
@@ -231,7 +231,7 @@
             // 
             // moduleSerial
             // 
-            this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.moduleSerial.DataPropertyName = "moduleSerial";
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.ControlLight;
             this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle1;
@@ -243,7 +243,7 @@
             // 
             // inputName
             // 
-            this.inputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.inputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.inputName.DataPropertyName = "inputName";
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
             this.inputName.DefaultCellStyle = dataGridViewCellStyle2;
@@ -255,7 +255,7 @@
             // 
             // inputType
             // 
-            this.inputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.inputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.inputType.DataPropertyName = "inputType";
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
             this.inputType.DefaultCellStyle = dataGridViewCellStyle3;

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -453,12 +453,28 @@ namespace MobiFlight.UI.Panels
                 e.Row["guid"] = Guid.NewGuid();
         }
 
+        private void ActivateAutoColumnWidth()
+        {       
+            inputsDataGridView.Columns["moduleSerial"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
+            inputsDataGridView.Columns["inputName"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
+            inputsDataGridView.Columns["inputType"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
+        }
+
+        private void DeactivateAutoColumnWidth()
+        {           
+            inputsDataGridView.Columns["moduleSerial"].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            inputsDataGridView.Columns["inputName"].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            inputsDataGridView.Columns["inputType"].AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+        }
+
         /// <summary>
         /// use the settings from the config object and initialize the grid cells 
         /// this is needed after loading and saving configs
         /// </summary>
         public void RestoreValuesInGridView()
         {
+            // Needed for performance reasons
+            DeactivateAutoColumnWidth();
             foreach (DataRow row in ConfigDataTable.Rows)
             {
                 InputConfigItem cfg = row["settings"] as InputConfigItem;
@@ -504,6 +520,7 @@ namespace MobiFlight.UI.Panels
                     row["inputType"] = cfg.Type;                   
                 }
             }
+            ActivateAutoColumnWidth();
         } //_restoreValuesInGridView()
 
         private void inputsDataGridView_CellEndEdit(object sender, DataGridViewCellEventArgs e)

--- a/UI/Panels/InputConfigPanel.resx
+++ b/UI/Panels/InputConfigPanel.resx
@@ -197,6 +197,9 @@
   <data name="moduleSerial.ToolTipText" xml:space="preserve">
     <value>The board used in the config</value>
   </data>
+  <data name="moduleSerial.Width" type="System.Int32, mscorlib">
+    <value>67</value>
+  </data>
   <metadata name="inputName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -206,6 +209,9 @@
   <data name="inputName.ToolTipText" xml:space="preserve">
     <value>The device used in the config</value>
   </data>
+  <data name="inputName.Width" type="System.Int32, mscorlib">
+    <value>56</value>
+  </data>
   <metadata name="inputType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -214,6 +220,9 @@
   </data>
   <data name="inputType.ToolTipText" xml:space="preserve">
     <value>The type of device used in the config</value>
+  </data>
+  <data name="inputType.Width" type="System.Int32, mscorlib">
+    <value>56</value>
   </data>
   <metadata name="inputEditButtonColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -237,11 +246,8 @@
   <data name="inputsDataGridView.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="inputsDataGridView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="inputsDataGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1182, 798</value>
+    <value>788, 519</value>
   </data>
   <data name="inputsDataGridView.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -262,13 +268,10 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 20</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1182, 798</value>
+    <value>788, 519</value>
   </data>
   <data name="&gt;&gt;copyToolStripMenuItem.Name" xml:space="preserve">
     <value>copyToolStripMenuItem</value>

--- a/UI/Panels/OutputConfigPanel.Designer.cs
+++ b/UI/Panels/OutputConfigPanel.Designer.cs
@@ -120,7 +120,7 @@
             dataGridViewCellStyle10.ForeColor = System.Drawing.SystemColors.ControlText;
             dataGridViewCellStyle10.SelectionBackColor = System.Drawing.SystemColors.Highlight;
             dataGridViewCellStyle10.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle10.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+            dataGridViewCellStyle10.WrapMode = System.Windows.Forms.DataGridViewTriState.False;
             this.dataGridViewConfig.DefaultCellStyle = dataGridViewCellStyle10;
             resources.ApplyResources(this.dataGridViewConfig, "dataGridViewConfig");
             this.dataGridViewConfig.EditMode = System.Windows.Forms.DataGridViewEditMode.EditOnF2;
@@ -185,7 +185,7 @@
             // 
             // moduleSerial
             // 
-            this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.moduleSerial.DataPropertyName = "arcazeSerial";
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
             this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle3;
@@ -197,7 +197,7 @@
             // 
             // OutputName
             // 
-            this.OutputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
+            this.OutputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.OutputName.DataPropertyName = "OutputName";
             dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.ControlLight;
             this.OutputName.DefaultCellStyle = dataGridViewCellStyle4;
@@ -208,6 +208,7 @@
             // 
             // OutputType
             // 
+            this.OutputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.OutputType.DataPropertyName = "OutputType";
             dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.ControlLight;
             this.OutputType.DefaultCellStyle = dataGridViewCellStyle5;

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -562,12 +562,28 @@ namespace MobiFlight.UI.Panels
             e.Row.Cells["guid"].Value = Guid.NewGuid();
         }
 
+        private void ActivateAutoColumnWidth()
+        {                   
+            dataGridViewConfig.Columns["moduleSerial"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
+            dataGridViewConfig.Columns["OutputName"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
+            dataGridViewConfig.Columns["OutputType"].AutoSizeMode = DataGridViewAutoSizeColumnMode.AllCells;
+        }
+
+        private void DeactivateAutoColumnWidth()
+        {                   
+            dataGridViewConfig.Columns["moduleSerial"].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            dataGridViewConfig.Columns["OutputName"].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            dataGridViewConfig.Columns["OutputType"].AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+        }
+
         /// <summary>
         /// use the settings from the config object and initialize the grid cells 
         /// this is needed after loading and saving configs
         /// </summary>
         public void RestoreValuesInGridView()
         {
+            // Needed for performance reasons
+            DeactivateAutoColumnWidth();
             foreach (DataRow row in ConfigDataTable.Rows)
             {
                 OutputConfigItem cfgItem = row["settings"] as OutputConfigItem;
@@ -633,6 +649,8 @@ namespace MobiFlight.UI.Panels
                     }
                 }
             }
+
+            ActivateAutoColumnWidth();
         } //_restoreValuesInGridView()
 
         /// <summary>

--- a/UI/Panels/OutputConfigPanel.resx
+++ b/UI/Panels/OutputConfigPanel.resx
@@ -157,6 +157,9 @@
   <data name="moduleSerial.ToolTipText" xml:space="preserve">
     <value>The board used in the config</value>
   </data>
+  <data name="moduleSerial.Width" type="System.Int32, mscorlib">
+    <value>90</value>
+  </data>
   <metadata name="OutputName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -169,6 +172,9 @@
   <data name="OutputName.ToolTipText" xml:space="preserve">
     <value>The device used in the config</value>
   </data>
+  <data name="OutputName.Width" type="System.Int32, mscorlib">
+    <value>90</value>
+  </data>
   <metadata name="OutputType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -177,6 +183,9 @@
   </data>
   <data name="OutputType.ToolTipText" xml:space="preserve">
     <value>The type of device used in the config</value>
+  </data>
+  <data name="OutputType.Width" type="System.Int32, mscorlib">
+    <value>56</value>
   </data>
   <metadata name="FsuipcOffset.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -303,11 +312,8 @@
   <data name="dataGridViewConfig.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
-  <data name="dataGridViewConfig.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
-  </data>
   <data name="dataGridViewConfig.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1394, 968</value>
+    <value>929, 629</value>
   </data>
   <data name="dataGridViewConfig.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -331,13 +337,10 @@
     <value>280</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>9, 20</value>
-  </data>
-  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 13</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>1394, 968</value>
+    <value>929, 629</value>
   </data>
   <data name="&gt;&gt;active.Name" xml:space="preserve">
     <value>active</value>


### PR DESCRIPTION
Fixes #1533. Or better, fixes the root cause for the wish of #1533.

I'm also annoyed by the truncated or wrapped texts and all the time need to adjust the columns, so everything is visible.

I propose to just auto size Module, Input, Output and Type based on the content. Why not? Try it.

Opinions @neilenns , @DocMoebiuz ?
