### PR TITLE
Fix crash on changing a customized presets

### DIFF
--- a/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/UI/Panels/Config/HubHopPresetPanel.cs
@@ -393,7 +393,7 @@ namespace MobiFlight.UI.Panels.Config
                     code = Code,
                     description = "This is a customized preset or custom code."
                 };
-                FilteredPresetList.Items.Add(CustomPreset);
+                FilteredPresetList.Items.Insert(0, CustomPreset);
                 FilteredPresetListChanged();
                 // We have found the original preset
                 InitializeComboBoxesWithPreset(CustomPreset);


### PR DESCRIPTION
fixes #1814 

The display entry to show "Customized Preset or Custom Code" was appended to the end of the preset list. Since now only the first 1500 items are shown, that entry was cut as well, which caused issues.

Now the display entry "Customized Preset or Custom Code" is insert as first item of the preset list.