### PR TITLE
Don't crash when keys pressed in empty views

### DIFF
--- a/UI/Panels/InputConfigPanel.cs
+++ b/UI/Panels/InputConfigPanel.cs
@@ -327,7 +327,8 @@ namespace MobiFlight.UI.Panels
             {
 
                 // handle clicks on header cells or row-header cells
-                if (dgv.CurrentRow.Index < 0 || dgv.CurrentCell.ColumnIndex < 0) return;
+                // Issue 1863: Check for null (nothing in the grid) so there's no crash
+                if (dgv.CurrentRow == null || dgv.CurrentRow.Index < 0 || dgv.CurrentCell.ColumnIndex < 0) return;
 
                 dgv.CurrentCell = dgv[cellIndex, dgv.CurrentRow.Index];
 

--- a/UI/Panels/OutputConfigPanel.cs
+++ b/UI/Panels/OutputConfigPanel.cs
@@ -349,7 +349,8 @@ namespace MobiFlight.UI.Panels
             {
 
                 // handle clicks on header cells or row-header cells
-                if (dgv.CurrentRow.Index < 0 || dgv.CurrentCell.ColumnIndex < 0) return;
+                // Issue 1863: Check for null (nothing in the grid) so there's no crash
+                if (dgv.CurrentRow == null || dgv.CurrentRow.Index < 0 || dgv.CurrentCell.ColumnIndex < 0) return;
 
                 dgv.CurrentCell = dgv[cellIndex, dgv.CurrentRow.Index];
 


### PR DESCRIPTION
Fixes #1863 

Add a null check on the data grid's `CurrentRow` property before trying to access it.