### PR TITLE
Only prompt for WASM update if it changed

### DIFF
--- a/SimConnectMSFS/WasmModuleUpdater.cs
+++ b/SimConnectMSFS/WasmModuleUpdater.cs
@@ -155,22 +155,19 @@ namespace MobiFlight.SimConnectMSFS
 
             string installedWASM;
             string mobiflightWASM;
-            string installedEvents;
-            string mobiflightEvents;
 
             if (CommunityFolder == null) return true;
 
-
-            if (!File.Exists(CommunityFolder + $@"\mobiflight-event-module\modules\{WasmModuleName}"))
+            string wasmModulePath = Path.Combine(CommunityFolder, @"mobiflight-event-module\modules\", WasmModuleName);
+            if (!File.Exists(wasmModulePath))
+            { 
                 return true;
+            }
 
             installedWASM = CalculateMD5(CommunityFolder + $@"\mobiflight-event-module\modules\{WasmModuleName}");
             mobiflightWASM = CalculateMD5($@".\MSFS2020-module\mobiflight-event-module\modules\{WasmModuleName}");
 
-            installedEvents = CalculateMD5(CommunityFolder + $@"\mobiflight-event-module\modules\{WasmEventsTxtFile}");
-            mobiflightEvents = CalculateMD5($@".\MSFS2020-module\mobiflight-event-module\modules\{WasmEventsTxtFile}");
-
-            return (installedWASM != mobiflightWASM || installedEvents != mobiflightEvents);
+            return installedWASM != mobiflightWASM;
         }
 
         public bool InstallWasmEvents()

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -329,7 +329,7 @@ namespace MobiFlight.UI
 
             // MSFS2020
             WasmModuleUpdater updater = new WasmModuleUpdater();
-            if (updater.AutoDetectCommunityFolder())
+            if (updater.AutoDetectCommunityFolder() && updater.WasmModulesAreDifferent())
             {
                 // MSFS2020 installed
                 Msfs2020StartupForm msfsForm = new Msfs2020StartupForm();


### PR DESCRIPTION
Fixes #1594 

* Use the existing `WasmModulesAreDifferent()` method as a condition of prompting on first launch
* Update `WasmModulesAreDifferent()` so it no longer tests the events.txt file. 
* Use `Path.Combine()` to create the path to the wasm module

To test this you'll need to delete your `user.config` file for mobiflight, which is located in `%localappdata%\MobiFlight` and then in one of the gibberish folders with the matching app version.