### PR TITLE
Changes in Input Configs are effective without stopping MobiFlight

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -285,6 +285,7 @@ namespace MobiFlight.UI
                     execManager.ConfigItems[index] = wizard.Config;
                     MessageExchange.Instance.Publish(new ConfigValuePartialUpdate() { ConfigItems = new List<IConfigItem>() { wizard.Config } });
                     ExecManager_OnConfigHasChanged(wizard.Config, null);
+                    execManager.OnInputConfigSettingsChanged(wizard.Config, null);
                 }
             };
         }


### PR DESCRIPTION
- [x] Added missing invocation of `execManager.OnInputConfigSettingsChanged`
- [x] ~~Unit tests~~ - it was too complicated

fixes #2024 