### PR TITLE
Add try/catch for WasmModuleClient.Stop()

### DIFF
--- a/SimConnectMSFS/SimConnectCache.cs
+++ b/SimConnectMSFS/SimConnectCache.cs
@@ -371,7 +371,15 @@ namespace MobiFlight.SimConnectMSFS
 
         internal void Stop()
         {
-            WasmModuleClient.Stop(m_oSimConnect, WasmRuntimeClientData);
+            try
+            {
+                WasmModuleClient.Stop(m_oSimConnect, WasmRuntimeClientData);
+            }
+            catch (Exception e)
+            {
+                Log.Instance.log($"Unable to stop WasmModule: {e.Message}", LogSeverity.Error);
+            }
+
             ClearSimVars();
         }
 


### PR DESCRIPTION
Fixes #1821 

Well, doesn't really fix it. Opening the PR to get the CI build so we can get the actual error.