### PR TITLE
Winwing CDU: More robust parsing of SimConnect ClientDataArea

### DIFF
--- a/Scripts/Winwing/aerosoft_crj_winwing_cdu.py
+++ b/Scripts/Winwing/aerosoft_crj_winwing_cdu.py
@@ -58,6 +58,7 @@ CO_PILOT_CDU_URL: str = "ws://localhost:8320/winwing/cdu-co-pilot"
 CDU_COLUMNS: int = 24
 CDU_ROWS: int = 14
 CDU_CELLS: int = CDU_COLUMNS * CDU_ROWS
+CDU_CELL_BYTE_COUNT = 2
 
 # CDU Color constants
 CDU_COLOR_BLACK: int = 0
@@ -68,8 +69,6 @@ CDU_COLOR_BLUE: int = 4
 CDU_COLOR_CYAN: int = 5
 CDU_COLOR_MAGENTA: int = 6
 CDU_COLOR_YELLOW: int = 7
-
-ENTRY_BYTE_COUNT = 2
 
 # CRJ CDU Client Data Area Names and IDs
 CRJ_CDU_0_NAME: str = "ASCRJ CDU1 Data"
@@ -130,7 +129,7 @@ def create_mobi_json(data: bytes) -> str:
     for y in range(CDU_ROWS):
         for x in range(CDU_COLUMNS):
             # Convert from row-major to array index
-            src_idx = (y * CDU_COLUMNS + x) * ENTRY_BYTE_COUNT
+            src_idx = (y * CDU_COLUMNS + x) * CDU_CELL_BYTE_COUNT
             dst_idx = y * CDU_COLUMNS + x 
             
             try:
@@ -194,7 +193,7 @@ class CRJCDUClient:
                 self.sc_mobiflight.hSimConnect,
                 self.cdu_definition,
                 0, # offset to start
-                CDU_COLUMNS * CDU_ROWS * ENTRY_BYTE_COUNT, # size client data in bytes
+                CDU_COLUMNS * CDU_ROWS * CDU_CELL_BYTE_COUNT, # size client data in bytes
                 0,
                 0
             )
@@ -222,7 +221,7 @@ class CRJCDUClient:
     def handle_cdu_data(self, client_data: Any) -> None:
         try:
             if client_data.dwDefineID == self.cdu_definition and hasattr(client_data, 'dwData'):                
-                int_count : int = int(CDU_COLUMNS * CDU_ROWS * ENTRY_BYTE_COUNT / 4)              
+                int_count : int = int(CDU_COLUMNS * CDU_ROWS * CDU_CELL_BYTE_COUNT / 4)              
                 if len(client_data.dwData) >= int_count:
                     data_list : bytearray = bytearray()                  
                     for i in range(int_count): 

--- a/Scripts/Winwing/fbw_a32nx_winwing_cdu.py
+++ b/Scripts/Winwing/fbw_a32nx_winwing_cdu.py
@@ -17,7 +17,7 @@ class MfCharSize(IntEnum):
 
 class MfColour(StrEnum):
     Amber = "a"
-    Brown = "o"
+    Blue = "o"
     Cyan = "c"
     Green = "g"
     Grey = "e"

--- a/Scripts/Winwing/headwind_a33_winwing_cdu.py
+++ b/Scripts/Winwing/headwind_a33_winwing_cdu.py
@@ -17,7 +17,7 @@ class MfCharSize(IntEnum):
 
 class MfColour(StrEnum):
     Amber = "a"
-    Brown = "o"
+    Blue = "o"
     Cyan = "c"
     Green = "g"
     Grey = "e"

--- a/Scripts/Winwing/pmdg_737_winwing_cdu.py
+++ b/Scripts/Winwing/pmdg_737_winwing_cdu.py
@@ -5,6 +5,7 @@ import json
 import logging
 import asyncio
 import os
+import struct
 import websockets.asyncio.client as ws_client
 from typing import Optional, List, Dict, Union, Any
 from SimConnect import SimConnect, Enum
@@ -51,6 +52,7 @@ CO_PILOT_CDU_URL: str = "ws://localhost:8320/winwing/cdu-co-pilot"
 CDU_COLUMNS: int = 24
 CDU_ROWS: int = 14
 CDU_CELLS: int = CDU_COLUMNS * CDU_ROWS
+CDU_CELL_BYTE_COUNT: int = 3
 
 # CDU Color constants
 CDU_COLOR_WHITE: int = 0
@@ -120,7 +122,7 @@ def create_mobi_json(data: bytes) -> str:
     # Process data in column-major order as received from PMDG
     for x in range(CDU_COLUMNS):
         for y in range(CDU_ROWS):
-            src_idx: int = (x * CDU_ROWS + y) * 3
+            src_idx: int = (x * CDU_ROWS + y) * CDU_CELL_BYTE_COUNT
             dst_idx: int = y * CDU_COLUMNS + x
             
             if src_idx + 2 >= len(data):
@@ -216,15 +218,22 @@ class PMDGCDUClient:
         except Exception as e:
             logging.error(f"SimConnect setup failed for {self.cdu_name}: {e}")
             return False
+        
 
     def handle_cdu_data(self, client_data: Any) -> None:
         try:
