### PR TITLE
Automatically resolve simple orphaned serials

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -485,7 +485,7 @@ namespace MobiFlight.UI
         private async Task CleanRecentFilesAsync()
         {
             var recentSnapshot = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
-            
+
             var missingFiles = await Task.Run(() => CheckForMissingFiles(recentSnapshot)).ConfigureAwait(false);
 
             if (missingFiles.Count == 0) return;
@@ -2159,21 +2159,32 @@ namespace MobiFlight.UI
             {
                 var allConfigItems = execManager.Project.ConfigFiles.Select(file => file.ConfigItems).ToList();
                 OrphanedSerialsDialog opd = new OrphanedSerialsDialog(serials, allConfigItems);
+
+                void UpdateProject()
+                {
+                    ProjectHasUnsavedChanges = opd.HasChanged();
+                    var updatedConfigs = opd.GetUpdatedConfigs();
+
+                    for (int i = 0; i < execManager.Project.ConfigFiles.Count; i++)
+                    {
+                        execManager.Project.ConfigFiles[i].ConfigItems = updatedConfigs[i];
+                    }
+
+                    MessageExchange.Instance.Publish(execManager.Project);
+                }
+
                 opd.StartPosition = FormStartPosition.CenterParent;
                 if (opd.HasOrphanedSerials())
                 {
-                    if (opd.ShowDialog() == System.Windows.Forms.DialogResult.OK)
+                    if (opd.ShowDialog() == DialogResult.OK)
                     {
-                        ProjectHasUnsavedChanges = opd.HasChanged();
-                        var udpatedConfigs = opd.GetUpdatedConfigs();
-
-                        for (int i = 0; i < execManager.Project.ConfigFiles.Count; i++)
-                        {
-                            execManager.Project.ConfigFiles[i].ConfigItems = udpatedConfigs[i];
-                        }
-
-                        MessageExchange.Instance.Publish(execManager.Project);
+                        UpdateProject();
                     }
+                }
+                else if (opd.HasChanged())
+                {
+                    // If there are no orphaned serials, serials can still be changed automatically
+                    UpdateProject();
                 }
                 else
                 {


### PR DESCRIPTION
This was suggested in #2270.

The orphaned serials will be resolved automatically if there are only unique device names (e.g. one MCDU, one FCU) in a profile. If this happens successfully the dialog will not be displayed.

- [x] All device types are supported
  - [x] MobiFlight Controllers
  - [x] Joystick Controllers
  - [x] Midi Controllers
- [x] Automatic replacement
  - [x] For every device that is referenced in the profile but not connected, and
  - [x] if another device of same type and same name is found, it will be used 
- [x] No auto replacement if multiple devices are connected that match type and name
- [ ] User message presented in case:
  - [ ] automatic profile update happened successfully, now changes have to be saved (best to new file)
  - [ ] automatic profile was not possible because user has to manually select
  - [x] profile update was not possible because no matching device connected
- [ ] Unit tests are added

Context: I'm one of those people who only uses MobiFlight with off-the-shelf hardware. This makes things easier for people who download profiles from the web and don't make build their own hardware.