### PR TITLE
Remove non-existing files from recent project list automatically

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -502,24 +502,24 @@ namespace MobiFlight.UI
 
         internal static List<string> CheckForMissingFiles(IEnumerable<string> recentFiles)
         {
-            var missing = new List<string>();
-            if (recentFiles == null) return missing;
+            var missingFiles = new List<string>();
+            if (recentFiles == null) return missingFiles;
 
             foreach (var f in recentFiles)
             {
                 try
                 {
                     if (string.IsNullOrWhiteSpace(f) || !File.Exists(f))
-                        missing.Add(f);
+                        missingFiles.Add(f);
                 }
                 catch
                 {
                     // Treat IO errors as missing; keep scanning
-                    missing.Add(f);
+                    missingFiles.Add(f);
                 }
             }
 
-            return missing;
+            return missingFiles;
         }
 
         internal void RemoveMissingFilesFromSettings(IEnumerable<string> missingFiles)

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -466,8 +466,15 @@ namespace MobiFlight.UI
             Refresh();
 
             PublishSettings();
+            try
+            {
+                await CleanRecentFilesAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log($"Exception in CleanRecentFilesAsync: {ex.Message}", LogSeverity.Error);
+            }
 
-            await CleanRecentFilesAsync().ConfigureAwait(false);
             PublishRecentProjectList();
         }
 
@@ -529,13 +536,11 @@ namespace MobiFlight.UI
             var changed = false;
             foreach (var f in missingFiles)
             {
-                if (string.IsNullOrWhiteSpace(f)) continue;
-                if (Properties.Settings.Default.RecentFiles.Contains(f))
-                {
-                    Properties.Settings.Default.RecentFiles.Remove(f);
-                    Log.Instance.log($"Recent Project List - File doesn't exist: '{f}' removed.", LogSeverity.Info);
-                    changed = true;
-                }
+                if (!Properties.Settings.Default.RecentFiles.Contains(f)) continue;
+
+                Properties.Settings.Default.RecentFiles.Remove(f);
+                Log.Instance.log($"Recent Project List - File doesn't exist: '{f}' removed.", LogSeverity.Info);
+                changed = true;
             }
 
             if (changed)


### PR DESCRIPTION
Stale entries in the internal recent project list are now removed. In the past, we would simply only add to the list every time we open a new, additional file.

This way, the list is kept shorter and only contains valid entries.

fixes #2444 