### PR TITLE
Adjust support button graphically

### DIFF
--- a/frontend/src/components/CommunityMenu.tsx
+++ b/frontend/src/components/CommunityMenu.tsx
@@ -8,20 +8,20 @@ import IconBrandHubHopLogo from "./icons/IconBrandHubHopLogo"
 
 export const CommunityMenu = () => {
   return (
-    <div className="flex flex-row gap-2">
-      <Button className="bg-pink-700 px-2 py-1 text-white [&_svg]:size-6">
-        <IconHeartDollar className="fill-white stroke-white text-white" />
+    <div className="flex flex-row gap-1 py-2 text-sm items-center">
+      <Button className="group bg-pink-600 hover:bg-pink-400 dark:hover:bg-pink-600 dark:bg-transparent dark:border-pink-600 dark:border dark:text-pink-600 text-white dark:hover:text-white pl-3 pr-4 py-1 h-8 [&_svg]:size-5 rounded-full gap-1" variant={"default"}>
+        <IconHeartDollar className="fill-none stroke-white text-white dark:stroke-pink-600 group-hover:stroke-white " />
         Support us
       </Button>
-      <Button className="px-2 py-1 [&_svg]:size-6" variant={"ghost"}>
+      <Button className="px-4 py-1 [&_svg]:size-6 h-8 rounded-full gap-1" variant={"ghost"}>
         <IconBrandDiscordFilled className="fill-indigo-800 stroke-indigo-800" />
         Discord
       </Button>
-      <Button className="h-10 px-2 py-1 [&_svg]:size-6" variant={"ghost"}>
+      <Button className="px-4 py-1 [&_svg]:size-6 h-8 rounded-full gap-1" variant={"ghost"}>
         <IconBrandYoutubeFilled className="fill-red-700 stroke-red-700" />
         YouTube
       </Button>
-      <Button className="h-10 px-2 py-1 [&_svg]:size-6" variant={"ghost"}>
+      <Button className="px-4 py-1 [&_svg]:size-6 h-8 rounded-full gap-1" variant={"ghost"}>
         <IconBrandHubHopLogo className="fill-orange-400 stroke-orange-400" />
         HubHop
       </Button>

--- a/frontend/src/components/MainMenu.tsx
+++ b/frontend/src/components/MainMenu.tsx
@@ -175,7 +175,7 @@ export const MainMenu = () => {
           </MenubarContent>
         </MenubarMenu>
       </div>
-      <div className="flex items-center gap-16 px-2">
+      <div className="flex items-center gap-8 px-2">
         <CommunityMenu />
         <DarkModeToggle />
       </div>


### PR DESCRIPTION
![Image](https://github.com/user-attachments/assets/331e1e9c-e6ef-449d-9b85-b064b8e4aa5d)
**Light mode hover**
![Image](https://github.com/user-attachments/assets/0e2d4882-c9da-4f97-a127-73142161913f)

![Image](https://github.com/user-attachments/assets/3f00a489-5b99-4ba5-9510-f85e671abe86)

Darkmode hover is different from the specs to follow the style of the Add Output Config-button
> pink-600

![Image](https://github.com/user-attachments/assets/c6887450-54c4-43b2-9be9-bb8b1705f4cc)

fixes #2194 
