### PR TITLE
LCD panel doesn't trigger wrong pending changes alert

### DIFF
--- a/UI/Panels/Device/MFLcdDisplayPanel.Designer.cs
+++ b/UI/Panels/Device/MFLcdDisplayPanel.Designer.cs
@@ -109,12 +109,14 @@
             // 
             resources.ApplyResources(this.LinesTextBox, "LinesTextBox");
             this.LinesTextBox.Name = "LinesTextBox";
+            this.LinesTextBox.TextChanged += new System.EventHandler(this.value_Changed);
             this.LinesTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.ColTextBox_Validating);
             // 
             // ColTextBox
             // 
             resources.ApplyResources(this.ColTextBox, "ColTextBox");
             this.ColTextBox.Name = "ColTextBox";
+            this.ColTextBox.TextChanged += new System.EventHandler(this.value_Changed);
             this.ColTextBox.Validating += new System.ComponentModel.CancelEventHandler(this.ColTextBox_Validating);
             // 
             // label2

--- a/UI/Panels/Device/MFLcdDisplayPanel.cs
+++ b/UI/Panels/Device/MFLcdDisplayPanel.cs
@@ -1,10 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace MobiFlight.UI.Panels.Settings.Device
@@ -26,7 +22,6 @@ namespace MobiFlight.UI.Panels.Settings.Device
 
         public MFLcddDisplayPanel(MobiFlight.Config.LcdDisplay config, List<MobiFlightPin> Pins): this()
         {
-            //// TODO: Complete member initialization
             this.config = config;
             NameTextBox.Text = config.Name;
             AddressComboBox.SelectedItem = "0x" + config.Address.ToString("X2");
@@ -41,6 +36,7 @@ namespace MobiFlight.UI.Panels.Settings.Device
         {
             if (!initialized) return;
             setValues();
+
             if (Changed!=null)
                 Changed(config, new EventArgs());
         }
@@ -79,8 +75,6 @@ namespace MobiFlight.UI.Panels.Settings.Device
             }
 
             removeError(sender as Control);
-
-            value_Changed(sender, e);
         }
 
         private void displayError(Control control, String message)


### PR DESCRIPTION
- [x] remove the `value_Changed` from `validating` logic and use it on `text changed` only

fixes #2279 