### PR TITLE
Set Outputs via DeviceID

### DIFF
--- a/MobiFlight/FirmwareFeature.cs
+++ b/MobiFlight/FirmwareFeature.cs
@@ -6,5 +6,6 @@
         public const string SetName = "1.6.0";
         public const string LedModuleTypeTM1637 = "2.4.2";
         public const string CustomDevices = "2.4.2";
+        public const string AccessOutputByDeviceIndex = "3.0.0";
     }
 }

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -382,8 +382,8 @@ namespace MobiFlight
                             break;
                         case DeviceType.Output:
                             device.Name = GenerateUniqueDeviceName(outputs.Keys.ToArray(), device.Name);
-                            Int16 pin;
-                            if (!Int16.TryParse((device as Config.Output).Pin, out pin))
+
+                            if (!Int16.TryParse((device as Config.Output).Pin, out short pin))
                             {
                                 Log.Instance.log(
                                     $"Can't parse {Board.Info.FriendlyName} ({Port}) > [{(device as Config.Output).Name}]." +
@@ -391,12 +391,25 @@ namespace MobiFlight
                                     LogSeverity.Error);
                                 break;
                             }
-                            outputs.Add(device.Name, new MobiFlightOutput()
+                            if (HasFirmwareFeature(FirmwareFeature.AccessOutputByDeviceIndex))
                             {
-                                CmdMessenger = _cmdMessenger,
-                                Name = device.Name,
-                                Pin = pin
-                            });
+                                outputs.Add(device.Name, new MobiFlightOutputV3()
+                                {
+                                    CmdMessenger = _cmdMessenger,
+                                    Name = device.Name,
+                                    DeviceIndex = outputs.Count,
+                                    Pin = pin
+                                });
+                            }
+                            else
+                            {
+                                outputs.Add(device.Name, new MobiFlightOutput()
+                                {
+                                    CmdMessenger = _cmdMessenger,
+                                    Name = device.Name,
+                                    Pin = pin,
+                                });
+                            }
                             break;
                         case DeviceType.LcdDisplay:
                             device.Name = GenerateUniqueDeviceName(lcdDisplays.Keys.ToArray(), device.Name);

--- a/MobiFlight/MobiFlightOutput.cs
+++ b/MobiFlight/MobiFlightOutput.cs
@@ -27,23 +27,41 @@ namespace MobiFlight
 
         public CmdMessenger CmdMessenger { get; set; }
         public int Pin { get; set; }
-        
-        public MobiFlightOutput() { }
 
-        public void Set(int value)
+        public int OutputNumber { get; set; }
+
+        public virtual void Set(int value)
         {
             var command = new SendCommand((int)MobiFlightModule.Command.SetPin);
+
+            Log.Instance.log($"Command: SetPin <{(int)MobiFlightModule.Command.SetPin},{Pin},{value};>.", LogSeverity.Debug);
+
             command.AddArgument(Pin);
             command.AddArgument(value);
             // Send command
-            Log.Instance.log($"Command: SetPin <{(int)MobiFlightModule.Command.SetPin},{Pin},{value};>.", LogSeverity.Debug);
-
             CmdMessenger.SendCommand(command);
         }
 
         public void Stop()
         {
             Set(0);
+        }
+    }
+
+    public class MobiFlightOutputV3 : MobiFlightOutput
+    {
+        public int DeviceIndex { get; set; }
+
+        public override void Set(int value)
+        {
+            var command = new SendCommand((int)MobiFlightModule.Command.SetPin);
+
+            Log.Instance.log($"Command: SetPin <{(int)MobiFlightModule.Command.SetPin},{DeviceIndex},{value};>.", LogSeverity.Debug);
+
+            command.AddArgument(DeviceIndex);
+            command.AddArgument(value);
+            // Send command
+            CmdMessenger.SendCommand(command);
         }
     }
 }


### PR DESCRIPTION
This PR contains the changes from @DocMoebiuz branch [1885](https://github.com/MobiFlight/MobiFlight-Connector/tree/1885-output-uses-device-index), so it's **not** my work. An additional bugfix to show up PWM pins in the UI is added. For this the pin number also for version 3 has to be saved in the class.
PR is issued to get a compiled version of the connector for users which need to use FW version 3.0.0 (like A6/A7 for ProMicro, ...)

Changes:
Outputs will be set via the deviceID and not via the pin anymore. This harmonize how to address all devices. The required changes are already part of the FW release 3.0.0.
If the board has a FW version of 3.0.0 or higher, the setting of outputs gets overriden by a new class. The new class sends the deviceID instead of the pin number

Fixes #1885 