### PR TITLE
Check FW capabilities against CoreVersion

### DIFF
--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -242,6 +242,7 @@ namespace MobiFlight
         {
             Name = moduleInfo.Name ?? moduleInfo.Board.Info.FriendlyName;
             Version = moduleInfo.Version;
+            CoreVersion = moduleInfo.CoreVersion;
             Serial = moduleInfo.Serial;
             _comPort = moduleInfo.Port;
             Board = moduleInfo.Board;
@@ -914,7 +915,8 @@ namespace MobiFlight
                 // we also introduced CoreVersion
                 if (InfoCommand.Arguments.Length > 4)
                 {
-                    CoreVersion = InfoCommand.ReadStringArg();
+                    devInfo.CoreVersion = InfoCommand.ReadStringArg();
+                    CoreVersion = devInfo.CoreVersion;
                 }
 
                 Name = devInfo.Name;
@@ -1260,6 +1262,7 @@ namespace MobiFlight
                 Type = Type,
                 Port = Port,
                 Version = Version,
+                CoreVersion = CoreVersion,
                 HardwareId = HardwareId,
                 Board = Board
             };
@@ -1297,7 +1300,7 @@ namespace MobiFlight
             if (IsPullRequestBuild) return true;
 
             System.Version minVersion = new System.Version(FirmwareFeature);
-            System.Version currentVersion = new System.Version(Version != null ? Version : "0.0.0");
+            System.Version currentVersion = new System.Version(CoreVersion != null ? CoreVersion : "0.0.0");
 
             return (currentVersion.CompareTo(minVersion) >= 0);
         }

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -911,17 +911,32 @@ namespace MobiFlight
                     devInfo.Version = "1.0.0";
                 }
 
-                // With the support of Custom Devices
-                // we also introduced CoreVersion
+                // With the support of Community Devices we also introduced CoreVersion
+                // If no CoreVersion is available, it must be a board with FW version
+                // below 2.5.0. Fot this boards CoreVersion is always the same as Version
                 if (InfoCommand.Arguments.Length > 4)
                 {
                     devInfo.CoreVersion = InfoCommand.ReadStringArg();
-                    CoreVersion = devInfo.CoreVersion;
+                }
+                else
+                {
+                    // With the support of Custom Devices
+                    // we also introduced CoreVersion
+                    // if a CoreVersion was not provided 
+                    // we determine a fallback version
+                    devInfo.CoreVersion = FallbackCoreVersion(Version, Board);
+                    // if no guess is possibel, set CoreVersion to Version
+                    // this reflectes all boards with FW version below 2.5.0
+                    if (String.IsNullOrEmpty(devInfo.CoreVersion))
+                    {
+                        devInfo.CoreVersion = devInfo.Version;
+                    }
                 }
 
                 Name = devInfo.Name;
                 Version = devInfo.Version;
                 Serial = devInfo.Serial;
+                CoreVersion = devInfo.CoreVersion;
             }
 
             // Get the board specifics based on the MobiFlight type returned by the firmware. If there's no match,

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -911,9 +911,6 @@ namespace MobiFlight
                     devInfo.Version = "1.0.0";
                 }
 
-                // With the support of Community Devices we also introduced CoreVersion
-                // If no CoreVersion is available, it must be a board with FW version
-                // below 2.5.0. Fot this boards CoreVersion is always the same as Version
                 if (InfoCommand.Arguments.Length > 4)
                 {
                     devInfo.CoreVersion = InfoCommand.ReadStringArg();
@@ -924,9 +921,9 @@ namespace MobiFlight
                     // we also introduced CoreVersion
                     // if a CoreVersion was not provided 
                     // we determine a fallback version
-                    devInfo.CoreVersion = FallbackCoreVersion(Version, Board);
-                    // if no guess is possibel, set CoreVersion to Version
-                    // this reflectes all boards with FW version below 2.5.0
+                    devInfo.CoreVersion = FallbackCoreVersion(devInfo.Version, devInfo.Board);
+                    // if no guess is possible, set CoreVersion to Version
+                    // this reflectes all standard boards with FW version below 2.5.0
                     if (String.IsNullOrEmpty(devInfo.CoreVersion))
                     {
                         devInfo.CoreVersion = devInfo.Version;
@@ -948,15 +945,6 @@ namespace MobiFlight
             // where there was no firmware installed.
             devInfo.Board = BoardDefinitions.GetBoardByMobiFlightType(devInfo.Type) ?? Board;
             Board = devInfo.Board;
-
-            // With the support of Custom Devices
-            // we also introduced CoreVersion
-            // if a CoreVersion was not provided 
-            // we determine a fallback version
-            if (String.IsNullOrEmpty(CoreVersion))
-            {
-                CoreVersion = FallbackCoreVersion(Version, Board);
-            }
 
             Log.Instance.log($"Retrieved board: {Type}, {Name}, {Version}/{CoreVersion}, {Serial}.", LogSeverity.Debug);
             return devInfo;

--- a/MobiFlight/MobiFlightModuleInfo.cs
+++ b/MobiFlight/MobiFlightModuleInfo.cs
@@ -5,6 +5,7 @@ namespace MobiFlight
     public class MobiFlightModuleInfo : IModuleInfo
     {
         String _version = null;
+        String _coreversion = null;
         public String Type { get; set; }
         public String Serial { get; set; }
         public String Port { get; set; }
@@ -16,6 +17,13 @@ namespace MobiFlight
         {
             get { return _version; }
             set { _version = value; }
+        }
+ 
+        public String CoreVersion
+        {
+            get { return _coreversion; }
+            set { _coreversion = value; 
+            }
         }
 
         public bool HasMfFirmware()


### PR DESCRIPTION
With the introduction of community devices a CoreVersion was added where the actual FW is based on. This CoreVersion must be used to check the FW capabilities and not the releasd version of the FW.

1. Check FW capabiliteies against `CoreVersion` and not `Version`
2. Add `CoreVersion` to the class to remember it.
3. If no `CoreVersion` is provided and fallback check fails, set `CoreVersion` to `Version`. This reflects all standard FW below 2.5.0 whithout `CoreVersion`. In this case they are always the same.

Remark: I am not sure if `FallbackCoreVersion(string version, Board board)` is really required with this change. 
1. Partner Boards are based on FW versions > 2.5.0 and report a `CoreVersion` which is used -> OK
2. Partner Boards have a FW version > 2.5.0 and do not provide a `CoreVersion`, then `CoreVersion` is set to `Version` -> OK
3. Partner Boards have a FW version <= 2.5.0 and do not provide a `CoreVersion` **but** they are based on `CoreVersion` > 2.5.0. In this case it will fail, but as far as I know that is never the case.