### PR TITLE
Fix hover color for sponsor icon

### DIFF
--- a/frontend/src/components/CommunityMenu.tsx
+++ b/frontend/src/components/CommunityMenu.tsx
@@ -23,7 +23,7 @@ export const CommunityMenu = () => {
         variant={"default"}
         onClick={() => handleMenuItemClick({ action: "help.donate" })}
       >
-        <IconHeartDollar className="fill-none stroke-white text-white group-hover:stroke-white dark:stroke-pink-600" />
+        <IconHeartDollar className="fill-none stroke-white text-white group-hover:stroke-white dark:stroke-pink-600 dark:group-hover:stroke-white transition-colors" />
         Support us
       </Button>
       <Button


### PR DESCRIPTION
## Pull request overview

This PR fixes the hover color behavior for the sponsor icon in the community menu. In dark mode, when hovering over the "Support us" button, the icon now properly changes to white to match the button's hover state (pink background with white text).

### Key Changes
- Added `dark:group-hover:stroke-white` to make the icon stroke white on hover in dark mode
- Added `transition-colors` for smooth color transitions


No hover:

<img width="762" height="116" alt="image" src="https://github.com/user-attachments/assets/e72f87ee-f777-41ee-9e5f-054b49a416c8" />

Hover:

<img width="764" height="99" alt="image" src="https://github.com/user-attachments/assets/7a926ef8-eda8-4c11-a625-aa2543c41061" />


fixes #2416 