### PR TITLE
Wasm installation shows correct messages and dialogs

### DIFF
--- a/SimConnectMSFS/WasmModuleUpdater.cs
+++ b/SimConnectMSFS/WasmModuleUpdater.cs
@@ -155,22 +155,19 @@ namespace MobiFlight.SimConnectMSFS
 
             string installedWASM;
             string mobiflightWASM;
-            string installedEvents;
-            string mobiflightEvents;
 
             if (CommunityFolder == null) return true;
 
-
-            if (!File.Exists(CommunityFolder + $@"\mobiflight-event-module\modules\{WasmModuleName}"))
+            string wasmModulePath = Path.Combine(CommunityFolder, @"mobiflight-event-module\modules\", WasmModuleName);
+            if (!File.Exists(wasmModulePath))
+            { 
                 return true;
+            }
 
             installedWASM = CalculateMD5(CommunityFolder + $@"\mobiflight-event-module\modules\{WasmModuleName}");
             mobiflightWASM = CalculateMD5($@".\MSFS2020-module\mobiflight-event-module\modules\{WasmModuleName}");
 
-            installedEvents = CalculateMD5(CommunityFolder + $@"\mobiflight-event-module\modules\{WasmEventsTxtFile}");
-            mobiflightEvents = CalculateMD5($@".\MSFS2020-module\mobiflight-event-module\modules\{WasmEventsTxtFile}");
-
-            return (installedWASM != mobiflightWASM || installedEvents != mobiflightEvents);
+            return installedWASM != mobiflightWASM;
         }
 
         public bool InstallWasmEvents()

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -329,7 +329,7 @@ namespace MobiFlight.UI
 
             // MSFS2020
             WasmModuleUpdater updater = new WasmModuleUpdater();
-            if (updater.AutoDetectCommunityFolder())
+            if (updater.AutoDetectCommunityFolder() && updater.WasmModulesAreDifferent())
             {
                 // MSFS2020 installed
                 Msfs2020StartupForm msfsForm = new Msfs2020StartupForm();


### PR DESCRIPTION
The WASM installation routine doesn't check for the events.txt anymore which used to cause an error message on the second installation attempt (when a .wasm file was already present).

Additionally, the WASM installation dialog only shows on startup when a different WASM module was detected.

fixes #1574
includes #1601 