### PR TITLE
Respect the scan devices option for new devices

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -796,6 +796,10 @@ namespace MobiFlight.UI
             // This board is not flashed yet
             if (module.ToMobiFlightModuleInfo()?.FirmwareInstallPossible() ?? false)
             {
+                // We can install firmware on this device but the user
+                // has asked us not to auto scan devices so we bail
+                if (!Properties.Settings.Default.FwAutoUpdateCheck) return;
+
                 PerformFirmwareInstallProcess(module.ToMobiFlightModuleInfo());
                 return;
             } 


### PR DESCRIPTION
Fixes #1820 

The prompt to install MobiFlight on a compatible device will now be shown only if the "Scan for compatible boards" setting is enabled.