### PR TITLE
Fix Playwright with latest NodeJS

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 22.17
+        node-version: lts/*
     - name: Install dependencies
       run: npm ci
     - name: Install Playwright Browsers
@@ -22,7 +22,7 @@ jobs:
     - name: Run linter
       run: npm run lint
     - name: Run Playwright tests
-      run: npx playwright test
+      run: npm test
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}
       with:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "check:translations": "node src/scripts/check-translations.js"
+    "check:translations": "node src/scripts/check-translations.js",
+    "test": "node --no-experimental-strip-types node_modules/@playwright/test/cli.js test"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Fix Playwright with latest NodeJS by disabling type stripping. Note that you should run tests with `npm test` instead of `npx playwright test` for this to work.