### PR TITLE
Manually adjustable config columns after auto resize

### DIFF
--- a/UI/Panels/InputConfigPanel.Designer.cs
+++ b/UI/Panels/InputConfigPanel.Designer.cs
@@ -231,7 +231,7 @@
             // 
             // moduleSerial
             // 
-            this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.moduleSerial.DataPropertyName = "moduleSerial";
             dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.ControlLight;
             this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle1;
@@ -243,7 +243,7 @@
             // 
             // inputName
             // 
-            this.inputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.inputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.inputName.DataPropertyName = "inputName";
             dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
             this.inputName.DefaultCellStyle = dataGridViewCellStyle2;
@@ -255,7 +255,7 @@
             // 
             // inputType
             // 
-            this.inputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.inputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.inputType.DataPropertyName = "inputType";
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
             this.inputType.DefaultCellStyle = dataGridViewCellStyle3;

--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -461,10 +461,18 @@ namespace MobiFlight.UI.Panels
         }
 
         private void DeactivateAutoColumnWidth()
-        {           
-            inputsDataGridView.Columns["moduleSerial"].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
-            inputsDataGridView.Columns["inputName"].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
-            inputsDataGridView.Columns["inputType"].AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+        {
+            // Deactivate and adjust FillWeights
+            string[] columnNames = { "moduleSerial", "inputName", "inputType" };
+
+            // inputDescription has FillWeight 1000
+            var descColumn = inputsDataGridView.Columns["inputDescription"];
+            foreach (string name in columnNames)
+            {
+                int currentWidth = inputsDataGridView.Columns[name].Width;
+                inputsDataGridView.Columns[name].FillWeight = (float)currentWidth / (float)descColumn.Width * 1450;
+                inputsDataGridView.Columns[name].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            }
         }
 
         /// <summary>
@@ -520,7 +528,11 @@ namespace MobiFlight.UI.Panels
                     row["inputType"] = cfg.Type;                   
                 }
             }
+            // Auto adjust column width
             ActivateAutoColumnWidth();
+
+            // Deactivate again, to make them resizable
+            DeactivateAutoColumnWidth();
         } //_restoreValuesInGridView()
 
         private void inputsDataGridView_CellEndEdit(object sender, DataGridViewCellEventArgs e)

--- a/UI/Panels/InputConfigPanel.resx
+++ b/UI/Panels/InputConfigPanel.resx
@@ -197,9 +197,6 @@
   <data name="moduleSerial.ToolTipText" xml:space="preserve">
     <value>The board used in the config</value>
   </data>
-  <data name="moduleSerial.Width" type="System.Int32, mscorlib">
-    <value>67</value>
-  </data>
   <metadata name="inputName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -209,9 +206,6 @@
   <data name="inputName.ToolTipText" xml:space="preserve">
     <value>The device used in the config</value>
   </data>
-  <data name="inputName.Width" type="System.Int32, mscorlib">
-    <value>56</value>
-  </data>
   <metadata name="inputType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -220,9 +214,6 @@
   </data>
   <data name="inputType.ToolTipText" xml:space="preserve">
     <value>The type of device used in the config</value>
-  </data>
-  <data name="inputType.Width" type="System.Int32, mscorlib">
-    <value>56</value>
   </data>
   <metadata name="inputEditButtonColumn.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
@@ -246,8 +237,11 @@
   <data name="inputsDataGridView.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="inputsDataGridView.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
   <data name="inputsDataGridView.Size" type="System.Drawing.Size, System.Drawing">
-    <value>788, 519</value>
+    <value>1182, 798</value>
   </data>
   <data name="inputsDataGridView.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -268,10 +262,13 @@
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>9, 20</value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.Size" type="System.Drawing.Size, System.Drawing">
-    <value>788, 519</value>
+    <value>1182, 798</value>
   </data>
   <data name="&gt;&gt;copyToolStripMenuItem.Name" xml:space="preserve">
     <value>copyToolStripMenuItem</value>

--- a/UI/Panels/OutputConfigPanel.Designer.cs
+++ b/UI/Panels/OutputConfigPanel.Designer.cs
@@ -185,7 +185,7 @@
             // 
             // moduleSerial
             // 
-            this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.moduleSerial.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.moduleSerial.DataPropertyName = "arcazeSerial";
             dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
             this.moduleSerial.DefaultCellStyle = dataGridViewCellStyle3;
@@ -197,7 +197,7 @@
             // 
             // OutputName
             // 
-            this.OutputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.OutputName.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.Fill;
             this.OutputName.DataPropertyName = "OutputName";
             dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.ControlLight;
             this.OutputName.DefaultCellStyle = dataGridViewCellStyle4;
@@ -208,7 +208,6 @@
             // 
             // OutputType
             // 
-            this.OutputType.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
             this.OutputType.DataPropertyName = "OutputType";
             dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.ControlLight;
             this.OutputType.DefaultCellStyle = dataGridViewCellStyle5;

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -570,10 +570,18 @@ namespace MobiFlight.UI.Panels
         }
 
         private void DeactivateAutoColumnWidth()
-        {                   
-            dataGridViewConfig.Columns["moduleSerial"].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
-            dataGridViewConfig.Columns["OutputName"].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
-            dataGridViewConfig.Columns["OutputType"].AutoSizeMode = DataGridViewAutoSizeColumnMode.None;
+        {
+            // Deactivate and adjust FillWeights
+            string[] columnNames = { "moduleSerial", "OutputName", "OutputType" };
+
+            // description has FillWeight 1000
+            var descColumn = dataGridViewConfig.Columns["description"];
+            foreach (string name in columnNames)
+            {
+                int currentWidth = dataGridViewConfig.Columns[name].Width;
+                dataGridViewConfig.Columns[name].FillWeight = (float)currentWidth / (float)descColumn.Width * 1450;
+                dataGridViewConfig.Columns[name].AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill;
+            }
         }
 
         /// <summary>
@@ -649,8 +657,11 @@ namespace MobiFlight.UI.Panels
                     }
                 }
             }
-
+            // Auto adjust column width
             ActivateAutoColumnWidth();
+
+            // Deactivate again, to make them resizable
+            DeactivateAutoColumnWidth();
         } //_restoreValuesInGridView()
 
         /// <summary>

--- a/UI/Panels/OutputConfigPanel.resx
+++ b/UI/Panels/OutputConfigPanel.resx
@@ -157,9 +157,6 @@
   <data name="moduleSerial.ToolTipText" xml:space="preserve">
     <value>The board used in the config</value>
   </data>
-  <data name="moduleSerial.Width" type="System.Int32, mscorlib">
-    <value>90</value>
-  </data>
   <metadata name="OutputName.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -172,9 +169,6 @@
   <data name="OutputName.ToolTipText" xml:space="preserve">
     <value>The device used in the config</value>
   </data>
-  <data name="OutputName.Width" type="System.Int32, mscorlib">
-    <value>90</value>
-  </data>
   <metadata name="OutputType.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
@@ -183,9 +177,6 @@
   </data>
   <data name="OutputType.ToolTipText" xml:space="preserve">
     <value>The type of device used in the config</value>
-  </data>
-  <data name="OutputType.Width" type="System.Int32, mscorlib">
-    <value>56</value>
   </data>
   <metadata name="FsuipcOffset.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>


### PR DESCRIPTION
Alternative to #1536. Here the columns have relative sizes and the manual resizing behavior is closer to what it was before. But probably not needed.

We wait for feedback to #1536 
