### PR TITLE
Update lucide and  react-i18next to latest versions

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,7 @@
         "i18next-browser-languagedetector": "^8.0.2",
         "i18next-http-backend": "^3.0.1",
         "lodash-es": "^4.17.21",
-        "lucide-react": "^0.471.0",
+        "lucide-react": "^0.546.0",
         "next-themes": "^0.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3356,9 +3356,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.19.tgz",
-      "integrity": "sha512-zoKGUdu6vb2jd3YOq0nnhEDQVbPcHhco3UImJrv5dSkvxTc2pl2WjOPsjZXDwPDSl5eghIMuY3R6J9NDKF3KcQ==",
+      "version": "2.8.20",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.20.tgz",
+      "integrity": "sha512-JMWsdF+O8Orq3EMukbUN1QfbLK9mX2CkUmQBcW2T0s8OmdAUL5LLM/6wFwSrqXzlXB13yhyK9gTKS1rIizOduQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4694,9 +4694,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.471.2",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.471.2.tgz",
-      "integrity": "sha512-A8fDycQxGeaSOTaI7Bm4fg8LBXO7Qr9ORAX47bDRvugCsjLIliugQO0PkKFoeAD57LIQwlWKd3NIQ3J7hYp84g==",
+      "version": "0.546.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.546.0.tgz",
+      "integrity": "sha512-Z94u6fKT43lKeYHiVyvyR8fT7pwCzDu7RyMPpTvh054+xahSgj4HFQ+NmflvzdXsoAjYGdCguGaFKYuvq0ThCQ==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -5148,9 +5148,9 @@
       }
     },
     "node_modules/react-i18next": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.1.5.tgz",
-      "integrity": "sha512-+0dHUH7zQOXPhS3jt60Dq9nWIg+7xmN9ZrzN2YrBc1MN6kZl9u81qbN5JCkV/F5nsOu0udMbK7n7DiFMCs0PWg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-16.1.6.tgz",
+      "integrity": "sha512-62Iy0TO/2hJpTa80XaTIbHM4yjpile1YNieeg70vmdi91N2L3Q3MuxXBT0n6JpsryT88utpkqv0QbnIrDSxbAQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.27.6",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,7 @@
     "i18next-browser-languagedetector": "^8.0.2",
     "i18next-http-backend": "^3.0.1",
     "lodash-es": "^4.17.21",
-    "lucide-react": "^0.471.0",
+    "lucide-react": "^0.546.0",
     "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
Lucide package was still missing in #2385 and react-i18next received an update too today :D

fixes #2384 

related #2386 