### PR TITLE
Null reference fix for null InputAction expression in Replace method

### DIFF
--- a/MobiFlight/InputConfig/InputAction.cs
+++ b/MobiFlight/InputConfig/InputAction.cs
@@ -37,6 +37,7 @@ namespace MobiFlight.InputConfig
 
         public virtual string Replace(string expression, List<Tuple<string, string>> replacements) {
             if (replacements.Count == 0) return expression;
+            if (expression is null) return expression;
 
             foreach (Tuple<string, string> replacement in replacements)
             {


### PR DESCRIPTION
This is a pretty self-explanatory quick fix.

**Problem:**
When the expression in Replace method of the abstract class InputAction is null we run into NullReferenceError. This leads to devices not being detected correctly down the line:
![image](https://github.com/user-attachments/assets/c7ea6d73-261f-4e6d-8377-016a9e4c1d50)

**Solution:**
Detect if the expression is null. If it is, return early.