### PR TITLE
Suppress migration logs while only fetching ProjectInfo

### DIFF
--- a/MobiFlightUnitTests/Base/Migration/ProjectMigrationTests.cs
+++ b/MobiFlightUnitTests/Base/Migration/ProjectMigrationTests.cs
@@ -47,7 +47,7 @@ namespace MobiFlight.Base.Migration.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
-            var result = applyMigrationsMethod.Invoke(project, new object[] { currentSchemaVersionDocument }) as JObject;
+            var result = applyMigrationsMethod.Invoke(project, new object[] { currentSchemaVersionDocument, false }) as JObject;
 
             // Assert
             Assert.AreEqual(project.SchemaVersion.ToString(), result["_version"].ToString());
@@ -68,7 +68,7 @@ namespace MobiFlight.Base.Migration.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
-            var result = applyMigrationsMethod.Invoke(project, new object[] { documentWithoutVersion }) as JObject;
+            var result = applyMigrationsMethod.Invoke(project, new object[] { documentWithoutVersion, false }) as JObject;
 
             // Assert
             Assert.AreEqual(project.SchemaVersion.ToString(), result["_version"].ToString());
@@ -468,7 +468,7 @@ namespace MobiFlight.Base.Migration.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act & Assert - Should not throw
-            var result = applyMigrationsMethod.Invoke(project, new object[] { corruptedDocument }) as JObject;
+            var result = applyMigrationsMethod.Invoke(project, new object[] { corruptedDocument, false }) as JObject;
             
             // Verify version was still updated
             Assert.AreEqual(project.SchemaVersion.ToString(), result["_version"].ToString());
@@ -489,7 +489,7 @@ namespace MobiFlight.Base.Migration.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
-            var result = applyMigrationsMethod.Invoke(project, new object[] { documentWithInvalidVersion }) as JObject;
+            var result = applyMigrationsMethod.Invoke(project, new object[] { documentWithInvalidVersion, false }) as JObject;
 
             // Assert
             Assert.AreEqual(project.SchemaVersion.ToString(), result["_version"].ToString());
@@ -511,7 +511,7 @@ namespace MobiFlight.Base.Migration.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
-            var result = applyMigrationsMethod.Invoke(project, new object[] { documentWithEmptyVersion }) as JObject;
+            var result = applyMigrationsMethod.Invoke(project, new object[] { documentWithEmptyVersion, false }) as JObject;
 
             // Assert
             Assert.AreEqual(project.SchemaVersion.ToString(), result["_version"].ToString());
@@ -533,7 +533,7 @@ namespace MobiFlight.Base.Migration.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
-            var result = applyMigrationsMethod.Invoke(project, new object[] { documentWithNullVersion }) as JObject;
+            var result = applyMigrationsMethod.Invoke(project, new object[] { documentWithNullVersion, false }) as JObject;
 
             // Assert
             Assert.AreEqual(project.SchemaVersion.ToString(), result["_version"].ToString());
@@ -615,7 +615,7 @@ namespace MobiFlight.Base.Migration.Tests
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
-            var result = applyMigrationsMethod.Invoke(project, new object[] { futureDocument }) as JObject;
+            var result = applyMigrationsMethod.Invoke(project, new object[] { futureDocument, false }) as JObject;
 
             // Assert - Should not downgrade version
             Assert.AreEqual(futureVersion.ToString(), result["_version"].ToString());

--- a/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -1,5 +1,6 @@
-﻿using MobiFlight.Base;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.Base;
+using Moq;
 using System.IO;
 using System.Linq;
 
@@ -8,6 +9,29 @@ namespace MobiFlight.Base.Tests
     [TestClass()]
     public class ProjectTests
     {
+        private LogSeverity _logSeverity = LogSeverity.Error;
+        private Mock<ILogAppender> _mockLogAppender;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            // Create a mock log appender
+            _mockLogAppender = new Mock<ILogAppender>();
+            _logSeverity = Log.Instance.Severity; // Store the current log severity
+            Log.Instance.Severity = LogSeverity.Debug; // Set the log severity to Debug
+            Log.Instance.ClearAppenders();
+            Log.Instance.AddAppender(_mockLogAppender.Object);
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            // Remove the mock appender after each test
+            Log.Instance.ClearAppenders();
+            Log.Instance.Severity = _logSeverity; // Restore the original log severity
+            Log.Instance.Enabled = false; // Disable logging
+        }
+
         [TestMethod()]
         public void OpenFileTest_Single_Xml()
         {
@@ -52,7 +76,7 @@ namespace MobiFlight.Base.Tests
             Assert.IsTrue(outputConfig as OutputConfigItem != null);
             var preconditions = (outputConfig as OutputConfigItem).Preconditions;
 
-            Assert.AreEqual(0, preconditions.Count);    
+            Assert.AreEqual(0, preconditions.Count);
         }
 
         [TestMethod()]
@@ -809,7 +833,7 @@ namespace MobiFlight.Base.Tests
                 "Extension.FilePath.AIC",
                 "Extension.FilePath.mfproj",
             };
-           
+
             var mfprojExtension = "Extension.FilePath.mfproj";
 
             testExtensions.ToList().ForEach(ext =>
@@ -828,7 +852,8 @@ namespace MobiFlight.Base.Tests
                 "Extension.FilePath.config",
             };
 
