### PR TITLE
Block editing modules if firmware is not current

### DIFF
--- a/ProjectMessages/ProjectMessages.Designer.cs
+++ b/ProjectMessages/ProjectMessages.Designer.cs
@@ -1207,6 +1207,15 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Editing is disabled due to outdated firmware. Please update to the latest version..
+        /// </summary>
+        internal static string uiMessageSettingsDialogFirmwareRequiresUpdate {
+            get {
+                return ResourceManager.GetString("uiMessageSettingsDialogFirmwareRequiresUpdate", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The current firmware does not support this function. Please update to the latest firmware now!.
         /// </summary>
         internal static string uiMessageSettingsDialogFirmwareVersionTooLowException {

--- a/ProjectMessages/ProjectMessages.de.resx
+++ b/ProjectMessages/ProjectMessages.de.resx
@@ -667,4 +667,8 @@ Bist du sicher, dass du sie für Dein Board ({1}) laden willst? </value>
 
 Do you want to open it?</comment>
   </data>
+  <data name="uiMessageSettingsDialogFirmwareRequiresUpdate" xml:space="preserve">
+    <value>Bearbeiten ist deaktiviert, weil die Firmware veraltet ist. Bitte aktualisiere auf die neueste Version.</value>
+    <comment>Editing is disabled due to outdated firmware. Please update to the latest version.</comment>
+  </data>
 </root>

--- a/ProjectMessages/ProjectMessages.resx
+++ b/ProjectMessages/ProjectMessages.resx
@@ -638,4 +638,7 @@ Open anyway?
 
 Tip: Save the file after opening to update the associated board for future use.</value>
   </data>
+  <data name="uiMessageSettingsDialogFirmwareRequiresUpdate" xml:space="preserve">
+    <value>Editing is disabled due to outdated firmware. Please update to the latest version.</value>
+  </data>
 </root>


### PR DESCRIPTION
fixes #590 

- [x] Shows a dialog that informs about "editing disabled due to outdated firmware"
- [x] i18n
- [x] ~unit tests~

<img width="434" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/86157512/0c9bff5a-f13a-4510-a460-b15802755e00">
