### PR TITLE
Option to provide board specific images

### DIFF
--- a/MobiFlight/Board.cs
+++ b/MobiFlight/Board.cs
@@ -36,11 +36,6 @@ namespace MobiFlight
         /// The project's support, e.g. Discord Server link
         /// </summary>
         public String Support;
-
-        /// <summary>
-        /// The logo resource
-        /// </summary>
-        public Image Logo;
     }
 
     /// <summary>
@@ -201,6 +196,16 @@ namespace MobiFlight
         public Community Community;
 
         /// <summary>
+        /// The image resource
+        /// </summary>
+        public Image BoardIcon;
+
+        /// <summary>
+        /// The image resource
+        /// </summary>
+        public Image BoardPicture;
+
+        /// <summary>
         /// Provides the name of the firmware file for a given firmware version.
         /// </summary>
         /// <param name="latestFirmwareVersion">The version of the firmware, for example "1.14.0".</param>
@@ -332,11 +337,6 @@ namespace MobiFlight
         /// Base path for custom firmware
         /// </summary>
         public String BasePath;
-
-        /// <summary>
-        /// The image resource
-        /// </summary>
-        public Image BoardImage;
 
         /// <summary>
         /// Returns the correct Partner Level

--- a/MobiFlight/BoardDefinitions.cs
+++ b/MobiFlight/BoardDefinitions.cs
@@ -95,16 +95,24 @@ namespace MobiFlight
                     var boardPath = Path.GetDirectoryName(definitionFile);
                     board.BasePath = Path.GetDirectoryName(boardPath);
 
+                    // Take the logo as the fallback for the board picture
                     var logoPath = $@"{board.BasePath}\logo.png";
-                    if (File.Exists(logoPath) && board.Info.Community != null)
+                    if (File.Exists(logoPath))
                     {
-                        board.Info.Community.Logo = Image.FromFile(logoPath);
+                        board.Info.BoardPicture = Image.FromFile(logoPath);
                     }
 
-                    var boardLogoPath = $@"{boardPath}\board-logo.png";
-                    if (File.Exists(boardLogoPath))
+                    // check if we have a more board specifc picture
+                    logoPath = $@"{boardPath}\{board.Info.FirmwareBaseName}.png";
+                    if (File.Exists(logoPath))
                     {
-                        board.BoardImage = Image.FromFile(boardLogoPath);
+                        board.Info.BoardPicture = Image.FromFile(logoPath);
+                    }
+
+                    var boardIconPath = $@"{boardPath}\board-logo.png";
+                    if (File.Exists(boardIconPath))
+                    {
+                        board.Info.BoardIcon = Image.FromFile(boardIconPath);
                     }
                 },
                 onError: () => LoadingError = true

--- a/UI/Panels/Device/MFModulePanel.cs
+++ b/UI/Panels/Device/MFModulePanel.cs
@@ -74,9 +74,9 @@ namespace MobiFlight.UI.Panels.Settings.Device
             else
                 labelProjectValue.Text= "Unknown";
 
-            if (board.Info.Community != null)
+            if (board.Info.BoardPicture != null)
             {
-                pictureBoxLogo.Image = board.Info.Community.Logo;
+                pictureBoxLogo.Image = board.Info.BoardPicture;
                 pictureBoxLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             } else
             {

--- a/UI/Panels/Settings/MobiFlightPanel.cs
+++ b/UI/Panels/Settings/MobiFlightPanel.cs
@@ -402,9 +402,9 @@ namespace MobiFlight.UI.Panels.Settings
                     communityItem = new ToolStripMenuItem() { Text = currentProject };
                     communityItem2 = new ToolStripMenuItem() { Text = currentProject };
 
-                    if (board.BoardImage != null)
+                    if (board.Info.BoardIcon != null)
                     {
-                        communityItem2.Image = communityItem.Image = board.BoardImage;
+                        communityItem2.Image = communityItem.Image = board.Info.BoardIcon;
                     }
                     updateFirmwareToolStripMenuItem.DropDownItems.Add(communityItem);
                     UpdateFirmwareToolStripButton.DropDownItems.Add(communityItem2);
@@ -444,9 +444,9 @@ namespace MobiFlight.UI.Panels.Settings
                 UpdateModules(modules);
             };
 
-            if (board.BoardImage != null && board.PartnerLevel==BoardPartnerLevel.Core)
+            if (board.Info.BoardIcon != null && board.PartnerLevel==BoardPartnerLevel.Core)
             {
-                item.Image = board.BoardImage;
+                item.Image = board.Info.BoardIcon;
             }
 
             return item;
@@ -511,7 +511,7 @@ namespace MobiFlight.UI.Panels.Settings
 
         private void SetCorrectBoardIcon(TreeNode moduleNode, MobiFlightModule module)
         {
-            if (module.Board.BoardImage != null)
+            if (module.Board.Info.BoardIcon != null)
             {
                 // i had to do this with the imageKey
                 // the nodes don't support an image directly
@@ -530,7 +530,7 @@ namespace MobiFlight.UI.Panels.Settings
             var imageKey = board.Info.MobiFlightType;
             if (!mfTreeViewImageList.Images.ContainsKey(imageKey))
             {
-                mfTreeViewImageList.Images.Add(imageKey, board.BoardImage);
+                mfTreeViewImageList.Images.Add(imageKey, board.Info.BoardIcon);
             }
             return imageKey;
         }


### PR DESCRIPTION
fixes #1564

- [ ] introduced a new property `BoardPicture`, this can contain a board specific image
  - [ ] naming convention {firmwarename}.png defines the image used for `BoardPicture` 
- [ ] if no board specific image is provided, BoardPicture might use the logo.png from the project folder
- [ ] `BoardLogo` was renamed to `BoardIcon` because that's what it is used for
