### PR TITLE
Ignore FSUIPC aircraft name change events when directly connected to sim

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -934,53 +934,51 @@ namespace MobiFlight
 #endif
 
             // Check only for available sims if not in Offline mode.
-            if (true)
+            if (SimAvailable())
             {
-
-                if (SimAvailable())
+                if (LastDetectedSim != FlightSim.FlightSimType)
                 {
-                    if (LastDetectedSim != FlightSim.FlightSimType)
-                    {
-                        LastDetectedSim = FlightSim.FlightSimType;
-                        OnSimAvailable?.Invoke(FlightSim.FlightSimType, null);
-                    }
-
-                    if (!fsuipcCache.IsConnected())
-                    {
-                        if (!simConnectCache.IsConnected() && !xplaneCache.IsConnected())
-                        {
-                            // we don't want to spam the log
-                            // in case we have an active connection
-                            // through a different type
-                            Log.Instance.log("Trying auto connect to sim via FSUIPC", LogSeverity.Debug);
-                        }
-
-                        fsuipcCache.Connect();
-                    }
-#if SIMCONNECT
-                    if (FlightSim.FlightSimType == FlightSimType.MSFS2020 && !simConnectCache.IsConnected())
-                    {
-                        Log.Instance.log("Trying auto connect to sim via SimConnect (WASM)", LogSeverity.Debug);
-                        simConnectCache.Connect();
-                    }
-#endif
-                    if (FlightSim.FlightSimType == FlightSimType.XPLANE && !xplaneCache.IsConnected())
-                    {
-                        Log.Instance.log("Trying auto connect to sim via XPlane", LogSeverity.Debug);
-                        xplaneCache.Connect();
-                    }
-                    // we return here to prevent the disabling of the timer
-                    // so that autostart-feature can work properly
-                    _autoConnectTimerRunning = false;
-                    return;
+                    LastDetectedSim = FlightSim.FlightSimType;
+                    OnSimAvailable?.Invoke(FlightSim.FlightSimType, null);
                 }
-                else
+
+#if SIMCONNECT
+                if (FlightSim.FlightSimType == FlightSimType.MSFS2020 && !simConnectCache.IsConnected())
                 {
-                    if (LastDetectedSim != FlightSimType.NONE)
+                    Log.Instance.log("Trying auto connect to sim via SimConnect (WASM)", LogSeverity.Debug);
+                    simConnectCache.Connect();
+                }
+#endif
+                if (FlightSim.FlightSimType == FlightSimType.XPLANE && !xplaneCache.IsConnected())
+                {
+                    Log.Instance.log("Trying auto connect to sim via XPlane", LogSeverity.Debug);
+                    xplaneCache.Connect();
+                }
+
+                if (!fsuipcCache.IsConnected())
+                {
+                    if (!simConnectCache.IsConnected() && !xplaneCache.IsConnected())
                     {
-                        OnSimUnavailable?.Invoke(LastDetectedSim, null);
-                        LastDetectedSim = FlightSimType.NONE;
+                        // we don't want to spam the log
+                        // in case we have an active connection
+                        // through a different type
+                        Log.Instance.log("Trying auto connect to sim via FSUIPC", LogSeverity.Debug);
                     }
+
+                    fsuipcCache.Connect();
+                }
+
+                // we return here to prevent the disabling of the timer
+                // so that autostart-feature can work properly
+                _autoConnectTimerRunning = false;
+                return;
+            }
+            else
+            {
+                if (LastDetectedSim != FlightSimType.NONE)
+                {
+                    OnSimUnavailable?.Invoke(LastDetectedSim, null);
+                    LastDetectedSim = FlightSimType.NONE;
                 }
             }
 

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -472,6 +472,11 @@ namespace MobiFlight
 
         private void sim_AirCraftChanged(object sender, string e)
         {
+            if (sender is Fsuipc2Cache && (xplaneCache.IsConnected() || simConnectCache.IsConnected())) {
+                Log.Instance.log($"Aircraft change detected from {sender} but X-Plane or SimConnect are connected. Ignoring name change", LogSeverity.Info);
+                return;
+            }
+
             Log.Instance.log($"Aircraft change detected: [{e}] ({sender.ToString()})", LogSeverity.Info);
             OnSimAircraftChanged?.Invoke(sender, e);
         }


### PR DESCRIPTION
This resolves #2191 by ignoring FSUIPC Aircraft Changed events when either X-Plane or SimConnect are directly connected. I've gone with the path of least resistance on this one as, based on Discord searches, I can see that users are using both FSUIPC and SimConnect or XPUIPC and X-Plane direct for synchronizing their profiles against both sims, so both connections would be required.

Rather than redesigning parts of the events pub/sub, it's easier to ignore the events given how infrequently they should trigger.

I've also removed a superfluous `if (true) {}` condition from `AutoConnectTimer_TickAsync`