### PR TITLE
Precondition type "Config Item" can be used with input configs

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -15,7 +15,15 @@ using System.Windows.Forms;
 
 namespace MobiFlight
 {
-    public class ExecutionManager
+    public interface IExecutionManager
+    {
+        Dictionary<String, MobiFlightVariable> GetAvailableVariables();
+        JoystickManager GetJoystickManager();
+        MobiFlightCache getMobiFlightModuleCache();
+        MidiBoardManager GetMidiBoardManager();
+        // Add other methods and properties as needed
+    }
+    public class ExecutionManager : IExecutionManager
     {
         public event EventHandler OnConfigHasChanged;
         public event EventHandler OnExecute;
@@ -355,7 +363,7 @@ namespace MobiFlight
             OnSimAircraftPathChanged?.Invoke(sender, e);
         }
 
-        internal Dictionary<String, MobiFlightVariable> GetAvailableVariables()
+        public Dictionary<String, MobiFlightVariable> GetAvailableVariables()
         {
             Dictionary<String, MobiFlightVariable> variables = new Dictionary<string, MobiFlightVariable>();
 

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -151,6 +151,7 @@
     <Compile Include="Panels\Group\InterpolationPanelTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="HubHop\Msfs2020HubhopPresetListTests.cs" />
+    <Compile Include="UI\Dialogs\InputConfigWizardTests.cs" />
     <Compile Include="UI\Panels\Config\FsuipcConfigPanelTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/MobiFlightUnitTests/UI/Dialogs/InputConfigWizardTests.cs
+++ b/MobiFlightUnitTests/UI/Dialogs/InputConfigWizardTests.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MobiFlight.UI.Dialogs.Tests
+{
+    [TestClass()]
+    public class InputConfigWizardTests
+    {
+        [TestMethod()]
+        public void InputConfigWizardTest()
+        {
+            // Arrange
+            var executionManagerMock = new Mock<IExecutionManager>();
+            var inputConfigItem = new InputConfigItem { GUID = "test-guid" };
+            var outputConfigItems = new List<OutputConfigItem>
+            {
+                new OutputConfigItem { GUID = "output-guid-1", Name = "Output 1" },
+                new OutputConfigItem { GUID = "output-guid-2", Name = "Output 2" },
+                new OutputConfigItem { GUID = "test-guid", Name = "Ignore me, because I am the same GUID as the input config item." }
+            };
+
+            // Mock the GetAvailableVariables method
+            var availableVariables = new Dictionary<string, MobiFlightVariable>
+            {
+                { "var1", new MobiFlightVariable { Name = "Variable 1" } },
+                { "var2", new MobiFlightVariable { Name = "Variable 2" } }
+            };
+            executionManagerMock.Setup(em => em.GetAvailableVariables()).Returns(availableVariables);
+
+            // Act
+            var wizard = new InputConfigWizard(executionManagerMock.Object, 
+                inputConfigItem, 
+                null, 
+                null,
+                outputConfigItems);
+
+            // Assert
+            var expectedList = new List<ListItem>
+            {
+                new ListItem { Label = "Output 1", Value = "output-guid-1" },
+                new ListItem { Label = "Output 2", Value = "output-guid-2" }
+            };
+            Assert.IsTrue(expectedList.SequenceEqual(wizard.PreconditionPanel.Configs, new ListItemEqualityComparer()));
+
+            expectedList.Add(new ListItem { Label = outputConfigItems[2].Name, Value = outputConfigItems[2].GUID });
+
+            Assert.IsFalse(expectedList.SequenceEqual(wizard.PreconditionPanel.Configs, new ListItemEqualityComparer()));
+        }
+
+        public class ListItemEqualityComparer : IEqualityComparer<ListItem>
+        {
+            public bool Equals(ListItem x, ListItem y)
+            {
+                if (x == null || y == null) return x == y;
+                return x.Label == y.Label && x.Value == y.Value;
+            }
+
+            public int GetHashCode(ListItem obj)
+            {
+                return (obj.Label, obj.Value).GetHashCode();
+            }
+        }
+
+    }
+}

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -1,5 +1,6 @@
 ﻿using MobiFlight.Base;
 using MobiFlight.Config;
+using MobiFlight.UI.Panels.Config;
 using MobiFlight.UI.Panels.Input;
 using System;
 using System.Collections.Generic;
@@ -27,7 +28,7 @@ namespace MobiFlight.UI.Dialogs
 
         static int lastTabActive = 0;
 
-        ExecutionManager _execManager = null;
+        IExecutionManager _execManager = null;
         int displayPanelHeight = -1;
         List<UserControl> displayPanels = new List<UserControl>();
 
@@ -47,8 +48,9 @@ namespace MobiFlight.UI.Dialogs
         Dictionary<string, int> ScanForInputThreshold = new Dictionary<string, int>();
 
         bool IsShown = false;
+        public PreconditionPanel PreconditionPanel { get { return preconditionPanel; } }
 
-        public InputConfigWizard(ExecutionManager mainForm,
+        public InputConfigWizard(IExecutionManager mainForm,
                              InputConfigItem cfg,
 #if ARCAZE
                              ArcazeCache arcazeCache,
@@ -103,7 +105,7 @@ namespace MobiFlight.UI.Dialogs
             return !originalConfig.Equals(config);
         }
 
-        protected void Init(ExecutionManager mainForm, InputConfigItem cfg)
+        protected void Init(IExecutionManager mainForm, InputConfigItem cfg)
         {
             this._execManager = mainForm;
             // create a clone so that we don't edit 
@@ -170,6 +172,8 @@ namespace MobiFlight.UI.Dialogs
         /// <param name="arcazeCache"></param>
         public void initWithArcazeCache(ArcazeCache arcazeCache)
         {
+            if (arcazeCache == null) return;
+
             List<ListItem> PreconditionModuleList = new List<ListItem>();
 
             inputModuleNameComboBox.Items.Clear();


### PR DESCRIPTION
- [x] precondition type is working for input configs correctly
- [x] unit tests

fixes #2025 