### PR TITLE
Fix broken PR comment artifact link

### DIFF
--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -12,7 +12,7 @@ on:
         required: false
         type: number
       workflow_names:
-        description: 'Comma-separated list of workflow names to search for artifacts (e.g., "RunTests,Build")'
+        description: 'Comma-separated list of workflow names to search for artifacts (e.g., "RunTests,Build"), leave empty for all workflows'
         required: false
         type: string
         default: ''
@@ -86,7 +86,9 @@ jobs:
               
               // Parse workflow names to search for
               const workflowNames = '${{ inputs.workflow_names }}'.split(',').map(name => name.trim()).filter(name => name);
-              console.log(`Searching for artifacts in workflows: ${workflowNames.length > 0 ? workflowNames.join(', ') : 'all workflows'}`);
+              const searchAllWorkflows = workflowNames.length === 0;
+              
+              console.log(`Searching for artifacts in: ${searchAllWorkflows ? 'all workflows' : workflowNames.join(', ')}`);
               
               // Find workflow runs for this commit
               const workflowRuns = await github.rest.actions.listWorkflowRunsForRepo({
@@ -105,8 +107,8 @@ jobs:
               const workflowRunsWithArtifacts = [];
               
               for (const run of workflowRuns.data.workflow_runs) {
-                // Skip if workflow names are specified and this run doesn't match
-                if (workflowNames.length > 0 && !workflowNames.includes(run.name)) {
+                // Skip if specific workflow names are specified and this run doesn't match
+                if (!searchAllWorkflows && !workflowNames.includes(run.name)) {
                   console.log(`Skipping run ${run.id} (${run.name}) - not in specified workflows`);
                   continue;
                 }

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -42,6 +42,10 @@ jobs:
                              ? context.payload.workflow_run.pull_requests[0].number 
                              : context.payload.pull_request?.number);
             
+            console.log(`PR Number: ${prNumber}`);
+            console.log(`Input PR Number: ${{ inputs.pr_number }}`);
+            console.log(`Input Workflow Run ID: ${{ inputs.workflow_run_id }}`);
+            
             if (!prNumber) {
               console.log('No PR number found, skipping artifact comment');
               return;

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
         default: true
     secrets:
-      github_token:
+      token:
         description: 'GitHub token with repo permissions'
         required: false
 
@@ -34,7 +34,7 @@ jobs:
       - name: Add artifact links to PR comment
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.github_token || secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.token || secrets.GITHUB_TOKEN }}
           script: |
             // Get PR number from input, workflow_run event, or context
             const prNumber = ${{ inputs.pr_number }} || 

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -52,10 +52,15 @@ jobs:
                        context.payload.workflow_run?.id || 
                        context.runId;
             
+            console.log(`Initial runId: ${runId}`);
+            
             // Treat 0 as "no ID provided"
             if (runId === 0) {
+              console.log('Converting runId 0 to null');
               runId = null;
             }
+            
+            console.log(`Final runId before search: ${runId}`);
             
             // If no run ID and we have a PR number, find the most recent successful workflow run
             if (!runId && prNumber) {
@@ -78,17 +83,21 @@ jobs:
                 head_sha: headSha,
                 status: 'completed',
                 conclusion: 'success',
-                per_page: 10
+                per_page: 20
               });
+              
+              console.log(`Found ${workflowRuns.data.workflow_runs.length} completed successful runs for SHA ${headSha}`);
               
               // Find the most recent run that has artifacts
               for (const run of workflowRuns.data.workflow_runs) {
+                console.log(`Checking run ${run.id} (${run.name})`);
                 const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   run_id: run.id,
                 });
                 
