### PR TITLE
Fix minimum Python version check

### DIFF
--- a/MobiFlight/Scripts/ScriptRunner.cs
+++ b/MobiFlight/Scripts/ScriptRunner.cs
@@ -160,7 +160,7 @@ namespace MobiFlight.Scripts
                         Log.Instance.log($"Python version: {outputParts[1]}.", LogSeverity.Info);
                         if (Version.TryParse(outputParts[1], out Version version))
                         {
-                            if (version.CompareTo(new Version(3, 10, 0)) >= 0)
+                            if (version.CompareTo(new Version(3, 11, 0)) >= 0)
                             {
                                 return true;
                             }


### PR DESCRIPTION
Mobiflight requires Python 3.10. However, starting the MCDU with the FBW A320 using Python 3.10 fails:
```
ImportError: cannot import name 'StrEnum' from 'enum'
```

That import is only present in 3.11, so I'd suggest bumping the minimum version.

Docs change: https://github.com/neilenns-projects/mobiflight-docs/pull/318