### PR TITLE
added thrustmaster airbus stick right sidestick mode button names

### DIFF
--- a/Joysticks/t.a320_copilot.joystick.json
+++ b/Joysticks/t.a320_copilot.joystick.json
@@ -1,0 +1,114 @@
+﻿{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "T.A320 Copilot",
+  "VendorId":  "0x044F",
+  "ProductId": "0x0406",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type":  "Button",
+      "Label": "Button 1 - Trigger"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "Button 2 - Upper trigger"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "Button 3 - Handle left"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "Button 4 - Handle right"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "Button 5 - Left front 1"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "Button 6 - Left front 2"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "Button 7 - Left front 3"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "Button 10 - Left back 1"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "Button 9 - Left back 2"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "Button 8 - Left back 3"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "Button 11 - Right front 3"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "Button 12 - Right front 2"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "Button 13 - Right  front 1"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "Button 14 - Right back 1"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "Button 15 - Right back 2"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Button 16 - Right back 3"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "Button 17 - Slider switch"
+    },
+    {
+      "Id": 48,
+      "Type": "Axis",
+      "Label": "Axis - Roll"
+    },
+    {
+      "Id": 49,
+      "Type": "Axis",
+      "Label": "Axis - Pitch"
+    },
+    {
+      "Id": 53,
+      "Type": "Axis",
+      "Label": "Axis - Grip twist"
+    },
+    {
+      "Id": 54,
+      "Type": "Axis",
+      "Label": "Axis - Slider"
+    }
+  ],
+  "Outputs": []
+}

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -1104,6 +1104,9 @@
     <None Include="Joysticks\s_tecs_modern_throttle_standard_stem.joystick.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Joysticks\t.a320_copilot.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Joysticks\vkbsim_gladiator_evo_f14.joystick.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
It's the same joystick unit, but when you flip a switch under the stick, the USB product id changes (needs to be unplugged and plugged back in) - and the firmware also mirrors the button numbers horizontally.

Added json to reflect this.