### PR TITLE
Only trigger artifact append on CI pipeline run

### DIFF
--- a/.github/workflows/pr_artifact_comment.yml
+++ b/.github/workflows/pr_artifact_comment.yml
@@ -1,7 +1,7 @@
 name: Add PR Artifact Links As Comment
 on:
   workflow_run:
-    workflows: [CI Pipeline, Playwright Tests]
+    workflows: [CI Pipeline]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
In #2259 we reverted back to the old action, but I forgot to remove the workflow trigger for playwright tests.

relates to #2233 
relates to #2259 