### PR TITLE
Handle exception in DeviceMonitor from corrupt WMI registry

### DIFF
--- a/MobiFlight/Monitors/SerialPortMonitor.cs
+++ b/MobiFlight/Monitors/SerialPortMonitor.cs
@@ -79,88 +79,101 @@ namespace MobiFlight.Monitors
             var regex = new Regex(@"(?<id>VID_\S*)"); // Pattern to match the VID/PID of the connected devices
 
             // Code from https://stackoverflow.com/questions/45165299/wmi-get-list-of-all-serial-com-ports-including-virtual-ports
-            ManagementObjectSearcher searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_PnPEntity WHERE ClassGuid=\"{4d36e978-e325-11ce-bfc1-08002be10318}\"");
-            foreach (ManagementObject queryObj in searcher.Get().Cast<ManagementObject>())
+            try
             {
-                // At this point we have a list of possibly valid connected devices. Since everything at this point
-                // depends on the VID/PID extract that to start. USB devices seem to consistently have two hardwareID
-                // entries, in this order:
-                //
-                // USB\VID_1B4F&PID_9206&REV_0100&MI_00
-                // USB\VID_1B4F&PID_9206&MI_00
-                //
-                // Either will work with how the BoardDefinitions class and existing board definition files do regular expression
-                // lookups so just grab the first one in the array every time. Note the use of '?' to handle the (never seen)
-                // case where no hardware IDs are available.
-                var rawHardwareID = (queryObj["HardwareID"] as string[])?[0];
-
-                if (String.IsNullOrEmpty(rawHardwareID))
+                ManagementObjectSearcher searcher = new ManagementObjectSearcher("root\\CIMV2", "SELECT * FROM Win32_PnPEntity WHERE ClassGuid=\"{4d36e978-e325-11ce-bfc1-08002be10318}\"");
+                foreach (ManagementObject queryObj in searcher.Get().Cast<ManagementObject>())
                 {
-                    //Log.Instance.log($"Skipping module with no available VID/PID.", LogSeverity.Debug);
-                    continue;
+                    // At this point we have a list of possibly valid connected devices. Since everything at this point
+                    // depends on the VID/PID extract that to start. USB devices seem to consistently have two hardwareID
+                    // entries, in this order:
+                    //
+                    // USB\VID_1B4F&PID_9206&REV_0100&MI_00
+                    // USB\VID_1B4F&PID_9206&MI_00
+                    //
+                    // Either will work with how the BoardDefinitions class and existing board definition files do regular expression
+                    // lookups so just grab the first one in the array every time. Note the use of '?' to handle the (never seen)
+                    // case where no hardware IDs are available.
+                    var rawHardwareID = (queryObj["HardwareID"] as string[])?[0];
+
+                    if (String.IsNullOrEmpty(rawHardwareID))
+                    {
+                        //Log.Instance.log($"Skipping module with no available VID/PID.", LogSeverity.Debug);
+                        continue;
+                    }
+
+                    // Historically MobiFlight expects a straight VID/PID string without a leading USB\ or FTDI\ or \COMPORT so get
+                    // pick that out of the raw hardware ID.
+                    var match = regex.Match(rawHardwareID);
+                    if (!match.Success)
+                    {
+                        //Log.Instance.log($"Skipping device with no available VID/PID ({rawHardwareID}).", LogSeverity.Debug);
+                        continue;
+                    }
+
+                    // Get the matched hardware ID and use it going forward to identify the board.
+                    var hardwareId = match.Groups["id"].Value;
+
+                    //Log.Instance.log($"Checking for compatible module: {hardwareId}.", LogSeverity.Debug);
+                    var board = BoardDefinitions.GetBoardByHardwareId(hardwareId);
+
+                    // If no matching board definition is found at this point then it's an incompatible board and just keep going.
+                    if (board == null)
+                    {
+                        //Log.Instance.log($"Incompatible module skipped: {hardwareId}.", LogSeverity.Debug);
+                        continue;
+                    }
+
+                    // The board is a known type so grab the COM port for it. Every USB device seen so far has the
+                    // COM port in the full name of the device surrounded by (), for example:
+                    //
+                    // USB Serial Device (COM22)
+                    var portNameMatch = Regex.Match(queryObj["Caption"].ToString(), portNameRegEx); // Find the COM port.
+                    var portName = portNameMatch?.Value.Trim(new char[] { '(', ')' }); // Remove the surrounding ().
+
+                    if (string.IsNullOrEmpty(portName))
+                    {
+                        // Issue 1778: If someone renames the device in Device Manager and removes the COM
+                        // port from the device name then this will be blank. Log an error and continue.
+                        Log.Instance.log($"Detected {queryObj["Caption"].ToString()} but it has no COM port in its name.", LogSeverity.Error);
+                        continue;
+                    }
+
+                    // Safety check to ensure duplicate entires in the registry don't result in duplicate entires in the list.
+                    if (result.Any(p => p.Name == portName))
+                    {
+                        //Log.Instance.log($"Duplicate entry for port: {board.Info.FriendlyName} {portName}.", LogSeverity.Error);
+                        continue;
+                    }
+
+                    // If the device has a bad CH340 chip then log a warning.
+                    if (IsBadCH340(queryObj))
+                    {
+                        Log.Instance.log($"The device on port {portName} has a CH340 chip that will not work with the installed CH340 driver version. Install driver version 3.5.2019.1 or earlier, otherwise the board will not work with MobiFlight.", LogSeverity.Error);
+                    }
+
+                    result.Add(new PortDetails
+                    {
+                        Board = board,
+                        HardwareId = hardwareId,
+                        Name = portName
+                    });
+
+                    //Log.Instance.log($"Found potentially compatible module ({board.Info.FriendlyName}): {hardwareId}@{portName}.", LogSeverity.Debug);
                 }
 
-                // Historically MobiFlight expects a straight VID/PID string without a leading USB\ or FTDI\ or \COMPORT so get
-                // pick that out of the raw hardware ID.
-                var match = regex.Match(rawHardwareID);
-                if (!match.Success)
-                {
-                    //Log.Instance.log($"Skipping device with no available VID/PID ({rawHardwareID}).", LogSeverity.Debug);
-                    continue;
-                }
-
-                // Get the matched hardware ID and use it going forward to identify the board.
-                var hardwareId = match.Groups["id"].Value;
-
-                //Log.Instance.log($"Checking for compatible module: {hardwareId}.", LogSeverity.Debug);
-                var board = BoardDefinitions.GetBoardByHardwareId(hardwareId);
-
-                // If no matching board definition is found at this point then it's an incompatible board and just keep going.
-                if (board == null)
-                {
-                    //Log.Instance.log($"Incompatible module skipped: {hardwareId}.", LogSeverity.Debug);
-                    continue;
-                }
-
-                // The board is a known type so grab the COM port for it. Every USB device seen so far has the
-                // COM port in the full name of the device surrounded by (), for example:
-                //
-                // USB Serial Device (COM22)
-                var portNameMatch = Regex.Match(queryObj["Caption"].ToString(), portNameRegEx); // Find the COM port.
-                var portName = portNameMatch?.Value.Trim(new char[] { '(', ')' }); // Remove the surrounding ().
-
-                if (string.IsNullOrEmpty(portName))
-                {
-                    // Issue 1778: If someone renames the device in Device Manager and removes the COM
-                    // port from the device name then this will be blank. Log an error and continue.
-                    Log.Instance.log($"Detected {queryObj["Caption"].ToString()} but it has no COM port in its name.", LogSeverity.Error);
-                    continue;
-                }
-
-                // Safety check to ensure duplicate entires in the registry don't result in duplicate entires in the list.
-                if (result.Any(p => p.Name == portName))
-                {
-                    //Log.Instance.log($"Duplicate entry for port: {board.Info.FriendlyName} {portName}.", LogSeverity.Error);
-                    continue;
-                }
-
-                // If the device has a bad CH340 chip then log a warning.
-                if (IsBadCH340(queryObj))
-                {
-                    Log.Instance.log($"The device on port {portName} has a CH340 chip that will not work with the installed CH340 driver version. Install driver version 3.5.2019.1 or earlier, otherwise the board will not work with MobiFlight.", LogSeverity.Error);
-                }
-
-                result.Add(new PortDetails
-                {
-                    Board = board,
-                    HardwareId = hardwareId,
-                    Name = portName
-                });
-
-                //Log.Instance.log($"Found potentially compatible module ({board.Info.FriendlyName}): {hardwareId}@{portName}.", LogSeverity.Debug);
+                UpdatePorts(result);
             }
-
-            UpdatePorts(result);
+            catch (ManagementException ex)
+            {
+                // Issue #1122 and #1600: A corrupted WMI registry caused exceptions when attempting to enumerate connected devices with searcher.Get().
+                // Running "winmgmt /resetrepository" fixed it.
+                Log.Instance.log($"Unable to read connected devices. This is usually caused by a corrupted WMI registry. Run 'winmgmt /resetrepository' from an elevated command line to resolve the issue. (${ex.Message})", LogSeverity.Error);
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log($"Unable to read connected devices: ${ex.Message}", LogSeverity.Error);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #1600

Added back in the try/catch from #1122 that was lost when code was moved to monitor classes in version 10.1.