### PR TITLE
Include Thrustmaster profile in project

### DIFF
--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -1060,6 +1060,9 @@
     <None Include="Joysticks\octavi.joystick.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Joysticks\t.a320_pilot.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="MidiBoards\BoardEditorConfigs\intechf44\Mobiflight-SessionProfile.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Profile was not included in the project and not copied to the output directory. 
related to #1625 

Now joystick profile is loaded at startup:
<img width="764" alt="image" src="https://github.com/MobiFlight/MobiFlight-Connector/assets/86157512/73e03736-f98f-4a92-bfaf-6897181df651">
