### PR TITLE
Use ellipsis for long project names

### DIFF
--- a/frontend/src/components/project/ProjectNameLabel.tsx
+++ b/frontend/src/components/project/ProjectNameLabel.tsx
@@ -64,6 +64,7 @@ const ProjectNameLabel = () => {
       data-testid="project-name-label"
     >
       <InlineEditLabel
+        labelClassName="max-w-72 xl:max-w-96 3xl:max-w-120 truncate"
         ref={inlineEditRef}
         value={optimisticLabel}
         onSave={handleProjectNameSave}


### PR DESCRIPTION
## Pull request overview

This PR implements responsive text truncation with ellipsis for the project name label to improve UI layout on different screen sizes. The solution adds maximum width constraints that scale with viewport breakpoints (default, xl, and 3xl) combined with CSS truncation.

- Adds responsive max-width classes (`max-w-72`, `xl:max-w-96`, `3xl:max-w-120`) to prevent project names from extending too far horizontally
- Applies CSS `truncate` utility to show ellipsis for overflowing text
- Utilizes the existing `labelClassName` prop on the `InlineEditLabel` component

### Small screen

<img width="1205" height="294" alt="image" src="https://github.com/user-attachments/assets/aef23e51-af83-4b2d-bf73-5c1aa0406a57" />

### xl-screen width

<img width="1791" height="190" alt="image" src="https://github.com/user-attachments/assets/e33c09eb-22d9-4f79-8088-6ce3d922ee1e" />

### 3xl-screen width

<img width="2523" height="171" alt="image" src="https://github.com/user-attachments/assets/c1869d69-7270-4d74-b593-07faa8fde050" />

fixes #2410 
