### PR TITLE
Fix ProSim data reference handling by setting type for string values

### DIFF
--- a/MobiFlight/Execution/ConfigItemExecutor.cs
+++ b/MobiFlight/Execution/ConfigItemExecutor.cs
@@ -308,10 +308,12 @@ namespace MobiFlight.Execution
                 var datarefValue = proSimCache.readDataref(source.ProSimDataRef.Path);
                 if (datarefValue is string)
                 {
+                    result.type = FSUIPCOffsetType.String;
                     result.String = datarefValue as string;
                 }
                 else
                 {
+                    result.type = FSUIPCOffsetType.Float;
                     result.Float64 = (double)datarefValue;
                 }
             }

--- a/ProSim/ProSimCache.cs
+++ b/ProSim/ProSimCache.cs
@@ -205,11 +205,19 @@ namespace MobiFlight.ProSim
                 else
                 {
                     // Create new cache entry
-                    _subscribedDataRefs[datarefPath] = new CachedDataRef
+                    var newCachedRef = new CachedDataRef
                     {
                         Path = datarefPath,
                         Value = value,
                     };
+
+                    // Set DataRefDescription if available
+                    if (_dataRefDescriptions.TryGetValue(datarefPath, out var description))
+                    {
+                        newCachedRef.DataRefDescription = description;
+                    }
+
+                    _subscribedDataRefs[datarefPath] = newCachedRef;
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/MobiFlight/MobiFlight-Connector/issues/2452

`DataRefDescription`s are not being populated in cache causing strings to not be properly detected. Additionally we did not set the type on the `ConnectorValue` so even if the strings did get passed, they were not treating as the proper type.