### PR TITLE
Make `DownloadSingleFile` more robust, fix hang at 98%

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2347,27 +2347,26 @@ namespace MobiFlight.UI
             Control MainForm = this;
 
             updater.DownloadAndInstallProgress += progressForm.OnProgressUpdated;
-            var t = new Task(() =>
-            {
-                if (!updater.AutoDetectCommunityFolder())
+            Task.Run(async () =>
                 {
-                    Log.Instance.log(i18n._tr("uiMessageWasmUpdateCommunityFolderNotFound"), LogSeverity.Error);
-                    return;
-                }
+                    if (!updater.AutoDetectCommunityFolder())
+                    {
+                        Log.Instance.log(i18n._tr("uiMessageWasmUpdateCommunityFolderNotFound"), LogSeverity.Error);
+                        return;
+                    }
 
-                if (updater.InstallWasmEvents())
-                {
-                    progressForm.DialogResult = DialogResult.OK;
+                    if (await updater.InstallWasmEvents())
+                    {
+                        progressForm.DialogResult = DialogResult.OK;
+                    }
+                    else
+                    {
+                        progressForm.DialogResult = DialogResult.No;
+                        Log.Instance.log(i18n._tr("uiMessageWasmEventsInstallationError"), LogSeverity.Error);
+                    }
                 }
-                else
-                {
-                    progressForm.DialogResult = DialogResult.No;
-                    Log.Instance.log(i18n._tr("uiMessageWasmEventsInstallationError"), LogSeverity.Error);
-                }
-            }
             );
 
-            t.Start();
             if (progressForm.ShowDialog() == DialogResult.OK)
             {
                 TimeoutMessageDialog.Show(
@@ -2394,9 +2393,10 @@ namespace MobiFlight.UI
 
             progressForm.Text = i18n._tr("uiTitleHubhopAutoUpdate");
             updater.DownloadAndInstallProgress += progressForm.OnProgressUpdated;
-            var t = new Task(() =>
+
+            Task.Run(async () =>
             {
-                if (updater.DownloadHubHopPresets())
+                if (await updater.DownloadHubHopPresets())
                 {
                     Msfs2020HubhopPresetListSingleton.Instance.Clear();
                     XplaneHubhopPresetListSingleton.Instance.Clear();
@@ -2407,10 +2407,8 @@ namespace MobiFlight.UI
                     progressForm.DialogResult = DialogResult.No;
                     Log.Instance.log(i18n._tr("uiMessageHubHopUpdateError"), LogSeverity.Error);
                 }
-            }
-            );
+            });
 
-            t.Start();
             if (progressForm.ShowDialog() == DialogResult.OK)
             {
                 TimeoutMessageDialog.Show(
@@ -2427,10 +2425,9 @@ namespace MobiFlight.UI
                     i18n._tr("uiMessageWasmEventsInstallationError"),
                     i18n._tr("uiMessageWasmUpdater"),
                     MessageBoxButtons.OK, MessageBoxIcon.Error);
-            };
+            }
 
             progressForm.Dispose();
-
         }
 
         private void downloadHubHopPresetsToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
Fixes #2003.

I ran into this issue (progress stopped at 98%) and thought I'd try fixing it. This should make the download process more robust and observable.

**Success**
![image](https://github.com/user-attachments/assets/972a84b0-8c6d-4908-9feb-a7241defed60)

**Failure (internet disconnected)**
![image](https://github.com/user-attachments/assets/214e7f43-0d58-4b8f-bed6-5bd846316dde)

**Changes**
- Uses `HttpClient` instead of `WebClient`, which is obsolete in newer versions of .NET.
- Buffers the file in memory before writing it to disk, instead of using temp files. Results in less opportunities for overzealous anti-virus software to interrupt the update process.
- Retries 3 times, with a delay between each retry, in case of transient issues with network or disk.
- Removes the explicit setting of `ServicePointManager.SecurityProtocol`. [Microsoft recommends](https://learn.microsoft.com/en-us/dotnet/framework/network-programming/tls#recommendations) not setting the TLS version explicitly unless it's unavoidable.
- Other small changes due to the virality of async/await.

Other improvements could be made in the future, like showing the actual progress of the download, but that will require some server-side changes (`Content-Length` header needs to be set).