### PR TITLE
[X-Plane] Map size correctly in 777v2 and use Boeing font

### DIFF
--- a/Scripts/Winwing/flightfactor_777v2.py
+++ b/Scripts/Winwing/flightfactor_777v2.py
@@ -94,7 +94,7 @@ def get_size(size: int) -> int:
     # FlightFactor's 777v2 size starts at 1
     # 1 = large
     # 2 = small
-    return int(size == 2)
+    return 1 if size == 2 else 0
 
 
 def fetch_dataref_mapping(device: CduDevice):


### PR DESCRIPTION
FlightFactor's 777v2 size dataref begins uses a different integer layout for representing text size. This means that all text is currently being displayed with a small font.
* 1 = Large
* 2 = Small

As such, this update subtracts 1 from the size integer to translate it to
* 0 = Large
* 1 = Small