### PR TITLE
Prevent possible crash on scan for input

### DIFF
--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -760,7 +760,7 @@ namespace MobiFlight.UI.Dialogs
                 return;
             }
 
-            var module = inputModuleNameComboBox.Items.Cast<ListItem>().Where(i => i.Value.ToString().Contains(e.Serial)).First();
+            var module = inputModuleNameComboBox.Items.Cast<ListItem>().Where(i => i.Value.ToString().Contains(e.Serial)).FirstOrDefault();
 
             if (module == null) { return; }
             inputModuleNameComboBox.SelectedItem = module;


### PR DESCRIPTION
When the controller is connected after the input wizard is opened, the input events cannot be associated with an item from the drop-down. This used to trigger an exception.

With the fix, the user still has to close out the wizard and then open it again. Only on the next time the controller will be included in the drop down list.

fixes #1619 