### PR TITLE
Support LcdDisplays in custom joysticks

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -727,31 +727,40 @@ namespace MobiFlight
         }
 
         private string ExecuteDisplay(string value, OutputConfigItem cfg)
-        {
+        {            
             string serial = SerialNumber.ExtractSerial(cfg.DisplaySerial);
 
-            if (serial == "" && 
-                cfg.DisplayType!="InputAction") 
+            if (serial == "" && cfg.DisplayType != "InputAction") 
                 return value.ToString();
 
-            if (serial.IndexOf(Joystick.SerialPrefix)==0)
+            if (SerialNumber.IsJoystickSerial(serial) && cfg.DisplayType != "InputAction")
             {
                 Joystick joystick = joystickManager.GetJoystickBySerial(serial);
                 if(joystick != null)
                 {
-                    byte state = 0;
-                    if (value != "0") state = 1;
+                    switch (cfg.DisplayType)
+                    {
+                        case OutputConfig.LcdDisplay.Type:
+                            joystick.SetLcdDisplay(value, cfg.LcdDisplay.Address);                            
+                            break;
 
-                    joystick.SetOutputDeviceState(cfg.Pin.DisplayPin, state);
-                    joystick.UpdateOutputDeviceStates();
-                    joystick.Update();
-                } else
+                        default: // LED Output                          
+                            byte state = 0;
+                            if (value != "0") state = 1;
+
+                            joystick.SetOutputDeviceState(cfg.Pin.DisplayPin, state);
+                            joystick.UpdateOutputDeviceStates();
+                            joystick.Update();
+                            break;
+                    }
+                } 
+                else
                 {
                     var joystickName = SerialNumber.ExtractDeviceName(cfg.DisplaySerial);
                     throw new JoystickNotConnectedException(i18n._tr($"{joystickName} not connected"));
                 }
             }
-            else if (serial.IndexOf(MidiBoard.SerialPrefix) == 0)
+            else if (SerialNumber.IsMidiBoardSerial(serial) && cfg.DisplayType != "InputAction")
             {
                 MidiBoard midiBoard = midiBoardManager.GetMidiBoardBySerial(serial);
                 if (midiBoard != null)

--- a/MobiFlight/Joysticks/Joystick.cs
+++ b/MobiFlight/Joysticks/Joystick.cs
@@ -265,6 +265,11 @@ namespace MobiFlight
             return result;
         }
 
+        public virtual List<IBaseDevice> GetAvailableLcdDevices()
+        {
+            return new List<IBaseDevice>();
+        }
+
         public virtual void Update()
         {           
             if (DIJoystick == null) return;
@@ -424,6 +429,19 @@ namespace MobiFlight
                 RequiresOutputUpdate = true;
                 return;
             }
+        }
+
+        public virtual void SetLcdDisplay(string value, string address)
+        {
+            // Do nothing in base class
+        }
+
+
+        public virtual IEnumerable<DeviceType> GetConnectedOutputDeviceTypes()
+        {
+            List<DeviceType> result = new List<DeviceType>();
+            result.Add(DeviceType.Output);
+            return result;
         }
 
         protected virtual void SendData(byte[] data)

--- a/UI/Panels/Output/LCDDisplayPanel.cs
+++ b/UI/Panels/Output/LCDDisplayPanel.cs
@@ -34,7 +34,15 @@ namespace MobiFlight.UI.Panels
 
             DisplayComboBox.Enabled = ports.Count > 0;
         }
-        
+
+        public void DisableOutputDefinition()
+        {
+            label2.Visible = false;
+            panel2.Visible = false;
+            label3.Visible = false;
+            lcdDisplayTextBox.Text = string.Empty;
+        }
+
         internal void syncFromConfig(OutputConfigItem config)
         {
             // preselect display stuff


### PR DESCRIPTION
Draft for discussion on how to support LcdDisplay in custom joystick. That means in joysticks with inherited custom class like Octavi. That is probably all what is necessary.

Methods which need to implemented in derived class

- GetConnectedOutputDeviceTypes
- GetAvailableLcdDevices
- SetLcdDisplay
 