### PR TITLE
Add support for hex values in the joystick json files

### DIFF
--- a/Joysticks/honeycomb_bravo.joystick.json
+++ b/Joysticks/honeycomb_bravo.joystick.json
@@ -1,12 +1,12 @@
 {
   "$schema": "./mfjoystick.schema.json",
   "InstanceName": "Bravo Throttle Quadrant",
-  "VendorId": 10571,
-  "ProductId": 6401,
+  "VendorId": "0x294B",
+  "ProductId": "0x1901",
   "Inputs": [
     {
       "Id": 17,
-      "Type":  "Button",
+      "Type": "Button",
       "Label": "Mode - IAS"
     },
     {

--- a/Joysticks/mfjoystick.schema.json
+++ b/Joysticks/mfjoystick.schema.json
@@ -91,14 +91,16 @@
     "ProductId": {
       "$id": "#Root/VendorId",
       "title": "VendorId",
-      "type": "number",
-      "description": "The device's USB VendorId. Required if Outputs are provided."
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]+$",
+      "description": "The device's USB VendorId as a hexadcimal, e.g. `0x123A`. Required if Outputs are provided."
     },
     "VendorId": {
       "$id": "#Root/ProductId",
       "title": "ProductId",
-      "type": "number",
-      "description": "The device's USB ProductId. Required if Outputs are provided."
+      "type": "string",
+      "pattern": "^0x[0-9a-fA-F]+$",
+      "description": "The device's USB ProductId as a hexadecimal, e.g. `0x234A`. Required if Outputs are provided."
     }
   }
 }

--- a/Joysticks/octavi.joystick.json
+++ b/Joysticks/octavi.joystick.json
@@ -1,8 +1,8 @@
 {
   "$schema": "./mfjoystick.schema.json",
   "InstanceName": "Octavi",
-  "VendorId": 1240,
-  "ProductId": 59094,
+  "VendorId": "0x04D8",
+  "ProductId": "0xE6D6",
   "Inputs": [
 
   ],
@@ -42,7 +42,7 @@
       "Id": "AP.VS",
       "Byte": 1,
       "Bit": 5
-    },
-	
+    }
+
   ]
 }

--- a/MobiFlight/Joysticks/JoystickDefinition.cs
+++ b/MobiFlight/Joysticks/JoystickDefinition.cs
@@ -6,6 +6,55 @@ using System.Threading.Tasks;
 
 namespace MobiFlight
 {
+    using Newtonsoft.Json;
+    using System;
+
+    public class HexStringToNumberConverter : JsonConverter
+    {
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(int) || objectType == typeof(long);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.String)
+            {
+                string valueString = reader.Value.ToString();
+                // If the string starts with 0x then it is hex and should be converted. Otherwise assume it is decimal and convert normally.
+                if (valueString.StartsWith("0x", StringComparison.OrdinalIgnoreCase))
+                {
+                    valueString = valueString.Substring(2);
+                    return Convert.ToInt32(valueString, 16);
+                }
+                else
+                {
+                    return Convert.ToInt32(valueString);
+                }
+            }
+            // This handles backwards compatibility for old files where it was stored as an integer.
+            else if (reader.TokenType == JsonToken.Integer)
+            {
+                return Convert.ToInt32(reader.Value.ToString());
+            }
+
+            throw new JsonSerializationException("Unexpected token type: " + reader.TokenType);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is int || value is long)
+            {
+                string hexString = "0x" + Convert.ToString(Convert.ToInt64(value), 16);
+                writer.WriteValue(hexString);
+            }
+            else
+            {
+                throw new JsonSerializationException("Unexpected value type: " + value.GetType());
+            }
+        }
+    }
+
     public class JoystickDefinition : IMigrateable
     {
         /// <summary>
@@ -26,11 +75,13 @@ namespace MobiFlight
         /// <summary>
         /// The device's USB ProductId. Required if Outputs are provided.
         /// </summary>
+        [JsonConverter(typeof(HexStringToNumberConverter))]
         public int ProductId;
 
         /// <summary>
         /// The device's USB VendorId. Required if Outputs are provided.
         /// </summary>
+        [JsonConverter(typeof(HexStringToNumberConverter))]
         public int VendorId;
 
         /// <summary>


### PR DESCRIPTION
Fixes #1621 

* Add a new JsonConverter that can handle both integers and strings. If the string starts with `0x` it is treated as a hex value and converted to a number appropriately.
* Update the schema to specify the Joystick VID/PID values are hexadecimal strings starting with `0x`.