### PR TITLE
Ensure MIDI devices show in connected devices dropdown

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -148,22 +148,30 @@ namespace MobiFlight
                 joystickManager.Startup();
                 OnJoystickConnectedFinished?.Invoke(sender, e);
             };            
-            if (Properties.Settings.Default.EnableJoystickSupport)
-            {
-                joystickManager.Connect();
-            }
 
             midiBoardManager.OnButtonPressed += new ButtonEventHandler(mobiFlightCache_OnButtonPressed);
             midiBoardManager.Connected += (sender, e) => { 
                 midiBoardManager.Startup(); 
                 OnMidiBoardConnectedFinished?.Invoke(sender, e);
             };
+
+            mobiFlightCache.Start();
+        }
+
+        public void StartJoystickManager()
+        {
+            if (Properties.Settings.Default.EnableJoystickSupport)
+            {
+                joystickManager.Connect();
+            }
+        }
+
+        public void StartMidiBoardManager()
+        {
             if (Properties.Settings.Default.EnableMidiSupport)
             {
                 midiBoardManager.Connect();
             }
-
-            mobiFlightCache.Start();
         }
 
         private void ModuleCache_ModuleConnected(object sender, EventArgs e)

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -216,6 +216,10 @@ namespace MobiFlight.UI
             execManager.OnJoystickConnectedFinished += ExecManager_OnJoystickConnectedFinished;
             execManager.OnMidiBoardConnectedFinished += ExecManager_OnMidiBoardConnectedFinished;
 
+            // Now that the joystick and midi handlers are configured it's ok to start them
+            execManager.StartJoystickManager();
+            execManager.StartMidiBoardManager();
+
             connectedDevicesToolStripDropDownButton.DropDownDirection = ToolStripDropDownDirection.AboveRight;
             simStatusToolStripDropDownButton1.DropDownDirection = ToolStripDropDownDirection.AboveRight;
             toolStripAircraftDropDownButton.DropDownDirection = ToolStripDropDownDirection.AboveRight;
@@ -322,7 +326,7 @@ namespace MobiFlight.UI
                     Enabled = true
                 };
                 item.Click += peripheralsToolStripMenuItemClick;
-                joysticksToolStripMenuItem.DropDownItems.Add(item);
+                MIDIDevicesToolStripMenuItem.DropDownItems.Add(item);
 
                 hasConnectedMidiBoards = false;
             }
@@ -332,7 +336,7 @@ namespace MobiFlight.UI
                 {
                     var item = new ToolStripMenuItem(device.Name);
                     item.Click += peripheralsToolStripMenuItemClick;
-                    joysticksToolStripMenuItem.DropDownItems.Add(item);
+                    MIDIDevicesToolStripMenuItem.DropDownItems.Add(item);
                 }
 
                 hasConnectedMidiBoards = true;


### PR DESCRIPTION
Fixes #1944

There were two issues:

* The event handler for MIDI device lookup finishing was getting set *after* MIDI device manager was starting. This was a race condition, and on my computer the MIDI lookup was finishing before the event handler was added so it was never called.
* The code to actually add the menu items was adding things to the joystick menu instead of the MIDI menu.

The race condition could also happen for Joysticks so I did a minor refactor to create specific start methods to kick off the Joystick and MIDI managers, and only call them after the event handlers are added.

![image](https://github.com/user-attachments/assets/64bc4f42-15b1-41c3-b131-0c2579b7eae1)
