### PR TITLE
Fix crash with MSFS2024 SU2

### DIFF
--- a/SimConnectMSFS/WasmModuleUpdater.cs
+++ b/SimConnectMSFS/WasmModuleUpdater.cs
@@ -65,6 +65,7 @@ namespace MobiFlight.SimConnectMSFS
                 if (line.Contains("InstalledPackagesPath "))
                 {
                     InstalledPackagesPath = line;
+                    break;
                 }
             }
 


### PR DESCRIPTION
Fixes #2060 

It looks like MSFS2024 SU2 adds a new property to the UserCfg.opt file: `InstalledPackagesPathNextBoot`. Unfortunately, this causes a crash when we try and build the path to the community folder, since we are doing a substring search for `InstalledPackagesPath`, and we wind up including `NextBoot` as part of the path we're building.

Fix by searching for the string with a space after it, and also breaking out of the loop after it is found.