### PR TITLE
Make pull request build test more precise

### DIFF
--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -137,7 +137,7 @@ namespace MobiFlight
         // Returns true if the board is running a firmware build from a pull request.
         public bool IsPullRequestBuild
         {
-            get { return Version?.StartsWith("0.0.") ?? false; }
+            get { return CoreVersion?.StartsWith("0.0.") ?? false; }
         }
 
         public Config.Config Config


### PR DESCRIPTION
Fixes #1955

Change the test to `0.0.` instead of `0.` and use `CoreVersion` instead of `Version`.