+                console.log(`Run ${run.id} has ${artifacts.data.artifacts.length} artifacts`);
                 if (artifacts.data.artifacts.length > 0) {
                   runId = run.id;
                   console.log(`Found workflow run ${runId} with artifacts`);

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -11,6 +11,11 @@ on:
         description: 'Workflow run ID to get artifacts from (optional if triggered from workflow_run)'
         required: false
         type: number
+      workflow_names:
+        description: 'Comma-separated list of workflow names to search for artifacts (e.g., "RunTests,Build")'
+        required: false
+        type: string
+        default: ''
       comment_title:
         description: 'Title for the comment'
         required: false
@@ -65,7 +70,7 @@ jobs:
             
             console.log(`Final runId before search: ${runId}`);
             
-            // If no run ID and we have a PR number, find the most recent successful workflow run
+            // If no run ID and we have a PR number, find artifacts from specified workflows
             if (!runId && prNumber) {
               console.log('No workflow run ID provided, searching for recent successful runs...');
               
@@ -79,6 +84,10 @@ jobs:
               const headSha = pr.data.head.sha;
               console.log(`PR #${prNumber} head SHA: ${headSha}`);
               
+              // Parse workflow names to search for
+              const workflowNames = '${{ inputs.workflow_names }}'.split(',').map(name => name.trim()).filter(name => name);
+              console.log(`Searching for artifacts in workflows: ${workflowNames.length > 0 ? workflowNames.join(', ') : 'all workflows'}`);
+              
               // Find workflow runs for this commit
               const workflowRuns = await github.rest.actions.listWorkflowRunsForRepo({
                 owner: context.repo.owner,
@@ -86,13 +95,22 @@ jobs:
                 head_sha: headSha,
                 status: 'completed',
                 conclusion: 'success',
-                per_page: 20
+                per_page: 50
               });
               
               console.log(`Found ${workflowRuns.data.workflow_runs.length} completed successful runs for SHA ${headSha}`);
               
-              // Find the most recent run that has artifacts
+              // Collect all artifacts from matching workflows
+              const allArtifacts = [];
+              const workflowRunsWithArtifacts = [];
+              
               for (const run of workflowRuns.data.workflow_runs) {
+                // Skip if workflow names are specified and this run doesn't match
+                if (workflowNames.length > 0 && !workflowNames.includes(run.name)) {
+                  console.log(`Skipping run ${run.id} (${run.name}) - not in specified workflows`);
+                  continue;
+                }
+                
                 console.log(`Checking run ${run.id} (${run.name})`);
                 const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
                   owner: context.repo.owner,
@@ -102,11 +120,65 @@ jobs:
                 
                 console.log(`Run ${run.id} has ${artifacts.data.artifacts.length} artifacts`);
                 if (artifacts.data.artifacts.length > 0) {
-                  runId = run.id;
-                  console.log(`Found workflow run ${runId} with artifacts`);
-                  break;
+                  // Add workflow info to each artifact
+                  artifacts.data.artifacts.forEach(artifact => {
+                    artifact.workflow_name = run.name;
+                    artifact.workflow_run_id = run.id;
+                  });
+                  allArtifacts.push(...artifacts.data.artifacts);
+                  workflowRunsWithArtifacts.push(run.id);
                 }
               }
+              
+              console.log(`Found ${allArtifacts.length} total artifacts across ${workflowRunsWithArtifacts.length} workflow runs`);
+              
+              if (allArtifacts.length === 0) {
+                console.log('No artifacts found in any matching workflow runs');
+                return;
+              }
+              
+              // Create comment body with artifacts grouped by workflow
+              const commentTitle = '${{ inputs.comment_title }}';
+              let commentBody = `## ${commentTitle}:\n\n`;
+              
+              // Group artifacts by workflow
+              const artifactsByWorkflow = {};
+              allArtifacts.forEach(artifact => {
+                if (!artifactsByWorkflow[artifact.workflow_name]) {
+                  artifactsByWorkflow[artifact.workflow_name] = [];
+                }
+                artifactsByWorkflow[artifact.workflow_name].push(artifact);
+              });
+              
+              // Add artifacts grouped by workflow
+              for (const [workflowName, artifacts] of Object.entries(artifactsByWorkflow)) {
+                commentBody += `### ${workflowName}\n`;
+                artifacts.forEach(artifact => {
+                  const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${artifact.workflow_run_id}/artifacts/${artifact.id}`;
+                  commentBody += `- [${artifact.name}](${downloadUrl})\n`;
+                });
+                commentBody += '\n';
+              }
+              
+              // Add workflow run links if enabled
+              if (${{ inputs.include_workflow_link }}) {
+                commentBody += '*Generated from workflow runs: ';
+                const runLinks = workflowRunsWithArtifacts.map(runId => 
+                  `[#${runId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})`
+                );
+                commentBody += runLinks.join(', ') + '*';
+              }
+              
+              // Post comment
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+              
+              console.log(`Posted artifact links comment to PR #${prNumber} with ${allArtifacts.length} artifacts`);
+              return;
             }
             
             if (!runId) {

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       pr_number:
         description: 'Pull request number (optional if triggered from workflow_run)'
-        required: false
+        required: true
         type: number
       workflow_run_id:
         description: 'Workflow run ID to get artifacts from (optional if triggered from workflow_run)'

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -171,15 +171,36 @@ jobs:
                 commentBody += runLinks.join(', ') + '*';
               }
               
-              // Post comment
-              await github.rest.issues.createComment({
+              // Check if a comment already exists with our headline
+              const comments = await github.rest.issues.listComments({
                 issue_number: prNumber,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: commentBody
               });
               
-              console.log(`Posted artifact links comment to PR #${prNumber} with ${allArtifacts.length} artifacts`);
+              const existingComment = comments.data.find(comment => 
+                comment.body.includes('${{ inputs.comment_title }}')
+              );
+              
+              if (existingComment) {
+                // Update existing comment
+                await github.rest.issues.updateComment({
+                  comment_id: existingComment.id,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                });
+                console.log(`Updated existing artifact comment for PR #${prNumber}`);
+              } else {
+                // Create new comment
+                await github.rest.issues.createComment({
+                  issue_number: prNumber,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+                });
+                console.log(`Posted new artifact links comment to PR #${prNumber} with ${allArtifacts.length} artifacts`);
+              }
               return;
             }
             
@@ -222,8 +243,7 @@ jobs:
             });
             
             const existingComment = comments.data.find(comment => 
-              comment.body.includes(`workflow run [#${runId}]`) || 
-              comment.body.includes(`Generated from workflow run #${runId}`)
+              comment.body.includes('${{ inputs.comment_title }}')
             );
             
             if (existingComment) {

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -52,6 +52,11 @@ jobs:
                        context.payload.workflow_run?.id || 
                        context.runId;
             
+            // Treat 0 as "no ID provided"
+            if (runId === 0) {
+              runId = null;
+            }
+            
             // If no run ID and we have a PR number, find the most recent successful workflow run
             if (!runId && prNumber) {
               console.log('No workflow run ID provided, searching for recent successful runs...');

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -52,9 +52,8 @@ jobs:
             }
             
             // Get the workflow run ID
-            let runId = ${{ inputs.workflow_run_id }} || 
-                       context.payload.workflow_run?.id || 
-                       context.runId;
+            let runId = ${{ inputs.workflow_run_id }} !== undefined ? ${{ inputs.workflow_run_id }} : 
+                       (context.payload.workflow_run?.id || context.runId);
             
             console.log(`Initial runId: ${runId}`);
             

--- a/.github/workflows/add-artifact-links.yml
+++ b/.github/workflows/add-artifact-links.yml
@@ -1,0 +1,156 @@
+name: Add Artifact Links to PR
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: 'Pull request number (optional if triggered from workflow_run)'
+        required: false
+        type: number
+      workflow_run_id:
+        description: 'Workflow run ID to get artifacts from (optional if triggered from workflow_run)'
+        required: false
+        type: number
+      comment_title:
+        description: 'Title for the comment'
+        required: false
+        type: string
+        default: '🚀 Build for this pull request 🚀'
+      include_workflow_link:
+        description: 'Include link to workflow run in comment'
+        required: false
+        type: boolean
+        default: true
+    secrets:
+      github_token:
+        description: 'GitHub token with repo permissions'
+        required: false
+
+jobs:
+  add-artifact-links:
+    name: Add artifact links to pull request
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add artifact links to PR comment
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.github_token || secrets.GITHUB_TOKEN }}
+          script: |
+            // Get PR number from input, workflow_run event, or context
+            const prNumber = ${{ inputs.pr_number }} || 
+                            (context.payload.workflow_run && context.payload.workflow_run.pull_requests.length > 0 
+                             ? context.payload.workflow_run.pull_requests[0].number 
+                             : context.payload.pull_request?.number);
+            
+            if (!prNumber) {
+              console.log('No PR number found, skipping artifact comment');
+              return;
+            }
+            
+            // Get the workflow run ID
+            let runId = ${{ inputs.workflow_run_id }} || 
+                       context.payload.workflow_run?.id || 
+                       context.runId;
+            
+            // If no run ID and we have a PR number, find the most recent successful workflow run
+            if (!runId && prNumber) {
+              console.log('No workflow run ID provided, searching for recent successful runs...');
+              
+              // Get the PR to find the head SHA
+              const pr = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              
+              const headSha = pr.data.head.sha;
+              console.log(`PR #${prNumber} head SHA: ${headSha}`);
+              
+              // Find workflow runs for this commit
+              const workflowRuns = await github.rest.actions.listWorkflowRunsForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                head_sha: headSha,
+                status: 'completed',
+                conclusion: 'success',
+                per_page: 10
+              });
+              
+              // Find the most recent run that has artifacts
+              for (const run of workflowRuns.data.workflow_runs) {
+                const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  run_id: run.id,
+                });
+                
+                if (artifacts.data.artifacts.length > 0) {
+                  runId = run.id;
+                  console.log(`Found workflow run ${runId} with artifacts`);
+                  break;
+                }
+              }
+            }
+            
+            if (!runId) {
+              console.log('No workflow run ID found');
+              return;
+            }
+            
+            // Get artifacts from the workflow run
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            
+            if (artifacts.data.artifacts.length === 0) {
+              console.log('No artifacts found for this workflow run');
+              return;
+            }
+            
+            // Create comment body with artifact links
+            const commentTitle = '${{ inputs.comment_title }}';
+            let commentBody = `## ${commentTitle}:\n\n`;
+            
+            for (const artifact of artifacts.data.artifacts) {
+              const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${artifact.id}`;
+              commentBody += `- [${artifact.name}](${downloadUrl})\n`;
+            }
+            
+            // Add workflow run link if enabled
+            if (${{ inputs.include_workflow_link }}) {
+              commentBody += `\n*Generated from workflow run [#${runId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})*`;
+            }
+            
+            // Check if a comment already exists for this workflow run
+            const comments = await github.rest.issues.listComments({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            
+            const existingComment = comments.data.find(comment => 
+              comment.body.includes(`workflow run [#${runId}]`) || 
+              comment.body.includes(`Generated from workflow run #${runId}`)
+            );
+            
+            if (existingComment) {
+              // Update existing comment
+              await github.rest.issues.updateComment({
+                comment_id: existingComment.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+              console.log(`Updated existing comment for PR #${prNumber}`);
+            } else {
+              // Create new comment
+              await github.rest.issues.createComment({
+                issue_number: prNumber,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              });
+              console.log(`Posted new artifact links comment to PR #${prNumber}`);
+            }

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -21,13 +21,18 @@ jobs:
     steps:
       - name: Set inputs
         id: set-inputs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          WR_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
+          WR_ID: ${{ github.event.workflow_run.id || '' }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "pr_number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
-            echo "workflow_run_id=" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "pr_number=$INPUT_PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "workflow_run_id=null" >> $GITHUB_OUTPUT
           else
-            echo "pr_number=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_OUTPUT
-            echo "workflow_run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+            echo "pr_number=$WR_PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "workflow_run_id=$WR_ID" >> $GITHUB_OUTPUT
           fi
 
   call-artifact-links:
@@ -35,8 +40,8 @@ jobs:
     needs: prepare-inputs
     uses: ./.github/workflows/add-artifact-links.yml
     with:
-      pr_number: ${{ needs.prepare-inputs.outputs.pr_number }}
-      workflow_run_id: ${{ needs.prepare-inputs.outputs.workflow_run_id }}
+      pr_number: ${{ fromJSON(needs.prepare-inputs.outputs.pr_number) }}
+      workflow_run_id: ${{ needs.prepare-inputs.outputs.workflow_run_id != 'null' && fromJSON(needs.prepare-inputs.outputs.workflow_run_id) || null }}
       comment_title: 'Build for this pull request'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -18,5 +18,6 @@ jobs:
     with:
       pr_number: ${{ fromJSON(github.event.inputs.pr_number || github.event.workflow_run.pull_requests[0].number) }}
       workflow_run_id: ${{ github.event.workflow_run.id || 0 }}
+      workflow_names: 'RunTests'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -11,13 +11,32 @@ on:
         type: number
 
 jobs:
+  prepare-inputs:
+    name: Prepare inputs for artifact links
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    outputs:
+      pr_number: ${{ steps.set-inputs.outputs.pr_number }}
+      workflow_run_id: ${{ steps.set-inputs.outputs.workflow_run_id }}
+    steps:
+      - name: Set inputs
+        id: set-inputs
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "pr_number=${{ github.event.inputs.pr_number }}" >> $GITHUB_OUTPUT
+            echo "workflow_run_id=" >> $GITHUB_OUTPUT
+          else
+            echo "pr_number=${{ github.event.workflow_run.pull_requests[0].number }}" >> $GITHUB_OUTPUT
+            echo "workflow_run_id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
+          fi
+
   call-artifact-links:
     name: Add artifact links to pull request
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    needs: prepare-inputs
     uses: ./.github/workflows/add-artifact-links.yml
     with:
-      pr_number: ${{ github.event.inputs.pr_number || (github.event.workflow_run.pull_requests[0].number || null) }}
-      workflow_run_id: ${{ github.event.workflow_run.id || null }}
+      pr_number: ${{ needs.prepare-inputs.outputs.pr_number }}
+      workflow_run_id: ${{ needs.prepare-inputs.outputs.workflow_run_id }}
       comment_title: 'Build for this pull request'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -3,17 +3,83 @@ on:
   workflow_run:
     workflows: [RunTests]
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Pull request number'
+        required: true
+        type: number
 
 jobs:
   artifacts-url-comments:
     name: Add artifact links to pull request
     runs-on: windows-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: tonyhallett/artifacts-url-comments@v1.1.0
+      - name: Checkout latest code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Add artifact links to PR comment
+        uses: actions/github-script@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          prefix: "Build for this pull request:"
-          format: "[MobiFlightConnector.zip]({url})"
-          addTo: pull
+          script: |
+            const fs = require('fs');
+            
+            // Get PR number from input or workflow_run event
+            const prNumber = process.env.PR_NUMBER || 
+                            (context.payload.workflow_run && context.payload.workflow_run.pull_requests.length > 0 
+                             ? context.payload.workflow_run.pull_requests[0].number 
+                             : null);
+            
+            if (!prNumber) {
+              console.log('No PR number found, skipping artifact comment');
+              return;
+            }
+            
+            // Get the workflow run ID
+            const runId = context.payload.workflow_run?.id || 
+                         (process.env.WORKFLOW_RUN_ID ? parseInt(process.env.WORKFLOW_RUN_ID) : null);
+            
+            if (!runId) {
+              console.log('No workflow run ID found');
+              return;
+            }
+            
+            // Get artifacts from the workflow run
+            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            
+            if (artifacts.data.artifacts.length === 0) {
+              console.log('No artifacts found for this workflow run');
+              return;
+            }
+            
+            // Create comment body with artifact links
+            let commentBody = "## 🚀 Build for this pull request:\n\n";
+            
+            for (const artifact of artifacts.data.artifacts) {
+              const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${artifact.id}`;
+              commentBody += `- [${artifact.name}](${downloadUrl})\n`;
+            }
+            
+            commentBody += `\n*Generated from workflow run [#${runId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})*`;
+            
+            // Post comment to PR
+            await github.rest.issues.createComment({
+              issue_number: prNumber,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: commentBody
+            });
+            
+            console.log(`Posted artifact links to PR #${prNumber}`);
+        env:
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -16,8 +16,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/add-artifact-links.yml
     with:
-      pr_number: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event_name == 'workflow_run' && github.event.workflow_run.pull_requests[0].number }}
-      workflow_run_id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || null }}
-      comment_title: 'Build for this pull request'
+      pr_number: ${{ github.event_name == 'workflow_dispatch' && fromJSON(github.event.inputs.pr_number) || github.event_name == 'workflow_run' && github.event.workflow_run.pull_requests[0].number }}
+      workflow_run_id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   artifacts-url-comments:
     name: Add artifact links to pull request
-    runs-on: windows-2019
+    runs-on: windows-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: tonyhallett/artifacts-url-comments@v1.1.0

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -18,6 +18,5 @@ jobs:
     with:
       pr_number: ${{ fromJSON(github.event.inputs.pr_number || github.event.workflow_run.pull_requests[0].number) }}
       workflow_run_id: ${{ github.event.workflow_run.id || 0 }}
-      workflow_names: 'RunTests'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -11,37 +11,13 @@ on:
         type: number
 
 jobs:
-  prepare-inputs:
-    name: Prepare inputs for artifact links
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
-    outputs:
-      pr_number: ${{ steps.set-inputs.outputs.pr_number }}
-      workflow_run_id: ${{ steps.set-inputs.outputs.workflow_run_id }}
-    steps:
-      - name: Set inputs
-        id: set-inputs
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
-          WR_PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number || '' }}
-          WR_ID: ${{ github.event.workflow_run.id || '' }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "pr_number=$INPUT_PR_NUMBER" >> $GITHUB_OUTPUT
-            echo "workflow_run_id=null" >> $GITHUB_OUTPUT
-          else
-            echo "pr_number=$WR_PR_NUMBER" >> $GITHUB_OUTPUT
-            echo "workflow_run_id=$WR_ID" >> $GITHUB_OUTPUT
-          fi
-
   call-artifact-links:
     name: Add artifact links to pull request
-    needs: prepare-inputs
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/add-artifact-links.yml
     with:
-      pr_number: ${{ fromJSON(needs.prepare-inputs.outputs.pr_number) }}
-      workflow_run_id: ${{ needs.prepare-inputs.outputs.workflow_run_id != 'null' && fromJSON(needs.prepare-inputs.outputs.workflow_run_id) || null }}
+      pr_number: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number || github.event_name == 'workflow_run' && github.event.workflow_run.pull_requests[0].number }}
+      workflow_run_id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id || null }}
       comment_title: 'Build for this pull request'
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   call-artifact-links:
     name: Add artifact links to pull request
