### PR TITLE
Add CI check for Python scripts

### DIFF
--- a/.github/workflows/scripts.yml
+++ b/.github/workflows/scripts.yml
@@ -1,0 +1,38 @@
+name: Check Scripts
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main, mf2025/main ]
+    paths:
+      - 'Scripts/**/*.py'
+
+jobs:
+  check-scripts:
+    name: Python ${{ matrix.python-version }} Syntax Check
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.11'
+          - '3.12'
+          - '3.13'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pylint gql websockets simconnect
+
+      - name: Run linter on the Scripts folder
+        run: pylint Scripts --disable=all --enable=F,E

--- a/Scripts/Winwing/fbw_a32nx_winwing_cdu.py
+++ b/Scripts/Winwing/fbw_a32nx_winwing_cdu.py
@@ -60,7 +60,7 @@ REPLACED_CHARS = {
 
 class MobiFlightClient:
     def __init__(self, websocket_uri: str, max_retries: int = 3) -> None:
-        self.websocket: Optional[ws_client.WebSocketClientProtocol] = None
+        self.websocket: Optional[ws_client.ClientConnection] = None
         self.connected: asyncio.Event = asyncio.Event()
         self.websocket_uri: str = websocket_uri
         self.retries: int = 0

--- a/Scripts/Winwing/fenix_winwing_cdu.py
+++ b/Scripts/Winwing/fenix_winwing_cdu.py
@@ -119,7 +119,7 @@ class Mobiflight_Client:
                     # Break and stop for that CDU
                     break
                 else:
-                    logging.error(f"Error on trying to connect to MobiFlight websocket interface for {self.id}. Will retry: {ex}")    
+                    logging.error(f"Error on trying to connect to MobiFlight websocket interface for {self.id}. Will retry: {invalid}")    
             except Exception as ex:            
                 logging.error(f"Error on trying to connect to MobiFlight websocket interface for {self.id}. Will retry: {ex}")                  
                 self.websocket_connection = None                                        

--- a/Scripts/Winwing/fslabs_winwing_cdu.py
+++ b/Scripts/Winwing/fslabs_winwing_cdu.py
@@ -45,7 +45,6 @@ data_queue = asyncio.Queue()  # Thread-safe async queue for MCDU updates
 
 async def fetch_fsl_mcdu():
     """Fetch MCDU data using a persistent HTTP connection, avoiding redundant updates."""
-    global last_mcdu_data
     last_fetched_data = None
 
     conn = http.client.HTTPConnection("localhost", 8080, timeout=1)  # Persistent connection
@@ -80,8 +79,6 @@ async def fetch_fsl_mcdu():
 
 async def run_fsl_http_client():
     """Measure the time it takes to send updates to MobiFlight."""
-    global mobi_websocket_connection
-
     while True:
         mobi_json = await data_queue.get()
 

--- a/Scripts/Winwing/ifly_737_winwing_cdu.py
+++ b/Scripts/Winwing/ifly_737_winwing_cdu.py
@@ -4,7 +4,7 @@ import json
 import logging
 import asyncio
 from typing import Dict, List, Optional, Union
-from websockets.client import connect
+from websockets.asyncio.client import connect
 import mmap
 
 # WebSocket URLs

--- a/Scripts/Winwing/maddogx_winwing_cdu.py
+++ b/Scripts/Winwing/maddogx_winwing_cdu.py
@@ -97,7 +97,7 @@ MDX_CDU_1_DEFINITION: int = 802
 
 class MobiFlightClient:
     def __init__(self, websocket_uri: str, max_retries: int = 3) -> None:
-        self.websocket: Optional[ws_client.WebSocketClientProtocol] = None
+        self.websocket: Optional[ws_client.ClientConnection] = None
         self.connected: asyncio.Event = asyncio.Event()
         self.websocket_uri: str = websocket_uri
         self.retries: int = 0

--- a/Scripts/Winwing/pmdg_737_winwing_cdu.py
+++ b/Scripts/Winwing/pmdg_737_winwing_cdu.py
@@ -77,7 +77,7 @@ PMDG_CDU_1_DEFINITION: int = 0x4E473339
 
 class MobiFlightClient:
     def __init__(self, websocket_uri: str, max_retries: int = 3) -> None:
-        self.websocket: Optional[ws_client.WebSocketClientProtocol] = None
+        self.websocket: Optional[ws_client.ClientConnection] = None
         self.connected: asyncio.Event = asyncio.Event()
         self.websocket_uri: str = websocket_uri
         self.retries: int = 0

--- a/Scripts/Winwing/pmdg_777_winwing_cdu.py
+++ b/Scripts/Winwing/pmdg_777_winwing_cdu.py
@@ -81,7 +81,7 @@ PMDG_CDU_2_DEFINITION: int = 0x4E47783A
 
 class MobiFlightClient:
     def __init__(self, websocket_uri: str, max_retries: int = 3) -> None:
-        self.websocket: Optional[ws_client.WebSocketClientProtocol] = None
+        self.websocket: Optional[ws_client.ClientConnection] = None
         self.connected: asyncio.Event = asyncio.Event()
         self.websocket_uri: str = websocket_uri
         self.retries: int = 0

--- a/Scripts/Winwing/tfdi_md11_winwing_cdu.py
+++ b/Scripts/Winwing/tfdi_md11_winwing_cdu.py
@@ -78,7 +78,7 @@ class SimConnectMobiFlight(SimConnect):
 
 class MobiFlightClient:
     def __init__(self, websocket_uri: str, max_retries: int = 3) -> None:
-        self.websocket: Optional[ws_client.WebSocketClientProtocol] = None
+        self.websocket: Optional[ws_client.ClientConnection] = None
         self.connected: asyncio.Event = asyncio.Event()
         self.websocket_uri: str = websocket_uri
         self.retries: int = 0


### PR DESCRIPTION
Add CI check for Python scripts that verifies that the scripts work with supported Python versions and that there are no import issues.

Example failure when running with Python 3.10:
https://github.com/Nezz/MobiFlight-Connector/actions/runs/15087553498/job/42412022488

This revealed a couple of issues in the existing scripts that I fixed.