### PR TITLE
Load midiBoard definitions from subfolders

### DIFF
--- a/MobiFlight/MidiBoard/MidiBoardManager.cs
+++ b/MobiFlight/MidiBoard/MidiBoardManager.cs
@@ -83,10 +83,14 @@ namespace MobiFlight
         private void Load()
         {
             // Do the initial loading and validation against the schema
-            var rawDefinitions = JsonBackedObject.LoadDefinitions<MidiBoardDefinition>(Directory.GetFiles("MidiBoards", "*.midiboard.json"), "MidiBoards/mfmidiboard.schema.json",
-                onSuccess: (midiBoardDef, definitionFile) => Log.Instance.log($"Loaded midiBoard definition for {midiBoardDef.InstanceName}", LogSeverity.Info),
+            var jsonFiles = Directory.GetFiles("MidiBoards", "*.midiboard.json", SearchOption.AllDirectories);
+            var schemaFilePath = "MidiBoards/mfmidiboard.schema.json";
+            var rawDefinitions = JsonBackedObject.LoadDefinitions<MidiBoardDefinition>(
+                jsonFiles,
+                schemaFilePath,
+                onSuccess: (midiboard, definitionFile) => Log.Instance.log($"Loaded midiBoard definition for {midiboard.InstanceName}", LogSeverity.Info),
                 onError: () => LoadingError = true
-            ); ;
+            );
 
             foreach (var definition in rawDefinitions)
             {


### PR DESCRIPTION
Fixes #2369 

Following PR #2335 the definition files for MIDI controllers are automatically moved to subfolders grouped by vendor however the loading function in MidiBoardManager.cs remained only searching in the root MidiBoards folder resulting in no definitions being loaded, this patch adds searching through subfolders in the same way that JoystickManager.cs does for Joystick definition files. 

