### PR TITLE
Octavi shift modes controlled by .json file

### DIFF
--- a/Joysticks/octavi.joystick.json
+++ b/Joysticks/octavi.joystick.json
@@ -4,7 +4,31 @@
   "VendorId": "0x04D8",
   "ProductId": "0xE6D6",
   "Inputs": [
-
+    {
+      "Id": 0,
+      "Type": "Button",
+      "Label": "COM1"
+    },
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "COM2"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "NAV1"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "NAV2"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "XPDR"
+    }
   ],
   "Outputs": [
     {

--- a/MobiFlight/Joysticks/Octavi/Octavi.cs
+++ b/MobiFlight/Joysticks/Octavi/Octavi.cs
@@ -13,11 +13,13 @@ namespace MobiFlight.Joysticks.Octavi
 
         protected HidDeviceInputReceiver inputReceiver;
         protected ReportDescriptor reportDescriptor;
-        private readonly OctaviHandler octaviHandler = new OctaviHandler();
+        private readonly OctaviHandler octaviHandler;
+        private readonly JoystickDefinition Definition;
 
         public Octavi(SharpDX.DirectInput.Joystick joystick, JoystickDefinition definition) : base(joystick, definition)
         {
-
+            this.Definition = definition;
+            octaviHandler = new OctaviHandler(this.Definition);
         }
 
         public void Connect()

--- a/MobiFlight/Joysticks/Octavi/OctaviReport.cs
+++ b/MobiFlight/Joysticks/Octavi/OctaviReport.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace MobiFlight.Joysticks.Octavi
 {


### PR DESCRIPTION
This PR containts changes to enable users to define which Octavi IFR-1 context modes have a shift mode and which don't. This is done by defining inputs in the octavi.joystick.json. Those context modes that are listed in the json will have a shift mode, the others won't. In future versions, this definition should be moved to the profile .mcc.