### PR TITLE
Show correct labels for Joystick and Midi devices

### DIFF
--- a/MobiFlight/BrowserMessages/Outgoing/ControllerDefinitions.cs
+++ b/MobiFlight/BrowserMessages/Outgoing/ControllerDefinitions.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace MobiFlight.BrowserMessages.Outgoing
+{
+    public class  JoystickDefinitions
+    {
+        public List<JoystickDefinition> Definitions;
+    }
+}

--- a/MobiFlight/BrowserMessages/Outgoing/ControllerDefinitions.cs
+++ b/MobiFlight/BrowserMessages/Outgoing/ControllerDefinitions.cs
@@ -6,4 +6,9 @@ namespace MobiFlight.BrowserMessages.Outgoing
     {
         public List<JoystickDefinition> Definitions;
     }
+
+    public class MidiControllerDefinitions
+    {
+        public List<MidiBoardDefinition> Definitions;
+    }
 }

--- a/MobiFlight/BrowserMessages/Outgoing/ControllerDefinitions.cs
+++ b/MobiFlight/BrowserMessages/Outgoing/ControllerDefinitions.cs
@@ -2,7 +2,7 @@
 
 namespace MobiFlight.BrowserMessages.Outgoing
 {
-    public class  JoystickDefinitions
+    public class JoystickDefinitions
     {
         public List<JoystickDefinition> Definitions;
     }

--- a/MobiFlight/Joysticks/JoystickDefinition.cs
+++ b/MobiFlight/Joysticks/JoystickDefinition.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.Generic;
 
 namespace MobiFlight
 {

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Timers;
 using WebSocketSharp.Server;
+using MobiFlight.BrowserMessages;
 
 namespace MobiFlight
 {
@@ -30,7 +31,7 @@ namespace MobiFlight
             SharpDX.DirectInput.DeviceType.Supplemental
         };
 
-        private List<JoystickDefinition> Definitions = new List<JoystickDefinition>();
+        public readonly List<JoystickDefinition> Definitions = new List<JoystickDefinition>();
         public event EventHandler Connected;
         public event ButtonEventHandler OnButtonPressed;
         private readonly Timer PollTimer = new Timer(); 
@@ -74,10 +75,16 @@ namespace MobiFlight
         /// </summary>
         public void LoadDefinitions()
         {
-            Definitions = JsonBackedObject.LoadDefinitions<JoystickDefinition>(Directory.GetFiles("Joysticks", "*.joystick.json"), "Joysticks/mfjoystick.schema.json",
+            var rawDefinitions = JsonBackedObject.LoadDefinitions<JoystickDefinition>(Directory.GetFiles("Joysticks", "*.joystick.json"), "Joysticks/mfjoystick.schema.json",
                 onSuccess: (joystick, definitionFile) => Log.Instance.log($"Loaded joystick definition for {joystick.InstanceName}", LogSeverity.Info),
                 onError: () => LoadingError = true
             );
+
+            // now we have a symmetry with the MidiBoardManager
+            Definitions.Clear();
+            Definitions.AddRange(rawDefinitions);
+
+            MessageExchange.Instance.Publish(Definitions);
         }
 
         public string MapDeviceNameToLabel(string boardName, string deviceName)

--- a/MobiFlight/MidiBoard/MidiBoardDefinition.cs
+++ b/MobiFlight/MidiBoard/MidiBoardDefinition.cs
@@ -13,6 +13,7 @@ namespace MobiFlight
         /// <summary>
         /// Name of the midi output port, if different from input name. Optional.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string DifferingOutputName;
 
         /// <summary>
@@ -23,16 +24,19 @@ namespace MobiFlight
         /// <summary>
         /// When layer property is used, initial active layer on startup. Optional.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string InitialLayer;
 
         /// <summary>
         /// List of inputs supported by the device. Required.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public List<MidiInputDefinition> Inputs;
 
         /// <summary>
         /// List of LED outputs supported by the device. Optional.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)] 
         public List<MidiOutputDefinition> Outputs;
 
         private Dictionary<string, string> inputNameToLabelDictionary;

--- a/MobiFlight/MidiBoard/MidiBoardDevice.cs
+++ b/MobiFlight/MidiBoard/MidiBoardDevice.cs
@@ -1,4 +1,5 @@
 ﻿using MobiFlight.Config;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -9,7 +10,10 @@ namespace MobiFlight
         public DeviceType Type { get; set; }
         public String Name { get; set; }
         public String Label { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public String Layer;
+
         public List<MidiBoardOutputDevice> RelatedOutputDevices = new List<MidiBoardOutputDevice>();
     }
 

--- a/MobiFlight/MidiBoard/MidiBoardManager.cs
+++ b/MobiFlight/MidiBoard/MidiBoardManager.cs
@@ -21,7 +21,7 @@ namespace MobiFlight
         private readonly List<MidiBoard> MidiBoards = new List<MidiBoard>();
         private readonly List<MidiBoard> ExcludedMidiBoards = new List<MidiBoard>();        
         private readonly List<MidiBoard> BoardsToBeRemoved = new List<MidiBoard>();
-        private readonly Dictionary<string, MidiBoardDefinition> Definitions = new Dictionary<string, MidiBoardDefinition>();
+        public readonly Dictionary<string, MidiBoardDefinition> Definitions = new Dictionary<string, MidiBoardDefinition>();
         private readonly Timer ProcessTimer = new System.Windows.Forms.Timer();
         private int CheckAttachedRemovedCounter = 0;
 

--- a/MobiFlight/MidiBoard/MidiInputDefinition.cs
+++ b/MobiFlight/MidiBoard/MidiInputDefinition.cs
@@ -19,6 +19,7 @@ namespace MobiFlight
         /// <summary>
         /// Associated layer for the input. Optional.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Layer;
 
         /// <summary>

--- a/MobiFlight/MidiBoard/MidiOutputDefinition.cs
+++ b/MobiFlight/MidiBoard/MidiOutputDefinition.cs
@@ -19,6 +19,7 @@ namespace MobiFlight
         /// <summary>
         /// Associated layer for the output. Optional.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Layer;
 
         /// <summary>
@@ -45,6 +46,7 @@ namespace MobiFlight
         /// <summary>
         /// Midi message value for putting LED to blink mode. Optional.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public byte? ValueBlinkOn;
 
         /// <summary>
@@ -55,11 +57,13 @@ namespace MobiFlight
         /// <summary>
         /// Label of related input. When related input is triggered, output is auto refreshed. Optional.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string RelatedInputLabel;
 
         /// <summary>
         /// Label ids of related input, replacing the % in the related input label. Optional.
         /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string[] RelatedIds;
 
         public string GetLabelWithIndex(int index)

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -282,6 +282,7 @@
     <Compile Include="MobiFlight\BrowserMessages\Outgoing\ConfigValuePartialUpdate.cs" />
     <Compile Include="MobiFlight\BrowserMessages\Outgoing\ConfigValueFullUpdate.cs" />
     <Compile Include="MobiFlight\BrowserMessages\Outgoing\ConfigValueRawAndFinalUpdate.cs" />
+    <Compile Include="MobiFlight\BrowserMessages\Outgoing\ControllerDefinitions.cs" />
     <Compile Include="MobiFlight\BrowserMessages\Outgoing\LogEntry.cs" />
     <Compile Include="MobiFlight\BrowserMessages\Outgoing\Notification.cs" />
     <Compile Include="MobiFlight\BrowserMessages\Incoming\Test.cs" />

--- a/MobiFlightUnitTests/MobiFlight/OutputConfigItemTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfigItemTests.cs
@@ -88,8 +88,8 @@ namespace MobiFlight.Tests
             Assert.IsNotNull(oci.ButtonInputConfig, "ButtonInputConfig null");
             Assert.IsNotNull(oci.ButtonInputConfig.onPress, "ButtonInputConfig.onPress null");
             Assert.IsNotNull(oci.ButtonInputConfig.onRelease, "ButtonInputConfig.onRelease null");
-            Assert.IsNotNull(oci.ButtonInputConfig.onPress as MobiFlight.InputConfig.MSFS2020CustomInputAction, "Not of type MobiFlight.InputConfig.MSFS2020CustomInputAction");
-            Assert.AreEqual("Test", (oci.ButtonInputConfig.onPress as MobiFlight.InputConfig.MSFS2020CustomInputAction).Command, "Not correct Command.");
+            Assert.IsNotNull(oci.ButtonInputConfig.onPress as InputConfig.MSFS2020CustomInputAction, "Not of type MobiFlight.InputConfig.MSFS2020CustomInputAction");
+            Assert.AreEqual("Test", (oci.ButtonInputConfig.onPress as InputConfig.MSFS2020CustomInputAction).Command, "Not correct Command.");
             // read analoginputaction
 
             // read buttoninputaction
@@ -102,7 +102,7 @@ namespace MobiFlight.Tests
             Assert.IsNotNull(oci.ButtonInputConfig, "ButtonInputConfig null");
             Assert.IsNotNull(oci.ButtonInputConfig.onPress, "ButtonInputConfig.onPress null");
             Assert.IsNull(oci.ButtonInputConfig.onRelease, "ButtonInputConfig.onRelease is not null");
-            Assert.IsNotNull(oci.ButtonInputConfig.onPress as MobiFlight.InputConfig.MSFS2020CustomInputAction, "Not of type MobiFlight.InputConfig.MSFS2020CustomInputAction");
+            Assert.IsNotNull(oci.ButtonInputConfig.onPress as InputConfig.MSFS2020CustomInputAction, "Not of type MobiFlight.InputConfig.MSFS2020CustomInputAction");
             Assert.AreEqual(1, oci.ConfigRefs.Count, "Count is not 1");
 
             // read buttoninputaction

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -400,8 +400,9 @@ namespace MobiFlight.UI
             MessageExchange.Instance.Publish(new Settings(Properties.Settings.Default));
 
             if (execManager == null) return;
+
             MessageExchange.Instance.Publish(new JoystickDefinitions() { Definitions = execManager.GetJoystickManager().Definitions });
-            MessageExchange.Instance.Publish(execManager.GetMidiBoardManager().Definitions);
+            MessageExchange.Instance.Publish(new MidiControllerDefinitions() { Definitions = execManager.GetMidiBoardManager().Definitions.Values.ToList() });
         }
 
         private void InitializeExecutionManager()

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -398,6 +398,10 @@ namespace MobiFlight.UI
         private void PublishSettings()
         {
             MessageExchange.Instance.Publish(new Settings(Properties.Settings.Default));
+
+            if (execManager == null) return;
+            MessageExchange.Instance.Publish(new JoystickDefinitions() { Definitions = execManager.GetJoystickManager().Definitions });
+            MessageExchange.Instance.Publish(execManager.GetMidiBoardManager().Definitions);
         }
 
         private void InitializeExecutionManager()

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -33,7 +33,7 @@ export default defineConfig({
     trace: "on-first-retry",
 
     // Emulates `'prefers-colors-scheme'` media feature.
-    colorScheme: "light",
+    colorScheme: "light"
   },
 
   /* Configure projects for major browsers */
@@ -49,6 +49,6 @@ export default defineConfig({
     command: "npm run dev",
     url: "http://localhost:5173/",
     reuseExistingServer: !process.env.CI,
-    timeout: 10 * 1000,
+    timeout: 20 * 1000,
   },
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,6 +10,8 @@ import _ from "lodash"
 import { useProjectStore } from "./stores/projectStore"
 import { MainMenu } from "./components/MainMenu"
 import { useSettingsStore } from "./stores/settingsStore"
+import { useControllerDefinitionsStore } from "./stores/definitionStore"
+import { JoystickDefinitions } from "./types/messages"
 
 function App() {
   const [queryParameters] = useSearchParams()
@@ -17,6 +19,7 @@ function App() {
   const { setItems } = useConfigStore()
   const { setProject } = useProjectStore()
   const { setSettings } = useSettingsStore()
+  const { setJoystickDefinitions } = useControllerDefinitionsStore()
 
   const [startupProgress, setStartupProgress] = useState<StatusBarUpdate>({
     Value: 0,
@@ -46,6 +49,12 @@ function App() {
     const language = settings.Language.split("-")[0]
     if (!_.isEmpty(language)) i18next.changeLanguage(settings.Language)
     else i18next.changeLanguage()
+  })
+
+  useAppMessage("JoystickDefinitions", (message) => {
+    const joystickDefinitions = message.payload as JoystickDefinitions
+    console.log("JoystickDefinitions message received", joystickDefinitions.Definitions)
+    setJoystickDefinitions(joystickDefinitions.Definitions)
   })
 
   // this allows to get beyond the startup screen

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,7 +11,7 @@ import { useProjectStore } from "./stores/projectStore"
 import { MainMenu } from "./components/MainMenu"
 import { useSettingsStore } from "./stores/settingsStore"
 import { useControllerDefinitionsStore } from "./stores/definitionStore"
-import { JoystickDefinitions } from "./types/messages"
+import { JoystickDefinitions, MidiControllerDefinitions } from "./types/messages"
 
 function App() {
   const [queryParameters] = useSearchParams()
@@ -19,7 +19,7 @@ function App() {
   const { setItems } = useConfigStore()
   const { setProject } = useProjectStore()
   const { setSettings } = useSettingsStore()
-  const { setJoystickDefinitions } = useControllerDefinitionsStore()
+  const { setJoystickDefinitions, setMidiControllerDefinitions } = useControllerDefinitionsStore()
 
   const [startupProgress, setStartupProgress] = useState<StatusBarUpdate>({
     Value: 0,
@@ -55,6 +55,12 @@ function App() {
     const joystickDefinitions = message.payload as JoystickDefinitions
     console.log("JoystickDefinitions message received", joystickDefinitions.Definitions)
     setJoystickDefinitions(joystickDefinitions.Definitions)
+  })
+
+  useAppMessage("MidiControllerDefinitions", (message) => {
+    const definitions = message.payload as MidiControllerDefinitions
+    console.log("MidiControllerDefinitions message received", definitions.Definitions)
+    setMidiControllerDefinitions(definitions.Definitions)
   })
 
   // this allows to get beyond the startup screen

--- a/frontend/src/components/tables/config-item-table/items/ConfigItemTableControllerCell.tsx
+++ b/frontend/src/components/tables/config-item-table/items/ConfigItemTableControllerCell.tsx
@@ -28,7 +28,7 @@ const ConfigItemTableControllerCell = React.memo(({
     } as CommandConfigContextMenu)
   }, [publish, item])
 
-  return !isEmpty(label) ? (
+  return !isEmpty(label) && label!="-" ? (
     <div className="group flex flex-row items-center">
       <ToolTip
         content={

--- a/frontend/src/components/tables/config-item-table/items/ConfigItemTableDeviceCell.tsx
+++ b/frontend/src/components/tables/config-item-table/items/ConfigItemTableDeviceCell.tsx
@@ -17,14 +17,18 @@ interface ConfigItemTableDeviceCellProps {
 const ConfigItemTableDeviceCell = React.memo(
   ({ row }: ConfigItemTableDeviceCellProps) => {
     const { t } = useTranslation()
-    const { JoystickDefinitions } = useControllerDefinitionsStore()
+    const { JoystickDefinitions, MidiControllerDefinitions } = useControllerDefinitionsStore()
     const item = row.original as IConfigItem
     const Status = item.Status
     const Device = Status && !isEmpty(Status["Device"])
 
-    const controllerName = item.ModuleSerial.split("/")[0].trim() ?? "not set"
+    const controllerName = item.ModuleSerial.split(" / ")[0] ?? "not set"
 
     const JoystickDefinition = JoystickDefinitions.find(
+      (i) => i.InstanceName == controllerName,
+    )
+
+    const MidiControllerDefinition = MidiControllerDefinitions.find(
       (i) => i.InstanceName == controllerName,
     )
 
@@ -42,10 +46,15 @@ const ConfigItemTableDeviceCell = React.memo(
         variant={(deviceType ?? "default") as DeviceElementType}
       />
     )
-    const mappedLabel =
+    const mappedLabel = 
       JoystickDefinition != null
         ? (mapJoystickDeviceNameToLabel(JoystickDefinition, deviceName) ?? deviceName)
-        : deviceName
+        : 
+      MidiControllerDefinition != null 
+      ? (MidiControllerDefinition.ProcessedLabels?.[deviceName] ?? deviceName)
+      : deviceName
+
+
     const statusIcon = Device ? (
       <StackedIcons
         bottomIcon={icon}

--- a/frontend/src/components/tables/config-item-table/items/ConfigItemTableDeviceCell.tsx
+++ b/frontend/src/components/tables/config-item-table/items/ConfigItemTableDeviceCell.tsx
@@ -8,6 +8,8 @@ import { isEmpty } from "lodash-es"
 import { useTranslation } from "react-i18next"
 import StackedIcons from "@/components/icons/StackedIcons"
 import React from "react"
+import { useControllerDefinitionsStore } from "@/stores/definitionStore"
+import { mapJoystickDeviceNameToLabel } from "@/types/definitions"
 
 interface ConfigItemTableDeviceCellProps {
   row: Row<IConfigItem>
@@ -15,23 +17,35 @@ interface ConfigItemTableDeviceCellProps {
 const ConfigItemTableDeviceCell = React.memo(
   ({ row }: ConfigItemTableDeviceCellProps) => {
     const { t } = useTranslation()
+    const { JoystickDefinitions } = useControllerDefinitionsStore()
     const item = row.original as IConfigItem
     const Status = item.Status
     const Device = Status && !isEmpty(Status["Device"])
 
-    const deviceLabel =
+    const controllerName = item.ModuleSerial.split("/")[0].trim() ?? "not set"
+
+    const JoystickDefinition = JoystickDefinitions.find(
+      (i) => i.InstanceName == controllerName,
+    )
+
+    const deviceName =
       (item.Device as IDeviceConfig)?.Name ??
       (!isEmpty(item.DeviceName) ? item.DeviceName : "-")
-    const type =
+
+    const deviceType =
       (item.Device as IDeviceConfig)?.Type ??
       (!isEmpty(item.DeviceType) ? item.DeviceType : "-")
+
     const icon = (
       <DeviceIcon
         disabled={!item.Active}
-        variant={(type ?? "default") as DeviceElementType}
+        variant={(deviceType ?? "default") as DeviceElementType}
       />
     )
-
+    const mappedLabel =
+      JoystickDefinition != null
+        ? (mapJoystickDeviceNameToLabel(JoystickDefinition, deviceName) ?? deviceName)
+        : deviceName
     const statusIcon = Device ? (
       <StackedIcons
         bottomIcon={icon}
@@ -43,19 +57,19 @@ const ConfigItemTableDeviceCell = React.memo(
       icon
     )
     const typeLabel = t(
-      `Types.${type?.replace("MobiFlight.OutputConfigItem", "").replace("MobiFlight.InputConfigItem", "")}`,
+      `Types.${deviceType?.replace("MobiFlight.OutputConfigItem", "").replace("MobiFlight.InputConfigItem", "")}`,
     )
 
     const tooltipLabel = Device
       ? t(`ConfigList.Status.Device.${Status["Device"]}`)
       : typeLabel
 
-    return type != "-" ? (
+    return deviceType != "-" ? (
       <ToolTip content={tooltipLabel}>
         <div className="flex flex-row items-center gap-2">
           {statusIcon}
           <span className="text-md hidden truncate lg:inline">
-            {deviceLabel}
+            {mappedLabel}
           </span>
         </div>
       </ToolTip>

--- a/frontend/src/components/tables/config-item-table/items/ConfigItemTableDeviceCell.tsx
+++ b/frontend/src/components/tables/config-item-table/items/ConfigItemTableDeviceCell.tsx
@@ -24,11 +24,11 @@ const ConfigItemTableDeviceCell = React.memo(
 
     const controllerName = item.ModuleSerial.split(" / ")[0] ?? "not set"
 
-    const JoystickDefinition = JoystickDefinitions.find(
+    const joystickDefinition = JoystickDefinitions.find(
       (i) => i.InstanceName == controllerName,
     )
 
-    const MidiControllerDefinition = MidiControllerDefinitions.find(
+    const midiControllerDefinition = MidiControllerDefinitions.find(
       (i) => i.InstanceName == controllerName,
     )
 
@@ -47,11 +47,11 @@ const ConfigItemTableDeviceCell = React.memo(
       />
     )
     const mappedLabel = 
-      JoystickDefinition != null
-        ? (mapJoystickDeviceNameToLabel(JoystickDefinition, deviceName) ?? deviceName)
+      joystickDefinition != null
+        ? (mapJoystickDeviceNameToLabel(joystickDefinition, deviceName) ?? deviceName)
         : 
-      MidiControllerDefinition != null 
-      ? (MidiControllerDefinition.ProcessedLabels?.[deviceName] ?? deviceName)
+      midiControllerDefinition != null 
+      ? (midiControllerDefinition.ProcessedLabels?.[deviceName] ?? deviceName)
       : deviceName
 
 

--- a/frontend/src/pages/ConfigList.tsx
+++ b/frontend/src/pages/ConfigList.tsx
@@ -10,10 +10,14 @@ import {
   ConfigValueRawAndFinalUpdate,
 } from "@/types/messages"
 import testProject from "@/../tests/data/project.testdata.json" with { type: "json" }
+import testJsDefinition from "@/../tests/data/joystick.definition.json" with { type: "json" }
+import testMidiDefinition from "@/../tests/data/midicontroller.definition.json" with { type: "json" }
 import { IConfigItem, Project } from "@/types"
 import { useSearchParams } from "react-router"
 import ProjectPanel from "@/components/project/ProjectPanel"
 import { useProjectStore } from "@/stores/projectStore"
+import { useControllerDefinitionsStore } from "@/stores/definitionStore"
+import { JoystickDefinition, MidiControllerDefinition } from "@/types/definitions"
 
 const ConfigListPage = () => {
   const [queryParameters] = useSearchParams()
@@ -29,6 +33,11 @@ const ConfigListPage = () => {
     setProject,
     setConfigItems
   } = useProjectStore()
+
+  const {
+    setJoystickDefinitions,
+    setMidiControllerDefinitions
+  } = useControllerDefinitionsStore()
 
   const mySetItems = useCallback(
     (items: IConfigItem[]) => {
@@ -84,6 +93,12 @@ const ConfigListPage = () => {
       queryParameters.get("testdata") === "true"
     ) {
       setProject(testProject as Project)
+      setJoystickDefinitions(
+        [testJsDefinition as JoystickDefinition])
+
+      setMidiControllerDefinitions(
+        [testMidiDefinition as MidiControllerDefinition]
+      )
     }
   })
 

--- a/frontend/src/stores/definitionStore.ts
+++ b/frontend/src/stores/definitionStore.ts
@@ -1,12 +1,31 @@
-import { JoystickDefinition } from "@/types/definitions"
+import {
+  calculateNamesAndLabelsForMidiController,
+  JoystickDefinition,
+  MidiControllerDefinition,
+} from "@/types/definitions"
 import { create } from "zustand"
 
 interface ControllerDefinitionState {
   JoystickDefinitions: JoystickDefinition[]
+  MidiControllerDefinitions: MidiControllerDefinition[]
   setJoystickDefinitions: (definitions: JoystickDefinition[]) => void
+  setMidiControllerDefinitions: (
+    definitions: MidiControllerDefinition[],
+  ) => void
 }
 
-export const useControllerDefinitionsStore = create<ControllerDefinitionState>((set) => ({
-  JoystickDefinitions: [],
-  setJoystickDefinitions: (definitions) => set({ JoystickDefinitions: definitions })
-}))
+export const useControllerDefinitionsStore = create<ControllerDefinitionState>(
+  (set) => ({
+    JoystickDefinitions: [],
+    MidiControllerDefinitions: [],
+    setJoystickDefinitions: (definitions) =>
+      set({ JoystickDefinitions: definitions }),
+    setMidiControllerDefinitions: (definitions) => {
+      const extendedDefinitions = definitions.map((def) => {
+        const processedLabels = calculateNamesAndLabelsForMidiController(def)
+        return { ...def, ProcessedLabels: processedLabels }
+      })
+      set({ MidiControllerDefinitions: extendedDefinitions })
+    },
+  }),
+)

--- a/frontend/src/stores/definitionStore.ts
+++ b/frontend/src/stores/definitionStore.ts
@@ -1,0 +1,12 @@
+import { JoystickDefinition } from "@/types/definitions"
+import { create } from "zustand"
+
+interface ControllerDefinitionState {
+  JoystickDefinitions: JoystickDefinition[]
+  setJoystickDefinitions: (definitions: JoystickDefinition[]) => void
+}
+
+export const useControllerDefinitionsStore = create<ControllerDefinitionState>((set) => ({
+  JoystickDefinitions: [],
+  setJoystickDefinitions: (definitions) => set({ JoystickDefinitions: definitions })
+}))

--- a/frontend/src/types/definitions.ts
+++ b/frontend/src/types/definitions.ts
@@ -1,39 +1,141 @@
 export class JoystickDefinition {
   InstanceName!: string
-  Inputs?: ControllerInput[]
-  Outputs?: ControllerOutput[]
+  Inputs?: JoystickControllerInput[]
+  Outputs?: JoystickControllerOutput[]
   ProductId?: string
   VendorId?: string
-  [k: string]: unknown  
-}
-
-export function mapJoystickDeviceNameToLabel(definition: JoystickDefinition, name: string) : string | undefined {
-    const input = definition.Inputs?.find(input => input.Name === name);
-    if (input) {
-      return input.Label;
-    }
-    const output = definition.Outputs?.find(output => output.Name === name);
-    if (output) {
-      return output.Label;
-    }
-
-    return undefined
-  }
-
-
-export interface ControllerInput{
-  Id: string
-  Label: string
-  Name: string
-  Type: "Button" | "Axis"
   [k: string]: unknown
 }
 
-export interface ControllerOutput {
+export function mapJoystickDeviceNameToLabel(
+  definition: JoystickDefinition,
+  name: string,
+): string | undefined {
+  const input = definition.Inputs?.find((input) => input.Name === name)
+  if (input) {
+    return input.Label
+  }
+  const output = definition.Outputs?.find((output) => output.Name === name)
+  if (output) {
+    return output.Label
+  }
+
+  return undefined
+}
+
+export function calculateNamesAndLabelsForMidiController(
+  definition: MidiControllerDefinition,
+): Record<string, string> {
+  const processedLabels: Record<string, string> = {}
+
+  definition.Inputs?.forEach((input) => {
+    input.MessageIds.forEach((id, i) => {
+      const name = input.MessageType === "Pitch" ?
+        `${input.MessageType} ${input.MessageChannel}` :
+        `${input.MessageType} ${input.MessageChannel}_${id}`
+
+      const label = input.Label.replace("%", input.LabelIds[i])
+      processedLabels[name] = label 
+    })
+  })
+  return processedLabels
+}
+
+export interface JoystickControllerInput {
+  Id: string
+  Label: string
+  Name: string
+  Type: "Button" | "Axis" 
+  [k: string]: unknown
+}
+
+export interface JoystickControllerOutput {
   Id: string
   Name: string
   Label: string
   Byte: number
   Bit: number
   [k: string]: unknown
+}
+
+export interface MidiControllerDefinition {
+  InstanceName: string
+  DifferingOutputName?: string
+  EncoderNeutralPosition: number
+  InitialLayer?: string
+  Inputs?: MidiControllerInput[]
+  Outputs?: MidiControllerOutput[]
+  ProcessedLabels?: Record<string, string>
+}
+
+export interface MidiControllerInput {
+  /**
+   * Friendly label for the input. Required.
+   */
+  Label: string
+  LabelIds: string[]
+  /**
+   * Associated layer for the input. Optional.
+   */
+  Layer?: string
+  /**
+   * The input's type. Supported values: Button, EndlessKnob, LimitedKnob, Fader, Pitch. Required.
+   */
+  InputType: "Button" | "EndlessKnob" | "LimitedKnob" | "Fader" | "Pitch"
+  /**
+   * The midi message type. Supported values: Note, CC, Pitch. Required.
+   */
+  MessageType: "Note" | "CC" | "Pitch"
+  /**
+   * The midi message channel. Possible value range from 1 to 16. Required.
+   */
+  MessageChannel: number
+  /**
+   * The midi message ids. Possible value range from 0 to 127. Required.
+   */
+  MessageIds: number[]
+}
+
+export interface MidiControllerOutput {
+  /**
+   * Friendly label for the output. Required.
+   */
+  Label: string
+  LabelIds: string[]
+  /**
+   * Associated layer for the output. Optional.
+   */
+  Layer?: string
+  /**
+   * The midi message type. Supported values: Note, CC. Required.
+   */
+  MessageType: "Note" | "CC"
+  /**
+   * The midi message channel. Possible value range from 1 to 16. Required.
+   */
+  MessageChannel: number
+  /**
+   * The midi message ids. Possible value range from 0 to 127. Required.
+   */
+  MessageIds: number[]
+  /**
+   * Midi message value for turning on the LED. Required.
+   */
+  ValueOn: number
+  /**
+   * Midi message value for putting LED to blink mode. Optional.
+   */
+  ValueBlinkOn?: number
+  /**
+   * Midi message value for turning off the LED. Required.
+   */
+  ValueOff: number
+  /**
+   * Label of related input. When related input is triggered, output is auto refreshed. Optional.
+   */
+  RelatedInputLabel?: string
+  /**
+   * Label ids of related input, replacing the % in the related input label. Optional.
+   */
+  RelatedIds?: string[]
 }

--- a/frontend/src/types/definitions.ts
+++ b/frontend/src/types/definitions.ts
@@ -65,6 +65,8 @@ export interface MidiControllerDefinition {
   InitialLayer?: string
   Inputs?: MidiControllerInput[]
   Outputs?: MidiControllerOutput[]
+  // these are enriched on the frontend side
+  // see the definition store for the logic
   ProcessedLabels?: Record<string, string>
 }
 

--- a/frontend/src/types/definitions.ts
+++ b/frontend/src/types/definitions.ts
@@ -1,0 +1,39 @@
+export class JoystickDefinition {
+  InstanceName!: string
+  Inputs?: ControllerInput[]
+  Outputs?: ControllerOutput[]
+  ProductId?: string
+  VendorId?: string
+  [k: string]: unknown  
+}
+
+export function mapJoystickDeviceNameToLabel(definition: JoystickDefinition, name: string) : string | undefined {
+    const input = definition.Inputs?.find(input => input.Name === name);
+    if (input) {
+      return input.Label;
+    }
+    const output = definition.Outputs?.find(output => output.Name === name);
+    if (output) {
+      return output.Label;
+    }
+
+    return undefined
+  }
+
+
+export interface ControllerInput{
+  Id: string
+  Label: string
+  Name: string
+  Type: "Button" | "Axis"
+  [k: string]: unknown
+}
+
+export interface ControllerOutput {
+  Id: string
+  Name: string
+  Label: string
+  Byte: number
+  Bit: number
+  [k: string]: unknown
+}

--- a/frontend/src/types/messages.d.ts
+++ b/frontend/src/types/messages.d.ts
@@ -10,6 +10,7 @@ export type AppMessageKey =
   | "ConfigValueRawAndFinalUpdate"
   | "Settings"
   | "ExecutionState"
+  | "JoystickDefinitions"
 
 export type AppMessagePayload =
   | StatusBarUpdate
@@ -18,12 +19,13 @@ export type AppMessagePayload =
   | ConfigValuePartialUpdate
   | ConfigValueRawAndFinalUpdate
   | ExecutionState
+  | JoystickDefinitions
   
 // AppMessage is the message format
 // when receiving messages from the backend
 export type AppMessage = {
   key: AppMessageKey
-  payload: AppMessagePayload | Settings | Project | ExecutionState
+  payload: AppMessagePayload | Settings | Project | ExecutionState | JoystickDefinitions
 }
 
 // ConfigLoadedEvent
@@ -62,6 +64,10 @@ export interface ExecutionState {
   IsTesting: boolean
   RunAvailable: boolean
   TestAvailable: boolean
+}
+
+export interface JoystickDefinitions {
+  Definitions: JoystickDefinition[]
 }
 
 // Not sure what this is for

--- a/frontend/src/types/messages.d.ts
+++ b/frontend/src/types/messages.d.ts
@@ -1,5 +1,6 @@
 import { Settings } from "http2"
 import { IConfigValueOnlyItem } from "./config"
+import { JoystickDefinition, MidiControllerDefinition } from "./definitions"
 
 export type AppMessageKey =
   | "StatusBarUpdate"
@@ -11,6 +12,7 @@ export type AppMessageKey =
   | "Settings"
   | "ExecutionState"
   | "JoystickDefinitions"
+  | "MidiControllerDefinitions"
 
 export type AppMessagePayload =
   | StatusBarUpdate
@@ -20,6 +22,7 @@ export type AppMessagePayload =
   | ConfigValueRawAndFinalUpdate
   | ExecutionState
   | JoystickDefinitions
+  | MidiControllerDefinitions
   
 // AppMessage is the message format
 // when receiving messages from the backend
@@ -68,6 +71,10 @@ export interface ExecutionState {
 
 export interface JoystickDefinitions {
   Definitions: JoystickDefinition[]
+}
+
+export interface MidiControllerDefinitions {
+  Definitions: MidiControllerDefinition[]
 }
 
 // Not sure what this is for

--- a/frontend/tests/ConfigListView.spec.ts
+++ b/frontend/tests/ConfigListView.spec.ts
@@ -257,7 +257,7 @@ test.describe('Filter toolbar tests', () => {
 
     const searchTextBox = page.getByRole("textbox", { name: "Filter items" })
     const rows = page.locator("tbody tr")
-    await expect(rows).toHaveCount(10)
+    await expect(rows).toHaveCount(14)
 
     await searchTextBox.fill("A")
     await expect(rows).toHaveCount(2)
@@ -272,7 +272,7 @@ test.describe('Filter toolbar tests', () => {
     await expect(clearButton).not.toHaveCount(0)
 
     await clearButton.first().click()
-    await expect(rows).toHaveCount(10)
+    await expect(rows).toHaveCount(14)
 
     await configListPage.mobiFlightPage.trackCommand("CommandConfigBulkAction")
     await rows.first().click()
@@ -304,16 +304,16 @@ test.describe('Filter toolbar tests', () => {
 
     await inputOption.click()
     await outputOption.click()
-    await expect(visibleRows).toHaveCount(3)
+    await expect(visibleRows).toHaveCount(7)
 
     await clearFiltersOption.click()
-    await expect(visibleRows).toHaveCount(10)
+    await expect(visibleRows).toHaveCount(14)
 
     const inputField = page.getByPlaceholder("Config Type")
     await inputField.click()
     await inputField.fill("In")
     await inputField.press("Enter")
-    await expect(visibleRows).toHaveCount(3)
+    await expect(visibleRows).toHaveCount(7)
     await page.locator("#root").click()
     await page.waitForTimeout(500)
 
@@ -341,7 +341,7 @@ test.describe('Filter toolbar tests', () => {
       .click()
     await expect(rows).toHaveCount(1)
     await clearFilterOption.click()
-    await expect(rows).toHaveCount(10)
+    await expect(rows).toHaveCount(14)
 
     await page.getByRole("option", { name: "ProtoBoard" }).locator("div").click()
     await expect(rows).toHaveCount(8)
@@ -377,24 +377,24 @@ test.describe('Filter toolbar tests', () => {
       await page.getByRole("option", { name: deviceType }).first().click()
       await expect(rows).toHaveCount(expectedCount)
       await clearFilterOption.click()
-      await expect(rows).toHaveCount(10)
+      await expect(rows).toHaveCount(14)
     }
 
     const deviceTypes = [
-      "Analog Input",
-      "Encoder",
-      "Button",
-      "Output",
-      "Output Shift Register",
-      "LCD Display",
-      "Servo",
-      "Stepper",
-      "7-Segment",
-      "not set",
-    ]
+      ["Analog Input", 2],
+      ["Encoder", 2],
+      ["Button", 3],
+      ["Output", 1],
+      ["Output Shift Register", 1],
+      ["LCD Display", 1],
+      ["Servo", 1],
+      ["Stepper", 1],
+      ["7-Segment", 1],
+      ["not set", 1],
+    ] as Array<[string, number]>
 
-    for (const deviceType of deviceTypes) {
-      await testDeviceTypeFilter(deviceType, 1)
+    for (const [deviceTypeName, expectedCount] of deviceTypes) {
+      await testDeviceTypeFilter(deviceTypeName, expectedCount)
     }
 
   })
@@ -415,7 +415,7 @@ test.describe('Filter toolbar tests', () => {
       await page.getByRole("option", { name: deviceType }).first().click()
       await expect(rows).toHaveCount(expectedCount)
       await clearFilterOption.click()
-      await expect(rows).toHaveCount(10)
+      await expect(rows).toHaveCount(14)
     }
 
     const deviceNames = [

--- a/frontend/tests/ConfigListView.spec.ts
+++ b/frontend/tests/ConfigListView.spec.ts
@@ -446,6 +446,24 @@ test.describe('Controller device labels are displayed correctly', () => {
     await configListPage.initWithTestData()
     await expect(page.getByRole("cell", { name: "Line-Select-Key 1L" })).toBeVisible()
   })
+
+  test("Confirm Midi controller device labels are displayed correctly", async ({
+    configListPage,
+    page
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.initControllerDefinitions()
+    await configListPage.initWithTestData()
+
+    const midiButtonRow = page.getByRole("row").filter({ hasText: "Intech Studio: AC" }).first()
+    await expect(midiButtonRow.getByRole("cell", { name: "Button 1" })).toBeVisible()
+
+    const midiKnobRow = page.getByRole("row").filter({ hasText: "Intech Studio: AC" }).nth(1)
+    await expect(midiKnobRow.getByRole("cell", { name: "Knob 1" })).toBeVisible()
+
+    const midiSliderRow = page.getByRole("row").filter({ hasText: "Intech Studio: AC" }).nth(2)
+    await expect(midiSliderRow.getByRole("cell", { name: "Slider 1" })).toBeVisible()
+  })
 })
 
 test("Confirm `Controller Settings` link is working", async ({

--- a/frontend/tests/ConfigListView.spec.ts
+++ b/frontend/tests/ConfigListView.spec.ts
@@ -436,6 +436,18 @@ test.describe('Filter toolbar tests', () => {
   })
 })
 
+test.describe('Controller device labels are displayed correctly', () => {
+  test("Confirm Joystick device labels are displayed correctly", async ({
+    configListPage,
+    page
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.initControllerDefinitions()
+    await configListPage.initWithTestData()
+    await expect(page.getByRole("cell", { name: "Line-Select-Key 1L" })).toBeVisible()
+  })
+})
+
 test("Confirm `Controller Settings` link is working", async ({
   configListPage,
   page,

--- a/frontend/tests/data/joystick.definition.json
+++ b/frontend/tests/data/joystick.definition.json
@@ -1,464 +1,464 @@
 {
     "Inputs": [
         {
-            "Id": 1,
+            "Id": "1",
             "Label": "Line-Select-Key 1L",
             "Name": "Button 1",
             "Type": "Button"
         },
         {
-            "Id": 2,
+            "Id": "2",
             "Label": "Line-Select-Key 2L",
             "Name": "Button 2",
             "Type": "Button"
         },
         {
-            "Id": 3,
+            "Id": "3",
             "Label": "Line-Select-Key 3L",
             "Name": "Button 3",
             "Type": "Button"
         },
         {
-            "Id": 4,
+            "Id": "4",
             "Label": "Line-Select-Key 4L",
             "Name": "Button 4",
             "Type": "Button"
         },
         {
-            "Id": 5,
+            "Id": "5",
             "Label": "Line-Select-Key 5L",
             "Name": "Button 5",
             "Type": "Button"
         },
         {
-            "Id": 6,
+            "Id": "6",
             "Label": "Line-Select-Key 6L",
             "Name": "Button 6",
             "Type": "Button"
         },
         {
-            "Id": 7,
+            "Id": "7",
             "Label": "Line-Select-Key 1R",
             "Name": "Button 7",
             "Type": "Button"
         },
         {
-            "Id": 8,
+            "Id": "8",
             "Label": "Line-Select-Key 2R",
             "Name": "Button 8",
             "Type": "Button"
         },
         {
-            "Id": 9,
+            "Id": "9",
             "Label": "Line-Select-Key 3R",
             "Name": "Button 9",
             "Type": "Button"
         },
         {
-            "Id": 10,
+            "Id": "10",
             "Label": "Line-Select-Key 4R",
             "Name": "Button 10",
             "Type": "Button"
         },
         {
-            "Id": 11,
+            "Id": "11",
             "Label": "Line-Select-Key 5R",
             "Name": "Button 11",
             "Type": "Button"
         },
         {
-            "Id": 12,
+            "Id": "12",
             "Label": "Line-Select-Key 6R",
             "Name": "Button 12",
             "Type": "Button"
         },
         {
-            "Id": 13,
+            "Id": "13",
             "Label": "DIR Button",
             "Name": "Button 13",
             "Type": "Button"
         },
         {
-            "Id": 14,
+            "Id": "14",
             "Label": "PROG Button",
             "Name": "Button 14",
             "Type": "Button"
         },
         {
-            "Id": 15,
+            "Id": "15",
             "Label": "PERF Button",
             "Name": "Button 15",
             "Type": "Button"
         },
         {
-            "Id": 16,
+            "Id": "16",
             "Label": "INIT Button",
             "Name": "Button 16",
             "Type": "Button"
         },
         {
-            "Id": 17,
+            "Id": "17",
             "Label": "DATA Button",
             "Name": "Button 17",
             "Type": "Button"
         },
         {
-            "Id": 18,
+            "Id": "18",
             "Label": "Blank Button R",
             "Name": "Button 18",
             "Type": "Button"
         },
         {
-            "Id": 19,
+            "Id": "19",
             "Label": "BRT Button",
             "Name": "Button 19",
             "Type": "Button"
         },
         {
-            "Id": 20,
+            "Id": "20",
             "Label": "F-PLN Button",
             "Name": "Button 20",
             "Type": "Button"
         },
         {
-            "Id": 21,
+            "Id": "21",
             "Label": "RAD NAV Button",
             "Name": "Button 21",
             "Type": "Button"
         },
         {
-            "Id": 22,
+            "Id": "22",
             "Label": "FUEL PRED Button",
             "Name": "Button 22",
             "Type": "Button"
         },
         {
-            "Id": 23,
+            "Id": "23",
             "Label": "SEC F-PLN Button",
             "Name": "Button 23",
             "Type": "Button"
         },
         {
-            "Id": 24,
+            "Id": "24",
             "Label": "ATC COMM Button",
             "Name": "Button 24",
             "Type": "Button"
         },
         {
-            "Id": 25,
+            "Id": "25",
             "Label": "MCDU MENU Button",
             "Name": "Button 25",
             "Type": "Button"
         },
         {
-            "Id": 26,
+            "Id": "26",
             "Label": "DIM Button",
             "Name": "Button 26",
             "Type": "Button"
         },
         {
-            "Id": 27,
+            "Id": "27",
             "Label": "AIRPORT Button",
             "Name": "Button 27",
             "Type": "Button"
         },
         {
-            "Id": 28,
+            "Id": "28",
             "Label": "Blank Button L",
             "Name": "Button 28",
             "Type": "Button"
         },
         {
-            "Id": 29,
+            "Id": "29",
             "Label": "Left-Arrow Button",
             "Name": "Button 29",
             "Type": "Button"
         },
         {
-            "Id": 30,
+            "Id": "30",
             "Label": "Up-Arrow Button",
             "Name": "Button 30",
             "Type": "Button"
         },
         {
-            "Id": 31,
+            "Id": "31",
             "Label": "Right-Arrow Button",
             "Name": "Button 31",
             "Type": "Button"
         },
         {
-            "Id": 32,
+            "Id": "32",
             "Label": "Down-Arrow Button",
             "Name": "Button 32",
             "Type": "Button"
         },
         {
-            "Id": 33,
+            "Id": "33",
             "Label": "1 Button",
             "Name": "Button 33",
             "Type": "Button"
         },
         {
-            "Id": 34,
+            "Id": "34",
             "Label": "2 Button",
             "Name": "Button 34",
             "Type": "Button"
         },
         {
-            "Id": 35,
+            "Id": "35",
             "Label": "3 Button",
             "Name": "Button 35",
             "Type": "Button"
         },
         {
-            "Id": 36,
+            "Id": "36",
             "Label": "4 Button",
             "Name": "Button 36",
             "Type": "Button"
         },
         {
-            "Id": 37,
+            "Id": "37",
             "Label": "5 Button",
             "Name": "Button 37",
             "Type": "Button"
         },
         {
-            "Id": 38,
+            "Id": "38",
             "Label": "6 Button",
             "Name": "Button 38",
             "Type": "Button"
         },
         {
-            "Id": 39,
+            "Id": "39",
             "Label": "7 Button",
             "Name": "Button 39",
             "Type": "Button"
         },
         {
-            "Id": 40,
+            "Id": "40",
             "Label": "8 Button",
             "Name": "Button 40",
             "Type": "Button"
         },
         {
-            "Id": 41,
+            "Id": "41",
             "Label": "9 Button",
             "Name": "Button 41",
             "Type": "Button"
         },
         {
-            "Id": 42,
+            "Id": "42",
             "Label": ". Button",
             "Name": "Button 42",
             "Type": "Button"
         },
         {
-            "Id": 43,
+            "Id": "43",
             "Label": "0 Button",
             "Name": "Button 43",
             "Type": "Button"
         },
         {
-            "Id": 44,
+            "Id": "44",
             "Label": "+/- Button",
             "Name": "Button 44",
             "Type": "Button"
         },
         {
-            "Id": 45,
+            "Id": "45",
             "Label": "A Button",
             "Name": "Button 45",
             "Type": "Button"
         },
         {
-            "Id": 46,
+            "Id": "46",
             "Label": "B Button",
             "Name": "Button 46",
             "Type": "Button"
         },
         {
-            "Id": 47,
+            "Id": "47",
             "Label": "C Button",
             "Name": "Button 47",
             "Type": "Button"
         },
         {
-            "Id": 48,
+            "Id": "48",
             "Label": "D Button",
             "Name": "Button 48",
             "Type": "Button"
         },
         {
-            "Id": 49,
+            "Id": "49",
             "Label": "E Button",
             "Name": "Button 49",
             "Type": "Button"
         },
         {
-            "Id": 50,
+            "Id": "50",
             "Label": "F Button",
             "Name": "Button 50",
             "Type": "Button"
         },
         {
-            "Id": 51,
+            "Id": "51",
             "Label": "G Button",
             "Name": "Button 51",
             "Type": "Button"
         },
         {
-            "Id": 52,
+            "Id": "52",
             "Label": "H Button",
             "Name": "Button 52",
             "Type": "Button"
         },
         {
-            "Id": 53,
+            "Id": "53",
             "Label": "I Button",
             "Name": "Button 53",
             "Type": "Button"
         },
         {
-            "Id": 54,
+            "Id": "54",
             "Label": "J Button",
             "Name": "Button 54",
             "Type": "Button"
         },
         {
-            "Id": 55,
+            "Id": "55",
             "Label": "K Button",
             "Name": "Button 55",
             "Type": "Button"
         },
         {
-            "Id": 56,
+            "Id": "56",
             "Label": "L Button",
             "Name": "Button 56",
             "Type": "Button"
         },
         {
-            "Id": 57,
+            "Id": "57",
             "Label": "M Button",
             "Name": "Button 57",
             "Type": "Button"
         },
         {
-            "Id": 58,
+            "Id": "58",
             "Label": "N Button",
             "Name": "Button 58",
             "Type": "Button"
         },
         {
-            "Id": 59,
+            "Id": "59",
             "Label": "O Button",
             "Name": "Button 59",
             "Type": "Button"
         },
         {
-            "Id": 60,
+            "Id": "60",
             "Label": "P Button",
             "Name": "Button 60",
             "Type": "Button"
         },
         {
-            "Id": 61,
+            "Id": "61",
             "Label": "Q Button",
             "Name": "Button 61",
             "Type": "Button"
         },
         {
-            "Id": 62,
+            "Id": "62",
             "Label": "R Button",
             "Name": "Button 62",
             "Type": "Button"
         },
         {
-            "Id": 63,
+            "Id": "63",
             "Label": "S Button",
             "Name": "Button 63",
             "Type": "Button"
         },
         {
-            "Id": 64,
+            "Id": "64",
             "Label": "T Button",
             "Name": "Button 64",
             "Type": "Button"
         },
         {
-            "Id": 65,
+            "Id": "65",
             "Label": "U Button",
             "Name": "Button 65",
             "Type": "Button"
         },
         {
-            "Id": 66,
+            "Id": "66",
             "Label": "V Button",
             "Name": "Button 66",
             "Type": "Button"
         },
         {
-            "Id": 67,
+            "Id": "67",
             "Label": "W Button",
             "Name": "Button 67",
             "Type": "Button"
         },
         {
-            "Id": 68,
+            "Id": "68",
             "Label": "X Button",
             "Name": "Button 68",
             "Type": "Button"
         },
         {
-            "Id": 69,
+            "Id": "69",
             "Label": "Y Button",
             "Name": "Button 69",
             "Type": "Button"
         },
         {
-            "Id": 70,
+            "Id": "70",
             "Label": "Z Button",
             "Name": "Button 70",
             "Type": "Button"
         },
         {
-            "Id": 71,
+            "Id": "71",
             "Label": "/ Button",
             "Name": "Button 71",
             "Type": "Button"
         },
         {
-            "Id": 72,
+            "Id": "72",
             "Label": "SP Button",
             "Name": "Button 72",
             "Type": "Button"
         },
         {
-            "Id": 73,
+            "Id": "73",
             "Label": "OVFY Button",
             "Name": "Button 73",
             "Type": "Button"
         },
         {
-            "Id": 74,
+            "Id": "74",
             "Label": "CLR Button",
             "Name": "Button 74",
             "Type": "Button"
         },
         {
-            "Id": 51,
+            "Id": "51",
             "Label": "Light Sensor 1",
             "Name": "Axis RotationX",
             "Type": "Axis"
         },
         {
-            "Id": 52,
+            "Id": "52",
             "Label": "Light Sensor 2",
             "Name": "Axis RotationY",
             "Type": "Axis"
         }
     ],
     "InstanceName": "WINWING MCDU-32-CAPTAIN",
-    "Outputs": null,
+    "Outputs": [],
     "ProductId": "0xbb36",
     "VendorId": "0x4098"
 }

--- a/frontend/tests/data/joystick.definition.json
+++ b/frontend/tests/data/joystick.definition.json
@@ -1,0 +1,464 @@
+{
+    "Inputs": [
+        {
+            "Id": 1,
+            "Label": "Line-Select-Key 1L",
+            "Name": "Button 1",
+            "Type": "Button"
+        },
+        {
+            "Id": 2,
+            "Label": "Line-Select-Key 2L",
+            "Name": "Button 2",
+            "Type": "Button"
+        },
+        {
+            "Id": 3,
+            "Label": "Line-Select-Key 3L",
+            "Name": "Button 3",
+            "Type": "Button"
+        },
+        {
+            "Id": 4,
+            "Label": "Line-Select-Key 4L",
+            "Name": "Button 4",
+            "Type": "Button"
+        },
+        {
+            "Id": 5,
+            "Label": "Line-Select-Key 5L",
+            "Name": "Button 5",
+            "Type": "Button"
+        },
+        {
+            "Id": 6,
+            "Label": "Line-Select-Key 6L",
+            "Name": "Button 6",
+            "Type": "Button"
+        },
+        {
+            "Id": 7,
+            "Label": "Line-Select-Key 1R",
+            "Name": "Button 7",
+            "Type": "Button"
+        },
+        {
+            "Id": 8,
+            "Label": "Line-Select-Key 2R",
+            "Name": "Button 8",
+            "Type": "Button"
+        },
+        {
+            "Id": 9,
+            "Label": "Line-Select-Key 3R",
+            "Name": "Button 9",
+            "Type": "Button"
+        },
+        {
+            "Id": 10,
+            "Label": "Line-Select-Key 4R",
+            "Name": "Button 10",
+            "Type": "Button"
+        },
+        {
+            "Id": 11,
+            "Label": "Line-Select-Key 5R",
+            "Name": "Button 11",
+            "Type": "Button"
+        },
+        {
+            "Id": 12,
+            "Label": "Line-Select-Key 6R",
+            "Name": "Button 12",
+            "Type": "Button"
+        },
+        {
+            "Id": 13,
+            "Label": "DIR Button",
+            "Name": "Button 13",
+            "Type": "Button"
+        },
+        {
+            "Id": 14,
+            "Label": "PROG Button",
+            "Name": "Button 14",
+            "Type": "Button"
+        },
+        {
+            "Id": 15,
+            "Label": "PERF Button",
+            "Name": "Button 15",
+            "Type": "Button"
+        },
+        {
+            "Id": 16,
+            "Label": "INIT Button",
+            "Name": "Button 16",
+            "Type": "Button"
+        },
+        {
+            "Id": 17,
+            "Label": "DATA Button",
+            "Name": "Button 17",
+            "Type": "Button"
+        },
+        {
+            "Id": 18,
+            "Label": "Blank Button R",
+            "Name": "Button 18",
+            "Type": "Button"
+        },
+        {
+            "Id": 19,
+            "Label": "BRT Button",
+            "Name": "Button 19",
+            "Type": "Button"
+        },
+        {
+            "Id": 20,
+            "Label": "F-PLN Button",
+            "Name": "Button 20",
+            "Type": "Button"
+        },
+        {
+            "Id": 21,
+            "Label": "RAD NAV Button",
+            "Name": "Button 21",
+            "Type": "Button"
+        },
+        {
+            "Id": 22,
+            "Label": "FUEL PRED Button",
+            "Name": "Button 22",
+            "Type": "Button"
+        },
+        {
+            "Id": 23,
+            "Label": "SEC F-PLN Button",
+            "Name": "Button 23",
+            "Type": "Button"
+        },
+        {
+            "Id": 24,
+            "Label": "ATC COMM Button",
+            "Name": "Button 24",
+            "Type": "Button"
+        },
+        {
+            "Id": 25,
+            "Label": "MCDU MENU Button",
+            "Name": "Button 25",
+            "Type": "Button"
+        },
+        {
+            "Id": 26,
+            "Label": "DIM Button",
+            "Name": "Button 26",
+            "Type": "Button"
+        },
+        {
+            "Id": 27,
+            "Label": "AIRPORT Button",
+            "Name": "Button 27",
+            "Type": "Button"
+        },
+        {
+            "Id": 28,
+            "Label": "Blank Button L",
+            "Name": "Button 28",
+            "Type": "Button"
+        },
+        {
+            "Id": 29,
+            "Label": "Left-Arrow Button",
+            "Name": "Button 29",
+            "Type": "Button"
+        },
+        {
+            "Id": 30,
+            "Label": "Up-Arrow Button",
+            "Name": "Button 30",
+            "Type": "Button"
+        },
+        {
+            "Id": 31,
+            "Label": "Right-Arrow Button",
+            "Name": "Button 31",
+            "Type": "Button"
+        },
+        {
+            "Id": 32,
+            "Label": "Down-Arrow Button",
+            "Name": "Button 32",
+            "Type": "Button"
+        },
+        {
+            "Id": 33,
+            "Label": "1 Button",
+            "Name": "Button 33",
+            "Type": "Button"
+        },
+        {
+            "Id": 34,
+            "Label": "2 Button",
+            "Name": "Button 34",
+            "Type": "Button"
+        },
+        {
+            "Id": 35,
+            "Label": "3 Button",
+            "Name": "Button 35",
+            "Type": "Button"
+        },
+        {
+            "Id": 36,
+            "Label": "4 Button",
+            "Name": "Button 36",
+            "Type": "Button"
+        },
+        {
+            "Id": 37,
+            "Label": "5 Button",
+            "Name": "Button 37",
+            "Type": "Button"
+        },
+        {
+            "Id": 38,
+            "Label": "6 Button",
+            "Name": "Button 38",
+            "Type": "Button"
+        },
+        {
+            "Id": 39,
+            "Label": "7 Button",
+            "Name": "Button 39",
+            "Type": "Button"
+        },
+        {
+            "Id": 40,
+            "Label": "8 Button",
+            "Name": "Button 40",
+            "Type": "Button"
+        },
+        {
+            "Id": 41,
+            "Label": "9 Button",
+            "Name": "Button 41",
+            "Type": "Button"
+        },
+        {
+            "Id": 42,
+            "Label": ". Button",
+            "Name": "Button 42",
+            "Type": "Button"
+        },
+        {
+            "Id": 43,
+            "Label": "0 Button",
+            "Name": "Button 43",
+            "Type": "Button"
+        },
+        {
+            "Id": 44,
+            "Label": "+/- Button",
+            "Name": "Button 44",
+            "Type": "Button"
+        },
+        {
+            "Id": 45,
+            "Label": "A Button",
+            "Name": "Button 45",
+            "Type": "Button"
+        },
+        {
+            "Id": 46,
+            "Label": "B Button",
+            "Name": "Button 46",
+            "Type": "Button"
+        },
+        {
+            "Id": 47,
+            "Label": "C Button",
+            "Name": "Button 47",
+            "Type": "Button"
+        },
+        {
+            "Id": 48,
+            "Label": "D Button",
+            "Name": "Button 48",
+            "Type": "Button"
+        },
+        {
+            "Id": 49,
+            "Label": "E Button",
+            "Name": "Button 49",
+            "Type": "Button"
+        },
+        {
+            "Id": 50,
+            "Label": "F Button",
+            "Name": "Button 50",
+            "Type": "Button"
+        },
+        {
+            "Id": 51,
+            "Label": "G Button",
+            "Name": "Button 51",
+            "Type": "Button"
+        },
+        {
+            "Id": 52,
+            "Label": "H Button",
+            "Name": "Button 52",
+            "Type": "Button"
+        },
+        {
+            "Id": 53,
+            "Label": "I Button",
+            "Name": "Button 53",
+            "Type": "Button"
+        },
+        {
+            "Id": 54,
+            "Label": "J Button",
+            "Name": "Button 54",
+            "Type": "Button"
+        },
+        {
+            "Id": 55,
+            "Label": "K Button",
+            "Name": "Button 55",
+            "Type": "Button"
+        },
+        {
+            "Id": 56,
+            "Label": "L Button",
+            "Name": "Button 56",
+            "Type": "Button"
+        },
+        {
+            "Id": 57,
+            "Label": "M Button",
+            "Name": "Button 57",
+            "Type": "Button"
+        },
+        {
+            "Id": 58,
+            "Label": "N Button",
+            "Name": "Button 58",
+            "Type": "Button"
+        },
+        {
+            "Id": 59,
+            "Label": "O Button",
+            "Name": "Button 59",
+            "Type": "Button"
+        },
+        {
+            "Id": 60,
+            "Label": "P Button",
+            "Name": "Button 60",
+            "Type": "Button"
+        },
+        {
+            "Id": 61,
+            "Label": "Q Button",
+            "Name": "Button 61",
+            "Type": "Button"
+        },
+        {
+            "Id": 62,
+            "Label": "R Button",
+            "Name": "Button 62",
+            "Type": "Button"
+        },
+        {
+            "Id": 63,
+            "Label": "S Button",
+            "Name": "Button 63",
+            "Type": "Button"
+        },
+        {
+            "Id": 64,
+            "Label": "T Button",
+            "Name": "Button 64",
+            "Type": "Button"
+        },
+        {
+            "Id": 65,
+            "Label": "U Button",
+            "Name": "Button 65",
+            "Type": "Button"
+        },
+        {
+            "Id": 66,
+            "Label": "V Button",
+            "Name": "Button 66",
+            "Type": "Button"
+        },
+        {
+            "Id": 67,
+            "Label": "W Button",
+            "Name": "Button 67",
+            "Type": "Button"
+        },
+        {
+            "Id": 68,
+            "Label": "X Button",
+            "Name": "Button 68",
+            "Type": "Button"
+        },
+        {
+            "Id": 69,
+            "Label": "Y Button",
+            "Name": "Button 69",
+            "Type": "Button"
+        },
+        {
+            "Id": 70,
+            "Label": "Z Button",
+            "Name": "Button 70",
+            "Type": "Button"
+        },
+        {
+            "Id": 71,
+            "Label": "/ Button",
+            "Name": "Button 71",
+            "Type": "Button"
+        },
+        {
+            "Id": 72,
+            "Label": "SP Button",
+            "Name": "Button 72",
+            "Type": "Button"
+        },
+        {
+            "Id": 73,
+            "Label": "OVFY Button",
+            "Name": "Button 73",
+            "Type": "Button"
+        },
+        {
+            "Id": 74,
+            "Label": "CLR Button",
+            "Name": "Button 74",
+            "Type": "Button"
+        },
+        {
+            "Id": 51,
+            "Label": "Light Sensor 1",
+            "Name": "Axis RotationX",
+            "Type": "Axis"
+        },
+        {
+            "Id": 52,
+            "Label": "Light Sensor 2",
+            "Name": "Axis RotationY",
+            "Type": "Axis"
+        }
+    ],
+    "InstanceName": "WINWING MCDU-32-CAPTAIN",
+    "Outputs": null,
+    "ProductId": "0xbb36",
+    "VendorId": "0x4098"
+}

--- a/frontend/tests/data/midicontroller.definition.json
+++ b/frontend/tests/data/midicontroller.definition.json
@@ -1,0 +1,63 @@
+{
+    "EncoderNeutralPosition": 0,
+    "Inputs": [
+        {
+            "InputType": "EndlessKnob",
+            "Label": "Knob %",
+            "LabelIds": [
+                "1",
+                "2",
+                "3",
+                "4"
+            ],
+            "Layer": null,
+            "MessageChannel": 1,
+            "MessageIds": [
+                32,
+                33,
+                34,
+                35
+            ],
+            "MessageType": "CC"
+        },
+        {
+            "InputType": "Button",
+            "Label": "Button %",
+            "LabelIds": [
+                "1",
+                "2",
+                "3",
+                "4"
+            ],
+            "Layer": null,
+            "MessageChannel": 1,
+            "MessageIds": [
+                0,
+                1,
+                2,
+                3
+            ],
+            "MessageType": "CC"
+        },
+        {
+            "InputType": "Fader",
+            "Label": "Slider %",
+            "LabelIds": [
+                "1",
+                "2",
+                "3",
+                "4"
+            ],
+            "Layer": null,
+            "MessageChannel": 1,
+            "MessageIds": [
+                36,
+                37,
+                38,
+                39
+            ],
+            "MessageType": "CC"
+        }
+    ],
+    "InstanceName": "Intech Studio: AC  "
+}

--- a/frontend/tests/data/midicontroller.definition.json
+++ b/frontend/tests/data/midicontroller.definition.json
@@ -10,7 +10,6 @@
                 "3",
                 "4"
             ],
-            "Layer": null,
             "MessageChannel": 1,
             "MessageIds": [
                 32,
@@ -29,7 +28,6 @@
                 "3",
                 "4"
             ],
-            "Layer": null,
             "MessageChannel": 1,
             "MessageIds": [
                 0,
@@ -48,7 +46,6 @@
                 "3",
                 "4"
             ],
-            "Layer": null,
             "MessageChannel": 1,
             "MessageIds": [
                 36,

--- a/frontend/tests/data/project.testdata.json
+++ b/frontend/tests/data/project.testdata.json
@@ -434,7 +434,7 @@
             "Items": []
           },
           "ModuleSerial": "Intech Studio: AC   / MI-2222",
-          "Name": "Encoder",
+          "Name": "Midi Encoder Input",
           "Preconditions": [],
           "Status": {},
           "Type": "InputConfigItem",
@@ -459,7 +459,7 @@
             "Items": []
           },
           "ModuleSerial": "Intech Studio: AC   / MI-2222",
-          "Name": "AnalogInput",
+          "Name": "Midi Slider Input",
           "Preconditions": [],
           "Status": {},
           "Type": "InputConfigItem",

--- a/frontend/tests/data/project.testdata.json
+++ b/frontend/tests/data/project.testdata.json
@@ -388,6 +388,86 @@
           "RawValue": "",
           "Value": "",
           "Status": {}
+        },
+        {
+          "button": {
+            "onPress": {
+              "Type": "VariableInputAction",
+              "Variable": {
+                "TYPE": "number",
+                "Name": "COM2 MIC",
+                "Number": 0.0,
+                "Text": "",
+                "Expression": "1-$"
+              }
+            },
+            "onRelease": null,
+            "onLongRelease": null,
+            "onHold": null,
+            "LongReleaseDelay": 350,
+            "HoldDelay": 350,
+            "RepeatDelay": 0
+          },
+          "DeviceType": "Button",
+          "DeviceName": "CC 1_0",
+          "GUID": "39563d2e-9845-4c48-9b49-b024057181aa",
+          "Active": true,
+          "Name": "COM2 MIC",
+          "Type": "InputConfigItem",
+          "ModuleSerial": "Intech Studio: AC   / MI-2222",
+          "Preconditions": [],
+          "Modifiers": {
+            "Items": []
+          },
+          "ConfigRefs": [],
+          "RawValue": "",
+          "Value": "",
+          "Status": {}
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "DeviceName": "CC 1_32",
+          "DeviceType": "Encoder",
+          "GUID": "68285201-23d5-40ea-b81f-dbd3ffe7328e",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "Intech Studio: AC   / MI-2222",
+          "Name": "Encoder",
+          "Preconditions": [],
+          "Status": {},
+          "Type": "InputConfigItem",
+          "encoder": {
+            "onLeft": {
+              "Type": "MSFS2020CustomInputAction"
+            },
+            "onLeftFast": null,
+            "onRight": {
+              "Type": "MSFS2020CustomInputAction"
+            },
+            "onRightFast": null
+          }
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "DeviceName": "CC 1_36",
+          "DeviceType": "AnalogInput",
+          "GUID": "be1ffab3-4252-4001-a090-4b98c7cd126b",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "Intech Studio: AC   / MI-2222",
+          "Name": "AnalogInput",
+          "Preconditions": [],
+          "Status": {},
+          "Type": "InputConfigItem",
+          "analog": {
+            "onChange": {
+              "Type": "MSFS2020CustomInputAction"
+            }
+          }
         }
       ],
       "EmbedContent": true,

--- a/frontend/tests/data/project.testdata.json
+++ b/frontend/tests/data/project.testdata.json
@@ -1,427 +1,468 @@
 {
   "ConfigFiles": [
-      {
-          "ConfigItems": [
+    {
+      "ConfigItems": [
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "Device": {
+            "DisplayLedAddress": "7-Segment",
+            "DisplayLedBrightnessReference": "",
+            "DisplayLedConnector": 1,
+            "DisplayLedDecimalPoints": [],
+            "DisplayLedDigits": [],
+            "DisplayLedModuleSize": 8,
+            "DisplayLedPadding": false,
+            "DisplayLedPaddingChar": "0",
+            "DisplayLedReverseDigits": false,
+            "Name": "7-Segment",
+            "Type": "LedModule"
+          },
+          "DeviceType": "Display Module",
+          "GUID": "5b09dc42-d5cd-4284-9c03-355e579763f2",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
+          "Name": "7-Segment",
+          "Preconditions": [],
+          "Source": {
+            "SimConnectValue": {
+              "UUID": "b5a95362-411e-422d-9e6e-598b8b0bdcdf",
+              "Value": "(A:COM ACTIVE FREQUENCY:1,KHz)",
+              "VarType": 2
+            },
+            "SourceType": "SIMCONNECT",
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "Device": {
+            "Acceleration": 800,
+            "Address": "Stepper 1",
+            "CompassMode": false,
+            "InputRev": 1000,
+            "Name": "Stepper 1",
+            "OutputRev": 2040,
+            "Speed": 467,
+            "TestValue": 500,
+            "Type": "Stepper"
+          },
+          "DeviceType": "Stepper",
+          "GUID": "c6e321b0-d6e4-42db-be98-0b7867db58eb",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
+          "Name": "Stepper 2",
+          "Preconditions": [],
+          "Source": {
+            "SimConnectValue": {
+              "UUID": "02d438f0-b1cd-4920-8884-e3fc4998e49c",
+              "Value": "(A:PROP RPM:1,Rpm)",
+              "VarType": 2
+            },
+            "SourceType": "SIMCONNECT",
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "Device": {
+            "Address": "Servo 1",
+            "Max": "255",
+            "MaxRotationPercent": "100",
+            "Min": "0",
+            "Name": "Servo 1",
+            "Type": "Servo"
+          },
+          "DeviceType": "Servo",
+          "GUID": "4eb61c0f-a3c1-4b86-b0ff-d06e6ddc0363",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
+          "Name": "Servo",
+          "Preconditions": [],
+          "Source": {
+            "SimConnectValue": {
+              "UUID": "7de0a675-da06-4aef-8f02-8f93de402273",
+              "Value": "(A:FUEL SELECTED QUANTITY PERCENT,Percent Over 100)",
+              "VarType": 2
+            },
+            "SourceType": "SIMCONNECT",
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "Device": {
+            "Address": "LCD 1",
+            "Lines": [
+              "1234567890123456",
+              "******Test******",
+              "1234567890123456",
+              "******Test******"
+            ],
+            "Name": "LCD 1",
+            "Type": "LcdDisplay"
+          },
+          "DeviceType": "LcdDisplay",
+          "GUID": "61ae4145-c7d5-41ef-b2a9-c993f8986be1",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
+          "Name": "LCD",
+          "Preconditions": [],
+          "Source": {
+            "SimConnectValue": {
+              "UUID": "dbf414f2-5a45-4b55-9983-7703862edaf0",
+              "Value": "(A:COM ACTIVE FREQ NAME:1,String)",
+              "VarType": 2
+            },
+            "SourceType": "SIMCONNECT",
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [
             {
-                "Active": true,
-                "ConfigRefs": [],
-                "Device": {
-                    "DisplayLedAddress": "7-Segment",
-                    "DisplayLedBrightnessReference": "",
-                    "DisplayLedConnector": 1,
-                    "DisplayLedDecimalPoints": [],
-                    "DisplayLedDigits": [],
-                    "DisplayLedModuleSize": 8,
-                    "DisplayLedPadding": false,
-                    "DisplayLedPaddingChar": "0",
-                    "DisplayLedReverseDigits": false,
-                    "Name": "7-Segment",
-                    "Type": "LedModule"
-                },
-                "DeviceType": "Display Module",
-                "GUID": "5b09dc42-d5cd-4284-9c03-355e579763f2",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
-                "Name": "7-Segment",
-                "Preconditions": [],
-                "Source": {
-                    "SimConnectValue": {
-                        "UUID": "b5a95362-411e-422d-9e6e-598b8b0bdcdf",
-                        "Value": "(A:COM ACTIVE FREQUENCY:1,KHz)",
-                        "VarType": 2
-                    },
-                    "SourceType": "SIMCONNECT",
-                    "Type": "SimConnectSource"
-                },
-                "Status": {},
-                "TestValue": {
-                    "Float64": 1,
-                    "String": null,
-                    "type": 1
-                },
-                "Type": "OutputConfigItem"
+              "Active": true,
+              "Placeholder": "#",
+              "Ref": "5b09dc42-d5cd-4284-9c03-355e579763f2",
+              "TestValue": "1"
             },
             {
-                "Active": true,
-                "ConfigRefs": [],
-                "Device": {
-                    "Acceleration": 800,
-                    "Address": "Stepper 1",
-                    "CompassMode": false,
-                    "InputRev": 1000,
-                    "Name": "Stepper 1",
-                    "OutputRev": 2040,
-                    "Speed": 467,
-                    "TestValue": 500,
-                    "Type": "Stepper"
-                },
-                "DeviceType": "Stepper",
-                "GUID": "c6e321b0-d6e4-42db-be98-0b7867db58eb",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
-                "Name": "Stepper 2",
-                "Preconditions": [],
-                "Source": {
-                    "SimConnectValue": {
-                        "UUID": "02d438f0-b1cd-4920-8884-e3fc4998e49c",
-                        "Value": "(A:PROP RPM:1,Rpm)",
-                        "VarType": 2
-                    },
-                    "SourceType": "SIMCONNECT",
-                    "Type": "SimConnectSource"
-                },
-                "Status": {},
-                "TestValue": {
-                    "Float64": 1,
-                    "String": null,
-                    "type": 1
-                },
-                "Type": "OutputConfigItem"
-            },
-            {
-                "Active": true,
-                "ConfigRefs": [],
-                "Device": {
-                    "Address": "Servo 1",
-                    "Max": "255",
-                    "MaxRotationPercent": "100",
-                    "Min": "0",
-                    "Name": "Servo 1",
-                    "Type": "Servo"
-                },
-                "DeviceType": "Servo",
-                "GUID": "4eb61c0f-a3c1-4b86-b0ff-d06e6ddc0363",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
-                "Name": "Servo",
-                "Preconditions": [],
-                "Source": {
-                    "SimConnectValue": {
-                        "UUID": "7de0a675-da06-4aef-8f02-8f93de402273",
-                        "Value": "(A:FUEL SELECTED QUANTITY PERCENT,Percent Over 100)",
-                        "VarType": 2
-                    },
-                    "SourceType": "SIMCONNECT",
-                    "Type": "SimConnectSource"
-                },
-                "Status": {},
-                "TestValue": {
-                    "Float64": 1,
-                    "String": null,
-                    "type": 1
-                },
-                "Type": "OutputConfigItem"
-            },
-            {
-                "Active": true,
-                "ConfigRefs": [],
-                "Device": {
-                    "Address": "LCD 1",
-                    "Lines": [
-                        "1234567890123456",
-                        "******Test******",
-                        "1234567890123456",
-                        "******Test******"
-                    ],
-                    "Name": "LCD 1",
-                    "Type": "LcdDisplay"
-                },
-                "DeviceType": "LcdDisplay",
-                "GUID": "61ae4145-c7d5-41ef-b2a9-c993f8986be1",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
-                "Name": "LCD",
-                "Preconditions": [],
-                "Source": {
-                    "SimConnectValue": {
-                        "UUID": "dbf414f2-5a45-4b55-9983-7703862edaf0",
-                        "Value": "(A:COM ACTIVE FREQ NAME:1,String)",
-                        "VarType": 2
-                    },
-                    "SourceType": "SIMCONNECT",
-                    "Type": "SimConnectSource"
-                },
-                "Status": {},
-                "TestValue": {
-                    "Float64": 1,
-                    "String": null,
-                    "type": 1
-                },
-                "Type": "OutputConfigItem"
-            },
-            {
-                "Active": true,
-                "ConfigRefs": [
-                    {
-                        "Active": true,
-                        "Placeholder": "#",
-                        "Ref": "5b09dc42-d5cd-4284-9c03-355e579763f2",
-                        "TestValue": "1"
-                    },
-                    {
-                        "Active": true,
-                        "Placeholder": "!",
-                        "Ref": "c6e321b0-d6e4-42db-be98-0b7867db58eb",
-                        "TestValue": "1"
-                    }
-                ],
-                "Device": {
-                    "DisplayPin": "LED 2",
-                    "DisplayPinBrightness": 255,
-                    "DisplayPinPWM": false,
-                    "Name": "LED 2",
-                    "Type": "Output"
-                },
-                "DeviceType": "Output",
-                "GUID": "f79f75dd-0d45-4c91-870d-599cfc75ede1",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
-                "Name": "LED 1",
-                "Preconditions": [
-                    {
-                        "PreconditionActive": true,
-                        "PreconditionLabel": "Config: <Ref:5b09dc42-d5cd-4284-9c03-355e579763f2> < 1 <Logic:and>",
-                        "PreconditionLogic": "and",
-                        "PreconditionOperand": "<",
-                        "PreconditionPin": null,
-                        "PreconditionRef": "5b09dc42-d5cd-4284-9c03-355e579763f2",
-                        "PreconditionSerial": null,
-                        "PreconditionType": "config",
-                        "PreconditionValue": "1"
-                    }
-                ],
-                "Source": {
-                    "SimConnectValue": {
-                        "UUID": "0cf15a1c-712f-4bf2-bd16-eb4e6b103e20",
-                        "Value": "(A:BRAKE PARKING INDICATOR,Bool)",
-                        "VarType": 2
-                    },
-                    "SourceType": "SIMCONNECT",
-                    "Type": "SimConnectSource"
-                },
-                "Status": {},
-                "TestValue": {
-                    "Float64": 1,
-                    "String": null,
-                    "type": 1
-                },
-                "Type": "OutputConfigItem"
-            },
-            {
-                "Active": true,
-                "ConfigRefs": [],
-                "Device": {
-                    "Address": "ShiftRegister 1",
-                    "Name": "ShiftRegister 1",
-                    "Pin": "Output 0",
-                    "Type": "ShiftRegister"
-                },
-                "DeviceType": "ShiftRegister",
-                "GUID": "54e5ac64-e314-48de-8ebb-6d8ccc4689e4",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
-                "Name": "ShiftRegister - And a long name to test truncation",
-                "Preconditions": [],
-                "Source": {
-                    "SimConnectValue": {
-                        "UUID": "b0abd7a4-65cb-4109-b85b-6df6431ebcd6",
-                        "Value": "(A:LIGHT LANDING,Bool)",
-                        "VarType": 2
-                    },
-                    "SourceType": "SIMCONNECT",
-                    "Type": "SimConnectSource"
-                },
-                "Status": {},
-                "TestValue": {
-                    "Float64": 1,
-                    "String": null,
-                    "type": 1
-                },
-                "Type": "OutputConfigItem"
-            },
-            {
-                "Active": true,
-                "ConfigRefs": [],
-                "DeviceType": "",
-                "GUID": "de57dc80-be81-4049-95d0-2349109d58c1",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "",
-                "Name": "New Output Config",
-                "Preconditions": [],
-                "Source": {
-                    "SimConnectValue": {
-                        "VarType": 0
-                    },
-                    "SourceType": "SIMCONNECT",
-                    "Type": "SimConnectSource"
-                },
-                "Status": {},
-                "TestValue": {
-                    "Float64": 1,
-                    "String": null,
-                    "type": 1
-                },
-                "Type": "OutputConfigItem"
-            },
-            {
-                "Active": true,
-                "ConfigRefs": [],
-                "DeviceName": "Button 4 With A Long Name To Test Truncation",
-                "DeviceType": "Button",
-                "GUID": "49079f13-b7cc-442d-a64b-70edbf7a1334",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "WINWING Orion Joystick Base 2 + JGRIP-F16 / JS-3145ad90-c6f2-11ef-8001-444553540000",
-                "Name": "Button",
-                "Preconditions": [],
-                "Status": {},
-                "Type": "InputConfigItem",
-                "button": {
-                    "HoldDelay": 350,
-                    "LongReleaseDelay": 350,
-                    "RepeatDelay": 0,
-                    "onHold": null,
-                    "onLongRelease": null,
-                    "onPress": {
-                        "Type": "MSFS2020CustomInputAction"
-                    },
-                    "onRelease": null
-                }
-            },
-            {
-                "Active": true,
-                "ConfigRefs": [],
-                "DeviceName": "Encoder 1",
-                "DeviceType": "Encoder",
-                "GUID": "68285201-23d5-40ea-b81f-dbd3ffe7328d",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
-                "Name": "Encoder",
-                "Preconditions": [],
-                "Status": {},
-                "Type": "InputConfigItem",
-                "encoder": {
-                    "onLeft": {
-                        "Type": "MSFS2020CustomInputAction"
-                    },
-                    "onLeftFast": null,
-                    "onRight": {
-                        "Type": "MSFS2020CustomInputAction"
-                    },
-                    "onRightFast": null
-                }
-            },
-            {
-                "Active": true,
-                "ConfigRefs": [],
-                "DeviceName": "POT 1",
-                "DeviceType": "AnalogInput",
-                "GUID": "be1ffab3-4252-4001-a090-4b98c7cd126a",
-                "Modifiers": {
-                    "Items": []
-                },
-                "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
-                "Name": "AnalogInput",
-                "Preconditions": [],
-                "Status": {},
-                "Type": "InputConfigItem",
-                "analog": {
-                    "onChange": {
-                        "Type": "MSFS2020CustomInputAction"
-                    }
-                }
+              "Active": true,
+              "Placeholder": "!",
+              "Ref": "c6e321b0-d6e4-42db-be98-0b7867db58eb",
+              "TestValue": "1"
             }
           ],
-          "EmbedContent": true,
-          "FileName": null,
-          "Label": "Config 1",
-          "ReferenceOnly": false
-      },
-      {
-          "ConfigItems": [
-              {
-                  "Active": true,
-                  "ConfigRefs": [],
-                  "DeviceName": null,
-                  "DeviceType": null,
-                  "GUID": "0dc35235-118d-46a3-a7d7-6a1be0ffdbe6",
-                  "Modifiers": {
-                      "Items": []
-                  },
-                  "ModuleSerial": "",
-                  "Name": "Config 2",
-                  "Preconditions": [],
-                  "Source": {
-                      "SimConnectValue": {
-                          "VarType": 0
-                      },
-                      "Type": "SimConnectSource"
-                  },
-                  "Status": {},
-                  "TestValue": {
-                      "Float64": 1,
-                      "String": null,
-                      "type": 1
-                  },
-                  "Type": "OutputConfigItem"
-              }
+          "Device": {
+            "DisplayPin": "LED 2",
+            "DisplayPinBrightness": 255,
+            "DisplayPinPWM": false,
+            "Name": "LED 2",
+            "Type": "Output"
+          },
+          "DeviceType": "Output",
+          "GUID": "f79f75dd-0d45-4c91-870d-599cfc75ede1",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
+          "Name": "LED 1",
+          "Preconditions": [
+            {
+              "PreconditionActive": true,
+              "PreconditionLabel": "Config: <Ref:5b09dc42-d5cd-4284-9c03-355e579763f2> < 1 <Logic:and>",
+              "PreconditionLogic": "and",
+              "PreconditionOperand": "<",
+              "PreconditionPin": null,
+              "PreconditionRef": "5b09dc42-d5cd-4284-9c03-355e579763f2",
+              "PreconditionSerial": null,
+              "PreconditionType": "config",
+              "PreconditionValue": "1"
+            }
           ],
-          "EmbedContent": true,
-          "FileName": null,
-          "Label": "Config 2",
-          "ReferenceOnly": false
-      },
-      {
-          "ConfigItems": [
-              {
-                  "Active": true,
-                  "ConfigRefs": [],
-                  "DeviceName": null,
-                  "DeviceType": null,
-                  "GUID": "0db8514f-5132-49df-97ef-d6226cd15323",
-                  "Modifiers": {
-                      "Items": []
-                  },
-                  "ModuleSerial": "",
-                  "Name": "Config 3",
-                  "Preconditions": [],
-                  "Source": {
-                      "SimConnectValue": {
-                          "VarType": 0
-                      },
-                      "Type": "SimConnectSource"
-                  },
-                  "Status": {},
-                  "TestValue": {
-                      "Float64": 1,
-                      "String": null,
-                      "type": 1
-                  },
-                  "Type": "OutputConfigItem"
-              }
+          "Source": {
+            "SimConnectValue": {
+              "UUID": "0cf15a1c-712f-4bf2-bd16-eb4e6b103e20",
+              "Value": "(A:BRAKE PARKING INDICATOR,Bool)",
+              "VarType": 2
+            },
+            "SourceType": "SIMCONNECT",
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "Device": {
+            "Address": "ShiftRegister 1",
+            "Name": "ShiftRegister 1",
+            "Pin": "Output 0",
+            "Type": "ShiftRegister"
+          },
+          "DeviceType": "ShiftRegister",
+          "GUID": "54e5ac64-e314-48de-8ebb-6d8ccc4689e4",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
+          "Name": "ShiftRegister - And a long name to test truncation",
+          "Preconditions": [],
+          "Source": {
+            "SimConnectValue": {
+              "UUID": "b0abd7a4-65cb-4109-b85b-6df6431ebcd6",
+              "Value": "(A:LIGHT LANDING,Bool)",
+              "VarType": 2
+            },
+            "SourceType": "SIMCONNECT",
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "DeviceType": "",
+          "GUID": "de57dc80-be81-4049-95d0-2349109d58c1",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "",
+          "Name": "New Output Config",
+          "Preconditions": [],
+          "Source": {
+            "SimConnectValue": {
+              "VarType": 0
+            },
+            "SourceType": "SIMCONNECT",
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "DeviceName": "Button 4 With A Long Name To Test Truncation",
+          "DeviceType": "Button",
+          "GUID": "49079f13-b7cc-442d-a64b-70edbf7a1334",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "WINWING Orion Joystick Base 2 + JGRIP-F16 / JS-3145ad90-c6f2-11ef-8001-444553540000",
+          "Name": "Button",
+          "Preconditions": [],
+          "Status": {},
+          "Type": "InputConfigItem",
+          "button": {
+            "HoldDelay": 350,
+            "LongReleaseDelay": 350,
+            "RepeatDelay": 0,
+            "onHold": null,
+            "onLongRelease": null,
+            "onPress": {
+              "Type": "MSFS2020CustomInputAction"
+            },
+            "onRelease": null
+          }
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "DeviceName": "Encoder 1",
+          "DeviceType": "Encoder",
+          "GUID": "68285201-23d5-40ea-b81f-dbd3ffe7328d",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
+          "Name": "Encoder",
+          "Preconditions": [],
+          "Status": {},
+          "Type": "InputConfigItem",
+          "encoder": {
+            "onLeft": {
+              "Type": "MSFS2020CustomInputAction"
+            },
+            "onLeftFast": null,
+            "onRight": {
+              "Type": "MSFS2020CustomInputAction"
+            },
+            "onRightFast": null
+          }
+        },
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "DeviceName": "POT 1",
+          "DeviceType": "AnalogInput",
+          "GUID": "be1ffab3-4252-4001-a090-4b98c7cd126a",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "ProtoBoard-v2/ SN-5FC-1CF",
+          "Name": "AnalogInput",
+          "Preconditions": [],
+          "Status": {},
+          "Type": "InputConfigItem",
+          "analog": {
+            "onChange": {
+              "Type": "MSFS2020CustomInputAction"
+            }
+          }
+        },
+        {
+          "button": {
+            "onPress": {
+              "Type": "MSFS2020CustomInputAction",
+              "Command": "1 (>L:A32NX_MCDU_PUSH_ANIM_1_L1) (>H:A320_Neo_CDU_1_BTN_L1)",
+              "PresetId": "9f3ffb64-147d-423b-a4d5-31c5968aade7"
+            },
+            "onRelease": null,
+            "onLongRelease": null,
+            "onHold": null,
+            "LongReleaseDelay": 350,
+            "HoldDelay": 350,
+            "RepeatDelay": 0
+          },
+          "DeviceType": "Button",
+          "DeviceName": "Button 1",
+          "GUID": "3e83caea-6234-4f3e-9e33-7f5eb436999c",
+          "Active": true,
+          "Name": "MCDU - L1",
+          "Type": "InputConfigItem",
+          "ModuleSerial": "WINWING MCDU-32-CAPTAIN / JS-d2e9a050-00f1-11f0-8006-444553540000",
+          "Preconditions": [
+            {
+              "PreconditionType": "none",
+              "PreconditionRef": null,
+              "PreconditionSerial": null,
+              "PreconditionPin": null,
+              "PreconditionOperand": "=",
+              "PreconditionValue": null,
+              "PreconditionLogic": "and",
+              "PreconditionActive": true
+            }
           ],
-          "EmbedContent": true,
-          "FileName": null,
-          "Label": "Config 3",
-          "ReferenceOnly": false
-      }
+          "Modifiers": {
+            "Items": []
+          },
+          "ConfigRefs": [],
+          "RawValue": "",
+          "Value": "",
+          "Status": {}
+        }
+      ],
+      "EmbedContent": true,
+      "FileName": null,
+      "Label": "Config 1",
+      "ReferenceOnly": false
+    },
+    {
+      "ConfigItems": [
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "DeviceName": null,
+          "DeviceType": null,
+          "GUID": "0dc35235-118d-46a3-a7d7-6a1be0ffdbe6",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "",
+          "Name": "Config 2",
+          "Preconditions": [],
+          "Source": {
+            "SimConnectValue": {
+              "VarType": 0
+            },
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        }
+      ],
+      "EmbedContent": true,
+      "FileName": null,
+      "Label": "Config 2",
+      "ReferenceOnly": false
+    },
+    {
+      "ConfigItems": [
+        {
+          "Active": true,
+          "ConfigRefs": [],
+          "DeviceName": null,
+          "DeviceType": null,
+          "GUID": "0db8514f-5132-49df-97ef-d6226cd15323",
+          "Modifiers": {
+            "Items": []
+          },
+          "ModuleSerial": "",
+          "Name": "Config 3",
+          "Preconditions": [],
+          "Source": {
+            "SimConnectValue": {
+              "VarType": 0
+            },
+            "Type": "SimConnectSource"
+          },
+          "Status": {},
+          "TestValue": {
+            "Float64": 1,
+            "String": null,
+            "type": 1
+          },
+          "Type": "OutputConfigItem"
+        }
+      ],
+      "EmbedContent": true,
+      "FileName": null,
+      "Label": "Config 3",
+      "ReferenceOnly": false
+    }
   ],
   "Name": "Test Project"
 }

--- a/frontend/tests/fixtures/ConfigListPage.ts
+++ b/frontend/tests/fixtures/ConfigListPage.ts
@@ -1,12 +1,13 @@
 import {
   AppMessage,
   Project,
-  ConfigValuePartialUpdate,
   IConfigItem,
 } from "@/types"
 import { MobiFlightPage } from "./MobiFlightPage"
 import testdata from "../data/configlist.testdata.json" with { type: "json" }
 import testProject from "../data/project.testdata.json" with { type: "json" }
+import joystickDefinition from "../data/joystick.definition.json" with { type: "json" }
+import { ConfigValuePartialUpdate } from "@/types/messages"
 import { CommandUpdateConfigItem } from "@/types/commands"
 import { ConfigItemStatusType, IDictionary } from "@/types/config"
 import { Locator } from "@playwright/test"
@@ -37,6 +38,16 @@ export class ConfigListPage {
     const message: AppMessage = {
       key: "Project",
       payload: testProject
+    }
+    await this.mobiFlightPage.publishMessage(message)
+  }
+
+  async initControllerDefinitions() {
+    const message: AppMessage = {
+      key: "JoystickDefinitions",
+      payload: {
+        Definitions: [joystickDefinition]
+      },
     }
     await this.mobiFlightPage.publishMessage(message)
   }

--- a/frontend/tests/fixtures/ConfigListPage.ts
+++ b/frontend/tests/fixtures/ConfigListPage.ts
@@ -7,6 +7,7 @@ import { MobiFlightPage } from "./MobiFlightPage"
 import testdata from "../data/configlist.testdata.json" with { type: "json" }
 import testProject from "../data/project.testdata.json" with { type: "json" }
 import joystickDefinition from "../data/joystick.definition.json" with { type: "json" }
+import midiControllerDefinition from "../data/midicontroller.definition.json" with { type: "json" }
 import { ConfigValuePartialUpdate } from "@/types/messages"
 import { CommandUpdateConfigItem } from "@/types/commands"
 import { ConfigItemStatusType, IDictionary } from "@/types/config"
@@ -50,6 +51,14 @@ export class ConfigListPage {
       },
     }
     await this.mobiFlightPage.publishMessage(message)
+
+    const midiMessage : AppMessage = {
+      key: "MidiControllerDefinitions",
+      payload: {
+        Definitions: [midiControllerDefinition],
+      },
+    }
+    await this.mobiFlightPage.publishMessage(midiMessage)
   }
 
   async setupConfigItemEditConfirmationResponse() {


### PR DESCRIPTION
- [x] Joystick device labels are displayed instead of the device names
- [x] MidiController device labels are displayed instead of the device names
- [x] MidiController label generation logic replicated in frontend
- [x] playwright tests added

fixes #2083 