### PR TITLE
Prevent Octavi Exception on Connect

### DIFF
--- a/MobiFlight/Joysticks/Octavi/Octavi.cs
+++ b/MobiFlight/Joysticks/Octavi/Octavi.cs
@@ -20,20 +20,35 @@ namespace MobiFlight.Joysticks.Octavi
 
         }
 
+        /// <summary>
+        /// Method is not called by regular Joystick Manager
+        /// This method is called implicitly when Update() is called
+        /// </summary>
         public void Connect()
         {
-            if (Device == null)
+            // Prevent reentry and parallel execution by multiple threads
+            lock (this)
             {
-                Device = DeviceList.Local.GetHidDeviceOrNull(vendorID: VendorId, productID: ProductId);
-                if (Device == null) return;
-            }
+                if (Device == null)
+                {
+                    Device = DeviceList.Local.GetHidDeviceOrNull(vendorID: VendorId, productID: ProductId);
+                    if (Device == null) return;
+                }
 
-            Stream = Device.Open();
-            Stream.ReadTimeout = System.Threading.Timeout.Infinite;
-            reportDescriptor = Device.GetReportDescriptor();
-            inputReceiver = reportDescriptor.CreateHidDeviceInputReceiver();
-            inputReceiver.Received += InputReceiver_Received;
-            inputReceiver.Start(Stream);
+                if (Stream == null)
+                {
+                    Stream = Device.Open();
+                    Stream.ReadTimeout = System.Threading.Timeout.Infinite;
+                    reportDescriptor = Device.GetReportDescriptor();
+                }
+
+                if (inputReceiver == null)
+                {
+                    inputReceiver = reportDescriptor.CreateHidDeviceInputReceiver();
+                    inputReceiver.Received += InputReceiver_Received;
+                    inputReceiver.Start(Stream);
+                }
+            }
         }
 
         private void InputReceiver_Received(object sender, System.EventArgs e)
@@ -80,6 +95,8 @@ namespace MobiFlight.Joysticks.Octavi
 
         public override void Update()
         {
+            // Octavi is not a DirectInput device
+            // so we have to connect it here.
             if (Stream == null || inputReceiver == null)
             {
                 Connect();
@@ -99,10 +116,17 @@ namespace MobiFlight.Joysticks.Octavi
 
         public override void Shutdown()
         {
-            Stream.Close();
-            inputReceiver.Received -= InputReceiver_Received;
-            Stream = null;
-            inputReceiver = null;
+            if (Stream != null)
+            {
+                Stream.Close();
+                Stream = null;
+            }
+
+            if (inputReceiver != null)
+            {
+                inputReceiver.Received -= InputReceiver_Received;
+                inputReceiver = null;
+            }
         }
     }
 }


### PR DESCRIPTION
fixes #1697 

**Notes**
* The connect logic differs from the other built-in joysticks. Connect is called when Update() or SendData() is called which happens periodically. Especially in the rebrush2024 it happens a lot that Update() and SendData() are called concurrently from different threads which throws an Exception in the Connect method.
* With the lock and the additional checks that should not be a problem anymore.
* Once we remove the DirectInput we can use a common virtual Connect method for all classes