### PR TITLE
Test output directly from configuration overview

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -1233,7 +1233,7 @@ namespace MobiFlight
                 try
                 {
                     var currentGuid = (row.DataBoundItem as DataRowView).Row["guid"].ToString();
-                    ExecuteTestOn(cfg, currentGuid, null);
+                    ExecuteTestOn(cfg, currentGuid, cfg.TestValue);
                 }
                 catch (IndexOutOfRangeException ex)
                 {
@@ -1320,6 +1320,10 @@ namespace MobiFlight
                     break;
                 
                 case MobiFlightShiftRegister.TYPE:
+                    ExecuteDisplay(value?.ToString() ?? "1", cfg);
+                    break;
+
+                case MobiFlightCustomDevice.TYPE:
                     ExecuteDisplay(value?.ToString() ?? "1", cfg);
                     break;
 

--- a/UI/Panels/OutputConfigPanel.Designer.cs
+++ b/UI/Panels/OutputConfigPanel.Designer.cs
@@ -77,6 +77,8 @@
             this.guidDataColumn = new System.Data.DataColumn();
             this.outputDataColumn = new System.Data.DataColumn();
             this.outputTypeDataColumn = new System.Data.DataColumn();
+            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            this.testToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridViewConfig)).BeginInit();
             this.dataGridViewContextMenuStrip.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataSetConfig)).BeginInit();
@@ -267,7 +269,9 @@
             this.pasteToolStripMenuItem,
             this.toolStripMenuItem1,
             this.duplicateRowToolStripMenuItem,
-            this.deleteRowToolStripMenuItem});
+            this.deleteRowToolStripMenuItem,
+            this.toolStripMenuItem2,
+            this.testToolStripMenuItem});
             this.dataGridViewContextMenuStrip.Name = "dataGridViewContextMenuStrip";
             resources.ApplyResources(this.dataGridViewContextMenuStrip, "dataGridViewContextMenuStrip");
             this.dataGridViewContextMenuStrip.Opening += new System.ComponentModel.CancelEventHandler(this.DataGridViewContextMenuStrip_Opening);
@@ -432,6 +436,17 @@
             this.outputTypeDataColumn.ColumnMapping = System.Data.MappingType.Hidden;
             this.outputTypeDataColumn.ColumnName = "OutputType";
             // 
+            // toolStripMenuItem2
+            // 
+            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
+            resources.ApplyResources(this.toolStripMenuItem2, "toolStripMenuItem2");
+            // 
+            // testToolStripMenuItem
+            // 
+            resources.ApplyResources(this.testToolStripMenuItem, "testToolStripMenuItem");
+            this.testToolStripMenuItem.Name = "testToolStripMenuItem";
+            this.testToolStripMenuItem.Click += new System.EventHandler(this.testToolStripMenuItem_Click);
+            // 
             // OutputConfigPanel
             // 
             resources.ApplyResources(this, "$this");
@@ -485,5 +500,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn fsuipcValueColumn;
         private System.Windows.Forms.DataGridViewTextBoxColumn arcazeValueColumn;
         private System.Windows.Forms.DataGridViewButtonColumn EditButtonColumn;
+        private System.Windows.Forms.ToolStripSeparator toolStripMenuItem2;
+        private System.Windows.Forms.ToolStripMenuItem testToolStripMenuItem;
     }
 }

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -59,11 +59,12 @@ namespace MobiFlight.UI.Panels
             dataGridViewConfig.SelectionChanged += (s, e) => {
                 if (testToolStripMenuItem.Checked)
                 {
+                    // this disables the currently tested item
                     UpdateSingleItemTestMode();
                 }
 
-                testToolStripMenuItem.Enabled = dataGridViewConfig.SelectedRows.Count > 0 && !dataGridViewConfig.SelectedRows[0].IsNewRow;
-                if (testToolStripMenuItem.Enabled) return;
+                var AtLeastOneRowSelectedAndNotLastRow = dataGridViewConfig.SelectedRows.Count > 0 && !dataGridViewConfig.SelectedRows[0].IsNewRow;
+                testToolStripMenuItem.Enabled = AtLeastOneRowSelectedAndNotLastRow;
             };
         }
 

--- a/UI/Panels/OutputConfigPanel.resx
+++ b/UI/Panels/OutputConfigPanel.resx
@@ -255,7 +255,7 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="copyToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="copyToolStripMenuItem.Text" xml:space="preserve">
     <value>Copy</value>
@@ -264,19 +264,19 @@
     <value>False</value>
   </data>
   <data name="pasteToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="pasteToolStripMenuItem.Text" xml:space="preserve">
     <value>Paste</value>
   </data>
   <data name="toolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>144, 6</value>
+    <value>177, 6</value>
   </data>
   <data name="duplicateRowToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
     <value>False</value>
   </data>
   <data name="duplicateRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="duplicateRowToolStripMenuItem.Text" xml:space="preserve">
     <value>Duplicate row</value>
@@ -285,7 +285,7 @@
     <value>False</value>
   </data>
   <data name="deleteRowToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
-    <value>147, 22</value>
+    <value>180, 22</value>
   </data>
   <data name="deleteRowToolStripMenuItem.Text" xml:space="preserve">
     <value>Delete row(s)</value>
@@ -293,8 +293,20 @@
   <data name="deleteRowToolStripMenuItem.ToolTipText" xml:space="preserve">
     <value>Delete selected row(s)</value>
   </data>
+  <data name="toolStripMenuItem2.Size" type="System.Drawing.Size, System.Drawing">
+    <value>177, 6</value>
+  </data>
+  <data name="testToolStripMenuItem.Enabled" type="System.Boolean, mscorlib">
+    <value>False</value>
+  </data>
+  <data name="testToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
+    <value>180, 22</value>
+  </data>
+  <data name="testToolStripMenuItem.Text" xml:space="preserve">
+    <value>Test</value>
+  </data>
   <data name="dataGridViewContextMenuStrip.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 98</value>
+    <value>181, 148</value>
   </data>
   <data name="&gt;&gt;dataGridViewContextMenuStrip.Name" xml:space="preserve">
     <value>dataGridViewContextMenuStrip</value>
@@ -545,6 +557,18 @@
   </data>
   <data name="&gt;&gt;outputTypeDataColumn.Type" xml:space="preserve">
     <value>System.Data.DataColumn, System.Data, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem2.Name" xml:space="preserve">
+    <value>toolStripMenuItem2</value>
+  </data>
+  <data name="&gt;&gt;toolStripMenuItem2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripSeparator, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;testToolStripMenuItem.Name" xml:space="preserve">
+    <value>testToolStripMenuItem</value>
+  </data>
+  <data name="&gt;&gt;testToolStripMenuItem.Type" xml:space="preserve">
+    <value>System.Windows.Forms.ToolStripMenuItem, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;$this.Name" xml:space="preserve">
     <value>OutputConfigPanel</value>


### PR DESCRIPTION
fixes #1005 

You can now trigger the test mode for a single item in the config overview by using the context menu `Test` option.

**Note** 
The test mode uses the test value that has been defined in the Config Wizard.
This is also true for the general test mode (blue button) when going through all configs.

![test-mode-from-overview](https://github.com/MobiFlight/MobiFlight-Connector/assets/86157512/8589d896-5abe-4448-9591-48d87c24894f)

- [x] Add option to context menu 
- [x] Visual indication available that item is currently in test mode - the checkbox is active when test mode is active
- [x] Test mode is stopped as soon as another row is selected
- [x] i18n - not applicable
- [ ] documentation