### PR TITLE
Fix issue with loading of OnHold and OnLongRelease config in OUTPUT

### DIFF
--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -167,14 +167,8 @@ namespace MobiFlight.UI.Panels.OutputWizard
             }
             else
             {
-                var analogInputConfig = new AnalogInputConfig();
-                analogInputConfig.onChange = config.AnalogInputConfig?.onChange;
-                analogPanel1.syncFromConfig(analogInputConfig);
-
-                var buttonInputConfig = new ButtonInputConfig();
-                buttonInputConfig.onPress = config.ButtonInputConfig?.onPress;
-                buttonInputConfig.onRelease = config.ButtonInputConfig?.onRelease;
-                buttonPanel1.syncFromConfig(buttonInputConfig);
+                analogPanel1.syncFromConfig(config.AnalogInputConfig);
+                buttonPanel1.syncFromConfig(config.ButtonInputConfig);
 
                 InputTypeButtonRadioButton.Checked = config.AnalogInputConfig?.onChange == null;
                 InputTypeAnalogRadioButton.Checked = config.AnalogInputConfig?.onChange != null;


### PR DESCRIPTION
fixes #1689
Since `syncFromConfig` handles also null input and the whole config is cloned on opening the wizard, the previous code was unecessary and missed the new button config parameters.

I don't understand why new AnalogInputConfig and ButtonInputConfig objects were created. First I wanted to clone the config instead of assigning single parameters, but then I thought why cloning at all?
