### PR TITLE
Don't throw error on WASM install when MSFS2024 isn't installed

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2253,12 +2253,12 @@ namespace MobiFlight.UI
 
                 if (Is2020Different)
                 {
-                    Update2020Successful = HandleWasmInstall(updater, Is2020Different, updater.CommunityFolder, "2020");
+                    Update2020Successful = HandleWasmInstall(updater, updater.CommunityFolder, "2020");
                 }
 
                 if (Is2024Different)
                 {
-                    Update2024Successful = HandleWasmInstall(updater, Is2024Different, updater.CommunityFolder2024, "2024");
+                    Update2024Successful = HandleWasmInstall(updater, updater.CommunityFolder2024, "2024");
                 }
 
                 // If either update is successful then show the success dialog.
@@ -2287,22 +2287,15 @@ namespace MobiFlight.UI
         /// Handles all the necessary and log messages for installing the WASM with different versions of MSFS.
         /// </summary>
         /// <param name="updater">The WASM updater to use</param>
-        /// <param name="isDifferent">True if the versions of WASM were different</param>
         /// <param name="communityFolder">The path to the community folder</param>
         /// <param name="msfsVersion">The version of MSFS, either "2020" or "2024"</param>
         /// <returns></returns>
-        private static bool HandleWasmInstall(WasmModuleUpdater updater, bool isDifferent, string communityFolder, string msfsVersion)
+        private static bool HandleWasmInstall(WasmModuleUpdater updater,string communityFolder, string msfsVersion)
         {
             if (String.IsNullOrEmpty(communityFolder))
             {
                 Log.Instance.log($"Skipping WASM install for MSFS{msfsVersion} since no community folder was found. This likely means MSFS{msfsVersion} is not installed.", LogSeverity.Info);
-                return false;
-            }
-
-            if (!isDifferent)
-            {
-                Log.Instance.log($"WASM module for MSFS{msfsVersion} is already up-to-date.", LogSeverity.Info);
-                return false;
+                return true;
             }
 
             bool result = updater.InstallWasmModule(communityFolder);


### PR DESCRIPTION
Fixes #1916 

* Return `true` if the community folder isn't found instead of `false`
* Get rid of unnecessary parameter since the check happens elsewhere
* Make sure logs happen when one, but not both, are skipped due to up-to-date