### PR TITLE
Introduce new hid library to reduce mobiflight cpu load in conjunction with winwing fcu

### DIFF
--- a/MobiFlight/Joysticks/WinwingFcu/WinwingFcuReport.cs
+++ b/MobiFlight/Joysticks/WinwingFcu/WinwingFcuReport.cs
@@ -23,18 +23,18 @@ namespace MobiFlight.Joysticks.WinwingFcu
             targetReport.VsEncoderValue = this.VsEncoderValue;              
         }
 
-        public void ParseReport(byte[] buffer)
+        public void ParseReport(HidBuffer hidBuffer)
         {
-            // get Report ID
-            ReportId = buffer[0];
-            if (ReportId == BUTTONS_REPORT) 
+            byte[] data = hidBuffer.HidReport.TransferResult.Data;           
+            ReportId = hidBuffer.HidReport.ReportId;
+            if (ReportId == BUTTONS_REPORT)
             {
-                // get 32 bit Button report field - First 4 bytes: uint:  [4][3][2][1]
-                ButtonState = ((uint)buffer[1] + ((uint)buffer[2] << 8) + ((uint)buffer[3] << 16) + ((uint)buffer[4] << 24));
-                SpdEncoderValue = (ushort)(buffer[13] | (buffer[14] << 8)); // create an ushort from bytes 13 and 14
-                HdgEncoderValue = (ushort)(buffer[15] | (buffer[16] << 8));
-                AltEncoderValue = (ushort)(buffer[17] | (buffer[18] << 8));
-                VsEncoderValue  = (ushort)(buffer[19] | (buffer[20] << 8));                          
+                // get 32 bit Button report field - First 4 bytes: uint:  [3][2][1][0]
+                ButtonState = ((uint)data[0] + ((uint)data[1] << 8) + ((uint)data[2] << 16) + ((uint)data[3] << 24));
+                SpdEncoderValue = (ushort)(data[12] | (data[13] << 8)); // create an ushort from bytes 13 and 14
+                HdgEncoderValue = (ushort)(data[14] | (data[15] << 8));
+                AltEncoderValue = (ushort)(data[16] | (data[17] << 8));
+                VsEncoderValue = (ushort)(data[18] | (data[19] << 8));
             }
         }
     }

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -132,8 +132,14 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>lib\ArcazeHid.dll</HintPath>
     </Reference>
+    <Reference Include="Device.Net, Version=4.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Device.Net.4.2.1\lib\net45\Device.Net.dll</HintPath>
+    </Reference>
     <Reference Include="fsuipcClient, Version=3.3.3.403, Culture=neutral, PublicKeyToken=7e7559b53e380b17, processorArchitecture=MSIL">
       <HintPath>packages\FSUIPCClientDLL.3.3.3\lib\net462\fsuipcClient.dll</HintPath>
+    </Reference>
+    <Reference Include="Hid.Net, Version=4.2.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>packages\Hid.Net.4.2.1\lib\net45\Hid.Net.dll</HintPath>
     </Reference>
     <Reference Include="HidSharp, Version=2.1.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>packages\HidSharp.2.1.0\lib\net35\HidSharp.dll</HintPath>

--- a/UI/Dialogs/AboutForm.Designer.cs
+++ b/UI/Dialogs/AboutForm.Designer.cs
@@ -42,12 +42,14 @@
             this.licenseReferenceControl6 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl5 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl2 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            this.licenseReferenceControl7 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl4 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl3 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.licenseReferenceControl1 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.label5 = new System.Windows.Forms.Label();
             this.panel3 = new System.Windows.Forms.Panel();
-            this.licenseReferenceControl7 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            this.licenseReferenceControl8 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            this.licenseReferenceControl9 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
             this.panel3.SuspendLayout();
@@ -114,6 +116,8 @@
             // 
             // panel2
             // 
+            this.panel2.Controls.Add(this.licenseReferenceControl9);
+            this.panel2.Controls.Add(this.licenseReferenceControl8);
             this.panel2.Controls.Add(this.licenseReferenceControl6);
             this.panel2.Controls.Add(this.licenseReferenceControl5);
             this.panel2.Controls.Add(this.licenseReferenceControl2);
@@ -147,8 +151,16 @@
             resources.ApplyResources(this.licenseReferenceControl2, "licenseReferenceControl2");
             this.licenseReferenceControl2.Library = "SharpDX";
             this.licenseReferenceControl2.LibraryLink = "https://www.nuget.org/packages/SharpDX/";
-            this.licenseReferenceControl2.LicenseLink = "http://sharpdx.org/License.txt";
+            this.licenseReferenceControl2.LicenseLink = "https://github.com/sharpdx/SharpDX/blob/master/LICENSE";
             this.licenseReferenceControl2.Name = "licenseReferenceControl2";
