### PR TITLE
Create dependabot.yml configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"  
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "devcontainers"
+    target-branch: "mf2025/main"
+    directory: "/frontend/.devcontainer"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    target-branch: "mf2025/main"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
Provide a specific dependabot configuration file:

- [x] monitor nuget packages
- [x] monitor github actions

only for the mf2025/main branch
- [x] monitor npm packages
- [x] monitor .devcontainer