### PR TITLE
fix: unhandled exeption for python version check

### DIFF
--- a/MobiFlight/Scripts/ScriptRunner.cs
+++ b/MobiFlight/Scripts/ScriptRunner.cs
@@ -155,18 +155,23 @@ namespace MobiFlight.Scripts
                 {
                     string output = reader.ReadToEnd();
                     var x = output.Split(' ');
-                    var v = x[1].Split('.');
-                    Log.Instance.log($"Python version: {x[1]}.", LogSeverity.Info); 
-                    if ( (int.Parse(v[0]) >= 3) && (int.Parse(v[1]) >= 10))
+                    if (x.Length > 1)
                     {
-                        return true;
+                        var v = x[1].Split('.');
+                        Log.Instance.log($"Python version: {x[1]}.", LogSeverity.Info);
+
+                        if (v.Length >= 2 && int.TryParse(v[0], out int major) && int.TryParse(v[1], out int minor))
+                        {
+                            if (major >= 3 && minor >= 10)
+                            {
+                                return true;
+                            }
+                        }
                     }
-                    else
-                    {
-                        return false;
-                    }
+                    Log.Instance.log($"Failed to parse Python version : '{output}'.", LogSeverity.Warn);
                 }
             }
+            return false;
         }
 
         private bool IsPythonPathSet()


### PR DESCRIPTION
I got an error like this when I tried to load a profile that requires python script in version 10.5.2.5.
It turns out in my PC there are two Python version, one created by Microsoft Store.
```
C:\Users\XXX>where python
C:\Users\XXX\AppData\Local\Microsoft\WindowsApps\python.exe
C:\Users\XXX\AppData\Local\Programs\Python\Python313\python.exe
```
The store `python.exe` took place of my installed one and when you run `python` it gets executed but returns nothing (from cmd it will pop up store window to ask you for installation). I fixed it by changing the order in envar.

This change just improves the check such that if it cannot parse anyhow will return false as no version is still not satisfied with the minimal version :), instead of an unhandled exception.

![image](https://github.com/user-attachments/assets/7b01169d-70ad-4f34-ae0b-586d7e44dc51)