### PR TITLE
MobiFlight window shows in top after restore and update

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -637,7 +637,7 @@ namespace MobiFlight.UI
             {
                 // we can track the click.
             }
-            this.BringToFront();
+            this.ForceToFront();
         }
 
         private void OnFirstStart()
@@ -653,7 +653,7 @@ namespace MobiFlight.UI
             wd.StartPosition = FormStartPosition.CenterParent;
             wd.Text = String.Format(wd.Text, DisplayVersion());
             wd.ShowDialog();
-            this.BringToFront();
+            this.ForceToFront();
 
             // MSFS2020
             WasmModuleUpdater updater = new WasmModuleUpdater();
@@ -667,7 +667,7 @@ namespace MobiFlight.UI
                 {
                     InstallWasmModule();
                 }
-                this.BringToFront();
+                this.ForceToFront();
             }
 
             // if the user is not participating yet, ask for permission
@@ -679,7 +679,7 @@ namespace MobiFlight.UI
                 {
                     Properties.Settings.Default.CommunityFeedback = true;
                 }
-                this.BringToFront();
+                this.ForceToFront();
             }
         }
 
@@ -1670,11 +1670,22 @@ namespace MobiFlight.UI
                 this.Show();
                 if (this.WindowState != FormWindowState.Normal)
                     this.WindowState = FormWindowState.Normal;
-                this.BringToFront();
+                ForceToFront();
             }
 
             execManager?.OnMinimize(minimized);
         } //minimizeMainForm()
+
+        private void ForceToFront()
+        {
+            this.BringToFront();
+
+            // this is a hack to make sure that our window is really on top of all others
+            // this sequence works in all circumstances.
+            this.TopMost = false;
+            this.TopMost = true;
+            this.TopMost = false;
+        }
 
         /// <summary>
         /// restores the current main form when user clicks on "restore" menu item in notify icon context menu


### PR DESCRIPTION
Mobiflight Connector windows shows on top of all other desktop windows:
- [x] on restore from tray (minimized).
- [x] after downloading and performing update.

fixes #2321 