### PR TITLE
Remove links to assets from release notes

### DIFF
--- a/UI/Dialogs/WelcomeDialog.cs
+++ b/UI/Dialogs/WelcomeDialog.cs
@@ -34,7 +34,9 @@ namespace MobiFlight.UI.Dialogs
             await webView.ExecuteScriptAsync($"" +
                 $"document.getElementById('repository-container-header').remove();" +
                 $"document.getElementsByClassName('js-header-wrapper')[0].remove();" +
-                $"document.getElementsByClassName('footer')[0].remove();");
+                $"document.getElementsByClassName('footer')[0].remove();" +
+                @"document.getElementsByClassName('Box-footer')[0].childNodes.forEach((item, i)=>{{ if (i>0) item.remove(); }});"
+                );
         }
 
         private void button1_Click(object sender, EventArgs e)


### PR DESCRIPTION
This removes the asset links at the bottom of the release notes. 

fixes #1635 