### PR TITLE
Use serial number instead of name for joystick dictionary

### DIFF
--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -183,7 +183,7 @@ namespace MobiFlight
                 {
                     Log.Instance.log($"Adding attached joystick device: {d.InstanceName} Buttons: {js.Capabilities.ButtonCount} Axis: {js.Capabilities.AxeCount}.", LogSeverity.Info);
                     js.Connect(Handle);
-                    Joysticks.TryAdd(js.Name, js);
+                    Joysticks.TryAdd(js.Serial, js);
                     js.OnButtonPressed += Js_OnButtonPressed;
                     js.OnDisconnected += Js_OnDisconnected;
                 }       
@@ -199,7 +199,7 @@ namespace MobiFlight
         {
             var js = sender as Joystick;
             Log.Instance.log($"Joystick disconnected: {js.Name}.", LogSeverity.Info);
-            Joysticks.TryRemove(js.Name, out _);
+            Joysticks.TryRemove(js.Serial, out _);
         }
 
         private bool HasAxisOrButtons(Joystick js)


### PR DESCRIPTION
Fixes #1612 

Use the joystick `Serial` property instead of `Name` as the dictionary key.

Before this change:

<img width="139" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/662432a7-55e3-4a7d-8ff2-029e2f4dc22b">

After this change:

<img width="209" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/9524118/c20d549e-d654-4a79-8422-f311f1f6c254">
