### PR TITLE
Add VKBDevice type of HID controller

### DIFF
--- a/Joysticks/s_tecs_modern_throttle_max.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_max.joystick.json
@@ -1,0 +1,443 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "S-TECS MODERN THROTTLE MAX",
+  "VendorId": "0x231D",
+  "ProductId": "0x012E",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Sys"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Start"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Mode 1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Mode 2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Mode 3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Mode 4"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Mode 5"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Multi CCW"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "Multi CW"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "Safe"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "Number 1"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "Number 2"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "Number 3"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "Number 4"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "Armed"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Multi Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "Multi Down"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "Multi Right"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "Multi Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "Multi Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "MTG-L Aft Trigger"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "MTG-L Forward Trigger"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "MTG-L Weapon Select"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "MTG-L RST"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "MTG-R Aft Trigger"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "MTG-R Forward Trigger"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "MTG-R ENT"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "MTG-R OTS Push"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "MTG-R BRK Push"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Push"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Push"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Push"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Push"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "MTG-R BRK Up"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "MTG-R BRK Down"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "MTG-R BRK Fwd"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "MTG-R BRK Aft"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Left"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Right"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Down"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Up"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Down"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Up"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "STEM A1"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "STEM A2"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "STEM C1"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "STEM B1"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "STEM B2"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "STEM B3"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "STEM B4"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "STEM B5"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "STEM Sw1 Up"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "STEM Sw1 Center"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "STEM Sw1 Down"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "STEM Sw2 Up"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "STEM Sw2 Center"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "STEM Sw2 Down"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "STEM TGL Up"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "STEM TGL Dn"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "STEM En1 CCW"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "STEM En1 CW"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "STEM En2 CCW"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "STEM En2 CW"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "STEM En1 Push"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "STEM En2 Push"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "STEM Lever Up"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "STEM Lever Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "On - Blue",
+      "Id": "On.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "On - Red",
+      "Id": "On.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Red",
+      "Id": "Frame.Red",
+      "Byte": 1,
+      "Bit": 0
+    },
+    {
+      "Label": "Frame - Green",
+      "Id": "Frame.Green",
+      "Byte": 1,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Blue",
+      "Id": "Frame.Blue",
+      "Byte": 1,
+      "Bit": 2
+    },
+    {
+      "Label": "DNT - Red",
+      "Id": "DNT.Red",
+      "Byte": 2,
+      "Bit": 0
+    },
+    {
+      "Label": "DNT - Green",
+      "Id": "DNT.Green",
+      "Byte": 2,
+      "Bit": 1
+    },
+    {
+      "Label": "DNT - Blue",
+      "Id": "DNT.Blue",
+      "Byte": 2,
+      "Bit": 2
+    },
+    {
+      "Label": "Lock - Red",
+      "Id": "Lock.Red",
+      "Byte": 3,
+      "Bit": 0
+    },
+    {
+      "Label": "Lock - Green",
+      "Id": "Lock.Green",
+      "Byte": 3,
+      "Bit": 1
+    },
+    {
+      "Label": "Lock - Blue",
+      "Id": "Lock.Blue",
+      "Byte": 3,
+      "Bit": 2
+    },
+    {
+      "Label": "STEM On - Blue",
+      "Id": "STEM.On.Blue",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "STEM On - Red",
+      "Id": "STEM.On.Red",
+      "Byte": 10,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/s_tecs_modern_throttle_max_stem.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_max_stem.joystick.json
@@ -1,0 +1,493 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "S-TECS MODERN THROTTLE MAX STEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x012E",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Sys"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Start"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Mode 1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Mode 2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Mode 3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Mode 4"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Mode 5"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Multi CCW"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "Multi CW"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "Safe"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "Number 1"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "Number 2"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "Number 3"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "Number 4"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "Armed"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Multi Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "Multi Down"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "Multi Right"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "Multi Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "Multi Push"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "Multi CCW"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "Multi CW"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "MTG-L Aft Trigger"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "MTG-L Forward Trigger"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "MTG-L Weapon Select"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "MTG-L RST"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "MTG-R Aft Trigger"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "MTG-R Forward Trigger"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "MTG-R ENT"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "MTG-R OTS Push"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "MTG-R BRK Push"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Push"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Push"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Push"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Push"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "MTG-R BRK Up"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "MTG-R BRK Down"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "MTG-R BRK Fwd"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "MTG-R BRK Aft"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Left"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Right"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Down"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Up"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Down"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Up"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "STEM A1"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "STEM A2"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "STEM C1"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "STEM B1"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "STEM B2"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "STEM B3"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "STEM B4"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "STEM B5"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "STEM Sw1 Up"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "STEM Sw1 Center"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "STEM Sw1 Down"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "STEM Sw2 Up"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "STEM Sw2 Center"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "STEM Sw2 Down"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "STEM TGL Up"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "STEM TGL Dn"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "STEM En1 CCW"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "STEM En1 CW"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "STEM En2 CCW"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "STEM En2 CW"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "STEM En1 Push"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "STEM En2 Push"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "STEM Lever Up"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "STEM Lever Down"
+    },
+    {
+      "Id": 1030,
+      "Type": "Button",
+      "Label": "STEM En1 CCW"
+    },
+    {
+      "Id": 1035,
+      "Type": "Button",
+      "Label": "STEM En1 CW"
+    },
+    {
+      "Id": 1040,
+      "Type": "Button",
+      "Label": "STEM En2 CCW"
+    },
+    {
+      "Id": 1045,
+      "Type": "Button",
+      "Label": "STEM En2 CW"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "On - Blue",
+      "Id": "On.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "On - Red",
+      "Id": "On.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Red",
+      "Id": "Frame.Red",
+      "Byte": 1,
+      "Bit": 0
+    },
+    {
+      "Label": "Frame - Green",
+      "Id": "Frame.Green",
+      "Byte": 1,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Blue",
+      "Id": "Frame.Blue",
+      "Byte": 1,
+      "Bit": 2
+    },
+    {
+      "Label": "DNT - Red",
+      "Id": "DNT.Red",
+      "Byte": 2,
+      "Bit": 0
+    },
+    {
+      "Label": "DNT - Green",
+      "Id": "DNT.Green",
+      "Byte": 2,
+      "Bit": 1
+    },
+    {
+      "Label": "DNT - Blue",
+      "Id": "DNT.Blue",
+      "Byte": 2,
+      "Bit": 2
+    },
+    {
+      "Label": "Lock - Red",
+      "Id": "Lock.Red",
+      "Byte": 3,
+      "Bit": 0
+    },
+    {
+      "Label": "Lock - Green",
+      "Id": "Lock.Green",
+      "Byte": 3,
+      "Bit": 1
+    },
+    {
+      "Label": "Lock - Blue",
+      "Id": "Lock.Blue",
+      "Byte": 3,
+      "Bit": 2
+    },
+    {
+      "Label": "STEM On - Blue",
+      "Id": "STEM.On.Blue",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "STEM On - Red",
+      "Id": "STEM.On.Red",
+      "Byte": 10,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/s_tecs_modern_throttle_max_stem_fsm_ga.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_max_stem_fsm_ga.joystick.json
@@ -1,0 +1,837 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "S-TECS MODERN THROTTLE MAX STEM FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x012E",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Sys"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Start"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Mode 1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Mode 2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Mode 3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Mode 4"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Mode 5"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Multi CCW"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "Multi CW"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "Safe"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "Number 1"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "Number 2"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "Number 3"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "Number 4"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "Armed"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Multi Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "Multi Down"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "Multi Right"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "Multi Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "Multi Push"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "Multi CCW"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "Multi CW"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "MTG-L Aft Trigger"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "MTG-L Forward Trigger"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "MTG-L Weapon Select"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "MTG-L RST"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "MTG-R Aft Trigger"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "MTG-R Forward Trigger"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "MTG-R ENT"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "MTG-R OTS Push"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "MTG-R BRK Push"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Push"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Push"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Push"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Push"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "MTG-R BRK Up"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "MTG-R BRK Down"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "MTG-R BRK Fwd"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "MTG-R BRK Aft"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Left"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Right"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Down"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Up"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Fwd"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Aft"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Left"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Right"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Down"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Up"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Up"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Down"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Fwd"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Aft"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "STEM A1"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "STEM A2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "STEM C1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "STEM B1"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "STEM B2"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "STEM B3"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "STEM B4"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "STEM B5"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "STEM Sw1 Up"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "STEM Sw1 Center"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "STEM Sw1 Down"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "STEM Sw2 Up"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "STEM Sw2 Center"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "STEM Sw2 Down"
+    },
+    {
+      "Id": 72,
+      "Type": "Button",
+      "Label": "STEM TGL Up"
+    },
+    {
+      "Id": 73,
+      "Type": "Button",
+      "Label": "STEM TGL Dn"
+    },
+    {
+      "Id": 74,
+      "Type": "Button",
+      "Label": "STEM En1 CCW"
+    },
+    {
+      "Id": 75,
+      "Type": "Button",
+      "Label": "STEM En1 CW"
+    },
+    {
+      "Id": 76,
+      "Type": "Button",
+      "Label": "STEM En2 CCW"
+    },
+    {
+      "Id": 77,
+      "Type": "Button",
+      "Label": "STEM En2 CW"
+    },
+    {
+      "Id": 78,
+      "Type": "Button",
+      "Label": "STEM En1 Push"
+    },
+    {
+      "Id": 79,
+      "Type": "Button",
+      "Label": "STEM En2 Push"
+    },
+    {
+      "Id": 80,
+      "Type": "Button",
+      "Label": "STEM Lever Up"
+    },
+    {
+      "Id": 81,
+      "Type": "Button",
+      "Label": "STEM Lever Down"
+    },
+    {
+      "Id": 1030,
+      "Type": "Button",
+      "Label": "STEM En1 CCW"
+    },
+    {
+      "Id": 1035,
+      "Type": "Button",
+      "Label": "STEM En1 CW"
+    },
+    {
+      "Id": 1040,
+      "Type": "Button",
+      "Label": "STEM En2 CCW"
+    },
+    {
+      "Id": 1045,
+      "Type": "Button",
+      "Label": "STEM En2 CW"
+    },
+    {
+      "Id": 82,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 83,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 84,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 85,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 86,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 87,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 88,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 89,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 90,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 91,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 92,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 93,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 94,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 95,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 96,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 97,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 98,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 99,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 100,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 101,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 102,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 103,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 104,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 105,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1050,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1055,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1060,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1065,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1070,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1075,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "On - Blue",
+      "Id": "On.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "On - Red",
+      "Id": "On.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Red",
+      "Id": "Frame.Red",
+      "Byte": 1,
+      "Bit": 0
+    },
+    {
+      "Label": "Frame - Green",
+      "Id": "Frame.Green",
+      "Byte": 1,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Blue",
+      "Id": "Frame.Blue",
+      "Byte": 1,
+      "Bit": 2
+    },
+    {
+      "Label": "DNT - Red",
+      "Id": "DNT.Red",
+      "Byte": 2,
+      "Bit": 0
+    },
+    {
+      "Label": "DNT - Green",
+      "Id": "DNT.Green",
+      "Byte": 2,
+      "Bit": 1
+    },
+    {
+      "Label": "DNT - Blue",
+      "Id": "DNT.Blue",
+      "Byte": 2,
+      "Bit": 2
+    },
+    {
+      "Label": "Lock - Red",
+      "Id": "Lock.Red",
+      "Byte": 3,
+      "Bit": 0
+    },
+    {
+      "Label": "Lock - Green",
+      "Id": "Lock.Green",
+      "Byte": 3,
+      "Bit": 1
+    },
+    {
+      "Label": "Lock - Blue",
+      "Id": "Lock.Blue",
+      "Byte": 3,
+      "Bit": 2
+    },
+    {
+      "Label": "STEM On - Blue",
+      "Id": "STEM.On.Blue",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "STEM On - Red",
+      "Id": "STEM.On.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 21,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 22,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 22,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/s_tecs_modern_throttle_mini.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_mini.joystick.json
@@ -1,0 +1,236 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "S-TECS MODERN THROTTLE MINI",
+  "VendorId": "0x231D",
+  "ProductId": "0x012B",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Sys"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Start"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Mode 1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Mode 2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Mode 3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Mode 4"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Mode 5"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "MTG-L Aft Trigger"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "MTG-L Forward Trigger"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "MTG-L Weapon Select"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "MTG-L RST"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "MTG-R Aft Trigger"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "MTG-R Forward Trigger"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "MTG-R ENT"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "MTG-R OTS Push"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "MTG-R BRK Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Push"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Push"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Push"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Push"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "MTG-R BRK Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "MTG-R BRK Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "MTG-R BRK Fwd"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "MTG-R BRK Aft"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "On - Blue",
+      "Id": "On.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "On - Red",
+      "Id": "On.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Red",
+      "Id": "Frame.Red",
+      "Byte": 1,
+      "Bit": 0
+    },
+    {
+      "Label": "Frame - Green",
+      "Id": "Frame.Green",
+      "Byte": 1,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Blue",
+      "Id": "Frame.Blue",
+      "Byte": 1,
+      "Bit": 2
+    },
+    {
+      "Label": "DNT - Red",
+      "Id": "DNT.Red",
+      "Byte": 2,
+      "Bit": 0
+    },
+    {
+      "Label": "DNT - Green",
+      "Id": "DNT.Green",
+      "Byte": 2,
+      "Bit": 1
+    },
+    {
+      "Label": "DNT - Blue",
+      "Id": "DNT.Blue",
+      "Byte": 2,
+      "Bit": 2
+    },
+    {
+      "Label": "Lock - Red",
+      "Id": "Lock.Red",
+      "Byte": 3,
+      "Bit": 0
+    },
+    {
+      "Label": "Lock - Green",
+      "Id": "Lock.Green",
+      "Byte": 3,
+      "Bit": 1
+    },
+    {
+      "Label": "Lock - Blue",
+      "Id": "Lock.Blue",
+      "Byte": 3,
+      "Bit": 2
+    }
+  ]
+}

