### PR TITLE
Remove incorrect helper text from output configs

### DIFF
--- a/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.cs
@@ -68,7 +68,7 @@ namespace MobiFlight.UI.Panels.Config
             AVarExamplePanel.Visible = panelMode == HubHopPanelMode.Output && FlightSimType == FlightSimType.MSFS2020;
             ExampleLabel.Visible = panelMode == HubHopPanelMode.Output && FlightSimType == FlightSimType.MSFS2020;
             ValuePanel.Visible = panelMode == HubHopPanelMode.Input && FlightSimType == FlightSimType.XPLANE;
-            HintLabelPresetCodeLabel.Visible = FlightSimType == FlightSimType.MSFS2020;
+            HintLabelPresetCodeLabel.Visible = FlightSimType == FlightSimType.MSFS2020 && panelMode == HubHopPanelMode.Input;
 
             if (panelMode == HubHopPanelMode.Input)
             {


### PR DESCRIPTION
Fixes #1798

Add a test for whether the dialog is input vs. output to the existing test for when to show the helper text. After the change, output looks like this:

![image](https://github.com/user-attachments/assets/48e171cf-aaf4-4926-a1b7-a0becdf24cd8)

Input looks like this:

![image](https://github.com/user-attachments/assets/95b8f80f-6c3d-46c7-b53c-8d7903ee4df8)
