### PR TITLE
Fix: Display encoder pins correctly

### DIFF
--- a/UI/Panels/Device/MFEncoderPanel.cs
+++ b/UI/Panels/Device/MFEncoderPanel.cs
@@ -87,6 +87,7 @@ namespace MobiFlight.UI.Panels.Settings.Device
         {
             (encoder.PinLeft, encoder.PinRight) = (encoder.PinRight, encoder.PinLeft);
             UpdateFreePinsInDropDowns();
+            value_Changed(null, new EventArgs());
         }
     }
 }


### PR DESCRIPTION
The pins for encoders are displayed correctly again:
![image](https://github.com/user-attachments/assets/7e283bb4-069c-4855-8fe0-604b5c824bce)

fixes #1919 
related #1768