### PR TITLE
Fix issue setting font and sending display data at the same time

### DIFF
--- a/Scripts/Winwing/aerosoft_crj_winwing_cdu.py
+++ b/Scripts/Winwing/aerosoft_crj_winwing_cdu.py
@@ -100,6 +100,7 @@ class MobiFlightClient:
                     fontName = "Collins"
                     await self.websocket.send(f'{{ "Target": "Font", "Data": "{fontName}" }}')
                     logging.info(f"Setting font: {fontName}")
+                    await asyncio.sleep(1) # wait a second for font to be set
                     self.connected.set()
                 await self.websocket.recv()
             except Exception as e: 

--- a/Scripts/Winwing/flightfactor_777v2.py
+++ b/Scripts/Winwing/flightfactor_777v2.py
@@ -248,6 +248,7 @@ async def get_available_devices() -> list[CduDevice]:
 
                 try:
                     await socket.send(FONT_REQUEST)
+                    await asyncio.sleep(1) # wait a second for font to be set
                 except websockets.ConnectionClosed as e:
                     logging.warning(
                         "Attempt to change font on CDU device %s but request failed: %s",

--- a/Scripts/Winwing/fslabs_winwing_cdu.py
+++ b/Scripts/Winwing/fslabs_winwing_cdu.py
@@ -100,7 +100,7 @@ async def run_mobiflight_websocket_client():
                 fontName = "AirbusThales"
                 await mobi_websocket_connection.send(f'{{ "Target": "Font", "Data": "{fontName}" }}')
                 logging.info(f"Setting font: {fontName}")
-
+                await asyncio.sleep(1) # wait a second for font to be set
             await asyncio.sleep(0.05)
 
         except Exception as ex:

--- a/Scripts/Winwing/ifly_737_winwing_cdu.py
+++ b/Scripts/Winwing/ifly_737_winwing_cdu.py
@@ -44,13 +44,14 @@ class MobiFlightClient:
 
     async def connect(self) -> None:
         try:
-            self.websocket = await connect(self.url)
-            self._was_connected = True
+            self.websocket = await connect(self.url)            
             logging.info(f"Connected to WebSocket at {self.url}")
             # Load font           
             fontName: str = "Boeing"
             await self.websocket.send(f'{{ "Target": "Font", "Data": "{fontName}" }}')
             logging.info(f"Setting font: {fontName}")
+            await asyncio.sleep(1) # wait a second for font to be set
+            self._was_connected = True
         except Exception as e:
             logging.error(f"Failed to connect to WebSocket: {e}")
             self._was_connected = False

--- a/Scripts/Winwing/pmdg_737_winwing_cdu.py
+++ b/Scripts/Winwing/pmdg_737_winwing_cdu.py
@@ -1,4 +1,4 @@
-import copy
+﻿import copy
 from ctypes import wintypes
 import ctypes
 import json
@@ -96,6 +96,7 @@ class MobiFlightClient:
                     fontName: str = "Boeing"
                     await self.websocket.send(f'{{ "Target": "Font", "Data": "{fontName}" }}')
                     logging.info(f"Setting font: {fontName}")
+                    await asyncio.sleep(1) # wait a second for font to be set
                     self.connected.set()
                 await self.websocket.recv()
             except Exception as e: 

--- a/Scripts/Winwing/pmdg_777_winwing_cdu.py
+++ b/Scripts/Winwing/pmdg_777_winwing_cdu.py
@@ -101,6 +101,7 @@ class MobiFlightClient:
                     fontName: str = "Boeing"
                     await self.websocket.send(f'{{ "Target": "Font", "Data": "{fontName}" }}')
                     logging.info(f"Setting font: {fontName}")
+                    await asyncio.sleep(1) # wait a second for font to be set
                     self.connected.set()
                 await self.websocket.recv()
             except Exception as e: 

--- a/Scripts/Winwing/zibo_737_800x.py
+++ b/Scripts/Winwing/zibo_737_800x.py
@@ -263,6 +263,7 @@ async def get_available_devices() -> list[CduDevice]:
                 )
                 available_devices.append(device)
                 await socket.send(FONT_REQUEST)
+                await asyncio.sleep(1) # wait a second for font to be set
         except websockets.WebSocketException:
             logging.warning(
                 "Attempted to probe CDU device %s at endpoint %s but device wasn't available",


### PR DESCRIPTION
In rare cases transferring the font to the CDU interferes with setting new display data. Setting the font is asyncronous, the websocket does not wait for the operation to complete.

As a first solution a wait of 1 second is introduced to give enough time for transferring the font to the CDU.

For a perfect solution at some point in the future, a two way websocket communication needs to be introduced.