### PR TITLE
Update dialog titles for input and output configs

### DIFF
--- a/UI/Dialogs/ConfigWizard.resx
+++ b/UI/Dialogs/ConfigWizard.resx
@@ -1051,7 +1051,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Output</value>
+    <value>Output Config Wizard</value>
   </data>
   <data name="&gt;&gt;presetsDataSet.Name" xml:space="preserve">
     <value>presetsDataSet</value>

--- a/UI/Dialogs/ConfigWizard.resx
+++ b/UI/Dialogs/ConfigWizard.resx
@@ -1051,7 +1051,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>ConfigWizard</value>
+    <value>Output</value>
   </data>
   <data name="&gt;&gt;presetsDataSet.Name" xml:space="preserve">
     <value>presetsDataSet</value>

--- a/UI/Dialogs/InputConfigWizard.resx
+++ b/UI/Dialogs/InputConfigWizard.resx
@@ -835,7 +835,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>Input</value>
+    <value>Input Config Wizard</value>
   </data>
   <data name="&gt;&gt;presetsDataSet.Name" xml:space="preserve">
     <value>presetsDataSet</value>

--- a/UI/Dialogs/InputConfigWizard.resx
+++ b/UI/Dialogs/InputConfigWizard.resx
@@ -454,7 +454,7 @@
     <value>preconditionPanel</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
     <value>preconditionTabPage</value>
@@ -511,7 +511,7 @@
     <value>configRefPanel</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Parent" xml:space="preserve">
     <value>configRefTabPage</value>
@@ -835,7 +835,7 @@
     <value>CenterParent</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>InputConfigWizard</value>
+    <value>Input</value>
   </data>
   <data name="&gt;&gt;presetsDataSet.Name" xml:space="preserve">
     <value>presetsDataSet</value>


### PR DESCRIPTION
Fixes #1551

Not sure how I missed checking in the .resx files before. Oops.

Use "Input" and "Output" for the dialog titles instead of "InputConfigWizard" and "OutputConfigWizard".

<img width="384" alt="input" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/c7083ec7-8787-4a6f-89a8-cf8115c58a1c">

<img width="255" alt="output" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/10383b82-e717-49c5-9f98-387376ff51ae">
