### PR TITLE
Fix "link current config" in status bar menu

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2784,7 +2784,7 @@ namespace MobiFlight.UI
         private void ResetAutoLoadMenu()
         {
             toolStripAircraftDropDownButton.Image = null;
-            linkCurrentConfigToolStripMenuItem.Enabled = false;
+            linkCurrentConfigToolStripMenuItem.Enabled = (execManager?.Project?.FilePath != null);
             removeLinkConfigToolStripMenuItem.Enabled = false;
             openLinkedConfigToolStripMenuItem.Enabled = false;
             openLinkFilenameToolStripMenuItem.Text = "";


### PR DESCRIPTION
- [x] Config can be linked again

fixes #2219 