### PR TITLE
Fix midi device in orphaned serials dialog

### DIFF
--- a/UI/Dialogs/OrphanedSerialsDialog.cs
+++ b/UI/Dialogs/OrphanedSerialsDialog.cs
@@ -12,7 +12,6 @@ namespace MobiFlight.UI.Dialogs
         private List<string> connectedModuleSerials = new List<string>();
         private List<string> connectedArcazeSerials = new List<string>();
         private List<string> connectedJoystickSerials = new List<string>();
-        private List<string> connectedMidiSerials = new List<string>();
         private DataTable configDataTable = null;
         private DataTable realConfigDataTable = null;
         private DataTable inputDataTable = null;
@@ -33,10 +32,6 @@ namespace MobiFlight.UI.Dialogs
                 if (SerialNumber.IsJoystickSerial(serialNumber))
                 {
                     connectedJoystickSerials.Add(serial);
-                }
-                else if (SerialNumber.IsMidiBoardSerial(serialNumber))
-                {
-                    connectedMidiSerials.Add(serial);
                 }
                 else if (SerialNumber.IsMobiFlightSerial(serialNumber))
                 {
@@ -91,11 +86,10 @@ namespace MobiFlight.UI.Dialogs
             {
                 string serialNumber = SerialNumber.ExtractSerial(configSerial);
                 bool showOrphanedJoystick = SerialNumber.IsJoystickSerial(serialNumber) && connectedJoystickSerials.Count > 0;
-                bool showOrphanedModule = SerialNumber.IsMobiFlightSerial(serialNumber) && connectedModuleSerials.Count > 0;
-                bool showOrphanedMidi = SerialNumber.IsMidiBoardSerial(serialNumber) && connectedModuleSerials.Count > 0;
+                bool showOrphanedModule = SerialNumber.IsMobiFlightSerial(serialNumber) && connectedModuleSerials.Count > 0;        
                 bool showOrphanedArcaze = SerialNumber.IsArcazeSerial(serialNumber) && connectedArcazeSerials.Count > 0;
 
-                if (showOrphanedJoystick || showOrphanedModule || showOrphanedArcaze || showOrphanedMidi)
+                if (showOrphanedJoystick || showOrphanedModule || showOrphanedArcaze)
                 { 
                     configSerials.Add(configSerial);
                     orphanedSerialsListBox.Items.Add(configSerial);
@@ -167,10 +161,6 @@ namespace MobiFlight.UI.Dialogs
                 else if (SerialNumber.IsJoystickSerial(selectedSerial))
                 {
                     connectedModulesComboBox.Items.AddRange(connectedJoystickSerials.ToArray());
-                }
-                else if (SerialNumber.IsMidiBoardSerial(selectedSerial))
-                {
-                    connectedModulesComboBox.Items.AddRange(connectedMidiSerials.ToArray());
                 }
                 else
                 {


### PR DESCRIPTION
fixes #1795 
It was not intended to now have the orphaned serials dialoge include midi devices. Something was half prepared and not fully tested. Also orphaned serials are currently not necessary on midi devices.

-> Completely remove midi from orphaned serials.