### PR TITLE
Firmware update supports concurrent updates with individual base path

### DIFF
--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -14,11 +14,6 @@ namespace MobiFlight
         public static String ArduinoIdePath { get; set; }
         public static String AvrPath { get { return "hardware\\tools\\avr"; } }
 
-        /***
-         * C:\\Users\\SEBAST~1\\AppData\\Local\\Temp\\build2060068306446321513.tmp\\cmd_test_mega.cpp.hex
-         **/
-        public static String FirmwarePath { get; set; }
-
         public static bool IsValidArduinoIdePath(string path)
         {
             return Directory.Exists(path + "\\" + AvrPath);
@@ -111,10 +106,13 @@ namespace MobiFlight
         public static void RunAvrDude(String port, Board board, String firmwareName) 
         {
             String message = "";
+            String firmwarePath = $@"{Directory.GetCurrentDirectory()}\{board.BasePath}\firmware";
+            String FullFirmwarePath = $@"{firmwarePath}\{firmwareName}";
 
-            if (!IsValidFirmwareFilepath(FirmwarePath + "\\" + firmwareName))
+
+            if (!IsValidFirmwareFilepath(FullFirmwarePath))
             {
-                message = $"Firmware not found: {FirmwarePath}\\{firmwareName}.";
+                message = $"Firmware not found: {FullFirmwarePath}.";
                 Log.Instance.log(message, LogSeverity.Error);
                 throw new FileNotFoundException(message);
             }
@@ -132,7 +130,7 @@ namespace MobiFlight
 
                 var attempts = board.AvrDudeSettings.Attempts != null ? $" -x attempts={board.AvrDudeSettings.Attempts}" : "";
                 string anyCommand =
-                    $@"-C""{Path.Combine(FullAvrDudePath, "etc", "avrdude.conf")}""{verboseLevel}{attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{port} -b{baudRate} -D -Uflash:w:""{FirmwarePath}\{firmwareName}"":i";
+                    $@"-C""{Path.Combine(FullAvrDudePath, "etc", "avrdude.conf")}""{verboseLevel}{attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{port} -b{baudRate} -D -Uflash:w:""{FullFirmwarePath}"":i";
 
                 // StandardOutput and StandardError can only be captured when UseShellExecute is false
                 p.StartInfo.UseShellExecute = false;
@@ -181,7 +179,8 @@ namespace MobiFlight
 
         public static void FlashViaUsbDrive(String port, Board board, String firmwareName)
         {
-            String FullFirmwarePath = $"{FirmwarePath}\\{firmwareName}";
+            String firmwarePath = $@"{Directory.GetCurrentDirectory()}\{board.BasePath}\firmware";
+            String FullFirmwarePath = $@"{firmwarePath}\{firmwareName}";
             String message = "";
             DriveInfo driveInfo;
 

--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -70,8 +70,7 @@ namespace MobiFlight
 
             try
             {
-                String firmwarePath = $@"{Directory.GetCurrentDirectory()}\{module.Board.BasePath}\firmware";
-                String FullFirmwarePath = $@"{firmwarePath}\{FirmwareName}";
+                var FullFirmwarePath = Path.Combine(Directory.GetCurrentDirectory(), module.Board.BasePath, "firmware", FirmwareName);
 
                 if (module.Board.AvrDudeSettings != null)
                 {

--- a/MobiFlight/MobiFlightFirmwareUpdater.cs
+++ b/MobiFlight/MobiFlightFirmwareUpdater.cs
@@ -121,15 +121,17 @@ namespace MobiFlight
             //verboseLevel = " -v -v -v -v";
 
             // Process() requires an absolute, rather than relative, path when using UseShellExecute = false
-            String FullAvrDudePath = Path.GetFullPath(Path.Combine(ArduinoIdePath, AvrPath));
+            var FullAvrDudePath = Path.GetFullPath(Path.Combine(ArduinoIdePath, AvrPath));
 
             foreach (var baudRate in board.AvrDudeSettings.BaudRates)
             {
                 var p = new Process();
 
                 var attempts = board.AvrDudeSettings.Attempts != null ? $" -x attempts={board.AvrDudeSettings.Attempts}" : "";
+                var avrDudeConfPath = Path.Combine(FullAvrDudePath, "etc", "avrdude.conf");
+
                 string anyCommand =
-                    $@"-C""{Path.Combine(FullAvrDudePath, "etc", "avrdude.conf")}""{verboseLevel}{attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{port} -b{baudRate} -D -Uflash:w:""{fullFirmwarePath}"":i";
+                    $@"-C""{avrDudeConfPath}""{verboseLevel}{attempts} -p{board.AvrDudeSettings.Device} -c{board.AvrDudeSettings.Programmer} -P{port} -b{baudRate} -D -Uflash:w:""{fullFirmwarePath}"":i";
 
                 // StandardOutput and StandardError can only be captured when UseShellExecute is false
                 p.StartInfo.UseShellExecute = false;

--- a/UI/Forms/FirmwareUpdateProcess.cs
+++ b/UI/Forms/FirmwareUpdateProcess.cs
@@ -104,8 +104,7 @@ namespace MobiFlight.UI.Forms
             }
 
             String arduinoIdePath = Properties.Settings.Default.ArduinoIdePathDefault;
-            String firmwarePath = $@"{Directory.GetCurrentDirectory()}\{module.Board.BasePath}\firmware";
-
+            
             if (!MobiFlightFirmwareUpdater.IsValidArduinoIdePath(arduinoIdePath))
             {
                 MessageBox.Show(
@@ -117,8 +116,7 @@ namespace MobiFlight.UI.Forms
             OnBeforeFirmwareUpdate?.Invoke(module, null);
 
             MobiFlightFirmwareUpdater.ArduinoIdePath = arduinoIdePath;
-            MobiFlightFirmwareUpdater.FirmwarePath = firmwarePath;
-
+            
             var task = Task<bool>.Run(() => {
                 bool UpdateResult;
                 if (IsUpdate)


### PR DESCRIPTION
fixes #1562 

- [x] Remove the static `FirmwarePath` property
- [x] Determine the correct base path for every RunAvrDude