### PR TITLE
Tabs can scroll horizontally when not enough space available

### DIFF
--- a/frontend/src/components/InlineEditLabel.tsx
+++ b/frontend/src/components/InlineEditLabel.tsx
@@ -99,7 +99,7 @@ export const InlineEditLabel = forwardRef<
         ref={inputRef}
         className={cn(
           `border-primary bg-background hover:text-foreground rounded-md border-2 px-2 font-semibold focus-visible:ring-0 focus-visible:ring-transparent focus-visible:ring-offset-0 md:text-base`,
-          `field-sizing-content h-8 w-auto`,
+          `field-sizing-content h-8`,
           inputClassName,
         )}
         type="text"

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -1,22 +1,15 @@
 import { ConfigFile } from "@/types"
 import { VariantProps } from "class-variance-authority"
-import { IconDotsVertical, IconPencil, IconTrash } from "@tabler/icons-react"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { CommandFileContextMenu } from "@/types/commands"
 import { Button } from "@/components/ui/button"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu"
 import { buttonVariants } from "@/components/ui/variants"
 import { useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
-import { useTranslation } from "react-i18next"
 import { InlineEditLabel, InlineEditLabelRef } from "../InlineEditLabel"
 import { useDroppable } from "@dnd-kit/core"
 import { clamp } from "lodash-es"
+import ProfileTabContextMenu from "@/components/project/ProfileTab/ProfileTabContextMenu"
 
 export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
   file: ConfigFile
@@ -32,7 +25,6 @@ const ProfileTab = ({
   totalCount,
   selectActiveFile: onSelectActiveFile,
 }: ProfileTabProps) => {
-  const { t } = useTranslation()
   const { publish } = publishOnMessageExchange()
   const inlineEditRef = useRef<InlineEditLabelRef>(null)
   const label = file.Label ?? file.FileName
@@ -74,26 +66,26 @@ const ProfileTab = ({
 
   const labelWidthBasedOnCount: Record<number, string> = {
     0: "max-w-60 xl:max-w-80 3xl:max-w-65",
-    1: "max-w-50 xl:max-w-70 3xl:max-w-65",
-    2: "max-w-40 xl:max-w-60 3xl:max-w-65",
-    3: "max-w-30 xl:max-w-50 3xl:max-w-65",
-    4: "max-w-20 xl:max-w-40 3xl:max-w-65",
-    5: "max-w-10 xl:max-w-30 3xl:max-w-65",
-    6: "max-w-5 xl:max-w-20 3xl:max-w-50 4xl:max-w-60",
-    7: "max-w-3 xl:max-w-7 3xl:max-w-30 4xl:max-w-50",
-    8: "max-w-2 xl:max-w-7 3xl:max-w-25 4xl:max-w-40",
-    9: "max-w-2 xl:max-w-7 3xl:max-w-20 4xl:max-w-35",
-    10: "max-w-2 xl:max-w-15 3xl:max-w-15 4xl:max-w-30",
-    11: "max-w-2 xl:max-w-5 3xl:max-w-10 4xl:max-w-25",
-    12: "max-w-2 xl:max-w-5 3xl:max-w-5 4xl:max-w-20",
+    // 1: "max-w-50 xl:max-w-70 3xl:max-w-65",
+    // 2: "max-w-40 xl:max-w-60 3xl:max-w-65",
+    // 3: "max-w-30 xl:max-w-50 3xl:max-w-65",
+    // 4: "max-w-20 xl:max-w-40 3xl:max-w-65",
+    // 5: "max-w-10 xl:max-w-30 3xl:max-w-65",
+    // 6: "max-w-5 xl:max-w-20 3xl:max-w-50 4xl:max-w-60",
+    // 7: "max-w-3 xl:max-w-7 3xl:max-w-30 4xl:max-w-50",
+    // 8: "max-w-2 xl:max-w-7 3xl:max-w-25 4xl:max-w-40",
+    // 9: "max-w-2 xl:max-w-7 3xl:max-w-20 4xl:max-w-35",
+    // 10: "max-w-2 xl:max-w-15 3xl:max-w-15 4xl:max-w-30",
+    // 11: "max-w-2 xl:max-w-5 3xl:max-w-10 4xl:max-w-25",
+    // 12: "max-w-2 xl:max-w-5 3xl:max-w-5 4xl:max-w-20",
   }
 
-  const maxInputWidth = labelWidthBasedOnCount[clamp(totalCount, 0, 10)]
-  const labelClassName = `truncate transition-all duration-300 ease-in-out ${labelWidthBasedOnCount[clamp(totalCount, 0, 8)]}`
+  const maxInputWidth = labelWidthBasedOnCount[clamp(totalCount, 0, 0)]
+  const labelClassName = `truncate transition-all duration-300 ease-in-out ${labelWidthBasedOnCount[clamp(totalCount, 0, 0)]}`
 
   return (
     <div
-      className={`group flex justify-center`}
+      className={`group flex justify-center border-b border-muted-foreground/50`}
       ref={setNodeRef}
       role="tab"
       aria-selected={isActiveTab}
@@ -117,62 +109,14 @@ const ProfileTab = ({
           disabled={!isActiveTab}
         />
       </Button>
-      <div className="relative">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant={variant}
-              className={cn(
-                groupHoverStyle,
-                "w-8 rounded-l-none rounded-b-none border-b-0 border-l-0 p-0 pb-0",
-              )}
-            >
-              <span className="sr-only">{t("General.Action.OpenMenu")}</span>
-              <IconDotsVertical className="h-4 w-4" />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <DropdownMenuItem
-              onClick={() => {
-                inlineEditRef.current?.startEditing()
-              }}
-            >
-              <IconPencil />
-              {t("Project.File.Action.Rename")}
-            </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() => {
-                publish({
-                  key: "CommandFileContextMenu",
-                  payload: {
-                    action: "remove",
-                    index: index,
-                    file: file,
-                  },
-                } as CommandFileContextMenu)
-              }}
-            >
-              <IconTrash />
-              {t("Project.File.Action.Remove")}
-            </DropdownMenuItem>
-            {/* <DropdownMenuItem
-              onClick={() => {
-                publish({
-                  key: "CommandFileContextMenu",
-                  payload: {
-                    action: "export",
-                    index: index,
-                    file: file,
-                  },
-                } as CommandFileContextMenu)
-              }}
-            >
-              <IconFileExport />
-              {t("Project.File.Action.Export")}
-            </DropdownMenuItem> */}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+      <ProfileTabContextMenu 
+        variant={variant}
+        groupHoverStyle={groupHoverStyle}
+        index={index}
+        file={file.FileName}
+        inlineEditRef={inlineEditRef}
+      />
+
     </div>
   )
 }

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -8,7 +8,6 @@ import { forwardRef, useCallback, useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 import { InlineEditLabel, InlineEditLabelRef } from "../InlineEditLabel"
 import { useDroppable } from "@dnd-kit/core"
-import { clamp } from "lodash-es"
 import ProfileTabContextMenu from "@/components/project/ProfileTab/ProfileTabContextMenu"
 
 export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
@@ -19,133 +18,131 @@ export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
   resizeCallback?: () => void
 }
 
-export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
-  file,
-  index,
-  variant,
-  totalCount,
-  selectActiveFile: onSelectActiveFile,
-  resizeCallback
-}: ProfileTabProps, ref) => {
-  const { publish } = publishOnMessageExchange()
-  const inlineEditRef = useRef<InlineEditLabelRef>(null)
-  const buttonRef = useRef<HTMLButtonElement>(null)
+export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(
+  (
+    {
+      file,
+      index,
+      variant,
+      totalCount,
+      selectActiveFile: onSelectActiveFile,
+      resizeCallback,
+    }: ProfileTabProps,
+    ref,
+  ) => {
+    const { publish } = publishOnMessageExchange()
+    const inlineEditRef = useRef<InlineEditLabelRef>(null)
+    const buttonRef = useRef<HTMLButtonElement>(null)
 
-  const label = file.Label ?? file.FileName
-  const [ optimisticLabel, setOptimisticLabel ] = useState(label)
+    const label = file.Label ?? file.FileName
+    const [optimisticLabel, setOptimisticLabel] = useState(label)
 
-  const isActiveTab = variant === "tabActive"
+    const isActiveTab = variant === "tabActive"
 
-  useEffect(() => {
-    setOptimisticLabel(label)
-  }, [label])
+    useEffect(() => {
+      setOptimisticLabel(label)
+    }, [label])
 
-  const onSave = (newLabel: string) => {
-    setOptimisticLabel(newLabel)
-    publish({
-      key: "CommandFileContextMenu",
-      payload: {
-        action: "rename",
-        index: index,
-        file: {
-          ...file,
-          Label: newLabel,
+    const onSave = (newLabel: string) => {
+      setOptimisticLabel(newLabel)
+      publish({
+        key: "CommandFileContextMenu",
+        payload: {
+          action: "rename",
+          index: index,
+          file: {
+            ...file,
+            Label: newLabel,
+          },
         },
+      } as CommandFileContextMenu)
+    }
+
+    const groupHoverStyle =
+      variant === "tabActive"
+        ? "group-hover:bg-primary group-hover:text-primary-foreground"
+        : "group-hover:bg-accent group-hover:text-accent-foreground"
+
+    // this ensures correct text color
+    // when we are in edit mode
+    // but hover outside of the input field, e.g. the menu button
+    const groupHoverInputStyle = "group-hover:text-foreground"
+
+    const { setNodeRef } = useDroppable({
+      id: `file-button-${index}`,
+      data: {
+        type: `tab`,
+        index: index,
       },
-    } as CommandFileContextMenu)
-  }
-  
-  const groupHoverStyle =
-    variant === "tabActive"
-      ? "group-hover:bg-primary group-hover:text-primary-foreground"
-      : "group-hover:bg-accent group-hover:text-accent-foreground"
-
-  const { setNodeRef } = useDroppable({
-    id: `file-button-${index}`,
-    data: {
-      type: `tab`,
-      index: index,
-    },
-  })
-
-  const labelWidthBasedOnCount: Record<number, string> = {
-    0: "max-w-60 xl:max-w-80 3xl:max-w-65",
-    // 1: "max-w-50 xl:max-w-70 3xl:max-w-65",
-    // 2: "max-w-40 xl:max-w-60 3xl:max-w-65",
-    // 3: "max-w-30 xl:max-w-50 3xl:max-w-65",
-    // 4: "max-w-20 xl:max-w-40 3xl:max-w-65",
-    // 5: "max-w-10 xl:max-w-30 3xl:max-w-65",
-    // 6: "max-w-5 xl:max-w-20 3xl:max-w-50 4xl:max-w-60",
-    // 7: "max-w-3 xl:max-w-7 3xl:max-w-30 4xl:max-w-50",
-    // 8: "max-w-2 xl:max-w-7 3xl:max-w-25 4xl:max-w-40",
-    // 9: "max-w-2 xl:max-w-7 3xl:max-w-20 4xl:max-w-35",
-    // 10: "max-w-2 xl:max-w-15 3xl:max-w-15 4xl:max-w-30",
-    // 11: "max-w-2 xl:max-w-5 3xl:max-w-10 4xl:max-w-25",
-    // 12: "max-w-2 xl:max-w-5 3xl:max-w-5 4xl:max-w-20",
-  }
-
-  const maxInputWidth = labelWidthBasedOnCount[clamp(totalCount, 0, 0)]
-  const labelClassName = `truncate transition-all duration-300 ease-in-out ${labelWidthBasedOnCount[clamp(totalCount, 0, 0)]}`
-
-  const combinedRef = useCallback((node: HTMLDivElement | null) => {
-    setNodeRef(node)
-    if (typeof ref === 'function') ref(node)
-    else if (ref) ref.current = node
-  }, [ref, setNodeRef])
-
-  useEffect(() => {
-    const resizeObserver = new ResizeObserver(() => {
-      resizeCallback?.()
     })
 
-    const button = buttonRef.current
-    if (button) {
-      resizeObserver.observe(button)
-    }
+    const maxInputWidth = "max-w-60 xl:max-w-70 3xl:max-w-80"
+    const labelClassName = `truncate transition-all duration-300 ease-in-out ${maxInputWidth}`
 
-    return () => {
+    const combinedRef = useCallback(
+      (node: HTMLDivElement | null) => {
+        setNodeRef(node)
+        if (typeof ref === "function") ref(node)
+        else if (ref) ref.current = node
+      },
+      [ref, setNodeRef],
+    )
+
+    useEffect(() => {
+      const resizeObserver = new ResizeObserver(() => {
+        resizeCallback?.()
+      })
+
+      const button = buttonRef.current
       if (button) {
-        resizeObserver.unobserve(button)
+        resizeObserver.observe(button)
       }
-    }
-  }, [resizeCallback])
 
-  return (
-    <div
-      className={`group flex flex-row justify-center border-b`}
-      ref={combinedRef}
-      role="tab"
-      aria-selected={isActiveTab}
-      title={optimisticLabel}
-    >
-      <Button      
-        ref={buttonRef}
-        variant={variant}
-        value={optimisticLabel}
-        className={cn(
-          groupHoverStyle,
-          "rounded-r-none rounded-b-none border-r-0",
-          maxInputWidth
-        )}
-        onClick={() => onSelectActiveFile(index)}
+      return () => {
+        if (button) {
+          resizeObserver.unobserve(button)
+        }
+      }
+    }, [resizeCallback])
+
+    return (
+      <div
+        className={`group flex flex-row justify-center border-b`}
+        ref={combinedRef}
+        role="tab"
+        aria-selected={isActiveTab}
+        title={optimisticLabel}
       >
-        <InlineEditLabel
-          labelClassName={labelClassName}
-          ref={inlineEditRef}
+        <Button
+          ref={buttonRef}
+          variant={variant}
           value={optimisticLabel}
-          onSave={onSave}
-          disabled={!isActiveTab}
+          className={cn(
+            groupHoverStyle,
+            "rounded-r-none rounded-b-none border-r-0",
+            maxInputWidth,
+          )}
+          onClick={() => onSelectActiveFile(index)}
+        >
+          <InlineEditLabel
+            labelClassName={labelClassName}
+            inputClassName={groupHoverInputStyle}
+            ref={inlineEditRef}
+            value={optimisticLabel}
+            onSave={onSave}
+            disabled={!isActiveTab}
+          />
+        </Button>
+        <ProfileTabContextMenu
+          variant={variant}
+          groupHoverStyle={groupHoverStyle}
+          index={index}
+          file={file}
+          inlineEditRef={inlineEditRef}
         />
-      </Button>
-      <ProfileTabContextMenu 
-        variant={variant}
-        groupHoverStyle={groupHoverStyle}
-        index={index}
-        file={file}
-        inlineEditRef={inlineEditRef}
-      />
-    </div>
-  )
-})
+      </div>
+    )
+  },
+)
 
 ProfileTab.displayName = "ProfileTab"

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -85,7 +85,7 @@ const ProfileTab = ({
 
   return (
     <div
-      className={`group flex justify-center border-b border-muted-foreground/50`}
+      className={`group flex flex-row justify-center border-b`}
       ref={setNodeRef}
       role="tab"
       aria-selected={isActiveTab}
@@ -96,7 +96,7 @@ const ProfileTab = ({
         value={optimisticLabel}
         className={cn(
           groupHoverStyle,
-          "rounded-r-none rounded-b-none border-r-0 border-b-0",
+          "rounded-r-none rounded-b-none border-r-0",
           maxInputWidth
         )}
         onClick={() => onSelectActiveFile(index)}
@@ -116,7 +116,6 @@ const ProfileTab = ({
         file={file.FileName}
         inlineEditRef={inlineEditRef}
       />
-
     </div>
   )
 }

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -4,7 +4,7 @@ import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { CommandFileContextMenu } from "@/types/commands"
 import { Button } from "@/components/ui/button"
 import { buttonVariants } from "@/components/ui/variants"
-import { useEffect, useRef, useState } from "react"
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react"
 import { cn } from "@/lib/utils"
 import { InlineEditLabel, InlineEditLabelRef } from "../InlineEditLabel"
 import { useDroppable } from "@dnd-kit/core"
@@ -18,13 +18,13 @@ export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
   selectActiveFile: (index: number) => void
 }
 
-const ProfileTab = ({
+const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
   file,
   index,
   variant,
   totalCount,
   selectActiveFile: onSelectActiveFile,
-}: ProfileTabProps) => {
+}: ProfileTabProps, ref) => {
   const { publish } = publishOnMessageExchange()
   const inlineEditRef = useRef<InlineEditLabelRef>(null)
   const label = file.Label ?? file.FileName
@@ -83,15 +83,21 @@ const ProfileTab = ({
   const maxInputWidth = labelWidthBasedOnCount[clamp(totalCount, 0, 0)]
   const labelClassName = `truncate transition-all duration-300 ease-in-out ${labelWidthBasedOnCount[clamp(totalCount, 0, 0)]}`
 
+  const combinedRef = useCallback((node: HTMLDivElement | null) => {
+    setNodeRef(node)
+    if (typeof ref === 'function') ref(node)
+    else if (ref) ref.current = node
+  }, [ref, setNodeRef])
+
   return (
     <div
       className={`group flex flex-row justify-center border-b`}
-      ref={setNodeRef}
+      ref={combinedRef}
       role="tab"
       aria-selected={isActiveTab}
       title={optimisticLabel}
     >
-      <Button
+      <Button      
         variant={variant}
         value={optimisticLabel}
         className={cn(
@@ -118,6 +124,6 @@ const ProfileTab = ({
       />
     </div>
   )
-}
+})
 
 export default ProfileTab

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -13,7 +13,6 @@ import ProfileTabContextMenu from "@/components/project/ProfileTab/ProfileTabCon
 export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
   file: ConfigFile
   index: number
-  totalCount: number
   selectActiveFile: (index: number) => void
   resizeCallback?: () => void
 }
@@ -24,7 +23,6 @@ export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(
       file,
       index,
       variant,
-      totalCount,
       selectActiveFile: onSelectActiveFile,
       resizeCallback,
     }: ProfileTabProps,

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -18,7 +18,7 @@ export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
   selectActiveFile: (index: number) => void
 }
 
-const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
+export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
   file,
   index,
   variant,
@@ -126,4 +126,4 @@ const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
   )
 })
 
-export default ProfileTab
+ProfileTab.displayName = "ProfileTab"

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -16,6 +16,7 @@ export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
   index: number
   totalCount: number
   selectActiveFile: (index: number) => void
+  resizeCallback?: () => void
 }
 
 export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
@@ -24,9 +25,12 @@ export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
   variant,
   totalCount,
   selectActiveFile: onSelectActiveFile,
+  resizeCallback
 }: ProfileTabProps, ref) => {
   const { publish } = publishOnMessageExchange()
   const inlineEditRef = useRef<InlineEditLabelRef>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
   const label = file.Label ?? file.FileName
   const [ optimisticLabel, setOptimisticLabel ] = useState(label)
 
@@ -89,6 +93,23 @@ export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
     else if (ref) ref.current = node
   }, [ref, setNodeRef])
 
+  useEffect(() => {
+    const resizeObserver = new ResizeObserver(() => {
+      resizeCallback?.()
+    })
+
+    const button = buttonRef.current
+    if (button) {
+      resizeObserver.observe(button)
+    }
+
+    return () => {
+      if (button) {
+        resizeObserver.unobserve(button)
+      }
+    }
+  }, [resizeCallback])
+
   return (
     <div
       className={`group flex flex-row justify-center border-b`}
@@ -98,6 +119,7 @@ export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
       title={optimisticLabel}
     >
       <Button      
+        ref={buttonRef}
         variant={variant}
         value={optimisticLabel}
         className={cn(

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -17,18 +17,18 @@ import { useTranslation } from "react-i18next"
 import { InlineEditLabel, InlineEditLabelRef } from "../InlineEditLabel"
 import { useDroppable } from "@dnd-kit/core"
 
-export interface FileButtonProps extends VariantProps<typeof buttonVariants> {
+export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
   file: ConfigFile
   index: number
   selectActiveFile: (index: number) => void
 }
 
-const FileButton = ({
+const ProfileTab = ({
   file,
   index,
   variant,
   selectActiveFile: onSelectActiveFile,
-}: FileButtonProps) => {
+}: ProfileTabProps) => {
   const { t } = useTranslation()
   const { publish } = publishOnMessageExchange()
   const inlineEditRef = useRef<InlineEditLabelRef>(null)
@@ -152,4 +152,4 @@ const FileButton = ({
   )
 }
 
-export default FileButton
+export default ProfileTab

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -119,7 +119,7 @@ export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(({
         variant={variant}
         groupHoverStyle={groupHoverStyle}
         index={index}
-        file={file.FileName}
+        file={file}
         inlineEditRef={inlineEditRef}
       />
     </div>

--- a/frontend/src/components/project/ProfileTab.tsx
+++ b/frontend/src/components/project/ProfileTab.tsx
@@ -16,10 +16,12 @@ import { cn } from "@/lib/utils"
 import { useTranslation } from "react-i18next"
 import { InlineEditLabel, InlineEditLabelRef } from "../InlineEditLabel"
 import { useDroppable } from "@dnd-kit/core"
+import { clamp } from "lodash-es"
 
 export interface ProfileTabProps extends VariantProps<typeof buttonVariants> {
   file: ConfigFile
   index: number
+  totalCount: number
   selectActiveFile: (index: number) => void
 }
 
@@ -27,6 +29,7 @@ const ProfileTab = ({
   file,
   index,
   variant,
+  totalCount,
   selectActiveFile: onSelectActiveFile,
 }: ProfileTabProps) => {
   const { t } = useTranslation()
@@ -69,12 +72,32 @@ const ProfileTab = ({
     },
   })
 
+  const labelWidthBasedOnCount: Record<number, string> = {
+    0: "max-w-60 xl:max-w-80 3xl:max-w-65",
+    1: "max-w-50 xl:max-w-70 3xl:max-w-65",
+    2: "max-w-40 xl:max-w-60 3xl:max-w-65",
+    3: "max-w-30 xl:max-w-50 3xl:max-w-65",
+    4: "max-w-20 xl:max-w-40 3xl:max-w-65",
+    5: "max-w-10 xl:max-w-30 3xl:max-w-65",
+    6: "max-w-5 xl:max-w-20 3xl:max-w-50 4xl:max-w-60",
+    7: "max-w-3 xl:max-w-7 3xl:max-w-30 4xl:max-w-50",
+    8: "max-w-2 xl:max-w-7 3xl:max-w-25 4xl:max-w-40",
+    9: "max-w-2 xl:max-w-7 3xl:max-w-20 4xl:max-w-35",
+    10: "max-w-2 xl:max-w-15 3xl:max-w-15 4xl:max-w-30",
+    11: "max-w-2 xl:max-w-5 3xl:max-w-10 4xl:max-w-25",
+    12: "max-w-2 xl:max-w-5 3xl:max-w-5 4xl:max-w-20",
+  }
+
+  const maxInputWidth = labelWidthBasedOnCount[clamp(totalCount, 0, 10)]
+  const labelClassName = `truncate transition-all duration-300 ease-in-out ${labelWidthBasedOnCount[clamp(totalCount, 0, 8)]}`
+
   return (
     <div
-      className="group flex justify-center"
+      className={`group flex justify-center`}
       ref={setNodeRef}
       role="tab"
       aria-selected={isActiveTab}
+      title={optimisticLabel}
     >
       <Button
         variant={variant}
@@ -82,10 +105,12 @@ const ProfileTab = ({
         className={cn(
           groupHoverStyle,
           "rounded-r-none rounded-b-none border-r-0 border-b-0",
+          maxInputWidth
         )}
         onClick={() => onSelectActiveFile(index)}
       >
         <InlineEditLabel
+          labelClassName={labelClassName}
           ref={inlineEditRef}
           value={optimisticLabel}
           onSave={onSave}

--- a/frontend/src/components/project/ProfileTab/AddProfileTabMenu.tsx
+++ b/frontend/src/components/project/ProfileTab/AddProfileTabMenu.tsx
@@ -8,7 +8,7 @@ import {
 import { IconFolderPlus, IconPlus } from "@tabler/icons-react"
 import { useTranslation } from "react-i18next"
 
-interface AddProfileTabMenuProps {
+interface AddProfileTabMenuProps extends React.HTMLAttributes<HTMLDivElement> {
   onAddConfigFile: () => void
   onMergeConfigFile: () => void
   onMouseEnter?: () => void
@@ -20,11 +20,12 @@ export const AddProfileTabMenu = ({
   onMergeConfigFile,
   onMouseEnter,
   onMouseLeave,
-}: AddProfileTabMenuProps) => {
+  ...props
+} : AddProfileTabMenuProps) => {
   const { t } = useTranslation()
 
   return (
-    <div className="border-muted-foreground/50 border-b px-2">
+    <div className="border-muted-foreground/50 border-b px-2" {...props}>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <div

--- a/frontend/src/components/project/ProfileTab/AddProfileTabMenu.tsx
+++ b/frontend/src/components/project/ProfileTab/AddProfileTabMenu.tsx
@@ -1,0 +1,58 @@
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { IconFolderPlus, IconPlus } from "@tabler/icons-react"
+import { useTranslation } from "react-i18next"
+
+interface AddProfileTabMenuProps {
+  onAddConfigFile: () => void
+  onMergeConfigFile: () => void
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+}
+
+export const AddProfileTabMenu = ({
+  onAddConfigFile,
+  onMergeConfigFile,
+  onMouseEnter,
+  onMouseLeave,
+}: AddProfileTabMenuProps) => {
+  const { t } = useTranslation()
+
+  return (
+    <div className="border-muted-foreground/50 border-b px-2">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <div
+            className="py-1"
+            onMouseEnter={onMouseEnter}
+            onMouseLeave={onMouseLeave}
+          >
+            <Button variant={"default"} className="h-8 px-2">
+              <span className="sr-only">{t("General.Action.OpenMenu")}</span>
+              <IconPlus />
+            </Button>
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          onMouseEnter={onMouseEnter}
+          onMouseLeave={onMouseLeave}
+        >
+          <DropdownMenuItem onClick={onAddConfigFile}>
+            <IconPlus />
+            {t("Project.File.Action.New")}
+          </DropdownMenuItem>
+          <DropdownMenuItem onClick={onMergeConfigFile}>
+            <IconFolderPlus />
+            {t("Project.File.Action.Merge")}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
+++ b/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
@@ -20,7 +20,7 @@ export interface ProfileTabContextMenuProps
   index: number
   file: string | null
   groupHoverStyle: string
-  inlineEditRef: RefObject<InlineEditLabelRef | null> 
+  inlineEditRef: RefObject<InlineEditLabelRef | null>
 }
 
 const ProfileTabContextMenu = ({

--- a/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
+++ b/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
@@ -41,7 +41,7 @@ const ProfileTabContextMenu = ({
             variant={variant}
             className={cn(
               groupHoverStyle,
-              "w-8 rounded-l-none rounded-b-none border-b-0 border-l-0 p-0 pb-0",
+              "w-8 rounded-l-none rounded-b-none border-l-0 p-0 pb-0",
             )}
           >
             <span className="sr-only">{t("General.Action.OpenMenu")}</span>

--- a/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
+++ b/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
@@ -1,0 +1,96 @@
+import { InlineEditLabelRef } from "@/components/InlineEditLabel"
+import { Button } from "@/components/ui/button"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import { buttonVariants } from "@/components/ui/variants"
+import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import { cn } from "@/lib/utils"
+import { CommandFileContextMenu } from "@/types/commands"
+import { IconDotsVertical, IconPencil, IconTrash } from "@tabler/icons-react"
+import { VariantProps } from "class-variance-authority"
+import { RefObject } from "react"
+import { useTranslation } from "react-i18next"
+
+export interface ProfileTabContextMenuProps
+  extends VariantProps<typeof buttonVariants> {
+  index: number
+  file: string | null
+  groupHoverStyle: string
+  inlineEditRef: RefObject<InlineEditLabelRef | null> 
+}
+
+const ProfileTabContextMenu = ({
+  variant,
+  groupHoverStyle,
+  index,
+  file,
+  inlineEditRef,
+}: ProfileTabContextMenuProps) => {
+  const { t } = useTranslation()
+  const { publish } = publishOnMessageExchange()
+
+  return (
+    <div className="relative">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant={variant}
+            className={cn(
+              groupHoverStyle,
+              "w-8 rounded-l-none rounded-b-none border-b-0 border-l-0 p-0 pb-0",
+            )}
+          >
+            <span className="sr-only">{t("General.Action.OpenMenu")}</span>
+            <IconDotsVertical className="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem
+            onClick={() => {
+              inlineEditRef.current?.startEditing()
+            }}
+          >
+            <IconPencil />
+            {t("Project.File.Action.Rename")}
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onClick={() => {
+              publish({
+                key: "CommandFileContextMenu",
+                payload: {
+                  action: "remove",
+                  index: index,
+                  file: file,
+                },
+              } as CommandFileContextMenu)
+            }}
+          >
+            <IconTrash />
+            {t("Project.File.Action.Remove")}
+          </DropdownMenuItem>
+          {/* <DropdownMenuItem
+              onClick={() => {
+                publish({
+                  key: "CommandFileContextMenu",
+                  payload: {
+                    action: "export",
+                    index: index,
+                    file: file,
+                  },
+                } as CommandFileContextMenu)
+              }}
+            >
+              <IconFileExport />
+              {t("Project.File.Action.Export")}
+            </DropdownMenuItem> */}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}
+
+export default ProfileTabContextMenu

--- a/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
+++ b/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
@@ -9,6 +9,7 @@ import {
 import { buttonVariants } from "@/components/ui/variants"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { cn } from "@/lib/utils"
+import { ConfigFile } from "@/types"
 import { CommandFileContextMenu } from "@/types/commands"
 import { IconDotsVertical, IconPencil, IconTrash } from "@tabler/icons-react"
 import { VariantProps } from "class-variance-authority"
@@ -18,7 +19,7 @@ import { useTranslation } from "react-i18next"
 export interface ProfileTabContextMenuProps
   extends VariantProps<typeof buttonVariants> {
   index: number
-  file: string | null
+  file: ConfigFile | null
   groupHoverStyle: string
   inlineEditRef: RefObject<InlineEditLabelRef | null>
 }

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -17,11 +17,15 @@ import { useOverflowDetector } from "@/lib/hooks/useOverflowDetector"
 
 const ProjectPanel = () => {
   const SCROLL_TAB_INTO_VIEW_DELAY_MS = 1500
+
+  const overflowRef = useRef<HTMLDivElement | null>(null)
+
   const { t } = useTranslation()
   const { publish } = publishOnMessageExchange()
   const navigate = useNavigate()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const { width, height } = useWindowSize()
+  const { overflow, checkOverflow } = useOverflowDetector(overflowRef)
 
   // Track previous width and height
   const prevWindowSizeRef = useRef({ width, height })
@@ -63,6 +67,10 @@ const ProjectPanel = () => {
     })
   }, [activeConfigFileIndex])
 
+  useEffect(() => {
+    checkOverflow()
+  }, [activeConfigFileIndex, checkOverflow])
+
   const scrollIntoViewTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const scrollIntervalRef = useRef<NodeJS.Timeout | null>(null)
 
@@ -102,8 +110,6 @@ const ProjectPanel = () => {
     scrollActiveProfileTabIntoView,
     resetScrollActiveProfileTabIntoView,
   ])
-
-  const overflowRef = useRef<HTMLDivElement | null>(null)
 
   const handleMouseWheel = (event: React.WheelEvent) => {
     if (overflowRef.current === null) return
@@ -191,8 +197,6 @@ const ProjectPanel = () => {
     navigate("/home")
   }
 
-  const overflow = useOverflowDetector(overflowRef)
-
   // Hover timer ref
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const activeProfileTabRef = useRef<HTMLDivElement | null>(null)
@@ -260,7 +264,7 @@ const ProjectPanel = () => {
 
       <div className="border-muted-foreground/50 flex w-0 flex-col items-center gap-1 border-b py-0.5"></div>
 
-      <div className="relative h-full grow min-h-10" role="tablist">
+      <div className="relative h-full min-h-10 grow" role="tablist">
         <div
           className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden"
           ref={overflowRef}
@@ -285,6 +289,7 @@ const ProjectPanel = () => {
                   index={index}
                   totalCount={configFiles.length}
                   selectActiveFile={selectActiveFile}
+                  resizeCallback={checkOverflow}
                 />
               )
             })}
@@ -302,11 +307,17 @@ const ProjectPanel = () => {
         </div>
         {/* Left shadow */}
         {overflow.left && (
-          <div data-testid="tab-overflow-indicator-left" className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-2 rounded-tl-sm bg-linear-to-r to-transparent pb-1 dark:bottom-0.5 dark:w-3" />
+          <div
+            data-testid="tab-overflow-indicator-left"
+            className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-2 rounded-tl-sm bg-linear-to-r to-transparent pb-1 dark:bottom-0.5 dark:w-3"
+          />
         )}
         {/* Right shadow */}
         {overflow.right && (
-          <div data-testid="tab-overflow-indicator-right" className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 right-0 bottom-0 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
+          <div
+            data-testid="tab-overflow-indicator-right"
+            className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 right-0 bottom-0 z-200 w-2 bg-linear-to-l to-transparent pb-1"
+          />
         )}
       </div>
       {overflow.right && (

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -223,11 +223,15 @@ const ProjectPanel = () => {
                 />
               )
             })}
-            <div className="border-muted-foreground/50 relative grow border-b px-2">
+            <div className="border-muted-foreground/50 grow border-b"></div>
+          </div>
+        </div>
+      </div>
+      <div className="border-muted-foreground/50 border-b px-2">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
                   <div className="py-1">
-                    <Button variant={"ghost"} className="h-8 px-2">
+                    <Button variant={"default"} className="h-8 px-2">
                       <span className="sr-only">
                         {t("General.Action.OpenMenu")}
                       </span>
@@ -247,10 +251,6 @@ const ProjectPanel = () => {
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
-            <div className="border-muted-foreground/50 grow border-b"></div>
-          </div>
-        </div>
-      </div>
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent>
           <DialogHeader className="sr-only">

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -109,6 +109,8 @@ const ProjectPanel = () => {
     if (overflowRef.current === null) return
     const scrollContainer = overflowRef.current
     if (!scrollContainer) return
+
+    event.stopPropagation()
     const newScrollLeft = scrollContainer.scrollLeft + event.deltaY
     scrollContainer.scrollLeft = newScrollLeft
   }
@@ -258,7 +260,7 @@ const ProjectPanel = () => {
 
       <div className="border-muted-foreground/50 flex w-0 flex-col items-center gap-1 border-b py-0.5"></div>
 
-      <div className="relative h-full grow" role="tablist">
+      <div className="relative h-full grow min-h-10" role="tablist">
         <div
           className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden"
           ref={overflowRef}
@@ -288,6 +290,7 @@ const ProjectPanel = () => {
             })}
             {!overflow.right && (
               <AddProfileTabMenu
+                data-testid="add-profile-tab-menu-regular"
                 onAddConfigFile={addConfigFile}
                 onMergeConfigFile={mergeConfigFile}
                 onMouseEnter={resetScrollActiveProfileTabIntoView}
@@ -298,16 +301,17 @@ const ProjectPanel = () => {
           </div>
         </div>
         {/* Left shadow */}
-        {activeConfigFileIndex > 0 && overflow.left && (
-          <div className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-2 rounded-tl-sm bg-linear-to-r to-transparent pb-1 dark:bottom-0.5 dark:w-3" />
+        {overflow.left && (
+          <div data-testid="tab-overflow-indicator-left" className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-2 rounded-tl-sm bg-linear-to-r to-transparent pb-1 dark:bottom-0.5 dark:w-3" />
         )}
         {/* Right shadow */}
         {overflow.right && (
-          <div className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 right-0 bottom-0 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
+          <div data-testid="tab-overflow-indicator-right" className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 right-0 bottom-0 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
         )}
       </div>
       {overflow.right && (
         <AddProfileTabMenu
+          data-testid="add-profile-tab-menu-overflow"
           onAddConfigFile={addConfigFile}
           onMergeConfigFile={mergeConfigFile}
           onMouseEnter={resetScrollActiveProfileTabIntoView}

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -287,7 +287,6 @@ const ProjectPanel = () => {
                   }
                   file={file}
                   index={index}
-                  totalCount={configFiles.length}
                   selectActiveFile={selectActiveFile}
                   resizeCallback={checkOverflow}
                 />

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -228,29 +228,27 @@ const ProjectPanel = () => {
         </div>
       </div>
       <div className="border-muted-foreground/50 border-b px-2">
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <div className="py-1">
-                    <Button variant={"default"} className="h-8 px-2">
-                      <span className="sr-only">
-                        {t("General.Action.OpenMenu")}
-                      </span>
-                      <IconPlus />
-                    </Button>
-                  </div>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start">
-                  <DropdownMenuItem onClick={addConfigFile}>
-                    <IconPlus />
-                    {t("Project.File.Action.New")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onClick={mergeConfigFile}>
-                    <IconFolderPlus />
-                    {t("Project.File.Action.Merge")}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <div className="py-1">
+              <Button variant={"default"} className="h-8 px-2">
+                <span className="sr-only">{t("General.Action.OpenMenu")}</span>
+                <IconPlus />
+              </Button>
             </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start">
+            <DropdownMenuItem onClick={addConfigFile}>
+              <IconPlus />
+              {t("Project.File.Action.New")}
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={mergeConfigFile}>
+              <IconFolderPlus />
+              {t("Project.File.Action.Merge")}
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent>
           <DialogHeader className="sr-only">

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -1,4 +1,4 @@
-import ProfileTab from "./ProfileTab"
+import { ProfileTab } from "./ProfileTab"
 import { Button } from "../ui/button"
 import {
   IconChevronLeft,
@@ -99,7 +99,6 @@ const ProjectPanel = () => {
       SCROLL_TAB_INTO_VIEW_DELAY_MS,
     )
   }, [
-    SCROLL_TAB_INTO_VIEW_DELAY_MS,
     scrollActiveProfileTabIntoView,
     resetScrollActiveProfileTabIntoView,
   ])
@@ -109,10 +108,18 @@ const ProjectPanel = () => {
     // when activeConfigFileIndex changes
     resetScrollActiveProfileTabIntoView()
     scrollActiveProfileTabIntoView()
-  }, [activeConfigFileIndex, scrollActiveProfileTabIntoView, resetScrollActiveProfileTabIntoView])
+  }, [
+    activeConfigFileIndex,
+    scrollActiveProfileTabIntoView,
+    resetScrollActiveProfileTabIntoView,
+  ])
 
   useEffect(() => {
-    if (prevWindowSizeRef.current.width === width && prevWindowSizeRef.current.height === height) return
+    if (
+      prevWindowSizeRef.current.width === width &&
+      prevWindowSizeRef.current.height === height
+    )
+      return
     prevWindowSizeRef.current = { width, height }
     // scroll tab into view
     // when window size changes
@@ -202,6 +209,20 @@ const ProjectPanel = () => {
       }
     }
   }, [dragState?.ui.hoveredTabIndex, selectActiveFile])
+
+  // clear timers on unmount
+  useEffect(() => {
+    return () => {
+      if (scrollIntoViewTimeoutRef.current) {
+        clearTimeout(scrollIntoViewTimeoutRef.current)
+        scrollIntoViewTimeoutRef.current = null
+      }
+      if (hoverTimeoutRef.current) {
+        clearTimeout(hoverTimeoutRef.current)
+        hoverTimeoutRef.current = null
+      }
+    }
+  }, [])
 
   return (
     <div

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -1,4 +1,4 @@
-import FileButton from "./FileButton"
+import ProfileTab from "./ProfileTab"
 import { Button } from "../ui/button"
 import {
   IconChevronLeft,
@@ -175,7 +175,7 @@ const ProjectPanel = () => {
       <div className="flex flex-row items-end gap-0 rounded-md" role="tablist">
         {configFiles?.map((file, index) => {
           return (
-            <FileButton
+            <ProfileTab
               key={index}
               variant={
                 index === activeConfigFileIndex
@@ -187,7 +187,7 @@ const ProjectPanel = () => {
               file={file}
               index={index}
               selectActiveFile={selectActiveFile}
-            ></FileButton>
+            ></ProfileTab>
           )
         })}
       </div>

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -150,10 +150,10 @@ const ProjectPanel = () => {
 
   return (
     <div
-      className="border-b-solid border-b-muted-foreground/50 flex flex-row gap-2 border-b pt-1 pr-2 pb-0 pl-0"
+      className="flex flex-row gap-0 pt-1 pr-2 pb-0 pl-0"
       data-testid="project-panel"
     >
-      <div className="flex flex-row items-center gap-2">
+      <div className="flex flex-row items-center gap-2 border-b border-solid px-2">
         <IconChevronLeft
           role="button"
           onClick={() => {
@@ -166,31 +166,38 @@ const ProjectPanel = () => {
           }}
         />
       </div>
-      <div className="border-muted-foreground/50 flex flex-row items-center rounded-md rounded-br-none rounded-bl-none border border-b-0 border-solid px-2">
+
+      <div className="flex flex-row items-center rounded-md rounded-br-none rounded-bl-none border border-b-0 border-solid px-2">
         <ProjectNameLabel />
         <IconMinusVertical className="stroke-muted-foreground/50" />
         <ExecutionToolbar />
       </div>
 
-      <div className="flex flex-row items-end gap-0 rounded-md" role="tablist">
-        {configFiles?.map((file, index) => {
-          return (
-            <ProfileTab
-              key={index}
-              variant={
-                index === activeConfigFileIndex
-                  ? "tabActive"
-                  : dragState?.ui.hoveredTabIndex === index
-                    ? "tabDragging"
-                    : "tabDefault"
-              }
-              file={file}
-              index={index}
-              totalCount={configFiles.length}
-              selectActiveFile={selectActiveFile}
-            ></ProfileTab>
-          )
-        })}
+      <div className="w-2 border-b"></div>
+
+      <div className="relative h-full grow bg-amber-400" role="tablist">
+        <div className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden">
+          <div className="flex h-full flex-row">
+            {configFiles?.map((file, index) => {
+              return (
+                <ProfileTab
+                  key={index}
+                  variant={
+                    index === activeConfigFileIndex
+                      ? "tabActive"
+                      : dragState?.ui.hoveredTabIndex === index
+                        ? "tabDragging"
+                        : "tabDefault"
+                  }
+                  file={file}
+                  index={index}
+                  totalCount={configFiles.length}
+                  selectActiveFile={selectActiveFile}
+                />
+              )
+            })}
+          </div>
+        </div>
       </div>
       <div className="relative">
         <DropdownMenu>
@@ -217,7 +224,7 @@ const ProjectPanel = () => {
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent>
           <DialogHeader className="sr-only">
-            <DialogTitle >{t("Project.UnsavedChanges.Title")}</DialogTitle>
+            <DialogTitle>{t("Project.UnsavedChanges.Title")}</DialogTitle>
           </DialogHeader>
           <div>{t("Project.UnsavedChanges.Description")}</div>
           <div className="flex flex-row justify-end gap-4">

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -107,6 +107,16 @@ const ProjectPanel = () => {
     resetScrollActiveProfileTabIntoView,
   ])
 
+  const overflowRef = useRef<HTMLDivElement | null>(null)
+
+  const handleMouseWheel = (event: React.WheelEvent) => {
+    if (overflowRef.current === null) return
+    const scrollContainer = overflowRef.current
+    if (!scrollContainer) return
+    const newScrollLeft = scrollContainer.scrollLeft + event.deltaY
+    scrollContainer.scrollLeft = newScrollLeft
+  }
+
   const startScrolling = useCallback((direction: "left" | "right") => {
     if (!overflowRef.current) return
 
@@ -205,7 +215,6 @@ const ProjectPanel = () => {
     navigate("/home")
   }
 
-  const overflowRef = useRef<HTMLDivElement | null>(null)
   const overflow = useOverflowDetector(overflowRef)
 
   // Hover timer ref
@@ -273,7 +282,7 @@ const ProjectPanel = () => {
         <ExecutionToolbar />
       </div>
 
-      <div className="border-muted-foreground/50 flex w-5 flex-col items-center justify-between border-b py-0.5">
+      <div className="border-muted-foreground/50 flex w-5 flex-col items-center gap-1 border-b py-0.5">
         <Button
           className={`h-4 w-4 p-1 transition-opacity duration-200 ${!overflow.left ? "opacity-0" : ""}`}
           variant={"secondary"}
@@ -299,6 +308,7 @@ const ProjectPanel = () => {
         <div
           className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden"
           ref={overflowRef}
+          onWheel={handleMouseWheel}
         >
           <div className="flex h-full flex-row">
             {configFiles?.map((file, index) => {
@@ -334,11 +344,13 @@ const ProjectPanel = () => {
           </div>
         </div>
         {/* Left shadow */}
-        {activeConfigFileIndex > 0 && (
-          <div className="from-foreground/20 dark:from-background pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-2 rounded-tl-sm bg-linear-to-r to-transparent pb-1 dark:bottom-0.5 dark:w-3" />
+        {activeConfigFileIndex > 0 && overflow.left && (
+          <div className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-2 rounded-tl-sm bg-linear-to-r to-transparent pb-1 dark:bottom-0.5 dark:w-3" />
         )}
         {/* Right shadow */}
-        <div className="from-background pointer-events-none absolute top-0 right-0 bottom-0.5 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
+        {overflow.right && (
+          <div className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 right-0 bottom-0.5 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
+        )}
       </div>
       {overflow.right && (
         <AddProfileTabMenu

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -251,7 +251,7 @@ const ProjectPanel = () => {
         <ExecutionToolbar />
       </div>
 
-      <div className="border-muted-foreground/50 w-2 border-b"></div>
+      <div className="border-muted-foreground/50 w-0 border-b"></div>
 
       <div className="relative h-full grow" role="tablist">
         <div className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden">
@@ -280,6 +280,13 @@ const ProjectPanel = () => {
             <div className="border-muted-foreground/50 grow border-b"></div>
           </div>
         </div>
+        {/* Left shadow */}
+        {
+          activeConfigFileIndex > 0 &&
+          <div className="pointer-events-none absolute left-0 top-0 bottom-0 w-2 bg-linear-to-r from-foreground/20 dark:w-3 dark:from-background dark:bottom-0.5 to-transparent z-20 pb-1 rounded-tl-sm" />
+        }
+        {/* Right shadow */}
+        <div className="pointer-events-none absolute right-0 top-0 bottom-0.5 w-2 bg-linear-to-l from-background to-transparent z-200 pb-1" />
       </div>
       <div className="border-muted-foreground/50 border-b px-2">
         <DropdownMenu>

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -3,7 +3,6 @@ import { AddProfileTabMenu } from "./ProfileTab/AddProfileTabMenu"
 import { Button } from "../ui/button"
 import {
   IconChevronLeft,
-  IconChevronRight,
   IconMinusVertical,
 } from "@tabler/icons-react"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
@@ -117,27 +116,6 @@ const ProjectPanel = () => {
     scrollContainer.scrollLeft = newScrollLeft
   }
 
-  const startScrolling = useCallback((direction: "left" | "right") => {
-    if (!overflowRef.current) return
-
-    const scrollAmount = direction === "left" ? -15 : 15
-
-    // Immediate scroll
-    overflowRef.current.scrollLeft += scrollAmount
-
-    // Continuous scroll while holding
-    scrollIntervalRef.current = setInterval(() => {
-      if (!overflowRef.current) return
-      overflowRef.current.scrollLeft += scrollAmount
-    }, 50)
-  }, [])
-
-  const stopScrolling = useCallback(() => {
-    if (scrollIntervalRef.current) {
-      clearInterval(scrollIntervalRef.current)
-      scrollIntervalRef.current = null
-    }
-  }, [])
 
   useEffect(() => {
     if (
@@ -282,26 +260,7 @@ const ProjectPanel = () => {
         <ExecutionToolbar />
       </div>
 
-      <div className="border-muted-foreground/50 flex w-5 flex-col items-center gap-1 border-b py-0.5">
-        <Button
-          className={`h-4 w-4 p-1 transition-opacity duration-200 ${!overflow.left ? "opacity-0" : ""}`}
-          variant={"secondary"}
-          onMouseDown={() => startScrolling("left")}
-          onMouseUp={stopScrolling}
-          onMouseLeave={stopScrolling}
-        >
-          <IconChevronLeft />
-        </Button>
-
-        <Button
-          className={`h-4 w-4 p-1 transition-opacity duration-200 ${!overflow.right ? "opacity-0" : ""}`}
-          variant={"secondary"}
-          onMouseDown={() => startScrolling("right")}
-          onMouseUp={stopScrolling}
-          onMouseLeave={stopScrolling}
-        >
-          <IconChevronRight />
-        </Button>
+      <div className="border-muted-foreground/50 flex w-0 flex-col items-center gap-1 border-b py-0.5">
       </div>
 
       <div className="relative h-full grow" role="tablist">

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -153,7 +153,7 @@ const ProjectPanel = () => {
       className="flex flex-row gap-0 pt-1 pr-2 pb-0 pl-0"
       data-testid="project-panel"
     >
-      <div className="flex flex-row items-center gap-2 border-b border-solid px-2">
+      <div className="flex flex-row items-center gap-2 border-b border-solid px-2 border-muted-foreground/50">
         <IconChevronLeft
           role="button"
           onClick={() => {
@@ -167,15 +167,15 @@ const ProjectPanel = () => {
         />
       </div>
 
-      <div className="flex flex-row items-center rounded-md rounded-br-none rounded-bl-none border border-b-0 border-solid px-2">
+      <div className="flex flex-row items-center rounded-md rounded-br-none rounded-bl-none border border-b-0 border-solid px-2 border-muted-foreground/50">
         <ProjectNameLabel />
         <IconMinusVertical className="stroke-muted-foreground/50" />
         <ExecutionToolbar />
       </div>
 
-      <div className="w-2 border-b"></div>
+      <div className="w-2 border-b border-muted-foreground/50"></div>
 
-      <div className="relative h-full grow bg-amber-400" role="tablist">
+      <div className="relative h-full grow" role="tablist">
         <div className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden">
           <div className="flex h-full flex-row">
             {configFiles?.map((file, index) => {

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -1,10 +1,7 @@
 import { ProfileTab } from "./ProfileTab"
 import { AddProfileTabMenu } from "./ProfileTab/AddProfileTabMenu"
 import { Button } from "../ui/button"
-import {
-  IconChevronLeft,
-  IconMinusVertical,
-} from "@tabler/icons-react"
+import { IconChevronLeft, IconMinusVertical } from "@tabler/icons-react"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { useProjectStore } from "@/stores/projectStore"
 import { useCallback, useEffect, useRef, useState } from "react"
@@ -115,7 +112,6 @@ const ProjectPanel = () => {
     const newScrollLeft = scrollContainer.scrollLeft + event.deltaY
     scrollContainer.scrollLeft = newScrollLeft
   }
-
 
   useEffect(() => {
     if (
@@ -260,8 +256,7 @@ const ProjectPanel = () => {
         <ExecutionToolbar />
       </div>
 
-      <div className="border-muted-foreground/50 flex w-0 flex-col items-center gap-1 border-b py-0.5">
-      </div>
+      <div className="border-muted-foreground/50 flex w-0 flex-col items-center gap-1 border-b py-0.5"></div>
 
       <div className="relative h-full grow" role="tablist">
         <div
@@ -308,7 +303,7 @@ const ProjectPanel = () => {
         )}
         {/* Right shadow */}
         {overflow.right && (
-          <div className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 right-0 bottom-0.5 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
+          <div className="from-foreground/20 dark:from-background/50 pointer-events-none absolute top-0 right-0 bottom-0 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
         )}
       </div>
       {overflow.right && (

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -3,6 +3,7 @@ import { AddProfileTabMenu } from "./ProfileTab/AddProfileTabMenu"
 import { Button } from "../ui/button"
 import {
   IconChevronLeft,
+  IconChevronRight,
   IconMinusVertical,
 } from "@tabler/icons-react"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
@@ -245,7 +246,21 @@ const ProjectPanel = () => {
         <ExecutionToolbar />
       </div>
 
-      <div className="border-muted-foreground/50 w-0 border-b"></div>
+      <div className="border-muted-foreground/50 flex w-5 flex-col items-center justify-between border-b py-0.5">
+        <Button
+          className={`h-4 w-4 p-1 transition-opacity duration-200 ${!overflow.left ? "opacity-0" : ""}`}
+          variant={"secondary"}
+        >
+          <IconChevronLeft />
+        </Button>
+
+        <Button
+          className={`h-4 w-4 p-1 transition-opacity duration-200 ${!overflow.right ? "opacity-0" : ""}`}
+          variant={"secondary"}
+        >
+          <IconChevronRight />
+        </Button>
+      </div>
 
       <div className="relative h-full grow" role="tablist">
         <div

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -150,10 +150,10 @@ const ProjectPanel = () => {
 
   return (
     <div
-      className="flex flex-row gap-0 pt-1 pr-2 pb-0 pl-0"
+      className="flex flex-row gap-0 pt-1 pr-2 pb-0 pl-0 h-11"
       data-testid="project-panel"
     >
-      <div className="flex flex-row items-center gap-2 border-b border-solid px-2 border-muted-foreground/50">
+      <div className="border-muted-foreground/50 flex flex-row items-center gap-2 border-b border-solid px-2">
         <IconChevronLeft
           role="button"
           onClick={() => {
@@ -167,13 +167,13 @@ const ProjectPanel = () => {
         />
       </div>
 
-      <div className="flex flex-row items-center rounded-md rounded-br-none rounded-bl-none border border-b-0 border-solid px-2 border-muted-foreground/50">
+      <div className="border-muted-foreground/50 flex flex-row items-center rounded-md rounded-br-none rounded-bl-none border border-b-0 border-solid px-2">
         <ProjectNameLabel />
         <IconMinusVertical className="stroke-muted-foreground/50" />
         <ExecutionToolbar />
       </div>
 
-      <div className="w-2 border-b border-muted-foreground/50"></div>
+      <div className="border-muted-foreground/50 w-2 border-b"></div>
 
       <div className="relative h-full grow" role="tablist">
         <div className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden">
@@ -196,30 +196,33 @@ const ProjectPanel = () => {
                 />
               )
             })}
+            <div className="relative border-muted-foreground/50 grow border-b px-2">
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <div className="py-1">
+                    <Button variant={"ghost"} className="h-8 px-2">
+                      <span className="sr-only">
+                        {t("General.Action.OpenMenu")}
+                      </span>
+                      <IconPlus />
+                    </Button>
+                  </div>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  <DropdownMenuItem onClick={addConfigFile}>
+                    <IconPlus />
+                    {t("Project.File.Action.New")}
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onClick={mergeConfigFile}>
+                    <IconFolderPlus />
+                    {t("Project.File.Action.Merge")}
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+            <div className="border-muted-foreground/50 grow border-b"></div>
           </div>
         </div>
-      </div>
-      <div className="relative">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <div className="py-1">
-              <Button variant={"ghost"} className="h-8 px-2">
-                <span className="sr-only">{t("General.Action.OpenMenu")}</span>
-                <IconPlus />
-              </Button>
-            </div>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            <DropdownMenuItem onClick={addConfigFile}>
-              <IconPlus />
-              {t("Project.File.Action.New")}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={mergeConfigFile}>
-              <IconFolderPlus />
-              {t("Project.File.Action.Merge")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
       </div>
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent>

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -186,6 +186,7 @@ const ProjectPanel = () => {
               }
               file={file}
               index={index}
+              totalCount={configFiles.length}
               selectActiveFile={selectActiveFile}
             ></ProfileTab>
           )

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -1,20 +1,13 @@
 import { ProfileTab } from "./ProfileTab"
+import { AddProfileTabMenu } from "./ProfileTab/AddProfileTabMenu"
 import { Button } from "../ui/button"
 import {
   IconChevronLeft,
-  IconFolderPlus,
   IconMinusVertical,
-  IconPlus,
 } from "@tabler/icons-react"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { useProjectStore } from "@/stores/projectStore"
 import { useCallback, useEffect, useRef, useState } from "react"
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "../ui/dropdown-menu"
 import { useTranslation } from "react-i18next"
 import ExecutionToolbar from "../ExecutionToolbar"
 import ProjectNameLabel from "./ProjectNameLabel"
@@ -282,38 +275,12 @@ const ProjectPanel = () => {
               )
             })}
             {!overflow.right && (
-              <div className="border-muted-foreground/50 border-b px-2">
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <div
-                      className="py-1"
-                      onMouseEnter={resetScrollActiveProfileTabIntoView}
-                      onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
-                    >
-                      <Button variant={"default"} className="h-8 px-2">
-                        <span className="sr-only">
-                          {t("General.Action.OpenMenu")}
-                        </span>
-                        <IconPlus />
-                      </Button>
-                    </div>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent
-                    align="start"
-                    onMouseEnter={resetScrollActiveProfileTabIntoView}
-                    onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
-                  >
-                    <DropdownMenuItem onClick={addConfigFile}>
-                      <IconPlus />
-                      {t("Project.File.Action.New")}
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onClick={mergeConfigFile}>
-                      <IconFolderPlus />
-                      {t("Project.File.Action.Merge")}
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
+              <AddProfileTabMenu
+                onAddConfigFile={addConfigFile}
+                onMergeConfigFile={mergeConfigFile}
+                onMouseEnter={resetScrollActiveProfileTabIntoView}
+                onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
+              />
             )}
             <div className="border-muted-foreground/50 grow border-b"></div>
           </div>
@@ -326,38 +293,12 @@ const ProjectPanel = () => {
         <div className="from-background pointer-events-none absolute top-0 right-0 bottom-0.5 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
       </div>
       {overflow.right && (
-        <div className="border-muted-foreground/50 border-b px-2">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <div
-                className="py-1"
-                onMouseEnter={resetScrollActiveProfileTabIntoView}
-                onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
-              >
-                <Button variant={"default"} className="h-8 px-2">
-                  <span className="sr-only">
-                    {t("General.Action.OpenMenu")}
-                  </span>
-                  <IconPlus />
-                </Button>
-              </div>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent
-              align="start"
-              onMouseEnter={resetScrollActiveProfileTabIntoView}
-              onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
-            >
-              <DropdownMenuItem onClick={addConfigFile}>
-                <IconPlus />
-                {t("Project.File.Action.New")}
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={mergeConfigFile}>
-                <IconFolderPlus />
-                {t("Project.File.Action.Merge")}
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        </div>
+        <AddProfileTabMenu
+          onAddConfigFile={addConfigFile}
+          onMergeConfigFile={mergeConfigFile}
+          onMouseEnter={resetScrollActiveProfileTabIntoView}
+          onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
+        />
       )}
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent>

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -68,6 +68,7 @@ const ProjectPanel = () => {
   }, [activeConfigFileIndex])
 
   const scrollIntoViewTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const scrollIntervalRef = useRef<NodeJS.Timeout | null>(null)
 
   const scrollActiveProfileTabIntoView = useCallback(() => {
     if (activeConfigFileIndex === -1) return
@@ -105,6 +106,28 @@ const ProjectPanel = () => {
     scrollActiveProfileTabIntoView,
     resetScrollActiveProfileTabIntoView,
   ])
+
+  const startScrolling = useCallback((direction: "left" | "right") => {
+    if (!overflowRef.current) return
+
+    const scrollAmount = direction === "left" ? -15 : 15
+
+    // Immediate scroll
+    overflowRef.current.scrollLeft += scrollAmount
+
+    // Continuous scroll while holding
+    scrollIntervalRef.current = setInterval(() => {
+      if (!overflowRef.current) return
+      overflowRef.current.scrollLeft += scrollAmount
+    }, 50)
+  }, [])
+
+  const stopScrolling = useCallback(() => {
+    if (scrollIntervalRef.current) {
+      clearInterval(scrollIntervalRef.current)
+      scrollIntervalRef.current = null
+    }
+  }, [])
 
   useEffect(() => {
     if (
@@ -216,6 +239,10 @@ const ProjectPanel = () => {
         clearTimeout(hoverTimeoutRef.current)
         hoverTimeoutRef.current = null
       }
+      if (scrollIntervalRef.current) {
+        clearInterval(scrollIntervalRef.current)
+        scrollIntervalRef.current = null
+      }
     }
   }, [])
 
@@ -250,6 +277,9 @@ const ProjectPanel = () => {
         <Button
           className={`h-4 w-4 p-1 transition-opacity duration-200 ${!overflow.left ? "opacity-0" : ""}`}
           variant={"secondary"}
+          onMouseDown={() => startScrolling("left")}
+          onMouseUp={stopScrolling}
+          onMouseLeave={stopScrolling}
         >
           <IconChevronLeft />
         </Button>
@@ -257,6 +287,9 @@ const ProjectPanel = () => {
         <Button
           className={`h-4 w-4 p-1 transition-opacity duration-200 ${!overflow.right ? "opacity-0" : ""}`}
           variant={"secondary"}
+          onMouseDown={() => startScrolling("right")}
+          onMouseUp={stopScrolling}
+          onMouseLeave={stopScrolling}
         >
           <IconChevronRight />
         </Button>

--- a/frontend/src/components/project/ProjectPanel.tsx
+++ b/frontend/src/components/project/ProjectPanel.tsx
@@ -23,6 +23,7 @@ import { useNavigate } from "react-router"
 import { Dialog, DialogTitle } from "@radix-ui/react-dialog"
 import { DialogContent, DialogHeader } from "@/components/ui/dialog"
 import { useWindowSize } from "@/lib/hooks/useWindowSize"
+import { useOverflowDetector } from "@/lib/hooks/useOverflowDetector"
 
 const ProjectPanel = () => {
   const SCROLL_TAB_INTO_VIEW_DELAY_MS = 1500
@@ -98,10 +99,7 @@ const ProjectPanel = () => {
       scrollActiveProfileTabIntoView,
       SCROLL_TAB_INTO_VIEW_DELAY_MS,
     )
-  }, [
-    scrollActiveProfileTabIntoView,
-    resetScrollActiveProfileTabIntoView,
-  ])
+  }, [scrollActiveProfileTabIntoView, resetScrollActiveProfileTabIntoView])
 
   useEffect(() => {
     // scroll tab into view
@@ -190,6 +188,9 @@ const ProjectPanel = () => {
     navigate("/home")
   }
 
+  const overflowRef = useRef<HTMLDivElement | null>(null)
+  const overflow = useOverflowDetector(overflowRef)
+
   // Hover timer ref
   const hoverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const activeProfileTabRef = useRef<HTMLDivElement | null>(null)
@@ -254,7 +255,10 @@ const ProjectPanel = () => {
       <div className="border-muted-foreground/50 w-0 border-b"></div>
 
       <div className="relative h-full grow" role="tablist">
-        <div className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden">
+        <div
+          className="no-scrollbar absolute inset-0 overflow-x-auto overflow-y-hidden"
+          ref={overflowRef}
+        >
           <div className="flex h-full flex-row">
             {configFiles?.map((file, index) => {
               return (
@@ -277,47 +281,84 @@ const ProjectPanel = () => {
                 />
               )
             })}
+            {!overflow.right && (
+              <div className="border-muted-foreground/50 border-b px-2">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <div
+                      className="py-1"
+                      onMouseEnter={resetScrollActiveProfileTabIntoView}
+                      onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
+                    >
+                      <Button variant={"default"} className="h-8 px-2">
+                        <span className="sr-only">
+                          {t("General.Action.OpenMenu")}
+                        </span>
+                        <IconPlus />
+                      </Button>
+                    </div>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent
+                    align="start"
+                    onMouseEnter={resetScrollActiveProfileTabIntoView}
+                    onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
+                  >
+                    <DropdownMenuItem onClick={addConfigFile}>
+                      <IconPlus />
+                      {t("Project.File.Action.New")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={mergeConfigFile}>
+                      <IconFolderPlus />
+                      {t("Project.File.Action.Merge")}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
+            )}
             <div className="border-muted-foreground/50 grow border-b"></div>
           </div>
         </div>
         {/* Left shadow */}
-        {
-          activeConfigFileIndex > 0 &&
-          <div className="pointer-events-none absolute left-0 top-0 bottom-0 w-2 bg-linear-to-r from-foreground/20 dark:w-3 dark:from-background dark:bottom-0.5 to-transparent z-20 pb-1 rounded-tl-sm" />
-        }
+        {activeConfigFileIndex > 0 && (
+          <div className="from-foreground/20 dark:from-background pointer-events-none absolute top-0 bottom-0 left-0 z-20 w-2 rounded-tl-sm bg-linear-to-r to-transparent pb-1 dark:bottom-0.5 dark:w-3" />
+        )}
         {/* Right shadow */}
-        <div className="pointer-events-none absolute right-0 top-0 bottom-0.5 w-2 bg-linear-to-l from-background to-transparent z-200 pb-1" />
+        <div className="from-background pointer-events-none absolute top-0 right-0 bottom-0.5 z-200 w-2 bg-linear-to-l to-transparent pb-1" />
       </div>
-      <div className="border-muted-foreground/50 border-b px-2">
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <div
-              className="py-1"
+      {overflow.right && (
+        <div className="border-muted-foreground/50 border-b px-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <div
+                className="py-1"
+                onMouseEnter={resetScrollActiveProfileTabIntoView}
+                onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
+              >
+                <Button variant={"default"} className="h-8 px-2">
+                  <span className="sr-only">
+                    {t("General.Action.OpenMenu")}
+                  </span>
+                  <IconPlus />
+                </Button>
+              </div>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="start"
               onMouseEnter={resetScrollActiveProfileTabIntoView}
               onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
             >
-              <Button variant={"default"} className="h-8 px-2">
-                <span className="sr-only">{t("General.Action.OpenMenu")}</span>
+              <DropdownMenuItem onClick={addConfigFile}>
                 <IconPlus />
-              </Button>
-            </div>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="start"
-            onMouseEnter={resetScrollActiveProfileTabIntoView}
-            onMouseLeave={scrollActiveProfileTabIntoViewWithDelay}
-          >
-            <DropdownMenuItem onClick={addConfigFile}>
-              <IconPlus />
-              {t("Project.File.Action.New")}
-            </DropdownMenuItem>
-            <DropdownMenuItem onClick={mergeConfigFile}>
-              <IconFolderPlus />
-              {t("Project.File.Action.Merge")}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
+                {t("Project.File.Action.New")}
+              </DropdownMenuItem>
+              <DropdownMenuItem onClick={mergeConfigFile}>
+                <IconFolderPlus />
+                {t("Project.File.Action.Merge")}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      )}
       <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
         <DialogContent>
           <DialogHeader className="sr-only">

--- a/frontend/src/components/ui/variants.ts
+++ b/frontend/src/components/ui/variants.ts
@@ -35,8 +35,8 @@ export const buttonVariants = cva(
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         tabActive:
-          "border border-input border-b-0 bg-background text-foreground border-t-primary border-t-4",
-        tabDefault: "border border-input bg-background",
+          "border border-input border-b-0 bg-background text-foreground border-muted-foreground/50 border-t-primary border-t-4",
+        tabDefault: "border border-input bg-background border-muted-foreground/50",
         tabDragging: "border border-input bg-muted",
       },
       size: {

--- a/frontend/src/components/ui/variants.ts
+++ b/frontend/src/components/ui/variants.ts
@@ -35,8 +35,7 @@ export const buttonVariants = cva(
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         tabActive:
-          "relative z-10 border border-input border-b-0 border-t-primary border-t-4 bg-background text-foreground " +
-          "after:content-[''] after:absolute after:left-0 after:right-0 after:-bottom-px after:h-px after:bg-background",
+          "border border-input border-b-0 bg-background text-foreground border-t-primary border-t-4",
         tabDefault: "border border-input bg-background",
         tabDragging: "border border-input bg-muted",
       },

--- a/frontend/src/components/ui/variants.ts
+++ b/frontend/src/components/ui/variants.ts
@@ -21,7 +21,7 @@ export const badgeVariants = cva(
 )
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {

--- a/frontend/src/components/ui/variants.ts
+++ b/frontend/src/components/ui/variants.ts
@@ -1,4 +1,4 @@
-import { cva } from "class-variance-authority";
+import { cva } from "class-variance-authority"
 
 export const badgeVariants = cva(
   "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2",
@@ -17,11 +17,11 @@ export const badgeVariants = cva(
     defaultVariants: {
       variant: "default",
     },
-  }
+  },
 )
 
 export const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-all focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
@@ -36,7 +36,8 @@ export const buttonVariants = cva(
         link: "text-primary underline-offset-4 hover:underline",
         tabActive:
           "border border-input border-b-0 bg-background text-foreground border-muted-foreground/50 border-t-primary border-t-4",
-        tabDefault: "border border-input bg-background border-muted-foreground/50",
+        tabDefault:
+          "border border-input bg-background border-muted-foreground/50",
         tabDragging: "border border-input bg-muted",
       },
       size: {
@@ -50,5 +51,5 @@ export const buttonVariants = cva(
       variant: "default",
       size: "default",
     },
-  }
+  },
 )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -200,6 +200,17 @@
   }
 }
 
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    scrollbar-width: none;
+  }
+}
+
+
 @custom-variant vxs (@media (min-height: 500px));
 @custom-variant vsm (@media (min-height: 650px));
 @custom-variant vlg (@media (min-height: 900px));

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -208,6 +208,12 @@
     -ms-overflow-style: none;
     scrollbar-width: none;
   }
+
+  .inset-shadow-l-sm {
+    --tw-inset-shadow: inset 0 0 2px var(--tw-inset-shadow-color, rgb(0 0 0 / 0.05));
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+    clip-path: inset(0px 0px 0px 2px);
+  }
 }
 
 @custom-variant vxs (@media (min-height: 500px));

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,6 +1,6 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
-@plugin 'tailwindcss-animate';
+@plugin "tailwindcss-animate";
 
 @custom-variant dark (&:is(.dark *));
 
@@ -209,7 +209,6 @@
     scrollbar-width: none;
   }
 }
-
 
 @custom-variant vxs (@media (min-height: 500px));
 @custom-variant vsm (@media (min-height: 650px));

--- a/frontend/src/lib/hooks/useOverflowDetector.ts
+++ b/frontend/src/lib/hooks/useOverflowDetector.ts
@@ -19,6 +19,11 @@ export const useOverflowDetector = (ref: RefObject<HTMLElement | null>) => {
     }
 
     checkOverflow()
+    const resizeObserver = new ResizeObserver(() => {
+      checkOverflow()
+    })
+    
+    resizeObserver.observe(element)
     element.addEventListener('scroll', checkOverflow)
     window.addEventListener('resize', checkOverflow)
 

--- a/frontend/src/lib/hooks/useOverflowDetector.ts
+++ b/frontend/src/lib/hooks/useOverflowDetector.ts
@@ -1,37 +1,39 @@
-import { RefObject, useEffect, useState } from "react"
+import { RefObject, useCallback, useEffect, useState } from "react"
 
 export const useOverflowDetector = (ref: RefObject<HTMLElement | null>) => {
   const [overflow, setOverflow] = useState({ left: false, right: false })
+
+  const checkOverflow = useCallback(() => {
+    const element = ref.current
+    if (!element) return
+    const isOverflowingLeft = element.scrollLeft > 0
+    const isOverflowingRight =
+      (element.scrollLeft + element.clientWidth) < element.scrollWidth
+
+    setOverflow({
+      left: isOverflowingLeft,
+      right: isOverflowingRight,
+    })
+  }, [ref])
 
   useEffect(() => {
     const element = ref.current
     if (!element) return
 
-    const checkOverflow = () => {
-      const isOverflowingLeft = element.scrollLeft > 0
-      const isOverflowingRight = 
-        element.scrollLeft + element.clientWidth < element.scrollWidth
-
-      setOverflow({ 
-        left: isOverflowingLeft, 
-        right: isOverflowingRight 
-      })
-    }
-
     checkOverflow()
     const resizeObserver = new ResizeObserver(() => {
       checkOverflow()
     })
-    
+
     resizeObserver.observe(element)
-    element.addEventListener('scroll', checkOverflow)
-    window.addEventListener('resize', checkOverflow)
+    element.addEventListener("scroll", checkOverflow)
+    window.addEventListener("resize", checkOverflow)
 
     return () => {
-      element.removeEventListener('scroll', checkOverflow)
-      window.removeEventListener('resize', checkOverflow)
+      element.removeEventListener("scroll", checkOverflow)
+      window.removeEventListener("resize", checkOverflow)
     }
-  }, [ref])
+  }, [ref, checkOverflow])
 
-  return overflow
+  return { overflow, checkOverflow }
 }

--- a/frontend/src/lib/hooks/useOverflowDetector.ts
+++ b/frontend/src/lib/hooks/useOverflowDetector.ts
@@ -1,0 +1,32 @@
+import { RefObject, useEffect, useState } from "react"
+
+export const useOverflowDetector = (ref: RefObject<HTMLElement | null>) => {
+  const [overflow, setOverflow] = useState({ left: false, right: false })
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const checkOverflow = () => {
+      const isOverflowingLeft = element.scrollLeft > 0
+      const isOverflowingRight = 
+        element.scrollLeft + element.clientWidth < element.scrollWidth
+
+      setOverflow({ 
+        left: isOverflowingLeft, 
+        right: isOverflowingRight 
+      })
+    }
+
+    checkOverflow()
+    element.addEventListener('scroll', checkOverflow)
+    window.addEventListener('resize', checkOverflow)
+
+    return () => {
+      element.removeEventListener('scroll', checkOverflow)
+      window.removeEventListener('resize', checkOverflow)
+    }
+  }, [ref])
+
+  return overflow
+}

--- a/frontend/src/pages/ConfigList.tsx
+++ b/frontend/src/pages/ConfigList.tsx
@@ -14,8 +14,6 @@ import ProjectPanel from "@/components/project/ProjectPanel"
 import { ConfigItemTable } from "@/components/tables/config-item-table/config-item-table"
 
 const ConfigListPage = () => {
-  
-
   const {
     project,
     activeConfigFileIndex,
@@ -70,9 +68,12 @@ const ConfigListPage = () => {
     project?.ConfigFiles[activeConfigFileIndex]?.ConfigItems ?? []
 
   // Function to get config items from project store
-  const getConfigItems = useCallback((configIndex: number): IConfigItem[] => {
-    return project?.ConfigFiles[configIndex]?.ConfigItems ?? []
-  }, [project])
+  const getConfigItems = useCallback(
+    (configIndex: number): IConfigItem[] => {
+      return project?.ConfigFiles[configIndex]?.ConfigItems ?? []
+    },
+    [project],
+  )
 
   return (
     <div className="flex flex-col gap-2 overflow-y-auto">
@@ -83,12 +84,9 @@ const ConfigListPage = () => {
         selectActiveFile={setActiveConfigFileIndex}
       >
         <ProjectPanel />
-      <div className="flex flex-col gap-4 overflow-y-auto">
-        <ConfigItemTable
-          columns={columns}
-          data={configItems}
-        />
-      </div>
+        <div className="flex flex-col gap-4 overflow-y-auto">
+          <ConfigItemTable columns={columns} data={configItems} />
+        </div>
       </ConfigItemDragProvider>
     </div>
   )

--- a/frontend/tests/ProjectToolbar.spec.ts
+++ b/frontend/tests/ProjectToolbar.spec.ts
@@ -11,7 +11,9 @@ test("Confirm project name can be renamed", async ({
   const projectNameLabel = page.getByTestId("project-name-label")
   await expect(projectNameLabel.getByText("Test Project")).toBeVisible()
 
-  const projectContextMenu = projectNameLabel.getByRole('button', { name: 'Open menu' })
+  const projectContextMenu = projectNameLabel.getByRole("button", {
+    name: "Open menu",
+  })
   await projectContextMenu.click()
   await page.getByRole("menuitem", { name: "Rename" }).click()
   await expect(projectNameLabel.getByRole("textbox")).toBeVisible()
@@ -39,36 +41,34 @@ test("Confirm project name can be renamed", async ({
 
 test.describe("Test execution toolbar", () => {
   let toolbar: Locator
-  
+
   test.beforeEach(async ({ configListPage, page }) => {
     await configListPage.gotoPage()
     await configListPage.mobiFlightPage.initWithTestData()
     toolbar = page.getByRole("toolbar").first()
     await expect(toolbar).toBeVisible()
   })
-  
-  test("Confirm AutoRun works correctly", async ({
-    configListPage
-  }) => {
+
+  test("Confirm AutoRun works correctly", async ({ configListPage }) => {
     await configListPage.mobiFlightPage.trackCommand("CommandProjectToolbar")
     const autoRunButton = toolbar.getByRole("button", { name: "Auto" })
     await expect(autoRunButton).toBeVisible()
     await autoRunButton.click()
-    const postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
+    const postedCommands =
+      await configListPage.mobiFlightPage.getTrackedCommands()
     const lastCommand = postedCommands!.pop()
     expect(lastCommand.key).toEqual("CommandProjectToolbar")
     expect(lastCommand.payload.action).toEqual("toggleAutoRun")
   })
 
-  test("Confirm Run works correctly", async ({
-    configListPage
-  }) => {
+  test("Confirm Run works correctly", async ({ configListPage }) => {
     await configListPage.mobiFlightPage.trackCommand("CommandProjectToolbar")
     const runButton = toolbar.getByRole("button", { name: "Run", exact: true })
     await expect(runButton).toBeVisible()
     await runButton.click()
-    
-    const postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
+
+    const postedCommands =
+      await configListPage.mobiFlightPage.getTrackedCommands()
     const lastCommand = postedCommands!.pop()
     expect(lastCommand.key).toEqual("CommandProjectToolbar")
     expect(lastCommand.payload.action).toEqual("run")
@@ -81,7 +81,7 @@ test.describe("Test execution toolbar", () => {
       TestAvailable: false,
     })
     await expect(runButton).not.toBeVisible()
-    
+
     const stopButton = toolbar.getByRole("button", { name: "Stop" })
     await expect(stopButton).toBeVisible()
 
@@ -89,14 +89,16 @@ test.describe("Test execution toolbar", () => {
     await expect(testButton).toBeDisabled()
   })
 
-  test("Confirm Test works correctly", async ({
-    configListPage
-  }) => {
+  test("Confirm Test works correctly", async ({ configListPage }) => {
     await configListPage.mobiFlightPage.trackCommand("CommandProjectToolbar")
-    const testButton = toolbar.getByRole("button", { name: "Test", exact: true })
+    const testButton = toolbar.getByRole("button", {
+      name: "Test",
+      exact: true,
+    })
     await expect(testButton).toBeVisible()
     await testButton.click()
-    const postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
+    const postedCommands =
+      await configListPage.mobiFlightPage.getTrackedCommands()
     const lastCommand = postedCommands!.pop()
     expect(lastCommand.key).toEqual("CommandProjectToolbar")
     expect(lastCommand.payload.action).toEqual("test")
@@ -117,13 +119,11 @@ test.describe("Test execution toolbar", () => {
     await expect(runButton).toBeDisabled()
   })
 
-  test("Confirm Stop works correctly", async ({
-    configListPage,
-  }) => {
+  test("Confirm Stop works correctly", async ({ configListPage }) => {
     await configListPage.mobiFlightPage.trackCommand("CommandProjectToolbar")
     const stopButton = toolbar.getByRole("button", { name: "Stop" })
     await expect(stopButton).not.toBeVisible()
-    
+
     // Simulate that the config is running
     await configListPage.updateExecutionState({
       IsRunning: true,
@@ -131,72 +131,148 @@ test.describe("Test execution toolbar", () => {
       RunAvailable: false,
       TestAvailable: false,
     })
-    
+
     await expect(stopButton).toBeVisible()
     await stopButton.click()
-    const postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
+    const postedCommands =
+      await configListPage.mobiFlightPage.getTrackedCommands()
     const lastCommand = postedCommands!.pop()
     expect(lastCommand.key).toEqual("CommandProjectToolbar")
     expect(lastCommand.payload.action).toEqual("stop")
   })
 })
 
-test("Confirm file tabs count is correct", async ({ configListPage, page }) => {
-  await configListPage.gotoPage()
-  await configListPage.mobiFlightPage.initWithTestData()
+test.describe("Test profile tabs basic features", () => {
+  test("Confirm file tabs count is correct", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData()
 
-  const tabs = page.getByRole("tablist").getByRole("tab", { name: "Config" })
-  await expect(tabs).toHaveCount(3)
+    const tabs = page.getByRole("tablist").getByRole("tab", { name: "Config" })
+    await expect(tabs).toHaveCount(3)
+  })
+
+  test("Confirm file tab actions work", async ({ configListPage, page }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData()
+    await configListPage.mobiFlightPage.trackCommand("CommandActiveConfigFile")
+
+    // Select the second tab
+    const secondTab = page.getByRole("tablist").getByRole("tab").nth(1)
+    await secondTab.click()
+    let postedCommands =
+      await configListPage.mobiFlightPage.getTrackedCommands()
+    let lastCommand = postedCommands!.pop()
+    expect(lastCommand.key).toEqual("CommandActiveConfigFile")
+    expect(lastCommand.payload.index).toEqual(1)
+
+    // Rename the second tab
+    await configListPage.mobiFlightPage.trackCommand("CommandFileContextMenu")
+    const secondTabContextMenu = page
+      .getByRole("tablist")
+      .getByRole("tab")
+      .nth(1)
+      .getByRole("button", { name: "Open menu" })
+    await secondTabContextMenu.click()
+    // the overlay is not nested in the dom
+    // we have to use the page locator to find it
+    await page.getByRole("menuitem", { name: "Rename" }).click()
+    await secondTab
+      .getByRole("button", { name: "Config 2" })
+      .getByRole("textbox")
+      .fill("Config 2 Renamed")
+    await secondTab
+      .getByRole("button", { name: "Config 2" })
+      .getByRole("textbox")
+      .press("Enter")
+
+    postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
+    lastCommand = postedCommands!.pop()
+    expect(lastCommand.key).toEqual("CommandFileContextMenu")
+    expect(lastCommand.payload.action).toEqual("rename")
+    expect(lastCommand.payload.index).toEqual(1)
+    expect(lastCommand.payload.file.Label).toEqual("Config 2 Renamed")
+
+    // Remove the second tab
+    await configListPage.mobiFlightPage.trackCommand("CommandFileContextMenu")
+
+    await secondTabContextMenu.click()
+    await page.getByRole("menuitem", { name: "Remove" }).click()
+    postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
+    lastCommand = postedCommands!.pop()
+    expect(lastCommand.key).toEqual("CommandFileContextMenu")
+    expect(lastCommand.payload.action).toEqual("remove")
+    expect(lastCommand.payload.index).toEqual(1)
+  })
+
+  test("Confirm tab overflow indicators hide correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData()
+    const addTabMenu = page.getByTestId("add-profile-tab-menu-regular")
+    const addTabMenuOverflow = page.getByTestId("add-profile-tab-menu-overflow")
+
+    const tabOverflowIndicatorLeft = page.getByTestId(
+      "tab-overflow-indicator-left"
+    )
+    const tabOverflowIndicatorRight = page.getByTestId(
+      "tab-overflow-indicator-right"
+    )
+    // Initially, no overflow indicators should be visible
+    await expect(tabOverflowIndicatorLeft).toBeHidden()
+    await expect(tabOverflowIndicatorRight).toBeHidden()
+    await expect(addTabMenuOverflow).toBeHidden()
+    await expect(addTabMenu).toBeVisible()
+  })
 })
 
-test("Confirm file tab actions work", async ({ configListPage, page }) => {
-  await configListPage.gotoPage()
-  await configListPage.mobiFlightPage.initWithTestData()
-  await configListPage.mobiFlightPage.trackCommand("CommandActiveConfigFile")
+test.describe("Test profile tabs overflow features", () => {
+  test.use({ viewport: { width: 800, height: 600 } })
+  test("Confirm tab overflow indicators show correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData()
+    const addTabMenu = page.getByTestId("add-profile-tab-menu-regular")
+    const addTabMenuOverflow = page.getByTestId("add-profile-tab-menu-overflow")
 
-  // Select the second tab
-  const secondTab = page.getByRole("tablist").getByRole("tab").nth(1)
-  await secondTab.click()
-  let postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
-  let lastCommand = postedCommands!.pop()
-  expect(lastCommand.key).toEqual("CommandActiveConfigFile")
-  expect(lastCommand.payload.index).toEqual(1)
+    const tabOverflowIndicatorLeft = page.getByTestId(
+      "tab-overflow-indicator-left"
+    )
+    const tabOverflowIndicatorRight = page.getByTestId(
+      "tab-overflow-indicator-right"
+    )
+    
+    // Add multiple tabs to cause overflow
+    await expect(tabOverflowIndicatorLeft).toBeHidden()
+    await expect(tabOverflowIndicatorRight).toBeVisible()
+    await expect(addTabMenuOverflow).toBeVisible()
+    await expect(addTabMenu).toBeHidden()
 
-  // Rename the second tab
-  await configListPage.mobiFlightPage.trackCommand("CommandFileContextMenu")
-  const secondTabContextMenu = page
-    .getByRole("tablist")
-    .getByRole("tab")
-    .nth(1)
-    .getByRole("button", { name: "Open menu" })
-  await secondTabContextMenu.click()
-  // the overlay is not nested in the dom
-  // we have to use the page locator to find it
-  await page.getByRole("menuitem", { name: "Rename" }).click()
-  await secondTab
-    .getByRole("button", { name: "Config 2" })
-    .getByRole("textbox")
-    .fill("Config 2 Renamed")
-  await secondTab
-    .getByRole("button", { name: "Config 2" })
-    .getByRole("textbox")
-    .press("Enter")
+    // Scroll to the right to see the left overflow indicator
+    // use mouse wheel
+    const tabList = page.getByRole("tablist")
+    await tabList.hover()
+    await page.mouse.wheel(10, 0)
 
-  postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
-  lastCommand = postedCommands!.pop()
-  expect(lastCommand.key).toEqual("CommandFileContextMenu")
-  expect(lastCommand.payload.action).toEqual("rename")
-  expect(lastCommand.payload.index).toEqual(1)
-  expect(lastCommand.payload.file.Label).toEqual("Config 2 Renamed")
+    await expect(tabOverflowIndicatorLeft).toBeVisible()
+    await expect(tabOverflowIndicatorRight).toBeVisible()
 
-  // Remove the second tab
-  await configListPage.mobiFlightPage.trackCommand("CommandFileContextMenu")
+    await expect(addTabMenu).toBeHidden()
+    await expect(addTabMenuOverflow).toBeVisible()
 
-  await secondTabContextMenu.click()
-  await page.getByRole("menuitem", { name: "Remove" }).click()
-  postedCommands = await configListPage.mobiFlightPage.getTrackedCommands()
-  lastCommand = postedCommands!.pop()
-  expect(lastCommand.key).toEqual("CommandFileContextMenu")
-  expect(lastCommand.payload.action).toEqual("remove")
-  expect(lastCommand.payload.index).toEqual(1)
+    await page.mouse.wheel(1000, 0)
+    await expect(tabOverflowIndicatorLeft).toBeVisible()
+    await expect(tabOverflowIndicatorRight).toBeHidden()
+
+    // tab menu updated
+    // because we scrolled to the end of the tab list
+    await expect(addTabMenu).toBeVisible()
+    await expect(addTabMenuOverflow).toBeHidden()
+  })
 })

--- a/frontend/tests/ProjectToolbar.spec.ts
+++ b/frontend/tests/ProjectToolbar.spec.ts
@@ -1,5 +1,6 @@
 import { Locator } from "@playwright/test"
 import { test, expect } from "./fixtures"
+import { ConfigFile } from "../src/types"
 
 test("Confirm project name can be renamed", async ({
   configListPage,
@@ -205,6 +206,7 @@ test.describe("Test profile tabs basic features", () => {
     expect(lastCommand.key).toEqual("CommandFileContextMenu")
     expect(lastCommand.payload.action).toEqual("remove")
     expect(lastCommand.payload.index).toEqual(1)
+    expect(lastCommand.payload.file as ConfigFile).not.toBeNull()
   })
 
   test("Confirm tab overflow indicators hide correctly", async ({
@@ -217,10 +219,10 @@ test.describe("Test profile tabs basic features", () => {
     const addTabMenuOverflow = page.getByTestId("add-profile-tab-menu-overflow")
 
     const tabOverflowIndicatorLeft = page.getByTestId(
-      "tab-overflow-indicator-left"
+      "tab-overflow-indicator-left",
     )
     const tabOverflowIndicatorRight = page.getByTestId(
-      "tab-overflow-indicator-right"
+      "tab-overflow-indicator-right",
     )
     // Initially, no overflow indicators should be visible
     await expect(tabOverflowIndicatorLeft).toBeHidden()
@@ -242,12 +244,12 @@ test.describe("Test profile tabs overflow features", () => {
     const addTabMenuOverflow = page.getByTestId("add-profile-tab-menu-overflow")
 
     const tabOverflowIndicatorLeft = page.getByTestId(
-      "tab-overflow-indicator-left"
+      "tab-overflow-indicator-left",
     )
     const tabOverflowIndicatorRight = page.getByTestId(
-      "tab-overflow-indicator-right"
+      "tab-overflow-indicator-right",
     )
-    
+
     // Add multiple tabs to cause overflow
     await expect(tabOverflowIndicatorLeft).toBeHidden()
     await expect(tabOverflowIndicatorRight).toBeVisible()

--- a/frontend/tests/data/project.testdata.json
+++ b/frontend/tests/data/project.testdata.json
@@ -472,7 +472,7 @@
       ],
       "EmbedContent": true,
       "FileName": null,
-      "Label": "Config 1",
+      "Label": "Config 1 - This is a long label",
       "ReferenceOnly": false
     },
     {
@@ -506,7 +506,7 @@
       ],
       "EmbedContent": true,
       "FileName": null,
-      "Label": "Config 2",
+      "Label": "Config 2 - This is a long label",
       "ReferenceOnly": false
     },
     {
@@ -540,7 +540,7 @@
       ],
       "EmbedContent": true,
       "FileName": null,
-      "Label": "Config 3",
+      "Label": "Config 3 - This is a long label",
       "ReferenceOnly": false
     }
   ],

--- a/frontend/tests/data/project.testdata.json
+++ b/frontend/tests/data/project.testdata.json
@@ -472,7 +472,7 @@
       ],
       "EmbedContent": true,
       "FileName": null,
-      "Label": "Config 1 - This is a long label",
+      "Label": "Config 1 - Normal label",
       "ReferenceOnly": false
     },
     {
@@ -506,7 +506,7 @@
       ],
       "EmbedContent": true,
       "FileName": null,
-      "Label": "Config 2 - This is a long label",
+      "Label": "Config 2 - Normal label",
       "ReferenceOnly": false
     },
     {
@@ -540,7 +540,7 @@
       ],
       "EmbedContent": true,
       "FileName": null,
-      "Label": "Config 3 - This is a long label",
+      "Label": "Config 3 - Normal label",
       "ReferenceOnly": false
     }
   ],


### PR DESCRIPTION
https://github.com/user-attachments/assets/dec07237-d018-4a1b-9fcd-ab52c3f4f3c1

Tabs can now be scrolled horizontally if they require more than the available, visible space.
The active tab will scroll into view when the mouse leaves the tabs area.

- [x] tabs scroll beyond the available screen space
- [x] ~~i18n (not needed)~~
- [x] frontend tests

fixes #2450 