### PR TITLE
DRAFT: Limit max entries shown in MSFS 2020 preset combo box

### DIFF
--- a/UI/Panels/Config/HubHopPresetPanel.Designer.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.Designer.cs
@@ -545,10 +545,9 @@
             this.MatchLabel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.MatchLabel.Location = new System.Drawing.Point(425, 3);
             this.MatchLabel.Name = "MatchLabel";
-            this.MatchLabel.Size = new System.Drawing.Size(169, 18);
+            this.MatchLabel.Size = new System.Drawing.Size(169, 40);
             this.MatchLabel.TabIndex = 16;
             this.MatchLabel.Text = "{0} Presets match";
-            this.MatchLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // PresetComboBox
             // 

--- a/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.cs
@@ -207,7 +207,7 @@ namespace MobiFlight.UI.Panels.Config
                 try
                 {
                     PresetList.Load(PresetFile);
-                    FilterPresetList();
+                    FilterPresetListDelayedByMs(20);                    
                 }
                 catch (Exception e)
                 {
@@ -590,6 +590,7 @@ namespace MobiFlight.UI.Panels.Config
         {
             String SelectedValue = null;
             Msfs2020HubhopPreset selectedPreset = null;
+            int maxItemsCombobox = 3000;
 
             PresetComboBox.SelectedIndexChanged -= PresetComboBox_SelectedIndexChanged;
             if (PresetComboBox.SelectedIndex > 0)
@@ -601,20 +602,30 @@ namespace MobiFlight.UI.Panels.Config
                     FilteredPresetList.Items.Add(selectedPreset);
                 }
             }
-
             PresetComboBox.DataSource = null;
-            PresetComboBox.DataSource = FilteredPresetList.Items;
+            if (FilteredPresetList.Items.Count > maxItemsCombobox)
+            {
+                int MatchesFound = FilteredPresetList.Items.Count - 1;
+
+                PresetComboBox.DataSource = FilteredPresetList.Items.GetRange(0, maxItemsCombobox);           
+                MatchLabel.Text = $"Max {maxItemsCombobox} of {MatchesFound} shown." + $"{Environment.NewLine}Please extend filter.";
+            }
+            else
+            {
+                PresetComboBox.DataSource = FilteredPresetList.Items;
+            }
+
             PresetComboBox.ValueMember = "id";
             PresetComboBox.DisplayMember = "label";
 
             if (SelectedValue != null)
-            {                
+            {
                 PresetComboBox.SelectedValue = SelectedValue;
 
                 // we didn't find the preset within the current
                 // list
                 if (PresetComboBox.SelectedValue == null)
-                PresetComboBox.SelectedIndex = 0;
+                    PresetComboBox.SelectedIndex = 0;
             }
             else
             {
@@ -625,7 +636,6 @@ namespace MobiFlight.UI.Panels.Config
 
             PresetComboBox.SelectedIndexChanged += PresetComboBox_SelectedIndexChanged;
         }
-
         private void UpdateValues(ComboBox cb, String[] valueList)
         {
             String SelectedValue = null;


### PR DESCRIPTION
fixes #1809 

This change leads to instant loading. Also it probably does not make sense to scroll a list of more than 3000 entries.

![image](https://github.com/user-attachments/assets/650eaf78-d5cf-4e88-bfa1-3fa537bbe038)
