### PR TITLE
MobiFlight Connector can start with MSFS2020

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Windows.Forms;
-using System.Threading;
-using MobiFlight.UI;
+﻿using MobiFlight.UI;
+using System;
 using System.Configuration;
 using System.Globalization;
+using System.Threading;
+using System.Windows.Forms;
 
 namespace MobiFlight
 {

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -92,6 +92,16 @@ namespace MobiFlight.UI
             Log.Instance.log($"Logger initialized {Log.Instance.Severity}", LogSeverity.Info);
         }
 
+        private static void SetCurrentWorkingDirectory()
+        {
+            // Get the full path of the executable
+            string executablePath = Assembly.GetExecutingAssembly().Location;
+            // Extract the directory
+            string executableDirectory = Path.GetDirectoryName(executablePath);
+            // Set the current directory to the executable's directory
+            Directory.SetCurrentDirectory(executableDirectory);
+        }
+
         private void InitializeSettings()
         {
             UpgradeSettingsFromPreviousInstallation();
@@ -114,6 +124,9 @@ namespace MobiFlight.UI
 
             // then initialize components
             InitializeComponent();
+
+            // make sure to use app path as working dir
+            SetCurrentWorkingDirectory();
 
             // then restore settings
             InitializeSettings();


### PR DESCRIPTION
fixes #1592 

- [x] set working directroy correctly early during startup
- [x] remove unnecessary includes in program.cs

### Note
I decided to put the method to set the the working directory early in the main form init and not in the Program.cs file just to keep all these additional actions in one place, the main form (where all the other init stuff happens)