-    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/add-artifact-links.yml
     with:
       pr_number: ${{ fromJSON(github.event.inputs.pr_number || github.event.workflow_run.pull_requests[0].number) }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -20,4 +20,4 @@ jobs:
       workflow_run_id: ${{ github.event.workflow_run.id || null }}
       comment_title: 'Build for this pull request'
     secrets:
-      github_token: ${{ secrets.GITHUB_TOKEN }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -11,75 +11,13 @@ on:
         type: number
 
 jobs:
-  artifacts-url-comments:
+  call-artifact-links:
     name: Add artifact links to pull request
-    runs-on: windows-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
-    steps:
-      - name: Checkout latest code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - name: Add artifact links to PR comment
-        uses: actions/github-script@v7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          script: |
-            const fs = require('fs');
-            
-            // Get PR number from input or workflow_run event
-            const prNumber = process.env.PR_NUMBER || 
-                            (context.payload.workflow_run && context.payload.workflow_run.pull_requests.length > 0 
-                             ? context.payload.workflow_run.pull_requests[0].number 
-                             : null);
-            
-            if (!prNumber) {
-              console.log('No PR number found, skipping artifact comment');
-              return;
-            }
-            
-            // Get the workflow run ID
-            const runId = context.payload.workflow_run?.id || 
-                         (process.env.WORKFLOW_RUN_ID ? parseInt(process.env.WORKFLOW_RUN_ID) : null);
-            
-            if (!runId) {
-              console.log('No workflow run ID found');
-              return;
-            }
-            
-            // Get artifacts from the workflow run
-            const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              run_id: runId,
-            });
-            
-            if (artifacts.data.artifacts.length === 0) {
-              console.log('No artifacts found for this workflow run');
-              return;
-            }
-            
-            // Create comment body with artifact links
-            let commentBody = "## 🚀 Build for this pull request:\n\n";
-            
-            for (const artifact of artifacts.data.artifacts) {
-              const downloadUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId}/artifacts/${artifact.id}`;
-              commentBody += `- [${artifact.name}](${downloadUrl})\n`;
-            }
-            
-            commentBody += `\n*Generated from workflow run [#${runId}](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})*`;
-            
-            // Post comment to PR
-            await github.rest.issues.createComment({
-              issue_number: prNumber,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: commentBody
-            });
-            
-            console.log(`Posted artifact links to PR #${prNumber}`);
-        env:
-          PR_NUMBER: ${{ github.event.inputs.pr_number }}
-          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
+    uses: ./.github/workflows/add-artifact-links.yml
+    with:
+      pr_number: ${{ github.event.inputs.pr_number || (github.event.workflow_run.pull_requests[0].number || null) }}
+      workflow_run_id: ${{ github.event.workflow_run.id || null }}
+      comment_title: 'Build for this pull request'
+    secrets:
+      github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -16,7 +16,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     uses: ./.github/workflows/add-artifact-links.yml
     with:
-      pr_number: ${{ github.event_name == 'workflow_dispatch' && fromJSON(github.event.inputs.pr_number) || github.event_name == 'workflow_run' && github.event.workflow_run.pull_requests[0].number }}
-      workflow_run_id: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.id }}
+      pr_number: ${{ fromJSON(github.event.inputs.pr_number || github.event.workflow_run.pull_requests[0].number) }}
+      workflow_run_id: ${{ github.event.workflow_run.id || 0 }}
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/frontend/.devcontainer/devcontainer.json
+++ b/frontend/.devcontainer/devcontainer.json
@@ -3,6 +3,7 @@
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
 	"image": "mcr.microsoft.com/devcontainers/typescript-node:latest",
 	"features": {
+		"ghcr.io/devcontainers/features/github-cli:1": {}
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.


### PR DESCRIPTION
This PR completely replaces the former action which was not maintained anymore and used an outdated node version.

This PR introduces a newly written action which:
* uses github scripts to interact with the Github API
* can be triggered by PR workflow run, or also manually as workflow dispatch (which is great for testing)
* uses a more friendly title that can be set as workflow parameter
* attaches all artifacts that are produced by the PR workflows
* adds comment with links to the respective workflow runs for easy access'
* updates the comment on every build instead of creating multiple comments

fixes #2233