### PR TITLE
Exclude dependabot PRs from Release Notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,6 +2,7 @@ changelog:
   exclude:
     labels:
       - ignore-for-release-notes
+      - dependencies
   categories:
     - title: New Feature 🎉
       labels:


### PR DESCRIPTION
Exclude dependabot dependency updates from PRs based on their `dependencies` label.

fixes #2100 