+            // 
+            // licenseReferenceControl7
+            // 
+            resources.ApplyResources(this.licenseReferenceControl7, "licenseReferenceControl7");
+            this.licenseReferenceControl7.Library = "NewtonSoft JSON.NET Schema";
+            this.licenseReferenceControl7.LibraryLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema";
+            this.licenseReferenceControl7.LicenseLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema/3.0.15/License";
+            this.licenseReferenceControl7.Name = "licenseReferenceControl7";
             // 
             // licenseReferenceControl4
             // 
@@ -185,13 +197,21 @@
             resources.ApplyResources(this.panel3, "panel3");
             this.panel3.Name = "panel3";
             // 
-            // licenseReferenceControl7
+            // licenseReferenceControl8
             // 
-            resources.ApplyResources(this.licenseReferenceControl7, "licenseReferenceControl7");
-            this.licenseReferenceControl7.Library = "NewtonSoft JSON.NET Schema";
-            this.licenseReferenceControl7.LibraryLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema";
-            this.licenseReferenceControl7.LicenseLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema/3.0.15/License";
-            this.licenseReferenceControl7.Name = "licenseReferenceControl7";
+            resources.ApplyResources(this.licenseReferenceControl8, "licenseReferenceControl8");
+            this.licenseReferenceControl8.Library = "HidSharp";
+            this.licenseReferenceControl8.LibraryLink = "https://www.nuget.org/packages/HidSharp";
+            this.licenseReferenceControl8.LicenseLink = "https://www.zer7.com/files/oss/hidsharp/LICENSE.txt";
+            this.licenseReferenceControl8.Name = "licenseReferenceControl8";
+            // 
+            // licenseReferenceControl9
+            // 
+            resources.ApplyResources(this.licenseReferenceControl9, "licenseReferenceControl9");
+            this.licenseReferenceControl9.Library = "Device.Net";
+            this.licenseReferenceControl9.LibraryLink = "https://www.nuget.org/packages/Device.Net";
+            this.licenseReferenceControl9.LicenseLink = "https://github.com/MelbourneDeveloper/Device.Net/blob/main/LICENSE";
+            this.licenseReferenceControl9.Name = "licenseReferenceControl9";
             // 
             // AboutForm
             // 
@@ -231,5 +251,7 @@
         private System.Windows.Forms.Panel panel3;
         private Panels.About.LicenseReferenceControl licenseReferenceControl6;
         private Panels.About.LicenseReferenceControl licenseReferenceControl7;
+        private Panels.About.LicenseReferenceControl licenseReferenceControl9;
+        private Panels.About.LicenseReferenceControl licenseReferenceControl8;
     }
 }

--- a/UI/Dialogs/AboutForm.resx
+++ b/UI/Dialogs/AboutForm.resx
@@ -473,38 +473,65 @@ Copyright 2014-2022 - Sebastian Moebius</value>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="licenseReferenceControl7.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+  <data name="licenseReferenceControl9.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
-  <data name="licenseReferenceControl7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 185</value>
+  <data name="licenseReferenceControl9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 233</value>
   </data>
-  <data name="licenseReferenceControl7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+  <data name="licenseReferenceControl9.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
   </data>
-  <data name="licenseReferenceControl7.Size" type="System.Drawing.Size, System.Drawing">
+  <data name="licenseReferenceControl9.Size" type="System.Drawing.Size, System.Drawing">
     <value>315, 24</value>
   </data>
-  <data name="licenseReferenceControl7.TabIndex" type="System.Int32, mscorlib">
-    <value>9</value>
+  <data name="licenseReferenceControl9.TabIndex" type="System.Int32, mscorlib">
+    <value>11</value>
   </data>
-  <data name="&gt;&gt;licenseReferenceControl7.Name" xml:space="preserve">
-    <value>licenseReferenceControl7</value>
+  <data name="&gt;&gt;licenseReferenceControl9.Name" xml:space="preserve">
+    <value>licenseReferenceControl9</value>
   </data>
-  <data name="&gt;&gt;licenseReferenceControl7.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+  <data name="&gt;&gt;licenseReferenceControl9.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
-  <data name="&gt;&gt;licenseReferenceControl7.Parent" xml:space="preserve">
+  <data name="&gt;&gt;licenseReferenceControl9.Parent" xml:space="preserve">
     <value>panel2</value>
   </data>
