### PR TITLE
Reset filter on project change

### DIFF
--- a/frontend/src/components/tables/config-item-table/config-item-table.tsx
+++ b/frontend/src/components/tables/config-item-table/config-item-table.tsx
@@ -104,10 +104,15 @@ export function ConfigItemTable<TData, TValue>({
   const prevDataLength = useRef(data.length)
   const addedItem = useRef(false)
 
-  useAppMessage("Project", () => {
-    table.getColumn("Name")?.setFilterValue("")
-  })
 
+  // the useCallback hook is necessary so that playwright tests work correctly
+  const handleProjectMessage = useCallback(() => {
+    console.log("Project message received, resetting filters")
+    table.resetColumnFilters()
+  }, [table])
+
+  useAppMessage("Project", handleProjectMessage)
+  
   useEffect(() => {
     console.log("added item", addedItem.current) 
   }, [addedItem])

--- a/frontend/tests/ConfigListView.spec.ts
+++ b/frontend/tests/ConfigListView.spec.ts
@@ -440,6 +440,22 @@ test.describe('Filter toolbar tests', () => {
       await testDeviceNameFilter(deviceName, 1)
     }
   })
+
+  test("Confirm filter toolbar reset is working on Project change", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.initWithTestData()
+    
+    const searchTextBox = page.getByRole("textbox", { name: "Filter items" })
+    await searchTextBox.fill("Test")
+    await expect(searchTextBox).toHaveValue("Test")
+
+    await configListPage.initWithTestDataAndSpecificProjectName("Specific Project")
+
+    await expect(searchTextBox).toHaveValue("")
+  })
 })
 
 test.describe('Controller device labels are displayed correctly', () => {

--- a/frontend/tests/fixtures/ConfigListPage.ts
+++ b/frontend/tests/fixtures/ConfigListPage.ts
@@ -43,6 +43,19 @@ export class ConfigListPage {
     await this.mobiFlightPage.publishMessage(message)
   }
 
+  async initWithTestDataAndSpecificProjectName(name: string) {
+    const testProjectWithName = {
+      ...testProject,
+      Name: name,
+    }
+
+    const message: AppMessage = {
+      key: "Project",
+      payload: testProjectWithName
+    }
+    await this.mobiFlightPage.publishMessage(message)
+  }
+
   async initControllerDefinitions() {
     const message: AppMessage = {
       key: "JoystickDefinitions",


### PR DESCRIPTION
Every time a new project is loaded or a config tab is added, the filters will completely be reset. Uses same method that the "Reset filters" button is using.

- [x] filter reset on project change
- [x] playwright tests

fixes #2203 