### PR TITLE
Prevent accessing CoreWebView in case null

### DIFF
--- a/MobiFlight/ThreadSafeWebView2.cs
+++ b/MobiFlight/ThreadSafeWebView2.cs
@@ -9,11 +9,11 @@ namespace MobiFlight
         {
             if (this.InvokeRequired)
             {
-                this.Invoke(new Action(() => CoreWebView2.PostWebMessageAsJson(jsonMessage)));
+                this.Invoke(new Action(() => CoreWebView2?.PostWebMessageAsJson(jsonMessage)));
             }
             else
             {
-                CoreWebView2.PostWebMessageAsJson(jsonMessage);
+                CoreWebView2?.PostWebMessageAsJson(jsonMessage);
             }
         }
     }


### PR DESCRIPTION
This prevents an exception that I have had numerous times during debug sessions.
It might actually fix the problem which was reported in the linked issue.

- [x] null exception safe access of CoreWebView2

fixes #2145 