-  <data name="&gt;&gt;licenseReferenceControl7.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;licenseReferenceControl9.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="licenseReferenceControl8.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="licenseReferenceControl8.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 209</value>
+  </data>
+  <data name="licenseReferenceControl8.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 10, 3</value>
+  </data>
+  <data name="licenseReferenceControl8.Size" type="System.Drawing.Size, System.Drawing">
+    <value>315, 24</value>
+  </data>
+  <data name="licenseReferenceControl8.TabIndex" type="System.Int32, mscorlib">
+    <value>10</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl8.Name" xml:space="preserve">
+    <value>licenseReferenceControl8</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl8.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl8.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl8.ZOrder" xml:space="preserve">
+    <value>1</value>
   </data>
   <data name="licenseReferenceControl6.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 161</value>
+    <value>3, 185</value>
   </data>
   <data name="licenseReferenceControl6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
@@ -519,19 +546,19 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>licenseReferenceControl6</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl6.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl6.Parent" xml:space="preserve">
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl6.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="licenseReferenceControl5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 137</value>
+    <value>3, 161</value>
   </data>
   <data name="licenseReferenceControl5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
@@ -546,19 +573,19 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>licenseReferenceControl5</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl5.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl5.Parent" xml:space="preserve">
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl5.ZOrder" xml:space="preserve">
-    <value>2</value>
+    <value>3</value>
   </data>
   <data name="licenseReferenceControl2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 113</value>
+    <value>3, 137</value>
   </data>
   <data name="licenseReferenceControl2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
     <value>3, 3, 10, 3</value>
@@ -573,13 +600,40 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>licenseReferenceControl2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl2.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl2.Parent" xml:space="preserve">
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl2.ZOrder" xml:space="preserve">
-    <value>3</value>
+    <value>4</value>
+  </data>
+  <data name="licenseReferenceControl7.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="licenseReferenceControl7.Location" type="System.Drawing.Point, System.Drawing">
+    <value>3, 113</value>
+  </data>
+  <data name="licenseReferenceControl7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 10, 3</value>
+  </data>
+  <data name="licenseReferenceControl7.Size" type="System.Drawing.Size, System.Drawing">
+    <value>315, 24</value>
+  </data>
+  <data name="licenseReferenceControl7.TabIndex" type="System.Int32, mscorlib">
+    <value>9</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl7.Name" xml:space="preserve">
+    <value>licenseReferenceControl7</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl7.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl7.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl7.ZOrder" xml:space="preserve">
+    <value>5</value>
   </data>
   <data name="licenseReferenceControl4.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -600,13 +654,13 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>licenseReferenceControl4</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl4.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl4.Parent" xml:space="preserve">
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl4.ZOrder" xml:space="preserve">
-    <value>4</value>
+    <value>6</value>
   </data>
   <data name="licenseReferenceControl3.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -627,13 +681,13 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>licenseReferenceControl3</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl3.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl3.Parent" xml:space="preserve">
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl3.ZOrder" xml:space="preserve">
-    <value>5</value>
+    <value>7</value>
   </data>
   <data name="licenseReferenceControl1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -654,13 +708,13 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>licenseReferenceControl1</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=9.5.0.3, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl1.Parent" xml:space="preserve">
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl1.ZOrder" xml:space="preserve">
-    <value>6</value>
+    <value>8</value>
   </data>
   <data name="label5.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -693,7 +747,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;label5.ZOrder" xml:space="preserve">
-    <value>7</value>
+    <value>9</value>
   </data>
   <data name="panel2.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Fill</value>
@@ -705,7 +759,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>3, 0, 3, 0</value>
   </data>
   <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>321, 218</value>
+    <value>321, 298</value>
   </data>
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -726,7 +780,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>Bottom</value>
   </data>
   <data name="panel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 352</value>
+    <value>0, 432</value>
   </data>
   <data name="panel3.Size" type="System.Drawing.Size, System.Drawing">
     <value>321, 29</value>
@@ -753,7 +807,7 @@ Copyright 2014-2022 - Sebastian Moebius</value>
     <value>6, 13</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>321, 381</value>
+    <value>321, 461</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Device.Net" version="4.2.1" targetFramework="net48" />
   <package id="FSUIPCClientDLL" version="3.3.3" targetFramework="net48" />
+  <package id="Hid.Net" version="4.2.1" targetFramework="net48" />
   <package id="HidSharp" version="2.1.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights" version="2.21.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.21.0" targetFramework="net48" />


### PR DESCRIPTION
fixes #1779 
This PR switches for reception of winwing fcu hid reports to the very performant [Device.Net Library](https://www.nuget.org/packages/Device.Net). The library is very small, high performant and uses a MIT license. 

CPU load is more than halfed in comparison to before.
License dialog is also updated.