### PR TITLE
Bugfix - Set LED status via boolean or numerical value

### DIFF
--- a/MobiFlight/Execution/ConfigItemExecutor.cs
+++ b/MobiFlight/Execution/ConfigItemExecutor.cs
@@ -9,8 +9,8 @@ using MobiFlight.xplane;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
-using System.Windows.Forms;
 
 
 namespace MobiFlight.Execution
@@ -583,12 +583,12 @@ namespace MobiFlight.Execution
             return result;
         }
 
-        private static int ParseValue(string value)
+        internal static int ParseValue(string value)
         {
             double doubleState = 0;
             if (value != "0")
             {
-                if (!double.TryParse(value, out doubleState))
+                if (!double.TryParse(value, NumberStyles.Number, CultureInfo.InvariantCulture, out doubleState))
                 {
                     doubleState = 1;
                 }

--- a/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -299,5 +299,29 @@ namespace MobiFlight.Tests
                 Assert.AreEqual("Config reference not found", e.Message);
             }
         }
+
+        [TestMethod]
+        [DataRow("something", 1)]
+        [DataRow("0", 0)]
+        [DataRow("0.0", 0)]
+        [DataRow("-3", -3)]
+        [DataRow("-3.5", -3)]
+        [DataRow("22", 22)]
+        [DataRow("4.22223", 4)]
+        [DataRow("-500.8", -500)]
+        [DataRow("40,8", 408)]
+        [DataRow("10000.00", 10000)]
+        public void ExecuteDisplay_ParseValue_ParseDifferentInputStringValues(
+            string inputValue,
+            int expectedValue)
+        {
+            // Arrange
+
+            // Act
+            var actualValue = ConfigItemExecutor.ParseValue(inputValue);
+
+            // Assert
+            Assert.AreEqual(expectedValue, actualValue);
+        }
     }
 }


### PR DESCRIPTION
#2353 adjusted how LED values are parsed. Some can be integers/doubles and others as booleans (True/False)

To preserve backwards compatibility with profiles shared on X-Plane.to or FlightSim.to, this parse function will handle numerical values and booleans, otherwise it'll return 0 as default.

There's an open design decision here as to whether this should be a breaking change. On one hand it makes sense to support a boolean indicator as it does state whether the LED should be on or off.

On the other, it opens up edge cases. Nonetheless, the `TryParse` methods are generally preferred over `Convert.To`