### PR TITLE
Config execute doesn't stop if SimVarName is null

### DIFF
--- a/SimConnectMSFS/SimConnectCache.cs
+++ b/SimConnectMSFS/SimConnectCache.cs
@@ -463,6 +463,9 @@ namespace MobiFlight.SimConnectMSFS
             if (!IsConnected()) 
                 return simVarType;
 
+            if (simVarName == null)
+                return simVarType;  
+
             isFloat = SimVars.Exists(lvar => lvar.Name == simVarName);
             if(!isFloat)
             {


### PR DESCRIPTION
fixes #1666 

I added an additional test for null to make sure we return from the method early. Old version tried to use the null-value in the RegEx later.

- Cannot be unit tested at the moment.