-            if client_data.dwDefineID == self.cdu_definition and hasattr(client_data, 'dwData'):
-                data: bytes = bytes(client_data.dwData)
-                if len(data) >= CDU_COLUMNS * CDU_ROWS * 3:
+            if client_data.dwDefineID == self.cdu_definition and hasattr(client_data, 'dwData'):                
+                int_count : int = int(CDU_COLUMNS * CDU_ROWS * CDU_CELL_BYTE_COUNT / 4)              
+                if len(client_data.dwData) >= int_count:
+                    data_list : bytearray = bytearray()                  
+                    for i in range(int_count): 
+                        my_bytes : bytes = struct.pack("I", client_data.dwData[i])
+                        data_list.extend(my_bytes)                
+                    data: bytes = bytes(data_list)                                       
                     asyncio.run_coroutine_threadsafe(self.mobiflight.send(create_mobi_json(data)), self.event_loop)
         except Exception as e:
             logging.error(f"Error handling CDU data: {e}")
+        
 
     async def run(self) -> None:
         self.event_loop = asyncio.get_running_loop()

--- a/Scripts/Winwing/tfdi_md11_winwing_cdu.py
+++ b/Scripts/Winwing/tfdi_md11_winwing_cdu.py
@@ -3,6 +3,7 @@ import ctypes
 import json
 import logging
 import asyncio
+import struct
 import websockets.asyncio.client as ws_client
 from typing import Optional, List, Dict, Union, Any
 from SimConnect import SimConnect, Enum
@@ -35,7 +36,8 @@ MCDU_ROWS: int = 14
 MCDU_CHARS: int = MCDU_COLUMNS * MCDU_ROWS
 
 # Calculate MCDU_DATA_SIZE just like in the C++ code
-MCDU_DATA_SIZE: int = (ctypes.sizeof(MCDUChar) * MCDU_CHARS) + (ctypes.sizeof(c_bool) * 4)
+MCDU_CHAR_SIZE = ctypes.sizeof(MCDUChar)
+MCDU_DATA_SIZE: int = (MCDU_CHAR_SIZE * MCDU_CHARS) + (ctypes.sizeof(c_bool) * 4)
 
 # MD11 Client Data Area Names and IDs
 MD11_MCDU_NAME: str = "MD11MCDU"
@@ -132,18 +134,14 @@ def create_mobi_json(data: bytes) -> str:
     }
     
     # We know exactly how many characters we should have - it's MCDU_CHARS
-    # The data includes MCDU_CHARS number of MCDUChar structures plus 4 bools at the end
-    char_size = ctypes.sizeof(MCDUChar)
-    
+    # The data includes MCDU_CHARS number of MCDUChar structures plus 4 bools at the end    
     if len(data) < MCDU_DATA_SIZE:
         logging.error(f"Received data size {len(data)} is smaller than expected {MCDU_DATA_SIZE}")
         return json.dumps(message)
     
-
     # Now get the character array that follows the status lights
-    char_data_start = ctypes.sizeof(MCDUStatus)
-    char_size = ctypes.sizeof(MCDUChar)
-    mcdu_chars = (MCDUChar * MCDU_CHARS).from_buffer_copy(data[char_data_start:char_data_start + (MCDU_CHARS * char_size)])
+    char_data_start = ctypes.sizeof(MCDUStatus) 
+    mcdu_chars = (MCDUChar * MCDU_CHARS).from_buffer_copy(data[char_data_start:char_data_start + (MCDU_CHARS * MCDU_CHAR_SIZE)])
     
     # Process each character - note we're using row-major order here since that's how the display expects it
     for y in range(MCDU_ROWS):
@@ -221,16 +219,22 @@ class MD11CDUClient:
         except Exception as e:
             logging.error(f"SimConnect setup failed: {e}")
             return False
-
+                
     def handle_cdu_data(self, client_data: Any) -> None:
         try:
-            if client_data.dwDefineID == self.cdu_definition and hasattr(client_data, 'dwData'):
-                data: bytes = bytes(client_data.dwData)
-                # Only send if data has changed
-                if data != self.last_data:
-                    self.last_data = data
-                    json_data = create_mobi_json(data)
-                    asyncio.run_coroutine_threadsafe(self.mobiflight.send(json_data), self.event_loop)
+            if client_data.dwDefineID == self.cdu_definition and hasattr(client_data, 'dwData'):                
+                int_count : int = int(MCDU_DATA_SIZE / 4)              
+                if len(client_data.dwData) >= int_count:
+                    data_list : bytearray = bytearray()                  
+                    for i in range(int_count): 
+                        my_bytes : bytes = struct.pack("I", client_data.dwData[i])
+                        data_list.extend(my_bytes)                
+                    data: bytes = bytes(data_list) 
+                    # Only send if data has changed
+                    if data != self.last_data:
+                        self.last_data = data
+                        json_data = create_mobi_json(data)
+                        asyncio.run_coroutine_threadsafe(self.mobiflight.send(json_data), self.event_loop)                                              
         except Exception as e:
             logging.error(f"Error handling MCDU data: {e}")
 


### PR DESCRIPTION
fixes: #2178 

Improves the parsing of the ClientDataArea for:
- PMDG 737
- PMDG 777
- Maddog
- MD11

Just using `data: bytes = bytes(client_data.dwData)` led to a very sporadic fatal python error. The reported length of the dwData structure is also often longer than the length of the defined ClientDataArea. Now the number of bytes read corresponds to the defined size of the ClientDataArea.

And some minor tidying in other scripts.