--- a/Joysticks/s_tecs_modern_throttle_mini_plus.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_mini_plus.joystick.json
@@ -1,0 +1,311 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "S-TECS MODERN THROTTLE MINI PLUS",
+  "VendorId": "0x231D",
+  "ProductId": "0x012C",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Sys"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Start"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Mode 1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Mode 2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Mode 3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Mode 4"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Mode 5"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Multi CCW"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "Multi CW"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "Safe"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "Number 1"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "Number 2"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "Number 3"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "Number 4"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "Armed"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Multi Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "Multi Down"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "Multi Right"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "Multi Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "Multi Push"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "Multi CCW"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "Multi CW"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "MTG-L Aft Trigger"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "MTG-L Forward Trigger"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "MTG-L Weapon Select"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "MTG-L RST"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "MTG-R Aft Trigger"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "MTG-R Forward Trigger"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "MTG-R ENT"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "MTG-R OTS Push"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "MTG-R BRK Push"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Push"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Push"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Push"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Push"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "MTG-R BRK Up"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "MTG-R BRK Down"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "MTG-R BRK Fwd"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "MTG-R BRK Aft"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "On - Blue",
+      "Id": "On.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "On - Red",
+      "Id": "On.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Red",
+      "Id": "Frame.Red",
+      "Byte": 1,
+      "Bit": 0
+    },
+    {
+      "Label": "Frame - Green",
+      "Id": "Frame.Green",
+      "Byte": 1,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Blue",
+      "Id": "Frame.Blue",
+      "Byte": 1,
+      "Bit": 2
+    },
+    {
+      "Label": "DNT - Red",
+      "Id": "DNT.Red",
+      "Byte": 2,
+      "Bit": 0
+    },
+    {
+      "Label": "DNT - Green",
+      "Id": "DNT.Green",
+      "Byte": 2,
+      "Bit": 1
+    },
+    {
+      "Label": "DNT - Blue",
+      "Id": "DNT.Blue",
+      "Byte": 2,
+      "Bit": 2
+    },
+    {
+      "Label": "Lock - Red",
+      "Id": "Lock.Red",
+      "Byte": 3,
+      "Bit": 0
+    },
+    {
+      "Label": "Lock - Green",
+      "Id": "Lock.Green",
+      "Byte": 3,
+      "Bit": 1
+    },
+    {
+      "Label": "Lock - Blue",
+      "Id": "Lock.Blue",
+      "Byte": 3,
+      "Bit": 2
+    }
+  ]
+}

