### PR TITLE
Prevent crash when UserCfg.opt can't be opened

### DIFF
--- a/SimConnectMSFS/WasmModuleUpdater.cs
+++ b/SimConnectMSFS/WasmModuleUpdater.cs
@@ -49,7 +49,16 @@ namespace MobiFlight.SimConnectMSFS
             string CommunityFolder = null;
             string line;
             string InstalledPackagesPath = "";
-            StreamReader file = new StreamReader(UserCfg);
+            StreamReader file;
+
+            try
+            {
+                file = new StreamReader(UserCfg);
+            }
+            catch (Exception ex) {
+                Log.Instance.log($"Unable to open UserCfg.opt at {UserCfg}: {ex.Message}", LogSeverity.Error);
+                return CommunityFolder;
+            }
 
             while ((line = file.ReadLine()) != null)
             {
@@ -64,7 +73,7 @@ namespace MobiFlight.SimConnectMSFS
 
             InstalledPackagesPath = InstalledPackagesPath.Substring(23);
             char[] charsToTrim = { '"' };
-            
+
             InstalledPackagesPath = InstalledPackagesPath.TrimEnd(charsToTrim);
 
             string targetPath = Path.Combine(Path.Combine(InstalledPackagesPath, @"Community"));


### PR DESCRIPTION
Fixes #1921 

* Add try/catch block
* Log the exception
* Return null so things will carry on as usual