### PR TITLE
Remember window size, location and zoom level

### DIFF
--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -578,13 +578,13 @@ namespace MobiFlight.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("100")]
-        public int WindowZoomLevel {
+        [global::System.Configuration.DefaultSettingValueAttribute("0")]
+        public double WindowZoomFactor {
             get {
-                return ((int)(this["WindowZoomLevel"]));
+                return ((double)(this["WindowZoomFactor"]));
             }
             set {
-                this["WindowZoomLevel"] = value;
+                this["WindowZoomFactor"] = value;
             }
         }
         

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -141,8 +141,8 @@
     <Setting Name="WindowSize" Type="System.Drawing.Size" Scope="User">
       <Value Profile="(Default)">0, 0</Value>
     </Setting>
-    <Setting Name="WindowZoomLevel" Type="System.Int32" Scope="User">
-      <Value Profile="(Default)">100</Value>
+    <Setting Name="WindowZoomFactor" Type="System.Double" Scope="User">
+      <Value Profile="(Default)">0</Value>
     </Setting>
     <Setting Name="WindowState" Type="System.Windows.Forms.FormWindowState" Scope="User">
       <Value Profile="(Default)">Normal</Value>

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -115,8 +115,8 @@ namespace MobiFlight.UI
 
             UpdateAutoLoadConfig();
             RestoreAutoLoadConfig();
-            CurrentFilenameChanged += (s, e) => { 
-                
+            CurrentFilenameChanged += (s, e) => {
+
             };
 
             // we trigger this once:
@@ -308,6 +308,8 @@ namespace MobiFlight.UI
             };
 
             RestoreWindowsPositionAndZoomLevel();
+
+            frontendPanel1.WebViewKeyUp += MainForm_KeyUp;
         }
 
         private void MainForm_Shown(object sender, EventArgs e)
@@ -680,15 +682,22 @@ namespace MobiFlight.UI
             {
                 Properties.Settings.Default.WindowLocation = this.RestoreBounds.Location;
                 Properties.Settings.Default.WindowSize = this.RestoreBounds.Size;
-            }            
+            }
 
             if (this.WindowState != FormWindowState.Minimized)
             {
                 Properties.Settings.Default.WindowState = this.WindowState;
             }
+
+            Properties.Settings.Default.WindowZoomFactor = frontendPanel1.GetZoomFactor();
         }
 
         private void RestoreWindowsPositionAndZoomLevel() {
+            if (Properties.Settings.Default.WindowZoomFactor >= 0.0)
+            {
+                frontendPanel1.SetZoomFactor(Properties.Settings.Default.WindowZoomFactor);
+            }
+
             var proposedBounds = new Rectangle(Properties.Settings.Default.WindowLocation, Properties.Settings.Default.WindowSize);
 
             if (!IsOnScreen(proposedBounds)) return;
@@ -2029,7 +2038,7 @@ namespace MobiFlight.UI
                 MessageBox.Show($"Unable to save: {ex.Message}", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
-            
+
             _storeAsRecentFile(execManager.Project.FilePath);
             ResetProjectAndConfigChanges();
         }
@@ -2202,7 +2211,7 @@ namespace MobiFlight.UI
                 fd.InitialDirectory = Path.GetDirectoryName(execManager.Project.FilePath);
                 fd.FileName = Path.GetFileNameWithoutExtension(execManager.Project.FilePath);
             }
-            
+
             fd.Filter = fileExtensionSaveFilter;
             if (DialogResult.OK == fd.ShowDialog())
             {
@@ -2324,6 +2333,11 @@ namespace MobiFlight.UI
                 e.SuppressKeyPress = true;  // Stops bing! Also sets handled which stop event bubbling
                 if (saveToolStripButton.Enabled)
                     saveToolStripButton_Click(null, null);
+            }
+
+            if (e.Control && (e.KeyCode == Keys.D0 || e.KeyCode == Keys.NumPad0))
+            {
+                frontendPanel1.SetZoomFactor(1.0f);
             }
         }
 

--- a/UI/Panels/FrontendPanel.cs
+++ b/UI/Panels/FrontendPanel.cs
@@ -8,6 +8,7 @@ namespace MobiFlight.UI.Panels
 {
     public partial class FrontendPanel : UserControl
     {
+        public event KeyEventHandler WebViewKeyUp;
         public new bool DesignMode
         {
             get
@@ -15,6 +16,8 @@ namespace MobiFlight.UI.Panels
                 return (System.Diagnostics.Process.GetCurrentProcess().ProcessName == "devenv");
             }
         }
+
+        double _desiredZoomFactor = 0.0;
 
         public FrontendPanel()
         {
@@ -46,8 +49,37 @@ namespace MobiFlight.UI.Panels
             FrontendWebView.CoreWebView2.Settings.IsStatusBarEnabled = false;
             FrontendWebView.CoreWebView2.WebMessageReceived += CoreWebView2_WebMessageReceived;
             FrontendWebView.CoreWebView2.DOMContentLoaded += CoreWebView2_DOMContentLoaded;
+            FrontendWebView.KeyUp += (s, e) =>
+            {
+                WebViewKeyUp?.Invoke(s, e);
+            };
+
+            if (_desiredZoomFactor != 0.0)
+            {
+                FrontendWebView.ZoomFactor = _desiredZoomFactor;
+            }
 
             MessageExchange.Instance.SetPublisher(new PostMessagePublisher(FrontendWebView));
+        }
+
+        public  void SetZoomFactor(double zoomFactor)
+        {
+            if (FrontendWebView.CoreWebView2 != null)
+            {
+                FrontendWebView.ZoomFactor = zoomFactor;
+            } else
+            {
+                _desiredZoomFactor = zoomFactor;
+            }
+        }
+
+        public double GetZoomFactor()
+        {
+            if (FrontendWebView.CoreWebView2 != null)
+            {
+                return FrontendWebView.ZoomFactor;
+            }
+            return 0.0;
         }
 
         private void CoreWebView2_DOMContentLoaded(object sender, CoreWebView2DOMContentLoadedEventArgs e)

--- a/app.config
+++ b/app.config
@@ -166,8 +166,8 @@
       <setting name="WindowSize" serializeAs="String">
         <value>0, 0</value>
       </setting>
-      <setting name="WindowZoomLevel" serializeAs="String">
-        <value>100</value>
+      <setting name="WindowZoomFactor" serializeAs="String">
+        <value>0</value>
       </setting>
       <setting name="WindowState" serializeAs="String">
         <value>Normal</value>


### PR DESCRIPTION
- [x] Window **location** is saved on exit, and restored next session
- [x] Window **size** is saved on exit, and restored next session
- [x] Window **zoom level** is saved on exit, and restored next session
- [x] Window zoom level can be set to DEFAULT by using `CTRL+0` or `CTRL+NumPad0` 
- [x] Window **position on second monitor** is working correctly
- [x] Window is recentered on first monitor if second monitor is not available
- [x] When window maximized, it is restored maximized

**Note:**
`Ctrl+S` was not working because the Key events don't correctly bubble up. This is fixed now.

fixes #2144 