--- a/Joysticks/s_tecs_modern_throttle_standard.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_standard.joystick.json
@@ -1,0 +1,378 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "S-TECS MODERN THROTTLE STANDARD",
+  "VendorId": "0x231D",
+  "ProductId": "0x012D",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Sys"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Start"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Mode 1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Mode 2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Mode 3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Mode 4"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Mode 5"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "MTG-L Aft Trigger"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "MTG-L Forward Trigger"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "MTG-L Weapon Select"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "MTG-L RST"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "MTG-R Aft Trigger"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "MTG-R Forward Trigger"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "MTG-R ENT"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "MTG-R OTS Push"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "MTG-R BRK Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Push"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Push"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Push"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Push"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "MTG-R BRK Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "MTG-R BRK Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "MTG-R BRK Fwd"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "MTG-R BRK Aft"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Left"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Right"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Down"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Up"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Down"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Up"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "STEM A1"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "STEM A2"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "STEM C1"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "STEM B1"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "STEM B2"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "STEM B3"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "STEM B4"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "STEM B5"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "STEM Sw1 Up"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "STEM Sw1 Center"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "STEM Sw1 Down"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "STEM Sw2 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "STEM Sw2 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "STEM Sw2 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "STEM TGL Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "STEM TGL Dn"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "STEM En1 CCW"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "STEM En1 CW"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "STEM En2 CCW"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "STEM En2 CW"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "STEM En1 Push"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "STEM En2 Push"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "STEM Lever Up"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "STEM Lever Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "On - Blue",
+      "Id": "On.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "On - Red",
+      "Id": "On.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Red",
+      "Id": "Frame.Red",
+      "Byte": 1,
+      "Bit": 0
+    },
+    {
+      "Label": "Frame - Green",
+      "Id": "Frame.Green",
+      "Byte": 1,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Blue",
+      "Id": "Frame.Blue",
+      "Byte": 1,
+      "Bit": 2
+    },
+    {
+      "Label": "DNT - Red",
+      "Id": "DNT.Red",
+      "Byte": 2,
+      "Bit": 0
+    },
+    {
+      "Label": "DNT - Green",
+      "Id": "DNT.Green",
+      "Byte": 2,
+      "Bit": 1
+    },
+    {
+      "Label": "DNT - Blue",
+      "Id": "DNT.Blue",
+      "Byte": 2,
+      "Bit": 2
+    },
+    {
+      "Label": "Lock - Red",
+      "Id": "Lock.Red",
+      "Byte": 3,
+      "Bit": 0
+    },
+    {
+      "Label": "Lock - Green",
+      "Id": "Lock.Green",
+      "Byte": 3,
+      "Bit": 1
+    },
+    {
+      "Label": "Lock - Blue",
+      "Id": "Lock.Blue",
+      "Byte": 3,
+      "Bit": 2
+    },
+    {
+      "Label": "STEM On - Blue",
+      "Id": "STEM.On.Blue",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "STEM On - Red",
+      "Id": "STEM.On.Red",
+      "Byte": 10,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/s_tecs_modern_throttle_standard_stem.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_standard_stem.joystick.json
@@ -1,0 +1,418 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "S-TECS MODERN THROTTLE STANDARD STEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x012D",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Sys"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Start"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Mode 1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Mode 2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Mode 3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Mode 4"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Mode 5"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "MTG-L Aft Trigger"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "MTG-L Forward Trigger"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "MTG-L Weapon Select"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "MTG-L RST"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "MTG-L Front Encoder Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Fwd"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "MTG-L Side Encoder Aft"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "MTG-R Aft Trigger"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "MTG-R Forward Trigger"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "MTG-R ENT"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "MTG-R OTS Push"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "MTG-R BRK Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Push"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Push"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "MTG-R MB2 Push"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "MTG-R OP EXEC Push"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "MTG-R BRK Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "MTG-R BRK Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "MTG-R BRK Fwd"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "MTG-R BRK Aft"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Left"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Right"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Down"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "MTG-R MB1 Up"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Down"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "MTG-R RADIO Up"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "STEM A1"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "STEM A2"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "STEM C1"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "STEM B1"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "STEM B2"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "STEM B3"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "STEM B4"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "STEM B5"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "STEM Sw1 Up"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "STEM Sw1 Center"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "STEM Sw1 Down"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "STEM Sw2 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "STEM Sw2 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "STEM Sw2 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "STEM TGL Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "STEM TGL Dn"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "STEM En1 CCW"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "STEM En1 CW"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "STEM En2 CCW"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "STEM En2 CW"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "STEM En1 Push"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "STEM En2 Push"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "STEM Lever Up"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "STEM Lever Down"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "STEM En1 CCW"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "STEM En1 CW"
+    },
+    {
+      "Id": 1030,
+      "Type": "Button",
+      "Label": "STEM En2 CCW"
+    },
+    {
+      "Id": 1035,
+      "Type": "Button",
+      "Label": "STEM En2 CW"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "On - Blue",
+      "Id": "On.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "On - Red",
+      "Id": "On.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Red",
+      "Id": "Frame.Red",
+      "Byte": 1,
+      "Bit": 0
+    },
+    {
+      "Label": "Frame - Green",
+      "Id": "Frame.Green",
+      "Byte": 1,
+      "Bit": 1
+    },
+    {
+      "Label": "Frame - Blue",
+      "Id": "Frame.Blue",
+      "Byte": 1,
+      "Bit": 2
+    },
+    {
+      "Label": "DNT - Red",
+      "Id": "DNT.Red",
+      "Byte": 2,
+      "Bit": 0
+    },
+    {
+      "Label": "DNT - Green",
+      "Id": "DNT.Green",
+      "Byte": 2,
+      "Bit": 1
+    },
+    {
+      "Label": "DNT - Blue",
+      "Id": "DNT.Blue",
+      "Byte": 2,
+      "Bit": 2
+    },
+    {
+      "Label": "Lock - Red",
+      "Id": "Lock.Red",
+      "Byte": 3,
+      "Bit": 0
+    },
+    {
+      "Label": "Lock - Green",
+      "Id": "Lock.Green",
+      "Byte": 3,
+      "Bit": 1
+    },
+    {
+      "Label": "Lock - Blue",
+      "Id": "Lock.Blue",
+      "Byte": 3,
+      "Bit": 2
+    },
+    {
+      "Label": "STEM On - Blue",
+      "Id": "STEM.On.Blue",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "STEM On - Red",
+      "Id": "STEM.On.Red",
+      "Byte": 10,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_f14.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_f14.joystick.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO F14",
+  "VendorId": "0x231D",
+  "ProductId": "0x0A00",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Red Button"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Weapon Select Push"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Side Button"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Paddle Switch"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Pinky Switch"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Hat Push"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "Hat Down NU"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "Hat Left LWD"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "Hat Right RWD"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "Hat Up ND"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "Weapon Select SP PH"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "Weapon Select SW"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "Weapon Select Gun"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Weapon Select Off"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "Unused Button 24"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_kg12.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_kg12.joystick.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO KG12",
+  "VendorId": "0x231D",
+  "ProductId": "0x0600",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "B2 Hat Down"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "B2 Hat Left"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "B2 Hat Right"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B2 Hat Up"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "B1 Button"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A Trigger"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Paddle Switch"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Ring Finger Button"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Unused Button 16"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_l.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_l.joystick.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO L",
+  "VendorId": "0x231D",
+  "ProductId": "0x0201",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_l_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_l_sem.joystick.json
@@ -1,0 +1,472 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO L SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x0205",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_ot_l.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_ot_l.joystick.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO OT L",
+  "VendorId": "0x231D",
+  "ProductId": "0x3201",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_ot_l_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_ot_l_sem.joystick.json
@@ -1,0 +1,472 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO OT L SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x3205",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_ot_r.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_ot_r.joystick.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO OT R",
+  "VendorId": "0x231D",
+  "ProductId": "0x3200",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_ot_r_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_ot_r_sem.joystick.json
@@ -1,0 +1,472 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO OT R SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x3204",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_r.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r.joystick.json
@@ -1,0 +1,256 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO R",
+  "VendorId": "0x231D",
+  "ProductId": "0x0200",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_r_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_fsm_ga.joystick.json
@@ -1,0 +1,550 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO R FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x0220",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1030,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1035,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 21,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 22,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 22,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 23,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 23,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_r_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_sem.joystick.json
@@ -1,0 +1,472 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO R SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x0204",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_r_sem_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_sem_fsm_ga.joystick.json
@@ -1,0 +1,766 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO R SEM FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x0224",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 72,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 73,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 74,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 75,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 76,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 77,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 78,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 79,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 80,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 81,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 82,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 83,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 84,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 85,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 86,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 87,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 88,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1030,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1035,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 21,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 22,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 22,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 23,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 23,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 24,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 24,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 25,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 25,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 26,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 26,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 27,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 27,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 28,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 28,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 29,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 29,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 30,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 30,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 31,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 31,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_r_sem_thq.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_sem_thq.joystick.json
@@ -1,0 +1,512 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO R SEM THQ",
+  "VendorId": "0x231D",
+  "ProductId": "0x0214",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 72,
+      "Type": "Button",
+      "Label": "THQ B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_r_sem_thqx2.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_sem_thqx2.joystick.json
@@ -1,0 +1,552 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO R SEM THQx2",
+  "VendorId": "0x231D",
+  "ProductId": "0x0224",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 72,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 73,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 74,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 75,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 76,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 77,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 78,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 79,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 80,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_r_thq.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_thq.joystick.json
@@ -1,0 +1,296 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO R THQ",
+  "VendorId": "0x231D",
+  "ProductId": "0x0210",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "THQ B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_evo_r_thqx2.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_thqx2.joystick.json
@@ -1,0 +1,336 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator EVO R THQx2",
+  "VendorId": "0x231D",
+  "ProductId": "0x0220",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "Sw1 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Sw1 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_f14.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_f14.joystick.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT F14",
+  "VendorId": "0x231D",
+  "ProductId": "0x0A00",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Red Button"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Weapon Select Push"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Side Button"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Paddle Switch"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Pinky Switch"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Hat Push"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "Hat Down NU"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "Hat Left LWD"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "Hat Right RWD"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "Hat Up ND"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "Weapon Select SP PH"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "Weapon Select SW"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "Weapon Select Gun"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Weapon Select Off"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "Unused Button 24"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_kg12.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_kg12.joystick.json
@@ -1,0 +1,122 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT KG12",
+  "VendorId": "0x231D",
+  "ProductId": "0x0600",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "B2 Hat Down"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "B2 Hat Left"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "B2 Hat Right"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B2 Hat Up"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "B1 Button"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A Trigger"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Paddle Switch"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Ring Finger Button"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Unused Button 16"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_l.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_l.joystick.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT L",
+  "VendorId": "0x231D",
+  "ProductId": "0x0201",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_l_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_l_sem.joystick.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT L SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x0205",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_ot_l.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_ot_l.joystick.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT OT L",
+  "VendorId": "0x231D",
+  "ProductId": "0x3201",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_ot_l_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_ot_l_sem.joystick.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT OT L SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x3205",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_ot_r.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_ot_r.joystick.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT OT R",
+  "VendorId": "0x231D",
+  "ProductId": "0x3200",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_ot_r_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_ot_r_sem.joystick.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT OT R SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x3204",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_r.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r.joystick.json
@@ -1,0 +1,266 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT R",
+  "VendorId": "0x231D",
+  "ProductId": "0x0200",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_r_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_fsm_ga.joystick.json
@@ -1,0 +1,560 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT R FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x0220",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1030,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1035,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1040,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1045,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 21,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 22,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 22,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 23,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 23,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_r_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_sem.joystick.json
@@ -1,0 +1,482 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT R SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x0204",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_r_sem_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_sem_fsm_ga.joystick.json
@@ -1,0 +1,776 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT R SEM FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x0224",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 72,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 73,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 74,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 75,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 76,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 77,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 78,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 79,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 80,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 81,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 82,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 83,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 84,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 85,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 86,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 87,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 88,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1030,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1035,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1040,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1045,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 21,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 22,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 22,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 23,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 23,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 24,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 24,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 25,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 25,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 26,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 26,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 27,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 27,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 28,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 28,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 29,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 29,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 30,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 30,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 31,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 31,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_r_sem_thq.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_sem_thq.joystick.json
@@ -1,0 +1,522 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT R SEM THQ",
+  "VendorId": "0x231D",
+  "ProductId": "0x0214",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 72,
+      "Type": "Button",
+      "Label": "THQ B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_r_sem_thqx2.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_sem_thqx2.joystick.json
@@ -1,0 +1,562 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT R SEM THQx2",
+  "VendorId": "0x231D",
+  "ProductId": "0x0224",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 72,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 73,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 74,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 75,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 76,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 77,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 78,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 79,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 80,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 19,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_r_thq.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_thq.joystick.json
@@ -1,0 +1,306 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT R THQ",
+  "VendorId": "0x231D",
+  "ProductId": "0x0210",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "THQ B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_gladiator_nxt_r_thqx2.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_thqx2.joystick.json
@@ -1,0 +1,346 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBsim Gladiator NXT R THQx2",
+  "VendorId": "0x231D",
+  "ProductId": "0x0220",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Trigger Soft"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Trigger Hard"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "A2"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "B1"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "D1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "A3 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "A3 Right"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "A3 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "A3 Left"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "A3 Push"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "A4 Up"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "A4 Right"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "A4 Down"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "A4 Left"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "A4 Push"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "C1 Up"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "C1 Right"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "C1 Down"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "C1 Left"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "C1 Push"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Rapid Fire Up"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Rapid Fire Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "F1"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "F2"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "F3"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "A1 Push"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "Unused Button 31"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "Unused Button 32"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "Unused Button 33"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "Unused Button 34"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "Unused Button 35"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "Unused Button 36"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "Unused Button 37"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "Unused Button 38"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "Unused Button 39"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "Unused Button 40"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "En1 Up"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "En1 Down"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "En2 Up"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "En2 Down"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Red",
+      "Id": "SCG.Oval.Red",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SCG Oval - Green",
+      "Id": "SCG.Oval.Green",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SCG Oval - Blue",
+      "Id": "SCG.Oval.Blue",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "SCG Round",
+      "Id": "SCG.Round",
+      "Byte": 11,
+      "Bit": 0
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_nxt_fsm_ga.joystick.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x2220",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 21,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_sem.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem.joystick.json
@@ -1,0 +1,238 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT SEM",
+  "VendorId": "0x231D",
+  "ProductId": "0x2204",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 17,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_sem_thq.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem_thq.joystick.json
@@ -1,0 +1,308 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT SEM THQ",
+  "VendorId": "0x231D",
+  "ProductId": "0x2214",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "THQ Front Left"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "THQ Front Right"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "THQ Drehzahl kleiner"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "THQ Drehzahl groesser"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "THQ Thumb Black"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "THQ Thumb Red"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 17,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_sem_thqx2.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem_thqx2.joystick.json
@@ -1,0 +1,318 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT SEM THQx2",
+  "VendorId": "0x231D",
+  "ProductId": "0x2224",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 17,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_sem_thqx2_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem_thqx2_fsm_ga.joystick.json
@@ -1,0 +1,612 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT SEM THQx2 FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x2224",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 21,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 22,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 22,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 23,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 23,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 24,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 24,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 25,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 25,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 26,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 26,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 27,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 27,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 28,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 28,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 29,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 29,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_sem_thqx3.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem_thqx3.joystick.json
@@ -1,0 +1,358 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT SEM THQx3",
+  "VendorId": "0x231D",
+  "ProductId": "0x2234",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "SEM A1"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "SEM A2"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "SEM B1"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "SEM B2"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "SEM B3"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "SEM Sw1 Up"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "SEM Sw1 Center"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "SEM Sw1 Down"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "SEM Sw2 Up"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "SEM Sw2 Center"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "SEM Sw2 Down"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "SEM Start"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "SEM Mode 1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "SEM Mode 2"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "SEM Mode 3"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "SEM Mode 4"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "SEM C1"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "SEM Flaps 3"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "SEM Flaps 2"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "SEM Flaps 1"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "SEM Flaps 0"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "SEM Gear Down"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "SEM Gear Neutral"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "SEM Gear Up"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "THQ 3 A1"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "THQ 3 A2"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "THQ 3 A3"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "THQ 3 A4"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "THQ 3 B1"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "THQ 3 C1"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "THQ 3 C2"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "THQ 3 B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A1 - Green",
+      "Id": "SEM.A1.Green",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A1 - Red",
+      "Id": "SEM.A1.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM A2 - Green",
+      "Id": "SEM.A2.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM A2 - Red",
+      "Id": "SEM.A2.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B1 - Green",
+      "Id": "SEM.B1.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B1 - Red",
+      "Id": "SEM.B1.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B2 - Green",
+      "Id": "SEM.B2.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B2 - Red",
+      "Id": "SEM.B2.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM B3 - Green",
+      "Id": "SEM.B3.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM B3 - Red",
+      "Id": "SEM.B3.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Left - Green",
+      "Id": "SEM.GearL.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Left - Red",
+      "Id": "SEM.GearL.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Center - Green",
+      "Id": "SEM.GearC.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Center - Red",
+      "Id": "SEM.GearC.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "SEM Gear Right - Green",
+      "Id": "SEM.GearR.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "SEM Gear Right - Red",
+      "Id": "SEM.GearR.Red",
+      "Byte": 17,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_thq.joystick.json
+++ b/Joysticks/vkbsim_nxt_thq.joystick.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT THQ",
+  "VendorId": "0x231D",
+  "ProductId": "0x2210",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "THQ B2"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_thqx2_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_nxt_thqx2_fsm_ga.joystick.json
@@ -1,0 +1,396 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT THQx2 FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x2220",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 21,
+      "Bit": 1
+    }
+  ]
+}

