### PR TITLE
Tweak the logic for successful WASM install

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2213,8 +2213,8 @@ namespace MobiFlight.UI
             WasmModuleUpdater updater = new WasmModuleUpdater();
             bool Is2020Different = false;
             bool Is2024Different = false;
-            bool Update2020Successful = false;
-            bool Update2024Successful = false;
+            bool Update2020Successful = true;
+            bool Update2024Successful = true;
 
             try
             {
@@ -2231,16 +2231,6 @@ namespace MobiFlight.UI
                 Is2020Different = updater.WasmModulesAreDifferent(updater.CommunityFolder);
                 Is2024Different = updater.WasmModulesAreDifferent(updater.CommunityFolder2024);
 
-                // If neither are different then just tell the user and return, doing nothing.
-                if (!Is2020Different && !Is2024Different)
-                {
-                    TimeoutMessageDialog.Show(
-                       i18n._tr("uiMessageWasmUpdateAlreadyInstalled"),
-                       i18n._tr("uiMessageWasmUpdater"),
-                       MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    return;
-                }
-
                 // Issue 1872: If the sim is running warn the user then bail
                 if (IsMSFSRunning)
                 {
@@ -2251,9 +2241,25 @@ namespace MobiFlight.UI
                     return;
                 }
 
-                // Install for both versions
-                Update2020Successful = HandleWasmInstall(updater, Is2020Different, updater.CommunityFolder, "2020");
-                Update2024Successful = HandleWasmInstall(updater, Is2024Different, updater.CommunityFolder2024, "2024");
+                if (Is2020Different)
+                {
+                    Update2020Successful = HandleWasmInstall(updater, Is2020Different, updater.CommunityFolder, "2020");
+                }
+
+                if (Is2024Different)
+                {
+                    Update2024Successful = HandleWasmInstall(updater, Is2024Different, updater.CommunityFolder2024, "2024");
+                }
+
+                // If neither are different then just tell the user and return, doing nothing.
+                if (!Is2020Different && !Is2024Different)
+                {
+                    TimeoutMessageDialog.Show(
+                       i18n._tr("uiMessageWasmUpdateAlreadyInstalled"),
+                       i18n._tr("uiMessageWasmUpdater"),
+                       MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return;
+                }
 
                 // If either update is successful then show the success dialog.
                 if (Update2020Successful || Update2024Successful)


### PR DESCRIPTION
Fixes #1902 

The core problem is the test for a successful install was this:

```C#
                if (Update2020Successful || Update2024Successful)
```

However, `HandleWasmInstall()` returns false if there was nothing to do (because the correct version is already installed). So users with an up-to-date 2020 install, and no 2024 install, would wind up with `false` as the return from each of the `HandleWasmInstall()` calls. That skips the success message and falls through to an error.

The fix is to:

1. Default `Update2020Successful` and `Update2024Successful` to `true`
2. Only call `HandleWasmInstall()` if the modules are "different" (which also includes non-existent)

At least I think this fixes it. I tested by hand-hacking the path to the MSFS2024 community folder to be non-existent (to simulate 2024 not being installed) and it works.

There is an edge case, where if 2020 and 2024 are *both* not installed the user will still get a success message.