### PR TITLE
Restore default pointer cursor for buttons

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -188,3 +188,14 @@
     --selected-foreground: 0 0% 16%;
   }
 }
+
+/* 
+  Add pointer cursor to all buttons and elements with role="button" 
+  The default cursor had changed with tailwindcss v4.
+*/
+@layer base {
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
+}


### PR DESCRIPTION
With tailwind 4.0 the default cursor is not pointer anymore. This PR restores the old "pointer" cursor for all elements that have role button.