--- a/Joysticks/vkbsim_nxt_thqx3_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_nxt_thqx3_fsm_ga.joystick.json
@@ -1,0 +1,436 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "VKBSim NXT THQx3 FSM.GA",
+  "VendorId": "0x231D",
+  "ProductId": "0x2230",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "THQ A1"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "THQ A2"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "THQ A3"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "THQ A4"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "THQ B1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "THQ C1"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "THQ C2"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "THQ B2"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "THQ 2 A1"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "THQ 2 A2"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "THQ 2 A3"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "THQ 2 A4"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "THQ 2 B1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "THQ 2 C1"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "THQ 2 C2"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "THQ 2 B2"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "THQ 3 A1"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "THQ 3 A2"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "THQ 3 A3"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "THQ 3 A4"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "THQ 3 B1"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "THQ 3 C1"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "THQ 3 C2"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "THQ 3 B2"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "FSM.GA HDG"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "FSM.GA TRK"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "FSM.GA NAV"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "FSM.GA APR"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "FSM.GA ALT"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "FSM.GA LVL"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "FSM.GA VNAV"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "FSM.GA IAS"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "FSM.GA AP"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "FSM.GA FD"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "FSM.GA YD"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "FSM.GA VS"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "FSM.GA Avionic"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "FSM.GA Landing Lights"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "FSM.GA Strobe"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "FSM.GA Nav Lights"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK Push"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL Push"
+    },
+    {
+      "Id": 1000,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CCW"
+    },
+    {
+      "Id": 1005,
+      "Type": "Button",
+      "Label": "FSM.GA HDG TRK CW"
+    },
+    {
+      "Id": 1010,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CCW"
+    },
+    {
+      "Id": 1015,
+      "Type": "Button",
+      "Label": "FSM.GA ALT SEL CW"
+    },
+    {
+      "Id": 1020,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Down"
+    },
+    {
+      "Id": 1025,
+      "Type": "Button",
+      "Label": "FSM.GA VS Nose Up"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Sys - Blue",
+      "Id": "Sys.Blue",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "Sys - Red",
+      "Id": "Sys.Red",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA HDG - Green",
+      "Id": "FSMGA.HDG.Green",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA HDG - Red",
+      "Id": "FSMGA.HDG.Red",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA TRK - Green",
+      "Id": "FSMGA.TRK.Green",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA TRK - Red",
+      "Id": "FSMGA.TRK.Red",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA NAV - Green",
+      "Id": "FSMGA.NAV.Green",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA NAV - Red",
+      "Id": "FSMGA.NAV.Red",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA APR - Green",
+      "Id": "FSMGA.APR.Green",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA APR - Red",
+      "Id": "FSMGA.APR.Red",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA ALT - Green",
+      "Id": "FSMGA.ALT.Green",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA ALT - Red",
+      "Id": "FSMGA.ALT.Red",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA LVL - Green",
+      "Id": "FSMGA.LVL.Green",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA LVL - Red",
+      "Id": "FSMGA.LVL.Red",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VNAV - Green",
+      "Id": "FSMGA.VNAV.Green",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VNAV - Red",
+      "Id": "FSMGA.VNAV.Red",
+      "Byte": 16,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA IAS - Green",
+      "Id": "FSMGA.IAS.Green",
+      "Byte": 17,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA IAS - Red",
+      "Id": "FSMGA.IAS.Red",
+      "Byte": 17,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA AP - Green",
+      "Id": "FSMGA.AP.Green",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA AP - Red",
+      "Id": "FSMGA.AP.Red",
+      "Byte": 18,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA FD - Green",
+      "Id": "FSMGA.FD.Green",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA FD - Red",
+      "Id": "FSMGA.FD.Red",
+      "Byte": 19,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA YD - Green",
+      "Id": "FSMGA.YD.Green",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA YD - Red",
+      "Id": "FSMGA.YD.Red",
+      "Byte": 20,
+      "Bit": 1
+    },
+    {
+      "Label": "FSM.GA VS - Green",
+      "Id": "FSMGA.VS.Green",
+      "Byte": 21,
+      "Bit": 0
+    },
+    {
+      "Label": "FSM.GA VS - Red",
+      "Id": "FSMGA.VS.Red",
+      "Byte": 21,
+      "Bit": 1
+    }
+  ]
+}

