### PR TITLE
Power Saving Mode Fix

### DIFF
--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -61,7 +61,8 @@ namespace MobiFlight
 
         public MobiFlightCache()
         {
-            keepAwakeTimer.Interval = KeepAwakeIntervalInMinutes * 60 * 1000; // convert to milliseconds
+            // ticks every KeepAwakeIntervalInMinutes
+            keepAwakeTimer.Interval = KeepAwakeIntervalInMinutes * 60 * 1000;
             keepAwakeTimer.Tick += (s, e) => DeactivateConnectedModulePowerSave();
         }
 
@@ -866,6 +867,7 @@ namespace MobiFlight
 
         public void StartKeepAwake()
         {
+            DeactivateConnectedModulePowerSave();
             keepAwakeTimer.Start();
         }
 

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -1337,9 +1337,7 @@ namespace MobiFlight
 
         public void Stop()
         {
-            // Always clear the cache 
-            // also in case maybe later something goes wrong
-            // we will simply resend the value in that case
+            // Always clear the cache
             lastValue.Clear();
 
             // we have to make sure to not send messages

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -1293,9 +1293,17 @@ namespace MobiFlight
 
         // Sets the connected module's power save mode. True turns power save on,
         // false turns power save off.
-        public void SetPowerSaveMode(bool mode)
+        public virtual void SetPowerSaveMode(bool mode)
         {
             Log.Instance.log($"Setting power save for {this.Name} ({this.Port}) to {mode}", LogSeverity.Debug);
+
+            // Guard against null CmdMessenger (e.g., before Connect() is called)
+            if (_cmdMessenger == null)
+            {
+                Log.Instance.log("CmdMessenger not initialized, skipping SetPowerSaveMode command.", LogSeverity.Debug);
+                return;
+            }
+
             // Send the power save wakeup command. No timeout is used so this will still work with older firmware
             // that doesn't respond to the SetPowerSavingMode command.
             SendCommand command = new SendCommand((int)MobiFlightModule.Command.SetPowerSavingMode);
@@ -1332,7 +1340,6 @@ namespace MobiFlight
             // Always clear the cache 
             // also in case maybe later something goes wrong
             // we will simply resend the value in that case
-            // when we start again
             lastValue.Clear();
 
             // we have to make sure to not send messages

--- a/MobiFlightUnitTests/MobiFlight/MobiFlightCacheTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/MobiFlightCacheTests.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Collections.Generic;
+
+namespace MobiFlight.Tests
+{
+    [TestClass()]
+    public class MobiFlightCacheTests
+    {
+        [TestMethod()]
+        public void StartKeepAwake_CallsDeactivateConnectedModulePowerSave_Immediately()
+        {
+            // Arrange
+            var cache = new TestableMobiFlightCache();
+            var mockModule = new Mock<MobiFlightModule>("COM1", CreateMinimalBoard());
+
+            // Add a mock module to the cache
+            cache.AddTestModule("SERIAL1", mockModule.Object);
+
+            // Act
+            cache.StartKeepAwake();
+
+            // Assert
+            mockModule.Verify(m => m.SetPowerSaveMode(false), Times.Once(),
+                "SetPowerSaveMode(false) should be called immediately when StartKeepAwake is invoked");
+        }
+
+        [TestMethod()]
+        public void StopKeepAwake_CallsActivateConnectedModulePowerSave()
+        {
+            // Arrange
+            var cache = new TestableMobiFlightCache();
+            var mockModule = new Mock<MobiFlightModule>("COM1", CreateMinimalBoard());
+
+            // Add a mock module to the cache
+            cache.AddTestModule("SERIAL1", mockModule.Object);
+
+            // Act
+            cache.StopKeepAwake();
+
+            // Assert
+            mockModule.Verify(m => m.SetPowerSaveMode(true), Times.Once(),
+                "SetPowerSaveMode(true) should be called when StopKeepAwake is invoked");
+        }
+
+        // Testable subclass to expose internal members for testing
+        private class TestableMobiFlightCache : MobiFlightCache
+        {
+            public void AddTestModule(string serial, MobiFlightModule module)
+            {
+                // Use reflection to access the private Modules dictionary
+                var modulesField = typeof(MobiFlightCache).GetField("Modules",
+                    System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var modules = modulesField.GetValue(this) as System.Collections.Concurrent.ConcurrentDictionary<string, MobiFlightModule>;
+                modules.TryAdd(serial, module);
+            }
+        }
+        private static Board CreateMinimalBoard()
+        {
+            return new Board
+            {
+                Info = new Info
+                {
+                    MobiFlightType = "TestType",
+                    FriendlyName = "TestBoard",
+                    FirmwareBaseName = "test",
+                    FirmwareExtension = "hex"
+                },
+                Connection = new Connection
+                {
+                    ConnectionDelay = 0,
+                    TimeoutForFirmwareUpdate = 15000
+                },
+                AvrDudeSettings = new AvrDudeSettings
+                {
+                    Timeout = 15000
+                },
+                HardwareIds = new List<string>(),
+                ModuleLimits = new ModuleLimits(),
+                Pins = new List<MobiFlightPin>(),
+                UsbDriveSettings = new UsbDriveSettings()
+            };
+        }
+    }
+}

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -248,6 +248,7 @@
     <Compile Include="MobiFlight\Joysticks\WingFlex\FcuCubeReportTests.cs" />
     <Compile Include="MobiFlight\JsonDefinitionFilesTests.cs" />
     <Compile Include="MobiFlight\MidiBoard\MidiBoardDefinitionTests.cs" />
+    <Compile Include="MobiFlight\MobiFlightCacheTests.cs" />
     <Compile Include="MobiFlight\MobiFlightCustomDeviceTests.cs" />
     <Compile Include="MobiFlight\MobiFlightLedModuleTests.cs" />
     <Compile Include="MobiFlight\MobiFlightModuleInfoTests.cs" />


### PR DESCRIPTION
This PR fixes an issue with power saving mode by ensuring that when keep-alive is started, connected modules immediately deactivate power save mode rather than waiting for the first timer tick. The fix includes a null-safety guard for the CmdMessenger and adds the virtual keyword to enable testing through mocking.

- [x] Add missing command
- [x] Add unit test

fixes #2498
