### PR TITLE
Controller definition loading messages are now DEBUG level

### DIFF
--- a/MobiFlight/BoardDefinitions.cs
+++ b/MobiFlight/BoardDefinitions.cs
@@ -102,7 +102,7 @@ namespace MobiFlight
             files.AddRange(Directory.GetFiles("Community", "*.board.json", SearchOption.AllDirectories));
             boards = JsonBackedObject.LoadDefinitions<Board>(files.ToArray(), "Boards/mfboard.schema.json",
                 onSuccess: (board, definitionFile) => {
-                    Log.Instance.log($"Loaded board definition for {board.Info.MobiFlightType} ({board.Info.FriendlyName})", LogSeverity.Info);
+                    Log.Instance.log($"Loaded board definition for {board.Info.MobiFlightType} ({board.Info.FriendlyName})", LogSeverity.Debug);
 
                     var boardPath = Path.GetDirectoryName(definitionFile);
                     board.BasePath = Path.GetDirectoryName(boardPath);

--- a/MobiFlight/CustomDevices/CustomDeviceDefinitions.cs
+++ b/MobiFlight/CustomDevices/CustomDeviceDefinitions.cs
@@ -43,7 +43,7 @@ namespace MobiFlight.CustomDevices
 
             devices = JsonBackedObject.LoadDefinitions<CustomDevice>(files.ToArray(), "Devices/mfdevice.schema.json",
                 onSuccess: (device, definitionFile) => {
-                    Log.Instance.log($"Loaded custom device definition for {device.Info.Label} ({device.Info.Version})", LogSeverity.Info);
+                    Log.Instance.log($"Loaded custom device definition for {device.Info.Label} ({device.Info.Version})", LogSeverity.Debug);
                     device.BasePath = Path.GetDirectoryName(Path.GetDirectoryName(definitionFile));
                 },
                 onError: () => LoadingError = true

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -84,7 +84,7 @@ namespace MobiFlight
             var rawDefinitions = JsonBackedObject.LoadDefinitions<JoystickDefinition>(
                 jsonFiles, 
                 schemaFilePath,
-                onSuccess: (joystick, definitionFile) => Log.Instance.log($"Loaded joystick definition for {joystick.InstanceName}", LogSeverity.Info),
+                onSuccess: (joystick, definitionFile) => Log.Instance.log($"Loaded joystick definition for {joystick.InstanceName}", LogSeverity.Debug),
                 onError: () => LoadingError = true
             );
 

--- a/MobiFlight/MidiBoard/MidiBoardManager.cs
+++ b/MobiFlight/MidiBoard/MidiBoardManager.cs
@@ -88,7 +88,7 @@ namespace MobiFlight
             var rawDefinitions = JsonBackedObject.LoadDefinitions<MidiBoardDefinition>(
                 jsonFiles,
                 schemaFilePath,
-                onSuccess: (midiboard, definitionFile) => Log.Instance.log($"Loaded midiBoard definition for {midiboard.InstanceName}", LogSeverity.Info),
+                onSuccess: (midiboard, definitionFile) => Log.Instance.log($"Loaded midiBoard definition for {midiboard.InstanceName}", LogSeverity.Debug),
                 onError: () => LoadingError = true
             );
 


### PR DESCRIPTION
This PR reduces log verbosity by changing controller definition loading messages from Info to Debug level. This is a sensible change as definition loading is a routine initialization activity that doesn't require user attention, unlike runtime device connection/disconnection events which remain at Info level for visibility.