--- a/MobiFlight/Joysticks/Joystick.cs
+++ b/MobiFlight/Joysticks/Joystick.cs
@@ -292,8 +292,7 @@ namespace MobiFlight
             {
                 if (ex.Descriptor.ApiCode=="InputLost")
                 {
-                    DIJoystick.Unacquire();
-                    OnDisconnected?.Invoke(this, null);
+                    OnDeviceRemoved();
                 }
             }
         }
@@ -487,8 +486,7 @@ namespace MobiFlight
             catch (System.IO.IOException)
             {
                 // this happens when the device is removed.
-                DIJoystick.Unacquire();
-                OnDisconnected?.Invoke(this, null);
+                OnDeviceRemoved();
             }
         }
 
@@ -505,6 +503,13 @@ namespace MobiFlight
         public virtual void Shutdown()
         {
             // nothing to do
+        }
+
+        protected virtual void OnDeviceRemoved()
+        {
+            DIJoystick.Unacquire();
+            OnDisconnected?.Invoke(this, null);
+
         }
     }
 }

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -1,5 +1,6 @@
 ﻿using MobiFlight.Joysticks.Octavi;
 using MobiFlight.Joysticks.WinwingFcu;
+using MobiFlight.Joysticks.VKB;
 using Newtonsoft.Json;
 using SharpDX.DirectInput;
 using System;
