### PR TITLE
Add missing playwright tests

### DIFF
--- a/frontend/tests/CommunityToolbar.spec.ts
+++ b/frontend/tests/CommunityToolbar.spec.ts
@@ -19,6 +19,12 @@ test("Confirm community buttons in toolbar behave as expected", async ({
     const button = page.getByRole("button", { name: buttonName })
     await expect(button).toBeVisible()
     await expect(button).toBeEnabled()
+
+    // with tailwind v4, cursor pointer is not default anymore
+    // this test ensures that our custom css for pointer cursor is applied
+    await button.hover()
+    await expect(button).toHaveCSS("cursor", "pointer")
+
     await button.click()
     const trackedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
 


### PR DESCRIPTION
this is part of #2377 - the commit was not pushed to the remote before merging :(

This PR adds missing Playwright test coverage for the CommunityToolbar component, specifically testing that community buttons maintain pointer cursor styling after the upgrade to Tailwind v4 (where pointer cursor is no longer applied by default).

- [x] Adds CSS cursor validation test for community toolbar buttons
- [x] Verifies custom pointer cursor styling is properly applied on button hover