### PR TITLE
Truncate value for final and raw value

### DIFF
--- a/frontend/src/components/tables/config-item-table/items/ConfigItemTableFinalValueCell.tsx
+++ b/frontend/src/components/tables/config-item-table/items/ConfigItemTableFinalValueCell.tsx
@@ -23,7 +23,7 @@ function ConfigItemTableFinalValueCell({
   const label = item.Value
 
   return (
-    <div className="text-md">
+    <div className="text-md" data-testid="final-value">
       {!isEmpty(label) && !Modifier ? (
         item.Type == "InputConfigItem" ? (
           <ToolTip content={label}>

--- a/frontend/src/components/tables/config-item-table/items/ConfigItemTableRawValueCell.tsx
+++ b/frontend/src/components/tables/config-item-table/items/ConfigItemTableRawValueCell.tsx
@@ -24,7 +24,7 @@ function ConfigItemTableRawValueCell({
   const label = item.RawValue
 
   return (
-    <div className="text-md">
+    <div className="text-md" data-testid="raw-value">
       {!isEmpty(label) && !Source ? (
         item.Type == "InputConfigItem" ? (
           <ToolTip content={label}>

--- a/frontend/tests/ConfigListView.spec.ts
+++ b/frontend/tests/ConfigListView.spec.ts
@@ -883,11 +883,11 @@ test("Confirm Raw and Final Value update correctly", async ({
   await configListPage.gotoPage()
   await configListPage.mobiFlightPage.initWithTestData()
 
-  const rawValue = page.getByRole("row").nth(1).getByTitle("RawValue")
+  const rawValue = page.getByRole("row").nth(1).getByTestId("raw-value")
   const finalValue = page
     .getByRole("row")
     .nth(1)
-    .getByTitle("Value", { exact: true })
+    .getByTestId("final-value")
 
   await configListPage.updateConfigItemRawAndFinalValue(0, "1234", "5678")
   await expect(rawValue).toHaveText("1234")


### PR DESCRIPTION
<img width="1747" height="318" alt="image" src="https://github.com/user-attachments/assets/b883e26c-c8e8-4e33-be80-d261ec17a5b6" />

Also added some extra padding so that long values are not too close to each other which improves readability.

<img width="2629" height="329" alt="image" src="https://github.com/user-attachments/assets/0dec86e3-e01b-49f2-9009-acd834e32347" />

### Note
I ditched the idea of limiting the values to a certain resolution because of unknown side effects.
Yes, it would be possible to limit values only when they are displayed in the UI and not internally. I came to the conclusion that we should show what MobiFlight is currently processing.

If a user would like to see less resolution they can always apply a modifier to the value. This will only affect the final value though.

If we wanted to optimize the raw value resolution, too - then i believe it should become a global setting in mobiflight or part of the preset. In any case, anything related to resolution is outside of the scope of this PR.

fixes #2368 