@@ -75,7 +76,7 @@ namespace MobiFlight
             {
                 lock (Joysticks)
                 {
-                    foreach (MobiFlight.Joystick js in Joysticks.Values)
+                    foreach (Joystick js in Joysticks.Values)
                     {
                         js?.Update();
                     }
@@ -155,7 +156,7 @@ namespace MobiFlight
                     continue;
                 }
 
-                MobiFlight.Joystick js;
+                Joystick js;
                 SharpDX.DirectInput.Joystick diJoystick = new SharpDX.DirectInput.Joystick(di, d.InstanceGuid);
                 if (d.InstanceName == "Octavi" || d.InstanceName == "IFR1")
                 {
@@ -163,9 +164,15 @@ namespace MobiFlight
                     js = new Octavi(diJoystick, GetDefinitionByInstanceName("Octavi"));
                 }
                 else if (diJoystick.Properties.VendorId == 0x4098 && diJoystick.Properties.ProductId == 0xBB10)
-                {                                       
+                {
                     js = new WinwingFcu(diJoystick, GetDefinitionByInstanceName("WINWING FCU"));
-                }                
+                }
+                else if (diJoystick.Properties.VendorId == 0x231D)
+                {
+                    // VKB devices are highly configurable. DirectInput names can have old values cached in the registry, but HID names seem to be immune to that.
+                    // Also trim the extraneous whitespaces on VKB device names.
+                    js = new VKBDevice(diJoystick, GetDefinitionByInstanceName(VKBDevice.GetMatchingHidDevice(diJoystick).GetProductName().Trim()));
+                }
                 else
                 {
                     js = new Joystick(diJoystick, GetDefinitionByInstanceName(d.InstanceName));

--- a/MobiFlight/Joysticks/VKB/VKBDevice.cs
+++ b/MobiFlight/Joysticks/VKB/VKBDevice.cs
@@ -1,0 +1,192 @@
+﻿using HidSharp;
+using HidSharp.Reports;
+using HidSharp.Reports.Input;
+using System;
+using System.Collections.Generic;
+
+namespace MobiFlight.Joysticks.VKB
+{
+    internal class VKBDevice : Joystick
+    {
+        private HidStream Stream;
+        private readonly HidDevice Device;
+        private readonly JoystickDefinition Definition;
+        private readonly VKBLedContainer Lights = new VKBLedContainer();
+        private HidDeviceInputReceiver InputReceiver;
+        private readonly byte[] InputReportBuffer = new byte[64];
+        private readonly SortedList<byte, VKBEncoder> Encoders = new SortedList<byte, VKBEncoder>();
+        int lastSeqNo = -1;
+
+        public VKBDevice(SharpDX.DirectInput.Joystick joystick, JoystickDefinition definition) : base(joystick, definition)
+        {
+            Definition = definition;
+            if (Device == null)
+            {
+                Device = GetMatchingHidDevice(joystick);
+                if (Device == null) return;
+            }
+        }
+        public override void Connect(IntPtr handle)
+        {
+            base.Connect(handle);
+            if (Stream == null)
+            {
+                Stream = Device.Open();
+                Stream.ReadTimeout = System.Threading.Timeout.Infinite;
+            }
+
+            if (InputReceiver == null)
+            {
+                InputReceiver = new ReportDescriptor(VKBHidReport.Descriptor).CreateHidDeviceInputReceiver();
+                // We use our own descriptor since the one we get from Windows/HIDSharp has been altered and encoder data is missing
+                InputReceiver.Received += OnHidReportReceived;
+                InputReceiver.Start(Stream);
+            }
+        }
+        protected override void SendData(byte[] data)
+        {
+            // VKBLedContainer has its own handling that replaces RequiresOutputUpdate, so we just send.
+            // Don't try and send data if no outputs are defined.
+            if (Definition?.Outputs == null || Definition?.Outputs.Count == 0)
+            {
+                return;
+            }
+            Stream?.SetFeature(data);
+
+        }
+        protected override void EnumerateDevices()
+        {
+            base.EnumerateDevices();
+            SortedList<byte, JoystickDevice> EncoderDecList = new SortedList<byte, JoystickDevice>();
+            SortedList<byte, JoystickDevice> EncoderIncList = new SortedList<byte, JoystickDevice>();
+            if (Definition == null || Definition.Inputs == null) return;
+            foreach (var input in Definition.Inputs)
+            {
+                // The 1xxx range is limited to encoders. They are also not fed from DirectInput.
+                if (input.Id >= 1000 && input.Id < 2000 && input.Type == JoystickDeviceType.Button)
+                {
+                    byte encoderIndex = GetEncoderIndex(input);
+                    VKBEncoder.EncoderAction encoderAction = GetEncoderAction(input);
+                    if (encoderAction == VKBEncoder.EncoderAction.DEC)
+                    {
+                        EncoderDecList.Add(encoderIndex, new JoystickDevice { Name = $"Button {1000 + 10 * encoderIndex + (int)encoderAction}", Label = input.Label, Type = DeviceType.Button, JoystickDeviceType = input.Type });
+                    }
+                    if (encoderAction == VKBEncoder.EncoderAction.INC)
+                    {
+                        EncoderIncList.Add(encoderIndex, new JoystickDevice { Name = $"Button {1000 + 10 * encoderIndex + (int)encoderAction}", Label = input.Label, Type = DeviceType.Button, JoystickDeviceType = input.Type });
+                    }
+                    Buttons.FindAll(but => but.Label == input.Label).ForEach(but => but.Label += " (Legacy DirectInput)"); 
+                    // Rename the original buttons to keep indexing intact and ensure compatibility with devices not configured to use encoder channels.
+                }
+            }
+            foreach (var encdec in EncoderDecList)
+            {
+                if (EncoderIncList.ContainsKey(encdec.Key))
+                {
+                    Encoders.Add(encdec.Key, new VKBEncoder(EncoderIncList[encdec.Key], encdec.Value)); // If both increment and decrement were in the definition, we create an encoder object from the definition file
+                    Buttons.Add(Encoders[encdec.Key].DeviceDec); // And register their virtual buttons in the joystick's button list.
+                    Buttons.Add(Encoders[encdec.Key].DeviceInc);
+                }
+            }
+        }
+
+        private static byte GetEncoderIndex(JoystickInput input)
+        {
+            return (byte)((input.Id - 1000) / 10);
+        }
+        private static VKBEncoder.EncoderAction GetEncoderAction(JoystickInput input)
+        {
+            return (VKBEncoder.EncoderAction)(input.Id % 10);
+        }
+        protected override void EnumerateOutputDevices()
+        {
+            Definition?.Outputs?.ForEach(output => Lights.AddChannel(output));
+            base.EnumerateOutputDevices();
+        }
+
+        public override void SetOutputDeviceState(string name, byte state)
+        {
+            Lights.UpdateState(name, state);
+        }
+
+
+        public override void UpdateOutputDeviceStates()
+        {
+            var data = Lights.CreateMessage();
+            if (data[7] == 0) return; // Only send message if there are non-zero LEDs to be updated
+            try
+            {
+                SendData(data);
+            }
+            catch (System.IO.IOException)
+            {
+                base.OnDeviceRemoved();
+            }
+        }
+        private void OnHidReportReceived(object sender, System.EventArgs e)
+        {
+            var inputReceiver = sender as HidDeviceInputReceiver;
+            while (inputReceiver.TryRead(InputReportBuffer, 0, out _))
+            {
+                byte ReportId = InputReportBuffer[0];
+                if (ReportId != 0x08) // 0x08 = Monitoring channel / virtual bus
+                    continue;
+                byte MessageType = InputReportBuffer[1];
+                if (MessageType != 0x13) // 0x13 = Encoder status
+                    continue;
+                ParseEncoderReport(InputReportBuffer);
+            }
+        }
+        private void ParseEncoderReport(byte[] Report)
+        {
+            byte sequenceNo = Report[2];
+            if (((lastSeqNo + 1) & 0xFF) != sequenceNo)
+            {
+                Log.Instance.log("Some VKB encoder messages may have been missed", LogSeverity.Debug);
+                // Can easily happen if many updates are sent in quick succession (like when an encoder is spun fast)
+                // Not a problem since API reports absolute state, so the updates are just received on the next received message.
+            }
+            lastSeqNo = sequenceNo;
+            byte encoderCount = Report[3];
+            int maxEncoders = (Report.Length - 4) / 2;
+            if (encoderCount > maxEncoders)
+            {
+                Log.Instance.log($"Log message reports {encoderCount} encoders, but only has space for {maxEncoders}. Some encoders were ignored.", LogSeverity.Warn);
+                encoderCount = (byte)maxEncoders;
+                // Should not occur in most real-life scenarios, but it is theoretically possible to construct a device with more encoders than the report can handle.
+            }
+            List<InputEventArgs> events = new List<InputEventArgs>();
+            for (byte i = 0; i < encoderCount; i++)
+            {
+                ushort newPos = (ushort)(Report[5 + 2 * i] << 8 | Report[4 + 2 * i]);
+                if (!Encoders.ContainsKey(i))
+                {
+                    // Add encoders that were not part of definition when we first receive a message with them.
+                    Encoders.Add(i, new VKBEncoder(i, newPos));
+                    Buttons.Add(Encoders[i].DeviceDec);
+                    Buttons.Add(Encoders[i].DeviceInc);
+                }
+                else
+                {
+                    events.AddRange(Encoders[i].Update(newPos));
+                }
+            }
+            foreach (InputEventArgs e in events)
+            {
+                // Process the encoder events created by the encoder object.
+                e.Name = Name;
+                e.Serial = SerialPrefix + DIJoystick.Information.InstanceGuid.ToString();
+                TriggerButtonPressed(this, e);
+            }
+        }
+        public static HidDevice GetMatchingHidDevice(SharpDX.DirectInput.Joystick joystick)
+        {
+            // Get the HID device using the device path. We are not relying on PID alone because multiple devices may have the same PID under certain circumstances, e.g. identical module combos.
+            var DevList = DeviceList.Local.GetHidDevices(joystick.Properties.VendorId, joystick.Properties.ProductId);
+            foreach (HidDevice dev in DevList)
+                if (dev.DevicePath == joystick.Properties.InterfacePath)
+                    return dev;
+            return null;
+        }
+    }
+}

--- a/MobiFlight/Joysticks/VKB/VKBEncoder.cs
+++ b/MobiFlight/Joysticks/VKB/VKBEncoder.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using static MobiFlight.Joysticks.VKB.VKBEncoder;
+
+namespace MobiFlight.Joysticks.VKB
+{
+    internal class VKBEncoder
+    {
+        public enum EncoderAction
+        {
+            DEC = 0,
+            INC = 5
+        }
+        private bool firstStart = false; // Ensures initial values get pulled from the device when encoder object is created from definition file.
+        public JoystickDevice DeviceInc = null; // Virtual button for increment events.
+        public JoystickDevice DeviceDec = null; // Virtual button for decrement events.
+        private ushort value = 0; // Stores current state of encoder
+        public VKBEncoder(byte index, ushort? initialValue = null)
+        {
+            // Constructor if virtual button devices are not created otherwise.
+            if (initialValue == null) firstStart = true;
+            else
+            {
+                value = initialValue?? 0;
+                firstStart = false;
+            }
+            CreateDevices(index);
+        }
+        public VKBEncoder(JoystickDevice inc, JoystickDevice dec, ushort? initialValue = null)
+        {
+            // Constructor if virtual button devices have already been created from definition.
+            DeviceInc = inc;
+            DeviceDec = dec;
+            if (initialValue == null)
+            {
+                firstStart = true;
+            }
+            else
+            {
+                value = initialValue ?? 0;
+                firstStart = false;
+            }
+        }
+        private void CreateDevices(int index)
+        {
+            // Virtual buttons use a button ID range that is out of the reach of DirectInput.
+            // For ease of readability, the numbering scheme is 1IID, where II is a two-digit encoder ID and D is a direction (0 for decrement, 5 for increment).
+            DeviceInc = new JoystickDevice { Name = $"Button {1000 + 10 * index + (int)EncoderAction.INC}", Label = $"Encoder {index+1} INC", Type = DeviceType.Button, JoystickDeviceType = JoystickDeviceType.Button };
+            DeviceDec = new JoystickDevice { Name = $"Button {1000 + 10 * index + (int)EncoderAction.DEC}", Label = $"Encoder {index+1} DEC", Type = DeviceType.Button, JoystickDeviceType = JoystickDeviceType.Button };
+        }
+        public IEnumerable<InputEventArgs> Update(ushort newPosition)
+        {
+            List<InputEventArgs> events = new List<InputEventArgs>();
+            if (firstStart)
+            {
+                value = newPosition;
+                firstStart= false;
+                return events;
+            }
+            short deltaCount = (short)((newPosition - value) & 0xFFFF);
+            if (deltaCount > 0)
+            {
+                while (value != newPosition) // Send one press for each step moved and update value accordingly until the new position is reached.
+                {
+                    value++;
+                    events.Add(new InputEventArgs { DeviceId = DeviceInc.Name, DeviceLabel = DeviceInc.Label, Type = DeviceType.Button, Value = (int)MobiFlightButton.InputEvent.PRESS });
+                }
+            }
+            else if (deltaCount < 0)
+            {
+                while (value != newPosition)
+                {
+                    value--;
+                    events.Add(new InputEventArgs { DeviceId = DeviceDec.Name, DeviceLabel = DeviceDec.Label, Type = DeviceType.Button, Value = (int)MobiFlightButton.InputEvent.PRESS });
+                }
+            }
+            return events;
+        }
+    }
+}

--- a/MobiFlight/Joysticks/VKB/VKBHidReport.cs
+++ b/MobiFlight/Joysticks/VKB/VKBHidReport.cs
@@ -1,0 +1,26 @@
+﻿namespace MobiFlight.Joysticks.VKB
+{
+    internal class VKBHidReport
+    {
+        // Windows swallows a vital input report in the reconstructed descriptor. This fake descriptor helps us read all fields that are relevant for us, and only those.
+        public static readonly byte[] Descriptor = new byte[]{
+            0x05, 0x01,        // Usage Page (Generic Desktop Ctrls)
+            0x09, 0x04,        // Usage (Joystick)
+            0xA1, 0x01,        // Collection (Application)
+            0x85, 0x08,        //   Report ID (8)
+            0x05, 0x01,        //   Usage Page (Generic Desktop Ctrls)
+            0x09, 0x00,        //   Usage (Undefined)
+            0x75, 0x08,        //   Report Size (8)
+            0x95, 0x3F,        //   Report Count (63)
+            0x26, 0xFF, 0x00,  //   Logical Maximum (255)
+            0x15, 0x00,        //   Logical Minimum (0)
+            0x81, 0x01,        //   Input (Const,Array,Abs,No Wrap,Linear,Preferred State,No Null Position)
+            0x85, 0x59,        //   Report ID (89)
+            0x75, 0x08,        //   Report Size (8)
+            0x95, 0x80,        //   Report Count (-128)
+            0x09, 0x00,        //   Usage (Undefined)
+            0xB1, 0x02,        //   Feature (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+            0xC0              // End Collection
+        };
+    }
+}

--- a/MobiFlight/Joysticks/VKB/VKBLed.cs
+++ b/MobiFlight/Joysticks/VKB/VKBLed.cs
@@ -1,0 +1,171 @@
+﻿namespace MobiFlight.Joysticks.VKB
+{
+    internal class VKBLed
+    {
+        /*
+         * VKB LEDs come in three types: Mono, bi-color and RGB.
+         * Mobiflight uses a bit/byte system to handle LEDs in generic controllers (e.g. Honeycomb), where each LED is a bit flag.
+         * For VKB devices, this is co-opted to encode LED IDs (assigned in VKBDevCfg for each sub-device) and color channels.
+         * Monochrome LEDs just have "bit" 0 to turn the LED on and off
+         * Bicolor LEDs have bit 0 for color1 (usually green/blue) and bit 1 for color2 (usually red)
+         * RGB LEDs have bit 0 for the red channel, 1 for green and 2 for blue.
+         */
+        public enum ColorMode : byte // 1, 2 and 1+2 are relevant for Mobiflight. 1/2 and 2/1 are used with hardware flash patterns.
+        {
+            Color1 = 0,
+            Color2 = 1,
+            Color1_2 = 2,
+            Color2_1 = 3,
+            Color1plus2 = 4
+        };
+        public enum FlashPattern : byte // MobiFlight LEDs are not complex enough to take advantage of hardware flash patterns yet.
+        {
+            Off = 0,
+            Constantly = 1,
+            Slow = 2,
+            Fast = 3,
+            UltraFast = 4
+        };
+        private readonly JoystickOutputDevice[] LedChannels = new JoystickOutputDevice[3];
+        private bool dirty = true; // There have been changes since the last time the values were sent to the device
+                                   // Initialized as true to ensure that no output gets ignored.
+        private bool used = false; // Changes have been made to the LED since initialization.
+                                   // This prevents packets from being sent when no output is configured.
+        private bool greenred = false; // Special handling of green/red LEDs to get a decent amber when both are on
+        private readonly byte LedId = 0;
+        private const byte defaultBrightness = 5; // VKB LEDs have 7 brightness levels, but MobiFlight does not support PWM on HIDs
+        public VKBLed(byte id)
+        {
+            LedId = id;
+        }
+        public void AddChannel(JoystickOutput output)
+        {
+            if (LedChannels[output.Bit] != null) return;
+            LedChannels[output.Bit] = new JoystickOutputDevice
+            {
+                Label = output.Label,
+                Name = output.Id,
+                Byte = output.Byte,
+                Bit = output.Bit,
+                State = 0
+            };
+            // Green/Red LEDs need special treatment, so let us track that:
+            if (LedChannels[0] != null
+             && LedChannels[0].Label.Contains("Green") // feels like a dirty hack, but requires no additional config data
+             && LedChannels[1] != null
+             && LedChannels[1].Label.Contains("Red"))
+            {
+                greenred = true;
+            }
+        }
+        public void SetState(byte channel, byte state)
+        {
+            used = true; // Ensure that the LED state is only sent if an output is associated with the LED.
+            if (LedChannels[channel].State != state) dirty = true;
+            LedChannels[channel].State = state;
+        }
+        public byte[] Serialize()
+        {
+            byte[] LedBlock = new byte[] { 0, 0, 0, 0 };
+            FlashPattern pattern = FlashPattern.Off;
+            ColorMode colmode = ColorMode.Color1;
+            byte[,] ColorIntensity = new byte[2, 3] { { 0, 0, 0 }, { 0, 0, 0 } };
+            int activeLeds = 0;
+            foreach (JoystickOutputDevice channel in LedChannels)
+            {
+                if ((channel?.State ?? 0) != 0)
+                {
+                    pattern = FlashPattern.Constantly;
+                    activeLeds++;
+                }
+            }
+            if (LedChannels[2] != null)
+            {
+                // RGB LED, use Color1 with RGB values;
+                foreach (JoystickOutputDevice channel in LedChannels)
+                {
+                    ColorIntensity[0, channel.Bit] = (byte)(channel.State * defaultBrightness);
+                }
+            }
+            else if (greenred)
+            {
+                // Green/Red LEDs need special treatment, due to the always-green feature and the overpowering green at high intensities
+                int color = ((LedChannels[0].State != 0) ? 1 : 0) + ((LedChannels[1].State != 0) ? 2 : 0); // 0: off, 1: green, 2: red, 3: amber
+                byte brightnessG = defaultBrightness;
+                byte brightnessR = defaultBrightness;
+                switch (color)
+                {
+                    case 0:
+                        brightnessG = 0;
+                        brightnessR = 0;
+                        pattern = FlashPattern.Constantly;  // Off would turn the LEDs on in a dim green unless a jumper
+                        colmode = ColorMode.Color1;         // is changed in hardware, so Color1 at brightness zero it is
+                        break;
+                    case 1:
+                        brightnessG = 3;
+                        brightnessR = 0;
+                        pattern = FlashPattern.Constantly;
+                        colmode = ColorMode.Color1;
+                        break;
+                    case 2:
+                        brightnessG = 0;
+                        brightnessR = 5;
+                        pattern = FlashPattern.Constantly;
+                        colmode = ColorMode.Color2;
+                        break;
+                    case 3:
+                        brightnessG = 2;
+                        brightnessR = 7;
+                        pattern = FlashPattern.Constantly;
+                        colmode = ColorMode.Color1plus2;
+                        break;
+                    default: // no default, all cases handled
+                        break;
+                }
+                ColorIntensity[0, 1] = brightnessG;
+                ColorIntensity[1, 1] = brightnessR;
+            }
+            else
+            {
+                // Single or bicolor LED, other than red/green LEDs
+                byte brightness = defaultBrightness;
+                if (activeLeds > 1) brightness = 7; // Since Color1+2 means the controller is alternating between both colors (like PWM), we need to increase
+                                                    // the brightness over the base brightness.
+                for (int col = 0; col < ColorIntensity.GetLength(0); col++)
+                {
+                    byte[] channelstate = new byte[2] { (LedChannels[0]?.State ?? 0), (LedChannels[1]?.State ?? 0) };
+                    if (channelstate[0] != 0)
+                    {
+                        ColorIntensity[0, col] = (byte)(channelstate[0] * brightness);
+                    }
+                    if (channelstate[1] != 0)
+                    {
+                        ColorIntensity[1, col] = (byte)(channelstate[1] * brightness);
+                        if (channelstate[0] != 0)
+                        {
+                            colmode = ColorMode.Color1plus2;
+                        }
+                        else
+                        {
+                            colmode = ColorMode.Color2;
+                        }
+
+                    }
+                    ColorIntensity[0, col] = (byte)((LedChannels[0]?.State ?? 0) * brightness);
+                    ColorIntensity[1, col] = (byte)((LedChannels[1]?.State ?? 0) * brightness);
+                }
+            }
+            // Serialize the block into a tightly-packed structure with several 3-bit variables - USB is LSB-first.
+            LedBlock[0] = LedId;
+            LedBlock[1] = (byte)(ColorIntensity[0, 0] | ColorIntensity[0, 1] << 3 | (ColorIntensity[0, 2] & 0x03) << 6);
+            LedBlock[2] = (byte)(ColorIntensity[0, 2] >> 2 | ColorIntensity[1, 0] << 1 | ColorIntensity[1, 1] << 4 | (ColorIntensity[1, 2] & 0x01) << 7);
+            LedBlock[3] = (byte)(ColorIntensity[1, 2] >> 1 | (byte)pattern << 2 | (byte)colmode << 5);
+            dirty = false;
+            return LedBlock;
+        }
+        public bool IsChanged()
+        {
+            return dirty && used; // The values have changed since the last message was sent.
+        }
+    }
+}

--- a/MobiFlight/Joysticks/VKB/VKBLedContainer.cs
+++ b/MobiFlight/Joysticks/VKB/VKBLedContainer.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace MobiFlight.Joysticks.VKB
+{
+    // This holds all LED channels of a single device along with a label list for speedy retrieval.
+    internal class VKBLedContainer
+    {
+        private readonly SortedList<byte, VKBLed> Leds = new SortedList<byte, VKBLed>();
+        private readonly Dictionary<String, (byte, byte)> Labels = new Dictionary<string, (byte, byte)>();
+        public void AddChannel(JoystickOutput output)
+        {
+            if (!Leds.ContainsKey(output.Byte))
+                Leds.Add(output.Byte, new VKBLed(output.Byte));
+            Leds[output.Byte].AddChannel(output);
+            Labels.Add(output.Label, (output.Byte, output.Bit));
+        }
+        public void UpdateState (string Label, byte State)
+        {
+            // Find the LED and its color channel and update it.
+            String[] updateLabels = Label.Split('|'); // Multiple output pin support
+            foreach (String updateLabel in updateLabels)
+            {
+                if (Labels.ContainsKey(updateLabel))
+                {
+                    (byte Byte, byte Bit) = Labels[updateLabel];
+                    Leds[Byte]?.SetState(Bit, State);
+                }
+            }
+        }
+        public byte[] CreateMessage()
+            // Serialize an entire feature report by iterating over all LEDs.
+        {
+            int LedCount = 0;
+            foreach(KeyValuePair<byte,VKBLed> entry in Leds)
+            {
+                if (entry.Value.IsChanged()) LedCount++;
+            }
+            byte[] buffer = new byte[129]; // Length defined by report descriptor.
+            buffer[0] = 0x59; // Report ID
+            buffer[1] = 0xA5; // Header preamble
+            buffer[2] = 0x0A; // Opcode
+                              // Bytes 4-7 are listed as "reserved", but have no details.
+                              // They are basically ignored, might as well leave them empty.
+            buffer[7] = (byte)LedCount;
+            int bufferoffset = 8;
+            foreach (KeyValuePair<byte, VKBLed> entry in Leds)
+            {
+                if (!entry.Value.IsChanged()) continue;
+                Buffer.BlockCopy(entry.Value.Serialize(), 0, buffer, bufferoffset, 4); // Serialize single LED
+                bufferoffset += 4;
+                if (bufferoffset > 126) break; // We are not able to update more than that at once without
+                                               // exceeding our buffer. But next call, only the remaning LEDs
+                                               // ought to still return true on IsChanged().
+                                               // In practice, we are more likely to deal with single LEDs here anyway.
+            }
+            return buffer;
+        }
+    }
+}

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -292,6 +292,11 @@
     <Compile Include="MobiFlight\Joysticks\JoystickInput.cs" />
     <Compile Include="MobiFlight\Joysticks\JoystickOutput.cs" />
     <Compile Include="MobiFlight\Joysticks\Octavi\Octavi.cs" />
+    <Compile Include="MobiFlight\Joysticks\VKB\VKBDevice.cs" />
+    <Compile Include="MobiFlight\Joysticks\VKB\VKBEncoder.cs" />
+    <Compile Include="MobiFlight\Joysticks\VKB\VKBHidReport.cs" />
+    <Compile Include="MobiFlight\Joysticks\VKB\VKBLed.cs" />
+    <Compile Include="MobiFlight\Joysticks\VKB\VKBLedContainer.cs" />
     <Compile Include="MobiFlight\Joysticks\WinwingFcu\WinwingFcu.cs" />
     <Compile Include="MobiFlight\Joysticks\WinwingFcu\WinwingFcuReport.cs" />
     <Compile Include="MobiFlight\JsonBackedObject.cs" />
@@ -1077,6 +1082,150 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="firmware\reset.raspberry_pico_flash_nuke.uf2">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\s_tecs_modern_throttle_max.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\s_tecs_modern_throttle_max_stem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\s_tecs_modern_throttle_max_stem_fsm_ga.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\s_tecs_modern_throttle_mini.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\s_tecs_modern_throttle_mini_plus.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\s_tecs_modern_throttle_standard.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\s_tecs_modern_throttle_standard_stem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_f14.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_kg12.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_l.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_l_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_ot_l.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_ot_l_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_ot_r.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_ot_r_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_r.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_r_fsm_ga.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_r_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_r_sem_fsm_ga.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_r_sem_thq.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_r_sem_thqx2.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_r_thq.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_evo_r_thqx2.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_f14.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_kg12.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_l.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_l_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_ot_l.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_ot_l_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_ot_r.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_ot_r_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_r.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_r_fsm_ga.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_r_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_r_sem_fsm_ga.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_r_sem_thq.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_r_sem_thqx2.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_r_thq.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_gladiator_nxt_r_thqx2.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_fsm_ga.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_sem.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_sem_thq.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_sem_thqx2.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_sem_thqx2_fsm_ga.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_sem_thqx3.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_thq.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_thqx2_fsm_ga.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\vkbsim_nxt_thqx3_fsm_ga.joystick.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Joysticks\winwing_fcu.joystick.json">


### PR DESCRIPTION
Solves #1789

- Implements VKB LED protocol (firmware 2.08.5+), allowing for control of single-color, bi-color and RGB LEDs. In accordance with current limitation on HID LEDs, only on and off are supported for each channel. The byte identifier is used for the LED ID, the bit identifier repurposed for the color channel.
- Implements VKB encoder protocol (firmware 2.17.9+, still experimental on VKB's end), solving slowness arising from the use of directinput buttons as the default form of output. Encoders suffer from the same limitations as Octavi and Winwing FCU encoders, specifically being affected by #1786.
- Changes identification of VKB device names (VID 0x231D):
  - Extraneous spaces (VKB quirk) are stripped
  - HID API is used to query names instead of DirectInput - more robust with configuration changes; DirectInput may cache outdated names 
- Includes a large array of definition files for common VKB controllers:
  - Stock configs of Gladiator NXT (including EVO), STECS and GNX module combos
  - GNX module configs featured in VKB instructional videos
  - Standalone GNX modules
  - a small selection of custom combos
- Tools for quickly making own definition files (VKB devices are very modular, so even that only covers the common use cases) are made available separately and are currently not planned to be distributed alongside MobiFlight.