### PR TITLE
Use an array of InstanceNames

### DIFF
--- a/Joysticks/honeycomb_alpha.joystick.json
+++ b/Joysticks/honeycomb_alpha.joystick.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "Alpha Flight Controls",
+  "InstanceNames": ["Alpha Flight Controls"],
   "Inputs": [
     {
       "Id": 1,

--- a/Joysticks/honeycomb_bravo.joystick.json
+++ b/Joysticks/honeycomb_bravo.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "Bravo Throttle Quadrant",
+  "InstanceNames": ["Bravo Throttle Quadrant"],
   "VendorId": "0x294B",
   "ProductId": "0x1901",
   "Inputs": [

--- a/Joysticks/mfjoystick.schema.json
+++ b/Joysticks/mfjoystick.schema.json
@@ -4,7 +4,7 @@
   "$id": "https://mobiflight.com/hid.schema.json",
   "title": "Root",
   "type": "object",
-  "required": ["InstanceName"],
+  "required": ["InstanceNames"],
   "dependentRequired": {
     "Outputs": ["VendorId", "ProductId"]
   },
@@ -13,7 +13,20 @@
       "$id": "#root/InstanceName",
       "title": "InstanceName",
       "type": "string",
-      "description": "Instance name for the device. Required. This is used to match the definition with a connected device."
+      "description": "Instance name for the device. Obsolete. Use InstanceNames instead."
+    },
+    "InstanceNames": {
+      "$id": "#root/InstanceNames",
+      "title": "InstanceNames",
+      "description": "List of instance names for the device. Required.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "$id": "#root/Inputs/items",
+        "title": "Items",
+        "type": "string",
+        "description":  "A string that identifies a specific joystick device."
+      }
     },
     "Inputs": {
       "$id": "#root/Inputs",

--- a/Joysticks/octavi.joystick.json
+++ b/Joysticks/octavi.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "Octavi",
+  "InstanceNames": ["Octavi"],
   "VendorId": "0x04D8",
   "ProductId": "0xE6D6",
   "Inputs": [

--- a/Joysticks/s_tecs_modern_throttle_max.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_max.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "S-TECS MODERN THROTTLE MAX",
+  "InstanceNames": ["S-TECS MODERN THROTTLE MAX"],
   "VendorId": "0x231D",
   "ProductId": "0x012E",
   "Inputs": [

--- a/Joysticks/s_tecs_modern_throttle_max_stem.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_max_stem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "S-TECS MODERN THROTTLE MAX STEM",
+  "InstanceNames": ["S-TECS MODERN THROTTLE MAX STEM"],
   "VendorId": "0x231D",
   "ProductId": "0x012E",
   "Inputs": [

--- a/Joysticks/s_tecs_modern_throttle_max_stem_fsm_ga.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_max_stem_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "S-TECS MODERN THROTTLE MAX STEM FSM.GA",
+  "InstanceNames": ["S-TECS MODERN THROTTLE MAX STEM FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x012E",
   "Inputs": [

--- a/Joysticks/s_tecs_modern_throttle_mini.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_mini.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "S-TECS MODERN THROTTLE MINI",
+  "InstanceNames": ["S-TECS MODERN THROTTLE MINI"],
   "VendorId": "0x231D",
   "ProductId": "0x012B",
   "Inputs": [

--- a/Joysticks/s_tecs_modern_throttle_mini_plus.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_mini_plus.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "S-TECS MODERN THROTTLE MINI PLUS",
+  "InstanceNames": ["S-TECS MODERN THROTTLE MINI PLUS"],
   "VendorId": "0x231D",
   "ProductId": "0x012C",
   "Inputs": [

--- a/Joysticks/s_tecs_modern_throttle_standard.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_standard.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "S-TECS MODERN THROTTLE STANDARD",
+  "InstanceNames": ["S-TECS MODERN THROTTLE STANDARD"],
   "VendorId": "0x231D",
   "ProductId": "0x012D",
   "Inputs": [

--- a/Joysticks/s_tecs_modern_throttle_standard_stem.joystick.json
+++ b/Joysticks/s_tecs_modern_throttle_standard_stem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "S-TECS MODERN THROTTLE STANDARD STEM",
+  "InstanceNames": ["S-TECS MODERN THROTTLE STANDARD STEM"],
   "VendorId": "0x231D",
   "ProductId": "0x012D",
   "Inputs": [

--- a/Joysticks/saitek_aviator_stick.joystick.json
+++ b/Joysticks/saitek_aviator_stick.joystick.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "Saitek Aviator Stick",
+  "InstanceNames": ["Saitek Aviator Stick"],
   "VendorId": 1699,
   "ProductId": 1121,
   "Inputs": [

--- a/Joysticks/t.a320_pilot.joystick.json
+++ b/Joysticks/t.a320_pilot.joystick.json
@@ -1,6 +1,6 @@
 ﻿{
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "T.A320 Pilot",
+  "InstanceNames": ["T.A320 Pilot"],
   "VendorId":  "0x044F",
   "ProductId": "0x0405",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_f14.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_f14.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO F14",
+  "InstanceNames": ["VKBsim Gladiator EVO F14"],
   "VendorId": "0x231D",
   "ProductId": "0x0A00",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_kg12.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_kg12.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO KG12",
+  "InstanceNames": ["VKBsim Gladiator EVO KG12"],
   "VendorId": "0x231D",
   "ProductId": "0x0600",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_l.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_l.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO L",
+  "InstanceNames": ["VKBsim Gladiator EVO L"],
   "VendorId": "0x231D",
   "ProductId": "0x0201",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_l_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_l_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO L SEM",
+  "InstanceNames": ["VKBsim Gladiator EVO L SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x0205",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_ot_l.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_ot_l.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO OT L",
+  "InstanceNames": ["VKBsim Gladiator EVO OT L"],
   "VendorId": "0x231D",
   "ProductId": "0x3201",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_ot_l_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_ot_l_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO OT L SEM",
+  "InstanceNames": ["VKBsim Gladiator EVO OT L SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x3205",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_ot_r.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_ot_r.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO OT R",
+  "InstanceNames": ["VKBsim Gladiator EVO OT R"],
   "VendorId": "0x231D",
   "ProductId": "0x3200",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_ot_r_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_ot_r_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO OT R SEM",
+  "InstanceNames": ["VKBsim Gladiator EVO OT R SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x3204",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_r.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO R",
+  "InstanceNames": ["VKBsim Gladiator EVO R"],
   "VendorId": "0x231D",
   "ProductId": "0x0200",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_r_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO R FSM.GA",
+  "InstanceNames": ["VKBsim Gladiator EVO R FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x0220",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_r_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO R SEM",
+  "InstanceNames": ["VKBsim Gladiator EVO R SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x0204",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_r_sem_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_sem_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO R SEM FSM.GA",
+  "InstanceNames": ["VKBsim Gladiator EVO R SEM FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x0224",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_r_sem_thq.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_sem_thq.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO R SEM THQ",
+  "InstanceNames": ["VKBsim Gladiator EVO R SEM THQ"],
   "VendorId": "0x231D",
   "ProductId": "0x0214",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_r_sem_thqx2.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_sem_thqx2.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO R SEM THQx2",
+  "InstanceNames": ["VKBsim Gladiator EVO R SEM THQx2"],
   "VendorId": "0x231D",
   "ProductId": "0x0224",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_r_thq.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_thq.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO R THQ",
+  "InstanceNames": ["VKBsim Gladiator EVO R THQ"],
   "VendorId": "0x231D",
   "ProductId": "0x0210",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_evo_r_thqx2.joystick.json
+++ b/Joysticks/vkbsim_gladiator_evo_r_thqx2.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator EVO R THQx2",
+  "InstanceNames": ["VKBsim Gladiator EVO R THQx2"],
   "VendorId": "0x231D",
   "ProductId": "0x0220",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_f14.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_f14.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT F14",
+  "InstanceNames": ["VKBsim Gladiator NXT F14"],
   "VendorId": "0x231D",
   "ProductId": "0x0A00",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_kg12.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_kg12.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT KG12",
+  "InstanceNames": ["VKBsim Gladiator NXT KG12"],
   "VendorId": "0x231D",
   "ProductId": "0x0600",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_l.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_l.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT L",
+  "InstanceNames": ["VKBsim Gladiator NXT L"],
   "VendorId": "0x231D",
   "ProductId": "0x0201",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_l_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_l_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT L SEM",
+  "InstanceNames": ["VKBsim Gladiator NXT L SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x0205",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_ot_l.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_ot_l.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT OT L",
+  "InstanceNames": ["VKBsim Gladiator NXT OT L"],
   "VendorId": "0x231D",
   "ProductId": "0x3201",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_ot_l_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_ot_l_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT OT L SEM",
+  "InstanceNames": ["VKBsim Gladiator NXT OT L SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x3205",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_ot_r.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_ot_r.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT OT R",
+  "InstanceNames": ["VKBsim Gladiator NXT OT R"],
   "VendorId": "0x231D",
   "ProductId": "0x3200",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_ot_r_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_ot_r_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT OT R SEM",
+  "InstanceNames": ["VKBsim Gladiator NXT OT R SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x3204",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_r.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT R",
+  "InstanceNames": ["VKBsim Gladiator NXT R"],
   "VendorId": "0x231D",
   "ProductId": "0x0200",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_r_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT R FSM.GA",
+  "InstanceNames": ["VKBsim Gladiator NXT R FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x0220",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_r_sem.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT R SEM",
+  "InstanceNames": ["VKBsim Gladiator NXT R SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x0204",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_r_sem_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_sem_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT R SEM FSM.GA",
+  "InstanceNames": ["VKBsim Gladiator NXT R SEM FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x0224",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_r_sem_thq.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_sem_thq.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT R SEM THQ",
+  "InstanceNames": ["VKBsim Gladiator NXT R SEM THQ"],
   "VendorId": "0x231D",
   "ProductId": "0x0214",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_r_sem_thqx2.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_sem_thqx2.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT R SEM THQx2",
+  "InstanceNames": ["VKBsim Gladiator NXT R SEM THQx2"],
   "VendorId": "0x231D",
   "ProductId": "0x0224",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_r_thq.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_thq.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT R THQ",
+  "InstanceNames": ["VKBsim Gladiator NXT R THQ"],
   "VendorId": "0x231D",
   "ProductId": "0x0210",
   "Inputs": [

--- a/Joysticks/vkbsim_gladiator_nxt_r_thqx2.joystick.json
+++ b/Joysticks/vkbsim_gladiator_nxt_r_thqx2.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBsim Gladiator NXT R THQx2",
+  "InstanceNames": ["VKBsim Gladiator NXT R THQx2"],
   "VendorId": "0x231D",
   "ProductId": "0x0220",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_nxt_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT FSM.GA",
+  "InstanceNames": ["VKBSim NXT FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x2220",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_sem.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT SEM",
+  "InstanceNames": ["VKBSim NXT SEM"],
   "VendorId": "0x231D",
   "ProductId": "0x2204",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_sem_thq.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem_thq.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT SEM THQ",
+  "InstanceNames": ["VKBSim NXT SEM THQ"],
   "VendorId": "0x231D",
   "ProductId": "0x2214",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_sem_thqx2.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem_thqx2.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT SEM THQx2",
+  "InstanceNames": ["VKBSim NXT SEM THQx2"],
   "VendorId": "0x231D",
   "ProductId": "0x2224",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_sem_thqx2_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem_thqx2_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT SEM THQx2 FSM.GA",
+  "InstanceNames": ["VKBSim NXT SEM THQx2 FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x2224",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_sem_thqx3.joystick.json
+++ b/Joysticks/vkbsim_nxt_sem_thqx3.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT SEM THQx3",
+  "InstanceNames": ["VKBSim NXT SEM THQx3"],
   "VendorId": "0x231D",
   "ProductId": "0x2234",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_thq.joystick.json
+++ b/Joysticks/vkbsim_nxt_thq.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT THQ",
+  "InstanceNames": ["VKBSim NXT THQ"],
   "VendorId": "0x231D",
   "ProductId": "0x2210",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_thqx2_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_nxt_thqx2_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT THQx2 FSM.GA",
+  "InstanceNames": ["VKBSim NXT THQx2 FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x2220",
   "Inputs": [

--- a/Joysticks/vkbsim_nxt_thqx3_fsm_ga.joystick.json
+++ b/Joysticks/vkbsim_nxt_thqx3_fsm_ga.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "VKBSim NXT THQx3 FSM.GA",
+  "InstanceNames": ["VKBSim NXT THQx3 FSM.GA"],
   "VendorId": "0x231D",
   "ProductId": "0x2230",
   "Inputs": [

--- a/Joysticks/winwing_fcu.joystick.json
+++ b/Joysticks/winwing_fcu.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceNames": ["WINWING FCU"],
+  "InstanceNames": [ "WINWING FCU", "WINWING FCU-320" ],
   "VendorId": "0x4098",
   "ProductId": "0xBB10",
   "Inputs": [

--- a/Joysticks/winwing_fcu.joystick.json
+++ b/Joysticks/winwing_fcu.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "WINWING FCU",
+  "InstanceNames": ["WINWING FCU"],
   "VendorId": "0x4098",
   "ProductId": "0xBB10",
   "Inputs": [

--- a/Joysticks/winwing_fcu_efisl.joystick.json
+++ b/Joysticks/winwing_fcu_efisl.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "WINWING FCU-320 + EFIS-320L",
+  "InstanceNames": ["WINWING FCU-320 + EFIS-320L"],
   "VendorId": "0x4098",
   "ProductId": "0xBC1D",
   "Inputs": [

--- a/Joysticks/winwing_fcu_efisl_efisr.joystick.json
+++ b/Joysticks/winwing_fcu_efisl_efisr.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "WINWING FCU-320 + EFIS-320L + EFIS-320R",
+  "InstanceNames": ["WINWING FCU-320 + EFIS-320L + EFIS-320R"],
   "VendorId": "0x4098",
   "ProductId": "0xBA01",
   "Inputs": [

--- a/Joysticks/winwing_fcu_efisr.joystick.json
+++ b/Joysticks/winwing_fcu_efisr.joystick.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./mfjoystick.schema.json",
-  "InstanceName": "WINWING FCU-320 + EFIS-320R",
+  "InstanceNames": ["WINWING FCU-320 + EFIS-320R"],
   "VendorId": "0x4098",
   "ProductId": "0xBC1E",
   "Inputs": [

--- a/MobiFlight/Joysticks/JoystickDefinition.cs
+++ b/MobiFlight/Joysticks/JoystickDefinition.cs
@@ -114,5 +114,10 @@ namespace MobiFlight
             }
 #pragma warning restore CS0618 // Type or member is obsolete
         }
+
+        public override string ToString()
+        {
+            return String.Join(", ", this.InstanceNames);
+        }
     }
 }

--- a/MobiFlight/Joysticks/JoystickDefinition.cs
+++ b/MobiFlight/Joysticks/JoystickDefinition.cs
@@ -68,6 +68,11 @@ namespace MobiFlight
         public string InstanceName;
 
         /// <summary>
+        /// Instance names for the device. This is used to match the definition with a connected device.
+        /// </summary>
+        public List<string> InstanceNames = new List<string>();
+
+        /// <summary>
         /// List of options supported by the device.
         /// </summary>
         public List<JoystickOutput> Outputs;
@@ -98,6 +103,13 @@ namespace MobiFlight
         /// <summary>
         /// Migrates values from a prior version of the JSON schema to the newest version.
         /// </summary>
-        public void Migrate() { }
+        public void Migrate() {
+
+            // Migrate a single InstanceName to a list of InstanceNames
+            if (this.InstanceName != null)
+            {
+                this.InstanceNames.Add(this.InstanceName);
+            }
+        }
     }
 }

--- a/MobiFlight/Joysticks/JoystickDefinition.cs
+++ b/MobiFlight/Joysticks/JoystickDefinition.cs
@@ -65,6 +65,7 @@ namespace MobiFlight
         /// <summary>
         /// Instance name for the device. This is used to match the definition with a connected device.
         /// </summary>
+        [Obsolete("Use InstanceNames list property instead.")]
         public string InstanceName;
 
         /// <summary>
@@ -106,10 +107,12 @@ namespace MobiFlight
         public void Migrate() {
 
             // Migrate a single InstanceName to a list of InstanceNames
+#pragma warning disable CS0618 // Type or member is obsolete
             if (this.InstanceName != null)
             {
                 this.InstanceNames.Add(this.InstanceName);
             }
+#pragma warning restore CS0618 // Type or member is obsolete
         }
     }
 }

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -71,7 +71,7 @@ namespace MobiFlight
         public void LoadDefinitions()
         {
             Definitions = JsonBackedObject.LoadDefinitions<JoystickDefinition>(Directory.GetFiles("Joysticks", "*.joystick.json"), "Joysticks/mfjoystick.schema.json",
-                onSuccess: (joystick, definitionFile) => Log.Instance.log($"Loaded joystick definition for {joystick.InstanceName}", LogSeverity.Info),
+                onSuccess: (joystick, definitionFile) => Log.Instance.log($"Loaded joystick definition for {String.Join(", ", joystick.InstanceNames)}", LogSeverity.Info),
                 onError: () => LoadingError = true
             );
         }

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -51,7 +51,7 @@ namespace MobiFlight
         /// <returns>The first definition matching the instanceMae, or null if none found.</returns>
         private JoystickDefinition GetDefinitionByInstanceName(String instanceName)
         {
-            return Definitions.Find(definition => definition.InstanceName == instanceName);
+            return Definitions.Find(definition => definition.InstanceNames.Contains(instanceName));
         }
 
         /// <summary>

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -71,7 +71,7 @@ namespace MobiFlight
         public void LoadDefinitions()
         {
             Definitions = JsonBackedObject.LoadDefinitions<JoystickDefinition>(Directory.GetFiles("Joysticks", "*.joystick.json"), "Joysticks/mfjoystick.schema.json",
-                onSuccess: (joystick, definitionFile) => Log.Instance.log($"Loaded joystick definition for {String.Join(", ", joystick.InstanceNames)}", LogSeverity.Info),
+                onSuccess: (joystick, definitionFile) => Log.Instance.log($"Loaded joystick definition for {joystick}", LogSeverity.Info),
                 onError: () => LoadingError = true
             );
         }


### PR DESCRIPTION
Draft PR of a change to use an array of `InstanceNames` to identify joysticks instead of a single `InstanceName`, based on a report in Discord: https://discord.com/channels/608690978081210392/1313961757672472687