-            invalidExtensions.ToList().ForEach(ext => {
+            invalidExtensions.ToList().ForEach(ext =>
+            {
                 project.FilePath = ext;
                 var result = project.MigrateFileExtension();
                 Assert.AreEqual(ext, project.FilePath, "Extension should not be changed for invalid extensions");
@@ -837,25 +862,6 @@ namespace MobiFlight.Base.Tests
         }
 
         #region OpenFile Log Suppression Tests
-
-        // Minimal test appender to capture log messages during tests.
-        class TestAppender : ILogAppender
-        {
-            private readonly object _sync = new object();
-            public readonly System.Collections.Generic.List<(string Message, LogSeverity Severity)> Entries = new System.Collections.Generic.List<(string, LogSeverity)>();
-
-            public void log(string message, LogSeverity severity)
-            {
-                lock (_sync)
-                {
-                    Entries.Add((message, severity));
-                }
-            }
-
-            // Some appenders implement cleanup hooks; provide a no-op to be safe.
-            public void Shutdown() { }
-        }
-
         [TestMethod()]
         public void OpenFile_LogSuppression_DoesNotEmitMigrationLogs()
         {
@@ -865,8 +871,6 @@ namespace MobiFlight.Base.Tests
                 // old schema version triggers migration path
                 File.WriteAllText(tempFile, "{ \"Name\": \"TestProject\", \"ConfigFiles\": [], \"_version\": \"0.1\" }");
 
-                var appender = new TestAppender();
-                Log.Instance.AddAppender(appender);
                 Log.Instance.Severity = LogSeverity.Debug;
                 Log.Instance.Enabled = true;
 
@@ -876,13 +880,21 @@ namespace MobiFlight.Base.Tests
                 p.OpenFile(suppressMigrationLogging: true);
 
                 // Assert - no migration-related entries
-                bool anyMigration = appender.Entries.Any(e =>
-                    e.Message.IndexOf("Migrating document", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    e.Message.IndexOf("Applying V0.9 migrations", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    e.Message.IndexOf("Migration complete", System.StringComparison.OrdinalIgnoreCase) >= 0
+                // Assert - migration-related entries present
+                _mockLogAppender.Verify(
+                    appender => appender.log(It.Is<string>(msg => msg.Contains("Migrating document")), LogSeverity.Debug),
+                    Times.Never
                 );
 
-                Assert.IsFalse(anyMigration, "Migration messages should be suppressed when suppressMigrationLogging == true");
+                _mockLogAppender.Verify(
+                    appender => appender.log(It.Is<string>(msg => msg.Contains("Applying V0.9 migrations")), LogSeverity.Debug),
+                    Times.Never
+                );
+
+                _mockLogAppender.Verify(
+                    appender => appender.log(It.Is<string>(msg => msg.Contains("Migration complete")), LogSeverity.Debug),
+                    Times.Never
+                );
             }
             finally
             {
@@ -899,8 +911,6 @@ namespace MobiFlight.Base.Tests
                 // old schema version triggers migration path
                 File.WriteAllText(tempFile, "{ \"Name\": \"TestProject\", \"ConfigFiles\": [], \"_version\": \"0.1\" }");
 
-                var appender = new TestAppender();
-                Log.Instance.AddAppender(appender);
                 Log.Instance.Severity = LogSeverity.Debug;
                 Log.Instance.Enabled = true;
 
@@ -910,13 +920,20 @@ namespace MobiFlight.Base.Tests
                 p.OpenFile();
 
                 // Assert - migration-related entries present
-                bool anyMigration = appender.Entries.Any(e =>
-                    e.Message.IndexOf("Migrating document", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    e.Message.IndexOf("Applying V0.9 migrations", System.StringComparison.OrdinalIgnoreCase) >= 0 ||
-                    e.Message.IndexOf("Migration complete", System.StringComparison.OrdinalIgnoreCase) >= 0
+                _mockLogAppender.Verify(
+                    appender => appender.log(It.Is<string>(msg => msg.Contains("Migrating document")), LogSeverity.Debug),
+                    Times.Once
                 );
 
-                Assert.IsTrue(anyMigration, "Migration messages should be emitted when suppressMigrationLogging == false");
+                _mockLogAppender.Verify(
+                    appender => appender.log(It.Is<string>(msg => msg.Contains("Applying V0.9 migrations")), LogSeverity.Debug),
+                    Times.Once
+                );
+
+                _mockLogAppender.Verify(
+                    appender => appender.log(It.Is<string>(msg => msg.Contains("Migration complete")), LogSeverity.Debug),
+                    Times.Once
+                );
             }
             finally
             {

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -481,7 +481,7 @@ namespace MobiFlight.UI
                     {
                         var p = new Project();
                         p.FilePath = project;
-                        p.OpenFile();
+                        p.OpenFile(suppressMigrationLogging: true);
                         p.DetermineProjectInfos();
 
                         recentProjects.Add(p.ToProjectInfo());


### PR DESCRIPTION
This PR adds the ability to suppress migration log messages when opening project files solely to fetch metadata (ProjectInfo), addressing issue https://github.com/MobiFlight/MobiFlight-Connector/issues/2474. This prevents verbose migration logs from cluttering the output when the application is simply building a list of recent projects.

**Key Changes:**

- [x] Added suppressMigrationLogging parameter to Project.OpenFile() and ApplyMigrations() methods
- [x] Conditionally suppress migration-related log messages based on the flag
- [x] Updated MainForm to use log suppression when loading recent projects
- [x] Added comprehensive test coverage for the suppression feature

fixes #2474 