### PR TITLE
Filter output and input config options based on selected sim from project settings

### DIFF
--- a/Base/AppTelemetry.cs
+++ b/Base/AppTelemetry.cs
@@ -87,7 +87,7 @@ namespace MobiFlight.Base
                 if (!trackingEvent.Metrics.ContainsKey(key)) trackingEvent.Metrics[key] = 0;
                 trackingEvent.Metrics[key] += 1;
 
-                key = "output." + item.Source.SourceType;
+                key = "output." + item.Source?.SourceType ?? "none";
                 if (!trackingEvent.Metrics.ContainsKey(key)) trackingEvent.Metrics[key] = 0;
                 trackingEvent.Metrics[key] += 1;
             }

--- a/Base/ConfigFile.cs
+++ b/Base/ConfigFile.cs
@@ -112,10 +112,6 @@ namespace MobiFlight.Base
             {
                 return (new XplaneSource().SourceType).ToLower();
             }
-            else if (ContainsConfigOfSourceType(new ProSimSource()))
-            {
-                return (new ProSimSource()).SourceType.ToLower();
-            }
             return null;
         }
 

--- a/Base/ConfigFileExtensions.cs
+++ b/Base/ConfigFileExtensions.cs
@@ -30,6 +30,7 @@ namespace MobiFlight.Base
             }).ToList().ForEach(i =>
             {
                 var source = (i as OutputConfigItem).Source as VariableSource;
+                if (source == null) return;
                 if (variables.ContainsKey(source.MobiFlightVariable.Name)) return;
                 variables[source.MobiFlightVariable.Name] = source.MobiFlightVariable;
             });

--- a/Base/Project.cs
+++ b/Base/Project.cs
@@ -18,7 +18,7 @@ namespace MobiFlight.Base
     {
         public string Name { get; set; }
         public string Sim { get; set; }
-        public bool UseFsuipc { get; set; }
+        public bool UseFsuipc { get; set; } = false;
         public List<string> Aircraft { get; set; }
         public List<string> Controllers { get; set; }
         public string FilePath { get; set; }

--- a/Base/Project.cs
+++ b/Base/Project.cs
@@ -18,11 +18,71 @@ namespace MobiFlight.Base
     {
         public string Name { get; set; }
         public string Sim { get; set; }
-        public bool UseFsuipc { get; set; } = false;
+        public ProjectFeatures Features { get; set; }
         public List<string> Aircraft { get; set; }
         public List<string> Controllers { get; set; }
         public string FilePath { get; set; }
         public bool Favorite { get; set; } = false;
+    }
+
+
+    /// <summary>
+    /// Represents optional features that can be enabled for a MobiFlight project.
+    /// </summary>
+    public class ProjectFeatures : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        private bool _useFsuipc = false;
+        /// <summary>
+        /// Gets or sets whether the project uses FSUIPC integration.
+        /// </summary>
+        public bool FSUIPC
+        {
+            get => _useFsuipc;
+            set
+            {
+                if (_useFsuipc != value)
+                {
+                    _useFsuipc = value;
+                    OnPropertyChanged(nameof(FSUIPC));
+                }
+            }
+        }
+
+        private bool _useProSim = false;
+        /// <summary>
+        /// Gets or sets whether the project uses ProSim integration.
+        /// </summary>
+        public bool ProSim
+        {
+            get => _useProSim;
+            set
+            {
+                if (_useProSim != value)
+                {
+                    _useProSim = value;
+                    OnPropertyChanged(nameof(ProSim));
+                }
+            }
+        }
+
+        protected virtual void OnPropertyChanged(string propertyName)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+
+        /// <summary>
+        /// Creates a deep copy of the current features.
+        /// </summary>
+        public ProjectFeatures Clone()
+        {
+            return new ProjectFeatures
+            {
+                FSUIPC = this.FSUIPC,
+                ProSim = this.ProSim
+            };
+        }
     }
 
     /// <summary>
@@ -122,21 +182,6 @@ namespace MobiFlight.Base
             }
         }
 
-        private bool _useFsuipc = false;
-        public bool UseFsuipc
-        {
-            get => _useFsuipc;
-            set
-            {
-                if (_useFsuipc != value)
-                {
-                    _useFsuipc = value;
-                    OnPropertyChanged(nameof(UseFsuipc));
-                    OnProjectChanged();
-                }
-            }
-        }
-
         private ObservableCollection<string> _aircraft = new ObservableCollection<string>();
         /// <summary>
         /// Gets or sets the name of the project.
@@ -195,6 +240,38 @@ namespace MobiFlight.Base
             }
         }
 
+        private ProjectFeatures _features = new ProjectFeatures();
+
+        /// <summary>
+        /// Gets or sets optional features enabled for this project.
+        /// </summary>
+        public ProjectFeatures Features
+        {
+            get => _features;
+            set
+            {
+                if (_features != value)
+                {
+                    // Unsubscribe from old instance
+                    if (_features != null)
+                    {
+                        _features.PropertyChanged -= Features_PropertyChanged;
+                    }
+
+                    _features = value;
+
+                    // Subscribe to new instance
+                    if (_features != null)
+                    {
+                        _features.PropertyChanged += Features_PropertyChanged;
+                    }
+
+                    OnPropertyChanged(nameof(Features));
+                    OnProjectChanged();
+                }
+            }
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Project"/> class with default values.
         /// </summary>
@@ -215,7 +292,7 @@ namespace MobiFlight.Base
             {
                 Name = Name,
                 Sim = Sim,
-                UseFsuipc = UseFsuipc,
+                Features = Features,
                 Aircraft = Aircraft?.ToList() ?? new List<string>(),
                 Controllers = Controllers?.ToList() ?? new List<string>(),
                 FilePath = FilePath
@@ -227,6 +304,10 @@ namespace MobiFlight.Base
         public void DetermineProjectInfos()
         {
             var controllerSerials = new List<string>();
+
+            // reset features for clean determination
+            Features = new ProjectFeatures();
+
             foreach (var item in ConfigFiles)
             {
                 if (string.IsNullOrEmpty(Sim))
@@ -240,8 +321,8 @@ namespace MobiFlight.Base
                     }
                 }
 
-                var useFsuipc = item.DetermineUsingFsuipc();
-                UseFsuipc |= useFsuipc;
+                Features.FSUIPC |= item.DetermineUsingFsuipc();
+                Features.ProSim |= item.ContainsConfigOfSourceType(new ProSimSource());
 
                 item.GetIUniqueControllerSerials().ForEach(c => controllerSerials.Add(c));
             }
@@ -260,6 +341,13 @@ namespace MobiFlight.Base
         /// <param name="sender">The source of the event.</param>
         /// <param name="e">The collection change event arguments.</param>
         private void CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+        {
+            OnPropertyChanged(nameof(Features));
+            OnProjectChanged();
+        }
+
+        // Handle property changes within Features
+        private void Features_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
             OnProjectChanged();
         }
@@ -347,7 +435,7 @@ namespace MobiFlight.Base
         {
             this.Name = project.Name;
             this.Sim = project.Sim;
-            this.UseFsuipc = project.UseFsuipc;
+            this.Features = project.Features.Clone();
             this.Aircraft = project.Aircraft;
             this.ConfigFiles = project.ConfigFiles;
         }

--- a/Base/Source.cs
+++ b/Base/Source.cs
@@ -113,4 +113,25 @@ namespace MobiFlight.Base
                 this.ProSimDataRef.Equals((obj as ProSimSource).ProSimDataRef);
         }
     }
+
+    public static class SourceFactory
+    {
+        public static Source Create(string sim)
+        {
+            switch (sim)
+            {
+                case "msfs":
+                    return new SimConnectSource();
+                case "xplane":
+                    return new XplaneSource();
+                case "prosim":
+                    return new ProSimSource();
+                case "p3d":
+                case "fsuipc":
+                    return new FsuipcSource();
+            }
+
+            return null;
+        }
+    }
 }

--- a/Base/Source.cs
+++ b/Base/Source.cs
@@ -114,6 +114,10 @@ namespace MobiFlight.Base
         }
     }
 
+    /// <summary>
+    /// Creates Source instances based on sim type strings.
+    /// </summary>
+    /// <returns>Source instance corresponding to the specified sim type. Returns null for unknown sim names.</returns>
     public static class SourceFactory
     {
         public static Source Create(string sim)
@@ -131,7 +135,9 @@ namespace MobiFlight.Base
                     return new FsuipcSource();
             }
 
-            return null;
+            Log.Instance.log($"SourceFactory: Unknown sim '{sim}', returning null", LogSeverity.Error);
+            // use this as a default fallback
+            return new SimConnectSource();
         }
     }
 }

--- a/Base/Source.cs
+++ b/Base/Source.cs
@@ -127,7 +127,7 @@ namespace MobiFlight.Base
                 case "prosim":
                     return new ProSimSource();
                 case "p3d":
-                case "fsuipc":
+                case "fsx":
                     return new FsuipcSource();
             }
 

--- a/Base/Source.cs
+++ b/Base/Source.cs
@@ -136,8 +136,8 @@ namespace MobiFlight.Base
             }
 
             Log.Instance.log($"SourceFactory: Unknown sim '{sim}', returning null", LogSeverity.Error);
-            // use this as a default fallback
-            return new SimConnectSource();
+            // return null for unknown sim names
+            return null;
         }
     }
 }

--- a/MobiFlight/Execution/ConfigItemExecutor.cs
+++ b/MobiFlight/Execution/ConfigItemExecutor.cs
@@ -319,7 +319,7 @@ namespace MobiFlight.Execution
             }
             else
             {
-                Log.Instance.log("Unknown source type: " + cfg.Source.SourceType, LogSeverity.Error);
+                Log.Instance.log("Unknown source type: " + cfg.Source?.SourceType ?? "none", LogSeverity.Error);
             }
 
             return result;

--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -289,7 +289,9 @@ namespace MobiFlight
 
             MessageExchange.Instance.Subscribe<CommandAddConfigItem>((message) =>
             {
-                IConfigItem item = new OutputConfigItem();
+                IConfigItem item = new OutputConfigItem() {
+                    Source = SourceFactory.Create(Project.ToProjectInfo().Sim)
+                };
                 if (message.Type == "InputConfig")
                 {
                     item = new InputConfigItem();

--- a/MobiFlight/OutputConfigItem.cs
+++ b/MobiFlight/OutputConfigItem.cs
@@ -52,7 +52,7 @@ namespace MobiFlight
             return (
                 DeviceName == item.DeviceName &&
                 DeviceType == item.DeviceType &&
-                Source.AreEqual(item.Source) &&
+                (Source?.AreEqual(item.Source) ?? item.Source == null) &&
                 TestValue.AreEqual(item.TestValue) &&
                 Device.AreEqual(item.Device) &&
                 ButtonInputConfig.AreEqual(item.ButtonInputConfig) &&
@@ -380,7 +380,7 @@ namespace MobiFlight
 
         public OutputConfigItem(OutputConfigItem config) : base(config)
         {
-            this.Source = config.Source.Clone() as Source;
+            this.Source = config.Source?.Clone() as Source;
             
             this.DeviceType = config.DeviceType;
             this.ModuleSerial = config.ModuleSerial;

--- a/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -492,7 +492,8 @@ namespace MobiFlight.Base.Tests
             Assert.IsNotNull(project.Controllers);
             Assert.AreEqual(0, project.Controllers.Count);
             Assert.IsNull(project.Sim);
-            Assert.IsFalse(project.UseFsuipc);
+            Assert.IsFalse(project.Features.FSUIPC);
+            Assert.IsFalse(project.Features.ProSim);
         }
 
         [TestMethod()]
@@ -610,7 +611,8 @@ namespace MobiFlight.Base.Tests
 
             // Assert
             Assert.AreEqual("msfs", project.Sim);
-            Assert.IsFalse(project.UseFsuipc);
+            Assert.IsFalse(project.Features.FSUIPC);
+            Assert.IsFalse(project.Features.ProSim);
         }
 
         [TestMethod()]
@@ -625,6 +627,7 @@ namespace MobiFlight.Base.Tests
                 ModuleSerial = "SN-123-456",
                 Source = new XplaneSource()
             };
+
             config.ConfigItems.Add(outputConfig);
             project.ConfigFiles.Add(config);
 
@@ -633,11 +636,12 @@ namespace MobiFlight.Base.Tests
 
             // Assert
             Assert.AreEqual("xplane", project.Sim);
-            Assert.IsFalse(project.UseFsuipc);
+            Assert.IsFalse(project.Features.FSUIPC);
+            Assert.IsFalse(project.Features.ProSim);
         }
 
         [TestMethod()]
-        public void DetermineProjectInfos_WithProSimConfig_ShouldSetSimToProsim()
+        public void DetermineProjectInfos_WithProSimConfig_ShouldSetFeatureForProsim()
         {
             // Arrange
             var project = new Project();
@@ -648,15 +652,25 @@ namespace MobiFlight.Base.Tests
                 ModuleSerial = "SN-123-456",
                 Source = new ProSimSource()
             };
+
+            var msfsConfig = new OutputConfigItem
+            {
+                ModuleSerial = "SN-123-456",
+                Source = new SimConnectSource()
+            };
+
             config.ConfigItems.Add(outputConfig);
+            config.ConfigItems.Add(msfsConfig);
             project.ConfigFiles.Add(config);
 
             // Act
             project.DetermineProjectInfos();
 
             // Assert
-            Assert.AreEqual("prosim", project.Sim);
-            Assert.IsFalse(project.UseFsuipc);
+            Assert.AreNotEqual("prosim", project.Sim);
+            Assert.AreEqual("msfs", project.Sim);
+            Assert.IsFalse(project.Features.FSUIPC);
+            Assert.IsTrue(project.Features.ProSim);
         }
 
         [TestMethod()]
@@ -678,7 +692,7 @@ namespace MobiFlight.Base.Tests
             project.DetermineProjectInfos();
 
             // Assert
-            Assert.IsTrue(project.UseFsuipc);
+            Assert.IsTrue(project.Features.FSUIPC);
             // FSUIPC source alone doesn't set a specific sim
         }
 
@@ -744,7 +758,7 @@ namespace MobiFlight.Base.Tests
 
             // Assert
             Assert.AreEqual("msfs", project.Sim);
-            Assert.IsTrue(project.UseFsuipc);
+            Assert.IsTrue(project.Features.FSUIPC);
             Assert.AreEqual(2, project.Controllers.Count);
         }
 
@@ -786,7 +800,7 @@ namespace MobiFlight.Base.Tests
 
             // Assert
             Assert.AreEqual("msfs", project.Sim);
-            Assert.IsTrue(project.UseFsuipc);
+            Assert.IsTrue(project.Features.FSUIPC);
             Assert.AreEqual(3, project.Controllers.Count);
         }
 

--- a/MobiFlightUnitTests/Base/SourceFactoryTests.cs
+++ b/MobiFlightUnitTests/Base/SourceFactoryTests.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MobiFlight.Base.Tests
+{
+    [TestClass()]
+    public class SourceFactoryTests
+    {
+        [TestMethod()]
+        public void CreateTest()
+        {
+            var source = SourceFactory.Create("unknown_sim");
+            Assert.IsNull(source);
+            
+            source = SourceFactory.Create("msfs");
+            Assert.IsNotNull(source);
+            Assert.IsInstanceOfType(source, typeof(SimConnectSource));
+
+            source = SourceFactory.Create("xplane");
+            Assert.IsNotNull(source);
+            Assert.IsInstanceOfType(source, typeof(XplaneSource));
+
+            source = SourceFactory.Create("prosim");
+            Assert.IsNotNull(source);
+            Assert.IsInstanceOfType(source, typeof(ProSimSource));
+
+            source = SourceFactory.Create("fsx");
+            Assert.IsNotNull(source);
+            Assert.IsInstanceOfType(source, typeof(FsuipcSource));
+
+            source = SourceFactory.Create("p3d");
+            Assert.IsNotNull(source);
+            Assert.IsInstanceOfType(source, typeof(FsuipcSource));
+        }
+    }
+}

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Base\ProjectTests.cs" />
     <Compile Include="Base\Serialization\Json\SourceConverterTests.cs" />
     <Compile Include="Base\SerialNumberTests.cs" />
+    <Compile Include="Base\SourceFactoryTests.cs" />
     <Compile Include="EventIdInputPanelTests.cs" />
     <Compile Include="Forms\ConfigWizardTests.cs" />
     <Compile Include="MobiFlight\BoardTests.cs" />

--- a/MobiFlightUnitTests/UI/Dialogs/InputConfigWizardTests.cs
+++ b/MobiFlightUnitTests/UI/Dialogs/InputConfigWizardTests.cs
@@ -33,14 +33,15 @@ namespace MobiFlight.UI.Dialogs.Tests
                 { "var1", new MobiFlightVariable { Name = "Variable 1" } },
                 { "var2", new MobiFlightVariable { Name = "Variable 2" } }
             };
-            
+
             // Act
-            var wizard = new InputConfigWizard(executionManagerMock.Object, 
-                inputConfigItem, 
-                null, 
+            var wizard = new InputConfigWizard(executionManagerMock.Object,
+                inputConfigItem,
+                null,
                 null,
                 outputConfigItems,
-                availableVariables
+                availableVariables,
+                null
                 );
 
             // Assert
@@ -65,11 +66,11 @@ namespace MobiFlight.UI.Dialogs.Tests
             {
                 { "var1", new MobiFlightVariable { Name = "Variable 1" } }
             };
-            
+
             executionManagerMock.Setup(em => em.GetAvailableVariables()).Returns(availableVariables);
-            
-            var inputConfigItem = new InputConfigItem 
-            { 
+
+            var inputConfigItem = new InputConfigItem
+            {
                 GUID = "test-guid",
                 ModuleSerial = "TestModule / TestSerial",
                 button = new ButtonInputConfig(),
@@ -79,20 +80,21 @@ namespace MobiFlight.UI.Dialogs.Tests
                 inputMultiplexer = new InputMultiplexerConfig()
             };
 
-            var wizard = new InputConfigWizard(executionManagerMock.Object, 
-                inputConfigItem, 
-                null, 
+            var wizard = new InputConfigWizard(executionManagerMock.Object,
+                inputConfigItem,
+                null,
                 null,
                 new List<OutputConfigItem>(),
-                availableVariables);
+                availableVariables, 
+                null);
 
             // Get private fields using reflection
             var inputTypeComboBoxField = typeof(InputConfigWizard).GetField("inputTypeComboBox", BindingFlags.NonPublic | BindingFlags.Instance);
             var inputTypeComboBox = (ComboBox)inputTypeComboBoxField.GetValue(wizard);
-            
+
             var inputModuleNameComboBoxField = typeof(InputConfigWizard).GetField("inputModuleNameComboBox", BindingFlags.NonPublic | BindingFlags.Instance);
             var inputModuleNameComboBox = (ComboBox)inputModuleNameComboBoxField.GetValue(wizard);
-            
+
             var groupBoxInputSettingsField = typeof(InputConfigWizard).GetField("groupBoxInputSettings", BindingFlags.NonPublic | BindingFlags.Instance);
             var groupBoxInputSettings = (GroupBox)groupBoxInputSettingsField.GetValue(wizard);
 
@@ -126,10 +128,10 @@ namespace MobiFlight.UI.Dialogs.Tests
 
                 // Assert: Check that a panel was created and it implements IInputPanel
                 Assert.AreEqual(1, groupBoxInputSettings.Controls.Count, $"Expected 1 control for {testCase.DeviceType}, got {groupBoxInputSettings.Controls.Count}");
-                
+
                 var panel = groupBoxInputSettings.Controls[0];
                 Assert.IsInstanceOfType(panel, typeof(IInputPanel), $"Panel for {testCase.DeviceType} should implement IInputPanel");
-                
+
                 // Verify the panel is the correct type
                 switch (testCase.DeviceType)
                 {
@@ -151,7 +153,7 @@ namespace MobiFlight.UI.Dialogs.Tests
                 VerifyPanelInitialization(panel, executionManagerMock.Object, testCase.DeviceType);
 
                 // Verify that GetAvailableVariables was called for this panel
-                executionManagerMock.Verify(em => em.GetAvailableVariables(), Times.AtLeastOnce, 
+                executionManagerMock.Verify(em => em.GetAvailableVariables(), Times.AtLeastOnce,
                     $"GetAvailableVariables should be called at least once for {testCase.DeviceType}");
             }
         }
@@ -161,11 +163,11 @@ namespace MobiFlight.UI.Dialogs.Tests
             // Use reflection to check that the _executionManager field was set
             // This confirms that Init() was called
             var executionManagerField = panel.GetType().GetField("_executionManager", BindingFlags.NonPublic | BindingFlags.Instance);
-            
+
             Assert.IsNotNull(executionManagerField, $"Panel {deviceType} should have an _executionManager field");
-            
+
             var storedExecutionManager = executionManagerField.GetValue(panel);
-            Assert.AreSame(executionManager, storedExecutionManager, 
+            Assert.AreSame(executionManager, storedExecutionManager,
                 $"Panel {deviceType} should have the execution manager set via Init() call");
         }
 

--- a/UI/Dialogs/ConfigWizard.Designer.cs
+++ b/UI/Dialogs/ConfigWizard.Designer.cs
@@ -40,12 +40,13 @@
             this.fsuipcConfigPanel = new MobiFlight.UI.Panels.Config.FsuipcConfigPanel();
             this.fsuipcHintLabel = new System.Windows.Forms.Label();
             this.OffsetTypePanel = new System.Windows.Forms.Panel();
-            this.label1 = new System.Windows.Forms.Label();
-            this.OffsetTypeVariableRadioButton = new System.Windows.Forms.RadioButton();
+            this.groupBox1 = new System.Windows.Forms.GroupBox();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
             this.OffsetTypeSimConnectRadioButton = new System.Windows.Forms.RadioButton();
             this.OffsetTypeFsuipRadioButton = new System.Windows.Forms.RadioButton();
             this.OffsetTypeXplaneRadioButton = new System.Windows.Forms.RadioButton();
             this.OffsetTypeProSimRadioButton = new System.Windows.Forms.RadioButton();
+            this.OffsetTypeVariableRadioButton = new System.Windows.Forms.RadioButton();
             this.compareTabPage = new System.Windows.Forms.TabPage();
             this.modifierPanel1 = new MobiFlight.UI.Panels.OutputWizard.ModifierPanel();
             this.referencesGroupBox = new System.Windows.Forms.GroupBox();
@@ -67,6 +68,8 @@
             this.fsuipcTabPage.SuspendLayout();
             this.FsuipcSettingsPanel.SuspendLayout();
             this.OffsetTypePanel.SuspendLayout();
+            this.groupBox1.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             this.compareTabPage.SuspendLayout();
             this.referencesGroupBox.SuspendLayout();
             this.displayTabPage.SuspendLayout();
@@ -146,27 +149,26 @@
             // 
             // OffsetTypePanel
             // 
-            this.OffsetTypePanel.Controls.Add(this.label1);
-            this.OffsetTypePanel.Controls.Add(this.OffsetTypeVariableRadioButton);
-            this.OffsetTypePanel.Controls.Add(this.OffsetTypeSimConnectRadioButton);
-            this.OffsetTypePanel.Controls.Add(this.OffsetTypeFsuipRadioButton);
-            this.OffsetTypePanel.Controls.Add(this.OffsetTypeXplaneRadioButton);
-            this.OffsetTypePanel.Controls.Add(this.OffsetTypeProSimRadioButton);
+            this.OffsetTypePanel.Controls.Add(this.groupBox1);
             resources.ApplyResources(this.OffsetTypePanel, "OffsetTypePanel");
             this.OffsetTypePanel.Name = "OffsetTypePanel";
             // 
-            // label1
+            // groupBox1
             // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
+            this.groupBox1.Controls.Add(this.flowLayoutPanel1);
+            resources.ApplyResources(this.groupBox1, "groupBox1");
+            this.groupBox1.Name = "groupBox1";
+            this.groupBox1.TabStop = false;
             // 
-            // OffsetTypeVariableRadioButton
+            // flowLayoutPanel1
             // 
-            resources.ApplyResources(this.OffsetTypeVariableRadioButton, "OffsetTypeVariableRadioButton");
-            this.OffsetTypeVariableRadioButton.Name = "OffsetTypeVariableRadioButton";
-            this.OffsetTypeVariableRadioButton.TabStop = true;
-            this.OffsetTypeVariableRadioButton.UseVisualStyleBackColor = true;
-            this.OffsetTypeVariableRadioButton.CheckedChanged += new System.EventHandler(this.OffsetTypeFsuipRadioButton_CheckedChanged);
+            this.flowLayoutPanel1.Controls.Add(this.OffsetTypeSimConnectRadioButton);
+            this.flowLayoutPanel1.Controls.Add(this.OffsetTypeFsuipRadioButton);
+            this.flowLayoutPanel1.Controls.Add(this.OffsetTypeXplaneRadioButton);
+            this.flowLayoutPanel1.Controls.Add(this.OffsetTypeProSimRadioButton);
+            this.flowLayoutPanel1.Controls.Add(this.OffsetTypeVariableRadioButton);
+            resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             // 
             // OffsetTypeSimConnectRadioButton
             // 
@@ -199,6 +201,14 @@
             this.OffsetTypeProSimRadioButton.TabStop = true;
             this.OffsetTypeProSimRadioButton.UseVisualStyleBackColor = true;
             this.OffsetTypeProSimRadioButton.CheckedChanged += new System.EventHandler(this.OffsetTypeFsuipRadioButton_CheckedChanged);
+            // 
+            // OffsetTypeVariableRadioButton
+            // 
+            resources.ApplyResources(this.OffsetTypeVariableRadioButton, "OffsetTypeVariableRadioButton");
+            this.OffsetTypeVariableRadioButton.Name = "OffsetTypeVariableRadioButton";
+            this.OffsetTypeVariableRadioButton.TabStop = true;
+            this.OffsetTypeVariableRadioButton.UseVisualStyleBackColor = true;
+            this.OffsetTypeVariableRadioButton.CheckedChanged += new System.EventHandler(this.OffsetTypeFsuipRadioButton_CheckedChanged);
             // 
             // compareTabPage
             // 
@@ -298,7 +308,7 @@
             // 
             resources.ApplyResources(this.testValuePanel1, "testValuePanel1");
             this.testValuePanel1.Name = "testValuePanel1";
-            this.testValuePanel1.Result = "\'\'\'\'\'\'\'\'\'\'";
+            this.testValuePanel1.Result = "\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'\'";
             // 
             // ConfigWizard
             // 
@@ -320,7 +330,9 @@
             this.fsuipcTabPage.PerformLayout();
             this.FsuipcSettingsPanel.ResumeLayout(false);
             this.OffsetTypePanel.ResumeLayout(false);
-            this.OffsetTypePanel.PerformLayout();
+            this.groupBox1.ResumeLayout(false);
+            this.flowLayoutPanel1.ResumeLayout(false);
+            this.flowLayoutPanel1.PerformLayout();
             this.compareTabPage.ResumeLayout(false);
             this.referencesGroupBox.ResumeLayout(false);
             this.displayTabPage.ResumeLayout(false);
@@ -358,7 +370,6 @@
         private Panels.Config.SimConnectPanel simConnectPanel1;
         private System.Windows.Forms.RadioButton OffsetTypeVariableRadioButton;
         private Panels.Config.VariablePanel variablePanel1;
-        private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Label fsuipcHintLabel;
         private Panels.Config.PreconditionPanel preconditionPanel;
         private Panels.OutputWizard.DisplayPanel displayPanel1;
@@ -368,5 +379,7 @@
         private Panels.Config.TestValuePanel testValuePanel1;
         private System.Windows.Forms.RadioButton OffsetTypeProSimRadioButton;
         private Panels.Config.ProSimDataRefPanel proSimDatarefPanel1;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.GroupBox groupBox1;
     }
 }

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -146,7 +146,7 @@ namespace MobiFlight.UI.Dialogs
             xplaneDataRefPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
 
             // PROSIM DATAREF PANEL
-            OffsetTypeProSimRadioButton.Visible = (sim == "msfs");
+            OffsetTypeProSimRadioButton.Visible = (sim == "prosim");
             proSimDatarefPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
             proSimDatarefPanel1.Init(_execManager);
         }

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -124,7 +124,8 @@ namespace MobiFlight.UI.Dialogs
         private void ShowSourceOptionsBasedOnProjectInfo(ProjectInfo projectInfo)
         {
             var sim = projectInfo.Sim.Trim().ToLower();
-            var useFsuipc = (projectInfo?.UseFsuipc ?? false) || sim == "p3d" || sim == "fsx";
+            var useFsuipc = (projectInfo?.Features?.FSUIPC ?? false) || sim == "p3d" || sim == "fsx";
+            var useProSim = (projectInfo?.Features?.ProSim ?? false);
 
             // VARIABLE PANEL
             variablePanel1.SetVariableReferences(_execManager.GetAvailableVariables());
@@ -147,7 +148,7 @@ namespace MobiFlight.UI.Dialogs
             xplaneDataRefPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
 
             // PROSIM DATAREF PANEL
-            OffsetTypeProSimRadioButton.Visible = (sim == "prosim");
+            OffsetTypeProSimRadioButton.Visible = useProSim;
             proSimDatarefPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
             proSimDatarefPanel1.Init(_execManager);
         }

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -28,6 +28,7 @@ namespace MobiFlight.UI.Dialogs
         Dictionary<String, String> arcazeFirmware = new Dictionary<String, String>();
         Dictionary<string, ArcazeModuleSettings> moduleSettings;
 #endif
+        ProjectInfo ProjectInfo { get; set; }
 
         public ConfigWizard(ExecutionManager executionManager,
                              OutputConfigItem cfg,
@@ -36,10 +37,11 @@ namespace MobiFlight.UI.Dialogs
                              Dictionary<string, ArcazeModuleSettings> moduleSettings,
 #endif
                              List<OutputConfigItem> outputConfigs,
-                             Dictionary<string, MobiFlightVariable> scopedVariables
+                             Dictionary<string, MobiFlightVariable> scopedVariables,
+                             ProjectInfo projectInfo
             )
         {
-            Init(executionManager, cfg);
+            Init(executionManager, cfg, projectInfo);
 #if ARCAZE
             this.moduleSettings = moduleSettings;
             initWithArcazeCache(arcazeCache);
@@ -75,9 +77,11 @@ namespace MobiFlight.UI.Dialogs
             return !originalConfig.Equals(config);
         }
 
-        protected void Init(ExecutionManager executionManager, OutputConfigItem cfg)
+        protected void Init(ExecutionManager executionManager, OutputConfigItem cfg, ProjectInfo projectInfo)
         {
             this._execManager = executionManager;
+            ProjectInfo = projectInfo;
+
             // create a clone so that we don't edit 
             // the original item
             config = cfg.Clone() as OutputConfigItem;
@@ -89,6 +93,7 @@ namespace MobiFlight.UI.Dialogs
             InitializeComponent();
 
             ActivateCorrectTab(config);
+            ShowSourceOptionsBasedOnProjectInfo(ProjectInfo);
 
             // DISPLAY PANEL
             displayPanel1.Init(_execManager);
@@ -105,23 +110,7 @@ namespace MobiFlight.UI.Dialogs
                 tabControlFsuipc.SelectedTab = preconditionTabPage;
             };
 
-            variablePanel1.SetVariableReferences(_execManager.GetAvailableVariables());
-
-            // FSUIPC PANEL
-            fsuipcConfigPanel.setMode(true);
-            // fsuipcConfigPanel.syncFromConfig(cfg);
-
-            // SIMCONNECT SIMVARS PANEL
-            simConnectPanel1.HubHopPresetPanel.OnGetLVarListRequested += SimConnectPanel1_OnGetLVarListRequested;
-            _execManager.GetSimConnectCache().LVarListUpdated += ConfigWizard_LVarListUpdated;
-
-            fsuipcConfigPanel.ModifyTabLink += ConfigPanel_ModifyTabLink;
-            fsuipcConfigPanel.PresetChanged += FsuipcConfigPanel_PresetChanged;
-            simConnectPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
-            xplaneDataRefPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
-            variablePanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
-            proSimDatarefPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
-            proSimDatarefPanel1.Init(_execManager);
+            
 
             testValuePanel1.FromConfig(config);
             testValuePanel1.TestModeStart += TestValuePanel_TestModeStart;
@@ -130,6 +119,36 @@ namespace MobiFlight.UI.Dialogs
             TestTimer.Interval = Properties.Settings.Default.TestTimerInterval;
             TestTimer.Tick += TestTimer_Tick;
             modifierPanel1.ModifierChanged += ModifierPanel1_ModifierChanged;
+        }
+
+        private void ShowSourceOptionsBasedOnProjectInfo(ProjectInfo projectInfo)
+        {
+            var sim = projectInfo.Sim.Trim().ToLower();
+
+            // VARIABLE PANEL
+            variablePanel1.SetVariableReferences(_execManager.GetAvailableVariables());
+            variablePanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
+
+            // FSUIPC PANEL
+            OffsetTypeFsuipRadioButton.Visible = projectInfo.UseFsuipc;
+            fsuipcConfigPanel.setMode(true);
+            fsuipcConfigPanel.ModifyTabLink += ConfigPanel_ModifyTabLink;
+            fsuipcConfigPanel.PresetChanged += FsuipcConfigPanel_PresetChanged;
+
+            // SIMCONNECT SIMVARS PANEL
+            OffsetTypeSimConnectRadioButton.Visible = (sim == "msfs");
+            simConnectPanel1.HubHopPresetPanel.OnGetLVarListRequested += SimConnectPanel1_OnGetLVarListRequested;
+            _execManager.GetSimConnectCache().LVarListUpdated += ConfigWizard_LVarListUpdated;
+            simConnectPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
+
+            // X-PLANE DATAREF PANEL
+            OffsetTypeXplaneRadioButton.Visible = (sim == "xplane");
+            xplaneDataRefPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
+
+            // PROSIM DATAREF PANEL
+            OffsetTypeProSimRadioButton.Visible = (sim == "msfs");
+            proSimDatarefPanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
+            proSimDatarefPanel1.Init(_execManager);
         }
 
         private void ModifierPanel1_ModifierChanged(object sender, EventArgs e)

--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -110,7 +110,7 @@ namespace MobiFlight.UI.Dialogs
                 tabControlFsuipc.SelectedTab = preconditionTabPage;
             };
 
-            
+
 
             testValuePanel1.FromConfig(config);
             testValuePanel1.TestModeStart += TestValuePanel_TestModeStart;
@@ -124,13 +124,14 @@ namespace MobiFlight.UI.Dialogs
         private void ShowSourceOptionsBasedOnProjectInfo(ProjectInfo projectInfo)
         {
             var sim = projectInfo.Sim.Trim().ToLower();
+            var useFsuipc = (projectInfo?.UseFsuipc ?? false) || sim == "p3d" || sim == "fsx";
 
             // VARIABLE PANEL
             variablePanel1.SetVariableReferences(_execManager.GetAvailableVariables());
             variablePanel1.ModifyTabLink += ConfigPanel_ModifyTabLink;
 
             // FSUIPC PANEL
-            OffsetTypeFsuipRadioButton.Visible = projectInfo.UseFsuipc;
+            OffsetTypeFsuipRadioButton.Visible = useFsuipc;
             fsuipcConfigPanel.setMode(true);
             fsuipcConfigPanel.ModifyTabLink += ConfigPanel_ModifyTabLink;
             fsuipcConfigPanel.PresetChanged += FsuipcConfigPanel_PresetChanged;

--- a/UI/Dialogs/ConfigWizard.resx
+++ b/UI/Dialogs/ConfigWizard.resx
@@ -123,19 +123,22 @@
   </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="proSimDatarefPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 803</value>
+    <value>9, 1261</value>
+  </data>
+  <data name="proSimDatarefPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="proSimDatarefPanel1.MaximumSize" type="System.Drawing.Size, System.Drawing">
-    <value>1000, 1000</value>
+    <value>1500, 1538</value>
   </data>
   <data name="proSimDatarefPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>620, 400</value>
+    <value>930, 615</value>
   </data>
   <data name="proSimDatarefPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="proSimDatarefPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 400</value>
+    <value>1028, 615</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="proSimDatarefPanel1.TabIndex" type="System.Int32, mscorlib">
@@ -145,7 +148,7 @@
     <value>proSimDatarefPanel1</value>
   </data>
   <data name="&gt;&gt;proSimDatarefPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.ProSimDataRefPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.ProSimDataRefPanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;proSimDatarefPanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -160,13 +163,13 @@
     <value>Top</value>
   </data>
   <data name="xplaneDataRefPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 617</value>
+    <value>9, 975</value>
   </data>
   <data name="xplaneDataRefPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="xplaneDataRefPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 186</value>
+    <value>1028, 286</value>
   </data>
   <data name="xplaneDataRefPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>18</value>
@@ -175,7 +178,7 @@
     <value>xplaneDataRefPanel1</value>
   </data>
   <data name="&gt;&gt;xplaneDataRefPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.XplaneDataRefPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.XplaneDataRefPanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;xplaneDataRefPanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -190,13 +193,13 @@
     <value>Top</value>
   </data>
   <data name="variablePanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 522</value>
+    <value>9, 829</value>
   </data>
   <data name="variablePanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="variablePanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 95</value>
+    <value>1028, 146</value>
   </data>
   <data name="variablePanel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -205,7 +208,7 @@
     <value>variablePanel1</value>
   </data>
   <data name="&gt;&gt;variablePanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.VariablePanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.VariablePanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;variablePanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -220,13 +223,13 @@
     <value>Top</value>
   </data>
   <data name="simConnectPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 291</value>
+    <value>9, 474</value>
   </data>
   <data name="simConnectPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="simConnectPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 231</value>
+    <value>1028, 355</value>
   </data>
   <data name="simConnectPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -235,7 +238,7 @@
     <value>simConnectPanel1</value>
   </data>
   <data name="&gt;&gt;simConnectPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.SimConnectPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.SimConnectPanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;simConnectPanel1.Parent" xml:space="preserve">
     <value>fsuipcTabPage</value>
@@ -250,16 +253,16 @@
     <value>Top</value>
   </data>
   <data name="fsuipcConfigPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 23</value>
+    <value>0, 35</value>
   </data>
   <data name="fsuipcConfigPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="fsuipcConfigPanel.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>550, 0</value>
+    <value>825, 0</value>
   </data>
   <data name="fsuipcConfigPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 237</value>
+    <value>1028, 365</value>
   </data>
   <data name="fsuipcConfigPanel.TabIndex" type="System.Int32, mscorlib">
     <value>15</value>
@@ -268,7 +271,7 @@
     <value>fsuipcConfigPanel</value>
   </data>
   <data name="&gt;&gt;fsuipcConfigPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.FsuipcConfigPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.FsuipcConfigPanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;fsuipcConfigPanel.Parent" xml:space="preserve">
     <value>FsuipcSettingsPanel</value>
@@ -285,8 +288,11 @@
   <data name="fsuipcHintLabel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="fsuipcHintLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
   <data name="fsuipcHintLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 23</value>
+    <value>1028, 35</value>
   </data>
   <data name="fsuipcHintLabel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -313,10 +319,13 @@
     <value>Top</value>
   </data>
   <data name="FsuipcSettingsPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 39</value>
+    <value>9, 86</value>
+  </data>
+  <data name="FsuipcSettingsPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="FsuipcSettingsPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 252</value>
+    <value>1028, 388</value>
   </data>
   <data name="FsuipcSettingsPanel.TabIndex" type="System.Int32, mscorlib">
     <value>17</value>
@@ -333,50 +342,164 @@
   <data name="&gt;&gt;FsuipcSettingsPanel.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="label1.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+  <data name="OffsetTypeSimConnectRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="OffsetTypeSimConnectRadioButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="OffsetTypeSimConnectRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
-  <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 5</value>
+  <data name="OffsetTypeSimConnectRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>114, 5</value>
   </data>
-  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>2, 0, 2, 0</value>
+  <data name="OffsetTypeSimConnectRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
-  <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>111, 17</value>
+  <data name="OffsetTypeSimConnectRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>213, 24</value>
   </data>
-  <data name="label1.TabIndex" type="System.Int32, mscorlib">
-    <value>14</value>
+  <data name="OffsetTypeSimConnectRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>1</value>
   </data>
-  <data name="label1.Text" xml:space="preserve">
-    <value>Select Variable Type</value>
+  <data name="OffsetTypeSimConnectRadioButton.Text" xml:space="preserve">
+    <value>Microsoft Flight Simulator</value>
   </data>
-  <data name="label1.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
-    <value>MiddleRight</value>
+  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Name" xml:space="preserve">
+    <value>OffsetTypeSimConnectRadioButton</value>
   </data>
-  <data name="&gt;&gt;label1.Name" xml:space="preserve">
-    <value>label1</value>
+  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
-  <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
   </data>
-  <data name="&gt;&gt;label1.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;label1.ZOrder" xml:space="preserve">
+  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="OffsetTypeFsuipRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="OffsetTypeFsuipRadioButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="OffsetTypeFsuipRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="OffsetTypeFsuipRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>335, 5</value>
+  </data>
+  <data name="OffsetTypeFsuipRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="OffsetTypeFsuipRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>93, 24</value>
+  </data>
+  <data name="OffsetTypeFsuipRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="OffsetTypeFsuipRadioButton.Text" xml:space="preserve">
+    <value>FSUIPC</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Name" xml:space="preserve">
+    <value>OffsetTypeFsuipRadioButton</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="OffsetTypeXplaneRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="OffsetTypeXplaneRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="OffsetTypeXplaneRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>436, 5</value>
+  </data>
+  <data name="OffsetTypeXplaneRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="OffsetTypeXplaneRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>90, 24</value>
+  </data>
+  <data name="OffsetTypeXplaneRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>15</value>
+  </data>
+  <data name="OffsetTypeXplaneRadioButton.Text" xml:space="preserve">
+    <value>X-Plane</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Name" xml:space="preserve">
+    <value>OffsetTypeXplaneRadioButton</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="OffsetTypeProSimRadioButton.AutoSize" type="System.Boolean, mscorlib">
+    <value>True</value>
+  </data>
+  <data name="OffsetTypeProSimRadioButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
+  </data>
+  <data name="OffsetTypeProSimRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="OffsetTypeProSimRadioButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>534, 5</value>
+  </data>
+  <data name="OffsetTypeProSimRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="OffsetTypeProSimRadioButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>85, 24</value>
+  </data>
+  <data name="OffsetTypeProSimRadioButton.TabIndex" type="System.Int32, mscorlib">
+    <value>16</value>
+  </data>
+  <data name="OffsetTypeProSimRadioButton.Text" xml:space="preserve">
+    <value>ProSim</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeProSimRadioButton.Name" xml:space="preserve">
+    <value>OffsetTypeProSimRadioButton</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeProSimRadioButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeProSimRadioButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;OffsetTypeProSimRadioButton.ZOrder" xml:space="preserve">
+    <value>3</value>
   </data>
   <data name="OffsetTypeVariableRadioButton.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
+  </data>
+  <data name="OffsetTypeVariableRadioButton.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="OffsetTypeVariableRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
     <value>NoControl</value>
   </data>
   <data name="OffsetTypeVariableRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>242, 5</value>
+    <value>627, 5</value>
+  </data>
+  <data name="OffsetTypeVariableRadioButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="OffsetTypeVariableRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>114, 17</value>
+    <value>169, 24</value>
   </data>
   <data name="OffsetTypeVariableRadioButton.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -391,136 +514,91 @@
     <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;OffsetTypeVariableRadioButton.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
+    <value>flowLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;OffsetTypeVariableRadioButton.ZOrder" xml:space="preserve">
-    <value>1</value>
-  </data>
-  <data name="OffsetTypeSimConnectRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="OffsetTypeSimConnectRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="OffsetTypeSimConnectRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>119, 5</value>
-  </data>
-  <data name="OffsetTypeSimConnectRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>120, 17</value>
-  </data>
-  <data name="OffsetTypeSimConnectRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>1</value>
-  </data>
-  <data name="OffsetTypeSimConnectRadioButton.Text" xml:space="preserve">
-    <value>SimConnect (MSFS)</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Name" xml:space="preserve">
-    <value>OffsetTypeSimConnectRadioButton</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeSimConnectRadioButton.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
-  <data name="OffsetTypeFsuipRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="OffsetTypeFsuipRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="OffsetTypeFsuipRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>362, 5</value>
-  </data>
-  <data name="OffsetTypeFsuipRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>94, 17</value>
-  </data>
-  <data name="OffsetTypeFsuipRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>0</value>
-  </data>
-  <data name="OffsetTypeFsuipRadioButton.Text" xml:space="preserve">
-    <value>FSUIPC Offset</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Name" xml:space="preserve">
-    <value>OffsetTypeFsuipRadioButton</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeFsuipRadioButton.ZOrder" xml:space="preserve">
-    <value>3</value>
-  </data>
-  <data name="OffsetTypeXplaneRadioButton.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
-  </data>
-  <data name="OffsetTypeXplaneRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
-  </data>
-  <data name="OffsetTypeXplaneRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>468, 5</value>
-  </data>
-  <data name="OffsetTypeXplaneRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>105, 17</value>
-  </data>
-  <data name="OffsetTypeXplaneRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>15</value>
-  </data>
-  <data name="OffsetTypeXplaneRadioButton.Text" xml:space="preserve">
-    <value>X-Plane DataRef</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Name" xml:space="preserve">
-    <value>OffsetTypeXplaneRadioButton</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.Parent" xml:space="preserve">
-    <value>OffsetTypePanel</value>
-  </data>
-  <data name="&gt;&gt;OffsetTypeXplaneRadioButton.ZOrder" xml:space="preserve">
     <value>4</value>
   </data>
-  <data name="OffsetTypeProSimRadioButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
-    <value>NoControl</value>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
   </data>
-  <data name="OffsetTypeProSimRadioButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>579, 5</value>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 24</value>
   </data>
-  <data name="OffsetTypeProSimRadioButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>104, 17</value>
+  <data name="flowLayoutPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
-  <data name="OffsetTypeProSimRadioButton.TabIndex" type="System.Int32, mscorlib">
-    <value>16</value>
+  <data name="flowLayoutPanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>110, 0, 0, 0</value>
   </data>
-  <data name="OffsetTypeProSimRadioButton.Text" xml:space="preserve">
-    <value>ProSim DataRef</value>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1020, 40</value>
   </data>
-  <data name="&gt;&gt;OffsetTypeProSimRadioButton.Name" xml:space="preserve">
-    <value>OffsetTypeProSimRadioButton</value>
+  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
   </data>
-  <data name="&gt;&gt;OffsetTypeProSimRadioButton.Type" xml:space="preserve">
-    <value>System.Windows.Forms.RadioButton, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  <data name="flowLayoutPanel1.WrapContents" type="System.Boolean, mscorlib">
+    <value>False</value>
   </data>
-  <data name="&gt;&gt;OffsetTypeProSimRadioButton.Parent" xml:space="preserve">
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="groupBox1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="groupBox1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 8</value>
+  </data>
+  <data name="groupBox1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="groupBox1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="groupBox1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>1028, 69</value>
+  </data>
+  <data name="groupBox1.TabIndex" type="System.Int32, mscorlib">
+    <value>17</value>
+  </data>
+  <data name="groupBox1.Text" xml:space="preserve">
+    <value>Select source</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Name" xml:space="preserve">
+    <value>groupBox1</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.GroupBox, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;groupBox1.Parent" xml:space="preserve">
     <value>OffsetTypePanel</value>
   </data>
-  <data name="&gt;&gt;OffsetTypeProSimRadioButton.ZOrder" xml:space="preserve">
-    <value>5</value>
+  <data name="&gt;&gt;groupBox1.ZOrder" xml:space="preserve">
+    <value>0</value>
   </data>
   <data name="OffsetTypePanel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="OffsetTypePanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>9, 9</value>
+  </data>
+  <data name="OffsetTypePanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
+  <data name="OffsetTypePanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>0, 8, 0, 0</value>
   </data>
   <data name="OffsetTypePanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 33</value>
+    <value>1028, 77</value>
   </data>
   <data name="OffsetTypePanel.TabIndex" type="System.Int32, mscorlib">
     <value>16</value>
@@ -538,13 +616,16 @@
     <value>5</value>
   </data>
   <data name="fsuipcTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="fsuipcTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="fsuipcTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>9, 9, 9, 9</value>
   </data>
   <data name="fsuipcTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>695, 601</value>
+    <value>1046, 932</value>
   </data>
   <data name="fsuipcTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -568,16 +649,16 @@
     <value>Fill</value>
   </data>
   <data name="modifierPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 217</value>
+    <value>9, 334</value>
   </data>
   <data name="modifierPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>1, 1, 1, 1</value>
+    <value>2, 2, 2, 2</value>
   </data>
   <data name="modifierPanel1.MinimumSize" type="System.Drawing.Size, System.Drawing">
-    <value>650, 0</value>
+    <value>975, 0</value>
   </data>
   <data name="modifierPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 378</value>
+    <value>1028, 589</value>
   </data>
   <data name="modifierPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -586,7 +667,7 @@
     <value>modifierPanel1</value>
   </data>
   <data name="&gt;&gt;modifierPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.OutputWizard.ModifierPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.OutputWizard.ModifierPanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;modifierPanel1.Parent" xml:space="preserve">
     <value>compareTabPage</value>
@@ -598,16 +679,16 @@
     <value>Fill</value>
   </data>
   <data name="configRefPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 16</value>
+    <value>0, 24</value>
   </data>
   <data name="configRefPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="configRefPanel.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>5, 0, 5, 0</value>
+    <value>8, 0, 8, 0</value>
   </data>
   <data name="configRefPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 192</value>
+    <value>1028, 296</value>
   </data>
   <data name="configRefPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -616,7 +697,7 @@
     <value>configRefPanel</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.ConfigRefPanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;configRefPanel.Parent" xml:space="preserve">
     <value>referencesGroupBox</value>
@@ -628,13 +709,16 @@
     <value>Top</value>
   </data>
   <data name="referencesGroupBox.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>9, 9</value>
+  </data>
+  <data name="referencesGroupBox.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="referencesGroupBox.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>0, 3, 0, 3</value>
+    <value>0, 5, 0, 5</value>
   </data>
   <data name="referencesGroupBox.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 211</value>
+    <value>1028, 325</value>
   </data>
   <data name="referencesGroupBox.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -655,13 +739,16 @@
     <value>1</value>
   </data>
   <data name="compareTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="compareTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="compareTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>9, 9, 9, 9</value>
   </data>
   <data name="compareTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>695, 601</value>
+    <value>1046, 932</value>
   </data>
   <data name="compareTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -685,13 +772,13 @@
     <value>Fill</value>
   </data>
   <data name="displayPanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>9, 9</value>
   </data>
   <data name="displayPanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="displayPanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 589</value>
+    <value>1028, 914</value>
   </data>
   <data name="displayPanel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -700,7 +787,7 @@
     <value>displayPanel1</value>
   </data>
   <data name="&gt;&gt;displayPanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.OutputWizard.DisplayPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.OutputWizard.DisplayPanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;displayPanel1.Parent" xml:space="preserve">
     <value>displayTabPage</value>
@@ -709,13 +796,16 @@
     <value>0</value>
   </data>
   <data name="displayTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="displayTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="displayTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>9, 9, 9, 9</value>
   </data>
   <data name="displayTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>695, 601</value>
+    <value>1046, 932</value>
   </data>
   <data name="displayTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -739,13 +829,13 @@
     <value>Fill</value>
   </data>
   <data name="preconditionPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>6, 6</value>
+    <value>9, 9</value>
   </data>
   <data name="preconditionPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>4, 5, 4, 5</value>
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="preconditionPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>683, 589</value>
+    <value>1028, 914</value>
   </data>
   <data name="preconditionPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -754,7 +844,7 @@
     <value>preconditionPanel</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.PreconditionPanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;preconditionPanel.Parent" xml:space="preserve">
     <value>preconditionTabPage</value>
@@ -763,13 +853,16 @@
     <value>0</value>
   </data>
   <data name="preconditionTabPage.Location" type="System.Drawing.Point, System.Drawing">
-    <value>4, 22</value>
+    <value>4, 29</value>
+  </data>
+  <data name="preconditionTabPage.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="preconditionTabPage.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>6, 6, 6, 6</value>
+    <value>9, 9, 9, 9</value>
   </data>
   <data name="preconditionTabPage.Size" type="System.Drawing.Size, System.Drawing">
-    <value>695, 601</value>
+    <value>1046, 932</value>
   </data>
   <data name="preconditionTabPage.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -795,8 +888,11 @@
   <data name="tabControlFsuipc.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="tabControlFsuipc.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
   <data name="tabControlFsuipc.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 627</value>
+    <value>1054, 965</value>
   </data>
   <data name="tabControlFsuipc.TabIndex" type="System.Int32, mscorlib">
     <value>13</value>
@@ -819,8 +915,11 @@
   <data name="MainPanel.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <data name="MainPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
+  </data>
   <data name="MainPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 627</value>
+    <value>1054, 965</value>
   </data>
   <data name="MainPanel.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -844,10 +943,13 @@
     <value>NoControl</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>553, 0</value>
+    <value>830, 0</value>
+  </data>
+  <data name="button1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 28</value>
+    <value>112, 43</value>
   </data>
   <data name="button1.TabIndex" type="System.Int32, mscorlib">
     <value>30</value>
@@ -874,10 +976,13 @@
     <value>NoControl</value>
   </data>
   <data name="cancelButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>628, 0</value>
+    <value>942, 0</value>
+  </data>
+  <data name="cancelButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="cancelButton.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 28</value>
+    <value>112, 43</value>
   </data>
   <data name="cancelButton.TabIndex" type="System.Int32, mscorlib">
     <value>31</value>
@@ -901,10 +1006,13 @@
     <value>Bottom</value>
   </data>
   <data name="ButtonPanel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 683</value>
+    <value>0, 1051</value>
+  </data>
+  <data name="ButtonPanel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="ButtonPanel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 28</value>
+    <value>1054, 43</value>
   </data>
   <data name="ButtonPanel.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -928,13 +1036,16 @@
     <value>Bottom</value>
   </data>
   <data name="testValuePanel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 627</value>
+    <value>0, 965</value>
+  </data>
+  <data name="testValuePanel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>6, 8, 6, 8</value>
   </data>
   <data name="testValuePanel1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 3, 3</value>
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="testValuePanel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>703, 56</value>
+    <value>1054, 86</value>
   </data>
   <data name="testValuePanel1.TabIndex" type="System.Int32, mscorlib">
     <value>32</value>
@@ -943,7 +1054,7 @@
     <value>testValuePanel1</value>
   </data>
   <data name="&gt;&gt;testValuePanel1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.Config.TestValuePanel, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.Config.TestValuePanel, MFConnector, Version=0.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;testValuePanel1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -958,10 +1069,10 @@
     <value>25</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>9, 20</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>703, 711</value>
+    <value>1054, 1094</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1106,6 +1217,9 @@
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
 </value>
+  </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 5, 4, 5</value>
   </data>
   <data name="$this.StartPosition" type="System.Windows.Forms.FormStartPosition, System.Windows.Forms">
     <value>CenterParent</value>

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -565,7 +565,8 @@ namespace MobiFlight.UI.Dialogs
                         panel = new Panels.Input.ButtonPanel()
                         {
                             Enabled = (serial != ""),
-                            ProjectInfo = this.ProjectInfo
+                            ProjectInfo = this.ProjectInfo,
+                            CurrentConfig = Config
                         };
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.button);
                         break;
@@ -574,7 +575,8 @@ namespace MobiFlight.UI.Dialogs
                         panel = new Panels.Input.EncoderPanel()
                         {
                             Enabled = (serial != ""),
-                            ProjectInfo = this.ProjectInfo
+                            ProjectInfo = this.ProjectInfo,
+                            CurrentConfig = Config,
                         };
                         (panel as Panels.Input.EncoderPanel).syncFromConfig(config.encoder);
                         break;
@@ -584,7 +586,8 @@ namespace MobiFlight.UI.Dialogs
                         panel = new Panels.Input.ButtonPanel()
                         {
                             Enabled = (serial != ""),
-                            ProjectInfo = this.ProjectInfo
+                            ProjectInfo = this.ProjectInfo,
+                            CurrentConfig = Config
                         };
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.inputShiftRegister);
                         PopulateInputPinDropdown(Convert.ToInt32(selectedInputShifter.NumModules), config.inputShiftRegister?.ExtPin);
@@ -596,7 +599,8 @@ namespace MobiFlight.UI.Dialogs
                         panel = new Panels.Input.ButtonPanel()
                         {
                             Enabled = (serial != ""),
-                            ProjectInfo = this.ProjectInfo
+                            ProjectInfo = this.ProjectInfo,
+                            CurrentConfig = Config
                         };
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.inputMultiplexer);
                         PopulateInputPinDropdown(Convert.ToInt32(selectedInputMultiplexer.NumBytes), config.inputMultiplexer?.DataPin);
@@ -607,7 +611,8 @@ namespace MobiFlight.UI.Dialogs
                         panel = new Panels.Input.AnalogPanel()
                         {
                             Enabled = (serial != ""),
-                            ProjectInfo = this.ProjectInfo
+                            ProjectInfo = this.ProjectInfo,
+                            CurrentConfig = Config
                         };
                         (panel as Panels.Input.AnalogPanel).syncFromConfig(config.analog);
                         break;

--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -49,6 +49,7 @@ namespace MobiFlight.UI.Dialogs
 
         bool IsShown = false;
         public PreconditionPanel PreconditionPanel { get { return preconditionPanel; } }
+        ProjectInfo ProjectInfo { get; set; }
 
         public InputConfigWizard(IExecutionManager executionManager,
                              InputConfigItem cfg,
@@ -57,7 +58,8 @@ namespace MobiFlight.UI.Dialogs
                              Dictionary<string, ArcazeModuleSettings> moduleSettings,
 #endif
                              List<OutputConfigItem> outputConfigItems,
-                             Dictionary<string, MobiFlightVariable> scopedVariables)
+                             Dictionary<string, MobiFlightVariable> scopedVariables,
+            ProjectInfo projectInfo)
         {
             Init(executionManager, cfg);
 #if ARCAZE
@@ -89,6 +91,8 @@ namespace MobiFlight.UI.Dialogs
             {
                 this.Text = $"{this.Text} - {cfg.Name}";
             }
+
+            ProjectInfo = projectInfo;
         }
 
         private void initConfigRefDropDowns(List<OutputConfigItem> dataSetConfig, string filterGuid)
@@ -560,7 +564,8 @@ namespace MobiFlight.UI.Dialogs
                     case DeviceType.Button:
                         panel = new Panels.Input.ButtonPanel()
                         {
-                            Enabled = (serial != "")
+                            Enabled = (serial != ""),
+                            ProjectInfo = this.ProjectInfo
                         };
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.button);
                         break;
@@ -568,7 +573,8 @@ namespace MobiFlight.UI.Dialogs
                     case DeviceType.Encoder:
                         panel = new Panels.Input.EncoderPanel()
                         {
-                            Enabled = (serial != "")
+                            Enabled = (serial != ""),
+                            ProjectInfo = this.ProjectInfo
                         };
                         (panel as Panels.Input.EncoderPanel).syncFromConfig(config.encoder);
                         break;
@@ -577,7 +583,8 @@ namespace MobiFlight.UI.Dialogs
                         Config.InputShiftRegister selectedInputShifter = (inputTypeComboBox.SelectedItem as ListItem<Config.IBaseDevice>).Value as Config.InputShiftRegister;
                         panel = new Panels.Input.ButtonPanel()
                         {
-                            Enabled = (serial != "")
+                            Enabled = (serial != ""),
+                            ProjectInfo = this.ProjectInfo
                         };
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.inputShiftRegister);
                         PopulateInputPinDropdown(Convert.ToInt32(selectedInputShifter.NumModules), config.inputShiftRegister?.ExtPin);
@@ -588,7 +595,8 @@ namespace MobiFlight.UI.Dialogs
                         Config.InputMultiplexer selectedInputMultiplexer = (inputTypeComboBox.SelectedItem as ListItem<Config.IBaseDevice>).Value as Config.InputMultiplexer;
                         panel = new Panels.Input.ButtonPanel()
                         {
-                            Enabled = (serial != "")
+                            Enabled = (serial != ""),
+                            ProjectInfo = this.ProjectInfo
                         };
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.inputMultiplexer);
                         PopulateInputPinDropdown(Convert.ToInt32(selectedInputMultiplexer.NumBytes), config.inputMultiplexer?.DataPin);
@@ -598,7 +606,8 @@ namespace MobiFlight.UI.Dialogs
                     case DeviceType.AnalogInput:
                         panel = new Panels.Input.AnalogPanel()
                         {
-                            Enabled = (serial != "")
+                            Enabled = (serial != ""),
+                            ProjectInfo = this.ProjectInfo
                         };
                         (panel as Panels.Input.AnalogPanel).syncFromConfig(config.analog);
                         break;

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2997,7 +2997,7 @@ namespace MobiFlight.UI
         {
             execManager.Project.Name = project.Name;
             execManager.Project.Sim = project.Sim;
-            execManager.Project.UseFsuipc = project.UseFsuipc;
+            execManager.Project.Features = project.Features;
             execManager.Project.Aircraft = project.Aircraft;
             saveToolStripButton_Click(null, null);
         }

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -292,7 +292,8 @@ namespace MobiFlight.UI
                                             execManager.getModuleCache().GetArcazeModuleSettings(),
 #endif
                                             execManager.ConfigItems.Where(item => item is OutputConfigItem).Cast<OutputConfigItem>().ToList(),
-                                            execManager.GetAvailableVariables()
+                                            execManager.GetAvailableVariables(),
+                                            execManager.Project.ToProjectInfo()
                                           )
             {
                 StartPosition = FormStartPosition.CenterParent

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -347,7 +347,8 @@ namespace MobiFlight.UI
                                 execManager.getModuleCache().GetArcazeModuleSettings(),
 #endif
                                 execManager.ConfigItems.Where(item => item is OutputConfigItem).Cast<OutputConfigItem>().ToList(),
-                                execManager.GetAvailableVariables()
+                                execManager.GetAvailableVariables(),
+                                execManager.Project.ToProjectInfo()
                                 )
             {
                 StartPosition = FormStartPosition.CenterParent

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2235,7 +2235,6 @@ namespace MobiFlight.UI
             // errors during save and show it in a dialog instead of crashing.
             try
             {
-                execManager.Project.DetermineProjectInfos();
                 execManager.Project.SaveFile();
             }
             catch (Exception ex)
@@ -2999,7 +2998,7 @@ namespace MobiFlight.UI
             execManager.Project.Sim = project.Sim;
             execManager.Project.Features = project.Features;
             execManager.Project.Aircraft = project.Aircraft;
-            saveToolStripButton_Click(null, null);
+            MessageExchange.Instance.Publish(execManager.Project);
         }
 
         internal void RecentFilesRemove(int index)

--- a/UI/Panels/Config/ActionTypePanel.cs
+++ b/UI/Panels/Config/ActionTypePanel.cs
@@ -74,11 +74,11 @@ namespace MobiFlight.UI.Panels.Config
                 ActionTypeComboBox.Items.Add(InputConfig.LuaMacroInputAction.Label);
             }
 
-            if (showAllOptions || sim == "msfs")
+            if (showAllOptions || sim == "prosim")
             {
                 ActionTypeComboBox.Items.Add(InputConfig.ProSimInputAction.Label);
             }
-
+             
             ActionTypeComboBox.SelectedIndex = 0;
             ActionTypeComboBox.SelectedIndexChanged += new EventHandler(ActionTypeComboBox_SelectedIndexChanged);
         }

--- a/UI/Panels/Config/ActionTypePanel.cs
+++ b/UI/Panels/Config/ActionTypePanel.cs
@@ -64,7 +64,7 @@ namespace MobiFlight.UI.Panels.Config
             ActionTypeComboBox.Items.Add(InputConfig.KeyInputAction.Label);
             ActionTypeComboBox.Items.Add(InputConfig.VJoyInputAction.Label);
 
-            if (showAllOptions || (projectInfo?.UseFsuipc ?? false) || sim == "fsx" || sim == "p3d")
+            if (showAllOptions || (projectInfo?.Features?.FSUIPC ?? false) || sim == "fsx" || sim == "p3d")
             {
                 // --FSUIPC
                 ActionTypeComboBox.Items.Add(InputConfig.FsuipcOffsetInputAction.Label);
@@ -74,7 +74,7 @@ namespace MobiFlight.UI.Panels.Config
                 ActionTypeComboBox.Items.Add(InputConfig.LuaMacroInputAction.Label);
             }
 
-            if (showAllOptions || sim == "prosim")
+            if (showAllOptions || (projectInfo?.Features?.ProSim ?? false))
             {
                 ActionTypeComboBox.Items.Add(InputConfig.ProSimInputAction.Label);
             }

--- a/UI/Panels/Config/ActionTypePanel.cs
+++ b/UI/Panels/Config/ActionTypePanel.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 using MobiFlight.InputConfig;
+using MobiFlight.Base;
 
 namespace MobiFlight.UI.Panels.Config
 {
@@ -18,16 +19,44 @@ namespace MobiFlight.UI.Panels.Config
         public event EventHandler CopyButtonPressed;
         public event EventHandler PasteButtonPressed;
 
+        private ProjectInfo _projectInfo;
+        public ProjectInfo ProjectInfo
+        {
+            get { return _projectInfo; }
+            set
+            {
+                if (_projectInfo == value) return;
+                _projectInfo = value; 
+                InitActionTypeComboBox(_projectInfo);
+            }
+        }
+
         public ActionTypePanel()
         {
             InitializeComponent();
+            InitActionTypeComboBox();
+        }
+
+        private void InitActionTypeComboBox(ProjectInfo projectInfo = null)
+        {
+
             ActionTypeComboBox.Items.Clear();
             ActionTypeComboBox.Items.Add(i18n._tr("none"));
-            // --MSFS 2020 
-            ActionTypeComboBox.Items.Add(InputConfig.MSFS2020CustomInputAction.Label);
 
-            // -- Xplane
-            ActionTypeComboBox.Items.Add(InputConfig.XplaneInputAction.Label);
+            var sim = projectInfo?.Sim.Trim().ToLower();
+            var showAllOptions = projectInfo == null;
+
+            if (showAllOptions || sim == "msfs")
+            {
+                // --MSFS 2020 
+                ActionTypeComboBox.Items.Add(InputConfig.MSFS2020CustomInputAction.Label);
+            }
+
+            if (showAllOptions || sim == "xplane")
+            {
+                // -- Xplane
+                ActionTypeComboBox.Items.Add(InputConfig.XplaneInputAction.Label);
+            }
 
             // --MobiFlight
             ActionTypeComboBox.Items.Add(InputConfig.VariableInputAction.Label);
@@ -35,14 +64,20 @@ namespace MobiFlight.UI.Panels.Config
             ActionTypeComboBox.Items.Add(InputConfig.KeyInputAction.Label);
             ActionTypeComboBox.Items.Add(InputConfig.VJoyInputAction.Label);
 
-            // --FSUIPC
-            ActionTypeComboBox.Items.Add(InputConfig.FsuipcOffsetInputAction.Label);
-            ActionTypeComboBox.Items.Add(InputConfig.EventIdInputAction.Label);
-            ActionTypeComboBox.Items.Add(InputConfig.PmdgEventIdInputAction.Label);
-            ActionTypeComboBox.Items.Add(InputConfig.JeehellInputAction.Label);
-            ActionTypeComboBox.Items.Add(InputConfig.LuaMacroInputAction.Label);
+            if (showAllOptions || projectInfo.UseFsuipc || sim == "fsx" || sim == "p3d")
+            {
+                // --FSUIPC
+                ActionTypeComboBox.Items.Add(InputConfig.FsuipcOffsetInputAction.Label);
+                ActionTypeComboBox.Items.Add(InputConfig.EventIdInputAction.Label);
+                ActionTypeComboBox.Items.Add(InputConfig.PmdgEventIdInputAction.Label);
+                ActionTypeComboBox.Items.Add(InputConfig.JeehellInputAction.Label);
+                ActionTypeComboBox.Items.Add(InputConfig.LuaMacroInputAction.Label);
+            }
 
-            ActionTypeComboBox.Items.Add(InputConfig.ProSimInputAction.Label);
+            if (showAllOptions || sim == "msfs")
+            {
+                ActionTypeComboBox.Items.Add(InputConfig.ProSimInputAction.Label);
+            }
 
             ActionTypeComboBox.SelectedIndex = 0;
             ActionTypeComboBox.SelectedIndexChanged += new EventHandler(ActionTypeComboBox_SelectedIndexChanged);
@@ -130,7 +165,7 @@ namespace MobiFlight.UI.Panels.Config
 
         public void OnClipBoardChanged(InputAction value)
         {
-            PasteButton.Enabled = value!=null;
+            PasteButton.Enabled = value != null;
         }
     }
 }

--- a/UI/Panels/Config/ActionTypePanel.cs
+++ b/UI/Panels/Config/ActionTypePanel.cs
@@ -64,7 +64,7 @@ namespace MobiFlight.UI.Panels.Config
             ActionTypeComboBox.Items.Add(InputConfig.KeyInputAction.Label);
             ActionTypeComboBox.Items.Add(InputConfig.VJoyInputAction.Label);
 
-            if (showAllOptions || projectInfo.UseFsuipc || sim == "fsx" || sim == "p3d")
+            if (showAllOptions || (projectInfo?.UseFsuipc ?? false) || sim == "fsx" || sim == "p3d")
             {
                 // --FSUIPC
                 ActionTypeComboBox.Items.Add(InputConfig.FsuipcOffsetInputAction.Label);

--- a/UI/Panels/Config/ActionTypePanel.cs
+++ b/UI/Panels/Config/ActionTypePanel.cs
@@ -1,13 +1,9 @@
-﻿using System;
+﻿using MobiFlight.Base;
+using MobiFlight.InputConfig;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
-using System.Data;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using MobiFlight.InputConfig;
-using MobiFlight.Base;
 
 namespace MobiFlight.UI.Panels.Config
 {
@@ -26,9 +22,14 @@ namespace MobiFlight.UI.Panels.Config
             set
             {
                 if (_projectInfo == value) return;
-                _projectInfo = value; 
+                _projectInfo = value;
                 InitActionTypeComboBox(_projectInfo);
             }
+        }
+
+        public InputConfigItem CurrentConfig { 
+            get; 
+            set; 
         }
 
         public ActionTypePanel()
@@ -46,13 +47,21 @@ namespace MobiFlight.UI.Panels.Config
             var sim = projectInfo?.Sim.Trim().ToLower();
             var showAllOptions = projectInfo == null;
 
-            if (showAllOptions || sim == "msfs")
+            var currentConfigUsesFsuipc = ConfigFile.ContainsConfigOfSourceType(new List<IConfigItem>() { CurrentConfig }, new FsuipcSource());
+            var currentConfigUsesMsfs = ConfigFile.ContainsConfigOfSourceType(new List<IConfigItem>() { CurrentConfig }, new SimConnectSource());
+            var currentConfigUsesXplane = ConfigFile.ContainsConfigOfSourceType(new List<IConfigItem>() { CurrentConfig }, new XplaneSource());
+            var currentConfigUsesProsim = ConfigFile.ContainsConfigOfSourceType(new List<IConfigItem>() { CurrentConfig }, new ProSimSource());
+
+            var showFsuipcOptions = (projectInfo?.Features?.FSUIPC ?? false) || sim == "fsx" || sim == "p3d" || currentConfigUsesFsuipc;
+
+
+            if (showAllOptions || sim == "msfs" || currentConfigUsesMsfs)
             {
                 // --MSFS 2020 
                 ActionTypeComboBox.Items.Add(InputConfig.MSFS2020CustomInputAction.Label);
             }
 
-            if (showAllOptions || sim == "xplane")
+            if (showAllOptions || sim == "xplane" || currentConfigUsesXplane)
             {
                 // -- Xplane
                 ActionTypeComboBox.Items.Add(InputConfig.XplaneInputAction.Label);
@@ -64,7 +73,7 @@ namespace MobiFlight.UI.Panels.Config
             ActionTypeComboBox.Items.Add(InputConfig.KeyInputAction.Label);
             ActionTypeComboBox.Items.Add(InputConfig.VJoyInputAction.Label);
 
-            if (showAllOptions || (projectInfo?.Features?.FSUIPC ?? false) || sim == "fsx" || sim == "p3d")
+            if (showAllOptions || showFsuipcOptions)
             {
                 // --FSUIPC
                 ActionTypeComboBox.Items.Add(InputConfig.FsuipcOffsetInputAction.Label);
@@ -74,11 +83,11 @@ namespace MobiFlight.UI.Panels.Config
                 ActionTypeComboBox.Items.Add(InputConfig.LuaMacroInputAction.Label);
             }
 
-            if (showAllOptions || (projectInfo?.Features?.ProSim ?? false))
+            if (showAllOptions || (projectInfo?.Features?.ProSim ?? false) || currentConfigUsesProsim)
             {
                 ActionTypeComboBox.Items.Add(InputConfig.ProSimInputAction.Label);
             }
-             
+
             ActionTypeComboBox.SelectedIndex = 0;
             ActionTypeComboBox.SelectedIndexChanged += new EventHandler(ActionTypeComboBox_SelectedIndexChanged);
         }

--- a/UI/Panels/Input/AnalogPanel.cs
+++ b/UI/Panels/Input/AnalogPanel.cs
@@ -1,13 +1,14 @@
-﻿using System;
+﻿using MobiFlight;
+using MobiFlight.Base;
+using MobiFlight.InputConfig;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Data;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
-using MobiFlight;
-using MobiFlight.InputConfig;
 
 namespace MobiFlight.UI.Panels.Input
 {
@@ -28,11 +29,29 @@ namespace MobiFlight.UI.Panels.Input
             }
         }
 
+        private ProjectInfo _projectInfo;
+        public ProjectInfo ProjectInfo
+        {
+            get { return _projectInfo; }
+            set
+            {
+                if (_projectInfo == value) return;
+                _projectInfo = value;
+                UpdateActionPanelCallbacks(_projectInfo);
+            }
+        }
+
+        private void UpdateActionPanelCallbacks(ProjectInfo projectInfo)
+        {
+            onChangeActionTypePanel.ProjectInfo = projectInfo;
+            onChangeActionTypePanel.ActionTypeChanged -= onChangeActionTypePanel_ActionTypeChanged;
+            onChangeActionTypePanel.ActionTypeChanged += onChangeActionTypePanel_ActionTypeChanged;
+        }
+
         public AnalogPanel()
         {
             InitializeComponent();
-
-            onChangeActionTypePanel.ActionTypeChanged += new MobiFlight.UI.Panels.Config.ActionTypePanel.ActionTypePanelSelectHandler(onChangeActionTypePanel_ActionTypeChanged);
+            UpdateActionPanelCallbacks(null);
             onChangeActionTypePanel.CopyPasteFeatureActive(false);
         }
 

--- a/UI/Panels/Input/AnalogPanel.cs
+++ b/UI/Panels/Input/AnalogPanel.cs
@@ -1,13 +1,7 @@
-﻿using MobiFlight;
-using MobiFlight.Base;
+﻿using MobiFlight.Base;
 using MobiFlight.InputConfig;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace MobiFlight.UI.Panels.Input
@@ -41,9 +35,21 @@ namespace MobiFlight.UI.Panels.Input
             }
         }
 
+        private InputConfigItem _currentConfig;
+        public InputConfigItem CurrentConfig
+        {
+            get { return _currentConfig; }
+            set
+            {
+                _currentConfig = value;
+                UpdateActionPanelCallbacks(ProjectInfo);
+            }
+        }
+
         private void UpdateActionPanelCallbacks(ProjectInfo projectInfo)
         {
             onChangeActionTypePanel.ProjectInfo = projectInfo;
+            onChangeActionTypePanel.CurrentConfig = CurrentConfig;
             onChangeActionTypePanel.ActionTypeChanged -= onChangeActionTypePanel_ActionTypeChanged;
             onChangeActionTypePanel.ActionTypeChanged += onChangeActionTypePanel_ActionTypeChanged;
         }

--- a/UI/Panels/Input/ButtonPanel.cs
+++ b/UI/Panels/Input/ButtonPanel.cs
@@ -1,4 +1,5 @@
-﻿using MobiFlight.InputConfig;
+﻿using MobiFlight.Base;
+using MobiFlight.InputConfig;
 using MobiFlight.UI.Panels.Action;
 using MobiFlight.UI.Panels.Config;
 using System;
@@ -41,6 +42,19 @@ namespace MobiFlight.UI.Panels.Input
                 repeatTextBox.Enabled = value;
             }
         }
+
+        private ProjectInfo _projectInfo;
+        public ProjectInfo ProjectInfo
+        {
+            get { return _projectInfo; }
+            set
+            {
+                if (_projectInfo == value) return;
+                _projectInfo = value;
+                UpdateActionPanelCallbacks(_projectInfo);
+            }
+        }
+
         public ButtonPanel()
         {
             InitializeComponent();
@@ -59,13 +73,8 @@ namespace MobiFlight.UI.Panels.Input
             ActionTypePanelsToOwnerPanels.Add(onLongReleaseActionTypePanel, onLongRelActionConfigPanel);
             ActionTypePanelsToOwnerPanels.Add(onHoldActionTypePanel, onHoldActionConfigPanel);
 
-            foreach (ActionTypePanel panel in ActionTypePanelsToActionNames.Keys)
-            {
-                panel.ActionTypeChanged += onPressActionTypePanel_ActionTypeChanged;
-                panel.CopyButtonPressed += Action_CopyButtonPressed;
-                panel.PasteButtonPressed += Action_PasteButtonPressed;
-            }
-
+            UpdateActionPanelCallbacks();
+            
             Clipboard.Instance.PropertyChanged += (object sender, PropertyChangedEventArgs e) =>
             {
                 if (e.PropertyName != "InputAction") return;
@@ -78,6 +87,20 @@ namespace MobiFlight.UI.Panels.Input
             if (Clipboard.Instance.InputAction != null)
             {
                 clipBoardActionChanged(Clipboard.Instance.InputAction);
+            }
+        }
+
+        private void UpdateActionPanelCallbacks(ProjectInfo projectInfo = null)
+        {
+            foreach (ActionTypePanel panel in ActionTypePanelsToActionNames.Keys)
+            {
+                panel.ProjectInfo = projectInfo;
+                panel.ActionTypeChanged -= onPressActionTypePanel_ActionTypeChanged;
+                panel.ActionTypeChanged += onPressActionTypePanel_ActionTypeChanged;
+                panel.CopyButtonPressed -= Action_CopyButtonPressed;
+                panel.CopyButtonPressed += Action_CopyButtonPressed;
+                panel.PasteButtonPressed -= Action_PasteButtonPressed;
+                panel.PasteButtonPressed += Action_PasteButtonPressed;
             }
         }
 

--- a/UI/Panels/Input/ButtonPanel.cs
+++ b/UI/Panels/Input/ButtonPanel.cs
@@ -5,7 +5,6 @@ using MobiFlight.UI.Panels.Config;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
 using System.Windows.Forms;
 
 namespace MobiFlight.UI.Panels.Input
@@ -55,6 +54,17 @@ namespace MobiFlight.UI.Panels.Input
             }
         }
 
+        private InputConfigItem _currentConfig;
+        public InputConfigItem CurrentConfig
+        {
+            get { return _currentConfig; }
+            set
+            {
+                _currentConfig = value;
+                UpdateActionPanelCallbacks(ProjectInfo);
+            }
+        }
+
         public ButtonPanel()
         {
             InitializeComponent();
@@ -95,6 +105,7 @@ namespace MobiFlight.UI.Panels.Input
             foreach (ActionTypePanel panel in ActionTypePanelsToActionNames.Keys)
             {
                 panel.ProjectInfo = projectInfo;
+                panel.CurrentConfig = CurrentConfig;
                 panel.ActionTypeChanged -= onPressActionTypePanel_ActionTypeChanged;
                 panel.ActionTypeChanged += onPressActionTypePanel_ActionTypeChanged;
                 panel.CopyButtonPressed -= Action_CopyButtonPressed;

--- a/UI/Panels/Input/EncoderPanel.cs
+++ b/UI/Panels/Input/EncoderPanel.cs
@@ -1,15 +1,10 @@
-﻿using MobiFlight;
-using MobiFlight.Base;
+﻿using MobiFlight.Base;
 using MobiFlight.InputConfig;
 using MobiFlight.UI.Panels.Action;
 using MobiFlight.UI.Panels.Config;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Data;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace MobiFlight.UI.Panels.Input
@@ -44,6 +39,17 @@ namespace MobiFlight.UI.Panels.Input
                 onLeftFastActionConfigPanel.Enabled = value;
                 onRightActionConfigPanel.Enabled = value;
                 onRightFastActionConfigPanel.Enabled = value;
+            }
+        }
+
+        private InputConfigItem _currentConfig;
+        public InputConfigItem CurrentConfig
+        {
+            get { return _currentConfig; }
+            set
+            {
+                _currentConfig = value;
+                UpdateActionPanelCallbacks(ProjectInfo);
             }
         }
 
@@ -94,6 +100,7 @@ namespace MobiFlight.UI.Panels.Input
             panels.ForEach(action =>
             {
                 action.ProjectInfo = projectInfo;
+                action.CurrentConfig = CurrentConfig;
                 action.CopyButtonPressed -= Action_CopyButtonPressed;
                 action.CopyButtonPressed += Action_CopyButtonPressed;
                 action.PasteButtonPressed -= Action_PasteButtonPressed;

--- a/UI/Panels/Input/EncoderPanel.cs
+++ b/UI/Panels/Input/EncoderPanel.cs
@@ -1,15 +1,16 @@
-﻿using System;
+﻿using MobiFlight;
+using MobiFlight.Base;
+using MobiFlight.InputConfig;
+using MobiFlight.UI.Panels.Action;
+using MobiFlight.UI.Panels.Config;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Drawing;
 using System.Data;
+using System.Drawing;
 using System.Linq;
 using System.Text;
 using System.Windows.Forms;
-using MobiFlight;
-using MobiFlight.InputConfig;
-using MobiFlight.UI.Panels.Config;
-using MobiFlight.UI.Panels.Action;
 
 namespace MobiFlight.UI.Panels.Input
 {
@@ -18,6 +19,18 @@ namespace MobiFlight.UI.Panels.Input
         private InputConfig.EncoderInputConfig _config;
         private IExecutionManager _executionManager;
         private Dictionary<String, MobiFlightVariable> Variables = new Dictionary<String, MobiFlightVariable>();
+
+        private ProjectInfo _projectInfo;
+        public ProjectInfo ProjectInfo
+        {
+            get { return _projectInfo; }
+            set
+            {
+                if (_projectInfo == value) return;
+                _projectInfo = value;
+                UpdateActionPanelCallbacks(_projectInfo);
+            }
+        }
         public new bool Enabled
         {
             get { return onLeftActionTypePanel.Enabled; }
@@ -45,17 +58,14 @@ namespace MobiFlight.UI.Panels.Input
         public EncoderPanel()
         {
             InitializeComponent();
-            onLeftActionTypePanel.ActionTypeChanged += new ActionTypePanel.ActionTypePanelSelectHandler(onPressActionTypePanel_ActionTypeChanged);
-            onLeftFastActionTypePanel.ActionTypeChanged += new ActionTypePanel.ActionTypePanelSelectHandler(onPressActionTypePanel_ActionTypeChanged);
-            onRightActionTypePanel.ActionTypeChanged += new ActionTypePanel.ActionTypePanelSelectHandler(onPressActionTypePanel_ActionTypeChanged);
-            onRightFastActionTypePanel.ActionTypeChanged += new ActionTypePanel.ActionTypePanelSelectHandler(onPressActionTypePanel_ActionTypeChanged);
 
-            List<ActionTypePanel> panels = new List<ActionTypePanel>() { onLeftActionTypePanel, onLeftFastActionTypePanel, onRightActionTypePanel, onRightFastActionTypePanel };
-            panels.ForEach(action =>
-            {
-                action.CopyButtonPressed += Action_CopyButtonPressed;
-                action.PasteButtonPressed += Action_PasteButtonPressed;
-            });
+            onLeftActionTypePanel.ActionTypeChanged += onPressActionTypePanel_ActionTypeChanged;
+            onLeftFastActionTypePanel.ActionTypeChanged += onPressActionTypePanel_ActionTypeChanged;
+            onRightActionTypePanel.ActionTypeChanged += onPressActionTypePanel_ActionTypeChanged;
+            onRightFastActionTypePanel.ActionTypeChanged += onPressActionTypePanel_ActionTypeChanged;
+
+            UpdateActionPanelCallbacks();
+
 
             Clipboard.Instance.PropertyChanged += (object sender, PropertyChangedEventArgs e) =>
             {
@@ -70,6 +80,25 @@ namespace MobiFlight.UI.Panels.Input
             {
                 clipBoardActionChanged(Clipboard.Instance.InputAction);
             }
+        }
+
+        private void UpdateActionPanelCallbacks(ProjectInfo projectInfo = null)
+        {
+            List<ActionTypePanel> panels = new List<ActionTypePanel>() {
+                onLeftActionTypePanel,
+                onLeftFastActionTypePanel,
+                onRightActionTypePanel,
+                onRightFastActionTypePanel
+            };
+
+            panels.ForEach(action =>
+            {
+                action.ProjectInfo = projectInfo;
+                action.CopyButtonPressed -= Action_CopyButtonPressed;
+                action.CopyButtonPressed += Action_CopyButtonPressed;
+                action.PasteButtonPressed -= Action_PasteButtonPressed;
+                action.PasteButtonPressed += Action_PasteButtonPressed;
+            });
         }
 
         public void Init(IExecutionManager executionManager)

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -110,7 +110,8 @@
       "Simulator": {
         "Label": "Flugsimulator",
         "HelpText": "Wähle den primären Simulator für dieses Projekt aus.",
-        "UseFsuipc": "Verwende FSUIPC"
+        "UseFsuipc": "Verwende FSUIPC",
+        "UseProSim": "Verwende ProSim"
       },
       "Aircraft": {
         "Label": "Flugzeug",

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -110,8 +110,9 @@
       "Simulator": {
         "Label": "Flugsimulator",
         "HelpText": "Wähle den primären Simulator für dieses Projekt aus.",
-        "UseFsuipc": "Verwende FSUIPC",
-        "UseProSim": "Verwende ProSim"
+        "UseFsuipc": "FSUIPC - alternative alte Schnittstelle, teilweise von Addons verwendet, z.B. PMDG",
+        "UseProSim": "ProSim - Schnittstelle für ProSim Flugzeuge",
+        "Feature": "Zusätzliche Funktionen"
       },
       "Aircraft": {
         "Label": "Flugzeug",

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -75,7 +75,8 @@
       "xplane": "X-Plane",
       "p3d": "Prepar3D",
       "fsx": "FSX / FS2004",
-      "none": "No simulator"
+      "prosim": "ProSim",
+      "none": "Kein Simulator"
     },
     "Card": {
       "Main": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -110,7 +110,8 @@
       "Simulator": {
         "Label": "Flight simulator",
         "HelpText": "Select the primary simulator for this project.",
-        "UseFsuipc": "Use FSUIPC"
+        "UseFsuipc": "Use FSUIPC",
+        "UseProSim": "Use ProSim"
       },
       "Aircraft": {
         "Label": "Aircraft",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -75,6 +75,7 @@
       "xplane": "X-Plane",
       "p3d": "Prepar3D",
       "fsx": "FSX / FS2004",
+      "prosim": "ProSim",
       "none": "No simulator"
     },
     "Card": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -110,8 +110,9 @@
       "Simulator": {
         "Label": "Flight simulator",
         "HelpText": "Select the primary simulator for this project.",
-        "UseFsuipc": "Use FSUIPC",
-        "UseProSim": "Use ProSim"
+        "UseFsuipc": "FSUIPC - alternative legacy interface sometimes used by addons, e.g. PMDG",
+        "UseProSim": "ProSim - interface for ProSim aircraft",
+        "Feature": "Additional Features"
       },
       "Aircraft": {
         "Label": "Aircraft",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -110,7 +110,8 @@
       "Simulator": {
         "Label": "Simulador de vuelo",
         "HelpText": "Selecciona el simulador principal para este proyecto.",
-        "UseFsuipc": "Usar FSUIPC"
+        "UseFsuipc": "Usar FSUIPC",
+        "UseProSim": "Usar ProSim"
       },
       "Aircraft": {
         "Label": "Avión",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -110,8 +110,9 @@
       "Simulator": {
         "Label": "Simulador de vuelo",
         "HelpText": "Selecciona el simulador principal para este proyecto.",
-        "UseFsuipc": "Usar FSUIPC",
-        "UseProSim": "Usar ProSim"
+        "UseFsuipc": "FSUIPC - interfaz heredada alterna - a veces utilizada por \"addons\", ej., PMDG",
+        "UseProSim": "ProSim - interfaz para aviones ProSim",
+        "Feature": "Funciones adicionales"
       },
       "Aircraft": {
         "Label": "Avión",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -75,6 +75,7 @@
       "xplane": "X-Plane",
       "p3d": "Prepar3D",
       "fsx": "FSX / FS2004",
+      "prosim": "ProSim",
       "none": "Ningún simulador"
     },
     "Card": {

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -88,10 +88,11 @@ export const ProjectCardImage = ({
   className,
 }: HtmlHTMLAttributes<HTMLDivElement> & { summary: ProjectInfo }) => {
   const imageUrl = summary.Thumbnail || `/sim/${summary.Sim?.toLowerCase()}.jpg`
+  console.log("ProjectCardImage imageUrl:", imageUrl, import.meta.url)
   return summary.Sim ? (
     <div className={cn("bg-accent rounded-lg", className)}>
       <img
-        src={new URL(imageUrl, import.meta.url).href}
+        src={imageUrl}
         alt={summary.Name}
         className="h-full w-full rounded-lg object-cover"
       />

--- a/frontend/src/components/project/ProjectForm.tsx
+++ b/frontend/src/components/project/ProjectForm.tsx
@@ -13,7 +13,7 @@ import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Checkbox } from "@/components/ui/checkbox"
 import { useState } from "react"
-import { ProjectInfo } from "@/types/project"
+import { ProjectFeatures, ProjectInfo } from "@/types/project"
 import { useLocation } from "react-router"
 import { useTranslation } from "react-i18next"
 
@@ -21,7 +21,7 @@ type ProjectFormProps = {
   project: ProjectInfo
   isOpen: boolean
   onOpenChange: (open: boolean) => void
-  onSave: (values: { Name: string; Sim: string; UseFsuipc: boolean }) => void
+  onSave: (values: { Name: string; Sim: string; Features: ProjectFeatures }) => void
 }
 
 const ProjectForm = ({
@@ -32,7 +32,8 @@ const ProjectForm = ({
 }: ProjectFormProps) => {
   const [name, setName] = useState(project?.Name ?? "")
   const [simulator, setSimulator] = useState<string>(project?.Sim ?? "msfs")
-  const [useFsuipc, setUseFsuipc] = useState(project?.UseFsuipc ?? false)
+  const [useFsuipc, setUseFsuipc] = useState(project?.Features?.FSUIPC ?? false)
+  const [useProsim, setUseProsim] = useState(project?.Features?.ProSim ?? false)
   const [hasError, setHasError] = useState(false)
 
   const location = useLocation()
@@ -42,6 +43,10 @@ const ProjectForm = ({
 
   const FsuipcOptionIsDefaultForSimulator = (simulator: string) => {
     return simulator === "fsx" || simulator === "p3d"
+  }
+
+  const ProSimFeatureIsSupportedBySimulator =(simulator: string) => {
+    return simulator === "msfs" || simulator === "p3d"
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -57,7 +62,10 @@ const ProjectForm = ({
     onSave({
       Name: trimmedName,
       Sim: simulator,
-      UseFsuipc: useFsuipc || FsuipcOptionIsDefaultForSimulator(simulator),
+      Features: {
+        FSUIPC: useFsuipc || FsuipcOptionIsDefaultForSimulator(simulator),
+        ProSim: useProsim && ProSimFeatureIsSupportedBySimulator(simulator),
+      },
     })
   }
 
@@ -122,6 +130,7 @@ const ProjectForm = ({
               onValueChange={(value) => {
                 setSimulator(value)
                 setUseFsuipc(false) // Reset FSUIPC when changing simulator
+                setUseProsim(false) // Reset ProSim when changing simulator
               }}
             >
               <div className="flex items-center space-x-2">
@@ -145,16 +154,25 @@ const ProjectForm = ({
                   </Label>
                 </div>
               )}
+              {/* ProSim Option (MSFS & P3D) */}
+              {simulator === "msfs" && (
+                <div className="flex items-center space-x-2 pl-6">
+                  <Checkbox
+                    id="prosim"
+                    checked={useProsim}
+                    onCheckedChange={(checked) =>
+                      setUseProsim(Boolean(checked))
+                    }
+                  />
+                  <Label htmlFor="prosim" className="font-normal">
+                    {t("Project.Form.Simulator.UseProSim")}
+                  </Label>
+                </div>
+              )}
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="xplane" id="xplane" />
                 <Label htmlFor="xplane" className="font-normal">
                   {t("Project.Simulator.xplane")}
-                </Label>
-              </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="prosim" id="prosim" />
-                <Label htmlFor="prosim" className="font-normal">
-                  {t("Project.Simulator.prosim")}
                 </Label>
               </div>
               <div className="flex items-center space-x-2">
@@ -163,6 +181,21 @@ const ProjectForm = ({
                   {t("Project.Simulator.p3d")}
                 </Label>
               </div>
+               {/* ProSim Option (MSFS & P3D) */}
+              {simulator === "p3d" && (
+                <div className="flex items-center space-x-2 pl-6">
+                  <Checkbox
+                    id="prosim"
+                    checked={useProsim}
+                    onCheckedChange={(checked) =>
+                      setUseProsim(Boolean(checked))
+                    }
+                  />
+                  <Label htmlFor="prosim" className="font-normal">
+                    {t("Project.Simulator.prosim")}
+                  </Label>
+                </div>
+              )}
               <div className="flex items-center space-x-2">
                 <RadioGroupItem value="fsx" id="fsx" />
                 <Label htmlFor="fsx" className="font-normal">

--- a/frontend/src/components/project/ProjectForm.tsx
+++ b/frontend/src/components/project/ProjectForm.tsx
@@ -40,6 +40,10 @@ const ProjectForm = ({
 
   const { t } = useTranslation()
 
+  const FsuipcOptionIsDefaultForSimulator = (simulator: string) => {
+    return simulator === "fsx" || simulator === "p3d"
+  }
+
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault()
     const trimmedName = name.trim()
@@ -53,7 +57,7 @@ const ProjectForm = ({
     onSave({
       Name: trimmedName,
       Sim: simulator,
-      UseFsuipc: useFsuipc,
+      UseFsuipc: useFsuipc || FsuipcOptionIsDefaultForSimulator(simulator),
     })
   }
 

--- a/frontend/src/components/project/ProjectForm.tsx
+++ b/frontend/src/components/project/ProjectForm.tsx
@@ -138,6 +138,8 @@ const ProjectForm = ({
           <div className="flex flex-row gap-4">
             {["msfs", "xplane", "p3d", "fsx"].map((sim) => (
               <div
+                role="radio"
+                aria-checked={simulator === sim}
                 key={sim}
                 className={cn(
                   "inline-block h-48 flex-1 cursor-pointer rounded-lg transition-all duration-200 hover:scale-110",
@@ -145,7 +147,11 @@ const ProjectForm = ({
                     ? "drop-shadow-primary/50 ring-primary ring-3 drop-shadow-lg"
                     : "opacity-50 hover:opacity-100",
                 )}
-                onClick={() => setSimulator(sim)}
+                onClick={() => {
+                  setUseFsuipc(false)
+                  setUseProsim(false)
+                  setSimulator(sim)
+                }}
               >
                 <img
                   src={`/sim/${sim.toLowerCase()}.jpg`}

--- a/frontend/src/components/project/ProjectForm.tsx
+++ b/frontend/src/components/project/ProjectForm.tsx
@@ -10,18 +10,22 @@ import {
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Checkbox } from "@/components/ui/checkbox"
 import { useState } from "react"
 import { ProjectFeatures, ProjectInfo } from "@/types/project"
 import { useLocation } from "react-router"
 import { useTranslation } from "react-i18next"
+import { cn } from "@/lib/utils"
 
 type ProjectFormProps = {
   project: ProjectInfo
   isOpen: boolean
   onOpenChange: (open: boolean) => void
-  onSave: (values: { Name: string; Sim: string; Features: ProjectFeatures }) => void
+  onSave: (values: {
+    Name: string
+    Sim: string
+    Features: ProjectFeatures
+  }) => void
 }
 
 const ProjectForm = ({
@@ -45,7 +49,7 @@ const ProjectForm = ({
     return simulator === "fsx" || simulator === "p3d"
   }
 
-  const ProSimFeatureIsSupportedBySimulator =(simulator: string) => {
+  const ProSimFeatureIsSupportedBySimulator = (simulator: string) => {
     return simulator === "msfs" || simulator === "p3d"
   }
 
@@ -76,12 +80,14 @@ const ProjectForm = ({
     }
   }
 
-  
   const showErrorMessage = hasError && name.length === 0
 
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
-      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]" onKeyDown={handleFormKeyDown}>
+      <DialogContent
+        className="max-h-[90vh] overflow-y-auto sm:max-w-[600px]"
+        onKeyDown={handleFormKeyDown}
+      >
         <DialogHeader>
           <DialogTitle className="text-2xl">
             {isEdit
@@ -110,53 +116,69 @@ const ProjectForm = ({
               required
             />
             {showErrorMessage && (
-              <p className="text-sm text-red-500" data-testid="form-project-name-error">
+              <p
+                className="text-sm text-red-500"
+                data-testid="form-project-name-error"
+              >
                 {t("Project.Form.Name.Error.Required")}
               </p>
             )}{" "}
             {/* Show error */}
           </div>
-
-          {/* Flight Simulator Selection */}
-          <div className="grid gap-3">
+          <div>
             <Label className="text-base font-semibold">
               {t("Project.Form.Simulator.Label")}
             </Label>
             <p className="text-muted-foreground text-sm">
               {t("Project.Form.Simulator.HelpText")}
             </p>
-            <RadioGroup
-              value={simulator}
-              onValueChange={(value) => {
-                setSimulator(value)
-                setUseFsuipc(false) // Reset FSUIPC when changing simulator
-                setUseProsim(false) // Reset ProSim when changing simulator
-              }}
-            >
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="msfs" id="msfs" />
-                <Label htmlFor="msfs" className="font-normal">
-                  {t("Project.Simulator.msfs")}
-                </Label>
+          </div>
+          {/* Flight Simulator Selection */}
+
+          <div className="flex flex-row gap-4">
+            {["msfs", "xplane", "p3d", "fsx"].map((sim) => (
+              <div
+                key={sim}
+                className={cn(
+                  "inline-block h-48 flex-1 cursor-pointer rounded-lg transition-all duration-200 hover:scale-110",
+                  simulator === sim
+                    ? "drop-shadow-primary/50 ring-primary ring-3 drop-shadow-lg"
+                    : "opacity-50 hover:opacity-100",
+                )}
+                onClick={() => setSimulator(sim)}
+              >
+                <img
+                  src={`/sim/${sim.toLowerCase()}.jpg`}
+                  alt={sim}
+                  className="h-full w-full rounded-lg object-cover"
+                />
               </div>
-              {/* FSUIPC Option (only for MSFS) */}
-              {simulator === "msfs" && (
-                <div className="flex items-center space-x-2 pl-6">
-                  <Checkbox
-                    id="fsuipc"
-                    checked={useFsuipc}
-                    onCheckedChange={(checked) =>
-                      setUseFsuipc(Boolean(checked))
-                    }
-                  />
-                  <Label htmlFor="fsuipc" className="font-normal">
-                    {t("Project.Form.Simulator.UseFsuipc")}
-                  </Label>
-                </div>
-              )}
-              {/* ProSim Option (MSFS & P3D) */}
-              {simulator === "msfs" && (
-                <div className="flex items-center space-x-2 pl-6">
+            ))}
+          </div>
+          <div className="flex h-24 flex-col gap-2">
+            {(simulator === "msfs" || simulator === "p3d") && (
+              <div className="flex h-24 flex-col gap-2">
+                <p className="text-muted-foreground text-sm">
+                  {t("Project.Form.Simulator.Feature")}
+                </p>
+                {/* FSUIPC Option (only for MSFS) */}
+                {simulator === "msfs" && (
+                  <div className="flex items-center space-x-2 pl-2">
+                    <Checkbox
+                      id="fsuipc"
+                      checked={useFsuipc}
+                      onCheckedChange={(checked) =>
+                        setUseFsuipc(Boolean(checked))
+                      }
+                    />
+                    <Label htmlFor="fsuipc" className="font-normal">
+                      {t("Project.Form.Simulator.UseFsuipc")}
+                    </Label>
+                  </div>
+                )}
+
+                {/* ProSim Option (MSFS & P3D) */}
+                <div className="flex items-center space-x-2 pl-2">
                   <Checkbox
                     id="prosim"
                     checked={useProsim}
@@ -168,52 +190,21 @@ const ProjectForm = ({
                     {t("Project.Form.Simulator.UseProSim")}
                   </Label>
                 </div>
-              )}
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="xplane" id="xplane" />
-                <Label htmlFor="xplane" className="font-normal">
-                  {t("Project.Simulator.xplane")}
-                </Label>
               </div>
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="p3d" id="p3d" />
-                <Label htmlFor="p3d" className="font-normal">
-                  {t("Project.Simulator.p3d")}
-                </Label>
-              </div>
-               {/* ProSim Option (MSFS & P3D) */}
-              {simulator === "p3d" && (
-                <div className="flex items-center space-x-2 pl-6">
-                  <Checkbox
-                    id="prosim"
-                    checked={useProsim}
-                    onCheckedChange={(checked) =>
-                      setUseProsim(Boolean(checked))
-                    }
-                  />
-                  <Label htmlFor="prosim" className="font-normal">
-                    {t("Project.Simulator.prosim")}
-                  </Label>
-                </div>
-              )}
-              <div className="flex items-center space-x-2">
-                <RadioGroupItem value="fsx" id="fsx" />
-                <Label htmlFor="fsx" className="font-normal">
-                  {t("Project.Simulator.fsx")}
-                </Label>
-              </div>
-            </RadioGroup>
+            )}
           </div>
         </div>
 
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline" type="button">
-              { t("Project.Form.Buttons.Cancel") }
+              {t("Project.Form.Buttons.Cancel")}
             </Button>
           </DialogClose>
           <Button onClick={handleSubmit}>
-            {isEdit ? t("Project.Form.Buttons.Update") : t("Project.Form.Buttons.Create")}
+            {isEdit
+              ? t("Project.Form.Buttons.Update")
+              : t("Project.Form.Buttons.Create")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/project/ProjectForm.tsx
+++ b/frontend/src/components/project/ProjectForm.tsx
@@ -148,6 +148,12 @@ const ProjectForm = ({
                 </Label>
               </div>
               <div className="flex items-center space-x-2">
+                <RadioGroupItem value="prosim" id="prosim" />
+                <Label htmlFor="prosim" className="font-normal">
+                  {t("Project.Simulator.prosim")}
+                </Label>
+              </div>
+              <div className="flex items-center space-x-2">
                 <RadioGroupItem value="p3d" id="p3d" />
                 <Label htmlFor="p3d" className="font-normal">
                   {t("Project.Simulator.p3d")}

--- a/frontend/src/types/project.d.ts
+++ b/frontend/src/types/project.d.ts
@@ -5,7 +5,7 @@ export interface Project {
   FilePath: string
   ConfigFiles: ConfigFile[]
   Thumbnail?: string
-  Sim: string
+  Sim: "msfs" | "xplane" | "p3d" | "prosim" | "fsx" | "none"
   UseFsuipc: boolean
   Controllers?: string[]
 

--- a/frontend/src/types/project.d.ts
+++ b/frontend/src/types/project.d.ts
@@ -5,8 +5,8 @@ export interface Project {
   FilePath: string
   ConfigFiles: ConfigFile[]
   Thumbnail?: string
-  Sim: "msfs" | "xplane" | "p3d" | "prosim" | "fsx" | "none"
-  UseFsuipc: boolean
+  Sim: "msfs" | "xplane" | "p3d" | "fsx" | "none"
+  Features: ProjectFeatures
   Controllers?: string[]
 
   Aircraft?: {
@@ -23,11 +23,16 @@ export interface ProjectInfo {
   Thumbnail?: string
   Sim: string
   Favorite?: boolean
-  UseFsuipc: boolean
+  Features: ProjectFeatures
   Controllers?: string[]
 
   Aircraft?: {
     Name: string
     Filter: string
   }[]
+}
+
+export interface ProjectFeatures {
+  FSUIPC: boolean
+  ProSim: boolean
 }

--- a/frontend/tests/Dashboard.spec.ts
+++ b/frontend/tests/Dashboard.spec.ts
@@ -123,7 +123,7 @@ test.describe("Project settings modal features", () => {
     const createProjectDialog = page.getByRole("dialog", {
       name: "Create New Project",
     })
-    const fsuipcCheckbox = createProjectDialog.getByLabel("Use FSUIPC")
+    const fsuipcCheckbox = createProjectDialog.getByLabel("FSUIPC")
     const prosimCheckbox = createProjectDialog.getByLabel("ProSim")
     const projectNameInput = createProjectDialog.getByLabel("Project Name")
     const createButton = createProjectDialog.getByRole("button", {
@@ -171,17 +171,15 @@ test.describe("Project settings modal features", () => {
 
     for (const option of projectOptions) {
       await dashboardPage.gotoPage()
-
       await dashboardPage.mobiFlightPage.trackCommand("CommandMainMenu")
 
       await createProjectButton.click()
 
       await projectNameInput.fill(option.name)
 
-      const simOptionLocator = `[role="radio"][value="${option.value}"]`
-      const simOption = createProjectDialog.locator(simOptionLocator)
+      const simOption = createProjectDialog.getByRole("radio", { name: option.value })
 
-      await simOption.check()
+      await simOption.click()
       if (option.fsuipc.click) {
         await fsuipcCheckbox.check()
       }
@@ -218,7 +216,7 @@ test.describe("Project settings modal features", () => {
     const createProjectDialog = page.getByRole("dialog", {
       name: "Create New Project",
     })
-    const fsuipcCheckbox = createProjectDialog.getByLabel("Use FSUIPC")
+    const fsuipcCheckbox = createProjectDialog.getByLabel("FSUIPC")
     const prosimCheckbox = createProjectDialog.getByLabel("ProSim")
     const projectNameInput = createProjectDialog.getByLabel("Project Name")
 
@@ -226,10 +224,10 @@ test.describe("Project settings modal features", () => {
     await projectNameInput.fill("Test Reset Features")
 
     // Select MSFS and enable both features
-    const msfsOption = createProjectDialog.locator(
-      `[role="radio"][value="msfs"]`,
-    )
-    await msfsOption.check()
+    const msfsOption = createProjectDialog.getByRole("radio", {
+      name: "msfs",
+    })
+    await msfsOption.click()
     await fsuipcCheckbox.check()
     await prosimCheckbox.check()
 
@@ -237,14 +235,14 @@ test.describe("Project settings modal features", () => {
     expect(await prosimCheckbox.isChecked()).toBeTruthy()
 
     // Change to X-Plane and verify both features are disabled
-    const p3dOption = createProjectDialog.locator(
-      `[role="radio"][value="p3d"]`,
-    )
-    await p3dOption.check()
+    const p3dOption = createProjectDialog.getByRole("radio", {
+      name: "p3d",
+    })
+    await p3dOption.click()
     expect(await prosimCheckbox.isChecked()).toBeFalsy()
 
     // Change back to MSFS and verify both features are disabled
-    await msfsOption.check()
+    await msfsOption.click()
     expect(await fsuipcCheckbox.isChecked()).toBeFalsy()
     expect(await prosimCheckbox.isChecked()).toBeFalsy()
   })

--- a/frontend/tests/Dashboard.spec.ts
+++ b/frontend/tests/Dashboard.spec.ts
@@ -133,11 +133,12 @@ test.describe("Project settings modal features", () => {
     })
 
     const projectOptions = [
-      { name: "MSFS no FSUIPC", value: "msfs", useFsuipc: false },
-      { name: "MSFS with FSUIPC", value: "msfs", useFsuipc: true },
-      { name: "X-Plane", value: "xplane", useFsuipc: false },
-      { name: "Prepar3D", value: "p3d", useFsuipc: false },
-      { name: "ProSim", value: "prosim", useFsuipc: false },
+      { name: "MSFS no FSUIPC", value: "msfs", clickFsuipc: false, useFsuipc: false },
+      { name: "MSFS with FSUIPC", value: "msfs", clickFsuipc: true, useFsuipc: true },
+      { name: "X-Plane", value: "xplane", clickFsuipc: false, useFsuipc: false },
+      { name: "Prepar3D", value: "p3d", clickFsuipc: false, useFsuipc: true },
+      { name: "FSX / FS2004", value: "fsx", clickFsuipc: false, useFsuipc: true },
+      { name: "ProSim", value: "prosim", clickFsuipc: false, useFsuipc: false },
     ]
 
     for (const option of projectOptions) {
@@ -153,7 +154,7 @@ test.describe("Project settings modal features", () => {
       const simOption = createProjectDialog.locator(simOptionLocator)
 
       await simOption.check()
-      if (option.useFsuipc) {
+      if (option.clickFsuipc) {
         await fsuipcCheckbox.check()
       }
 

--- a/frontend/tests/Dashboard.spec.ts
+++ b/frontend/tests/Dashboard.spec.ts
@@ -137,6 +137,7 @@ test.describe("Project settings modal features", () => {
       { name: "MSFS with FSUIPC", value: "msfs", useFsuipc: true },
       { name: "X-Plane", value: "xplane", useFsuipc: false },
       { name: "Prepar3D", value: "p3d", useFsuipc: false },
+      { name: "ProSim", value: "prosim", useFsuipc: false },
     ]
 
     for (const option of projectOptions) {

--- a/frontend/tests/data/project.testdata.json
+++ b/frontend/tests/data/project.testdata.json
@@ -553,5 +553,8 @@
     "ProtoBoard-v2/ SN-3F1-FDD",
     "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000"
   ],
-  "UseFsuipc": false
+  "Features": {
+      "FSUIPC": false,
+      "ProSim": false
+  }
 }

--- a/frontend/tests/data/recentProjects.testdata.json
+++ b/frontend/tests/data/recentProjects.testdata.json
@@ -9,7 +9,10 @@
         "FilePath": ".\\Starship-MiniFCU-MiniEFIS-V2.mfproj",
         "Name": "Starship-MiniFCU+miniEFIS-V1",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -23,7 +26,10 @@
         "FilePath": ".\\FBW-A320DEV.mfproj",
         "Name": "FBW-A320DEV",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -35,7 +41,10 @@
         "FilePath": ".\\New Project.mfproj",
         "Name": "Test",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -46,7 +55,10 @@
         "FilePath": ".\\precondition-v1.1-test-migrated-optimized.mfproj",
         "Name": "New Project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -58,7 +70,10 @@
         "FilePath": ".\\CRJ_PUCDUV2_CPT_PROFILE_737NG_KP_9RKoh\\CRJ PU AIR KOREA MCDU  737NG KP CAPTAIN.mcc",
         "Name": "Air Korea MCDU",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -71,7 +86,10 @@
         "FilePath": ".\\Delta_Force_bug_minimum_example_AdvWS.mfproj",
         "Name": "unsaved",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -93,7 +111,10 @@
         "FilePath": ".\\Mini Overhead SMD - FBW.mfproj",
         "Name": "Mini Overhead SMD - FBW",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -110,7 +131,10 @@
         "FilePath": ".\\aero2023-combined-display.mfproj",
         "Name": "aero2023-combined-display",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -154,7 +178,10 @@
         "FilePath": ".\\A321 Toliss Extra.mfproj",
         "Name": "MobiFlight Project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -166,7 +193,10 @@
         "FilePath": ".\\Saitek-Multi-Panel.mfproj",
         "Name": "New Project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -177,7 +207,10 @@
         "FilePath": ".\\flitesim-FFB.mfproj",
         "Name": "FliteSim FFB Complete Config",
         "Sim": "xplane",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -190,7 +223,10 @@
         "FilePath": ".\\wingflex-fcu.mfproj",
         "Name": "Test project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -203,7 +239,10 @@
         "FilePath": ".\\wingflex-fcu.migrate.mfproj",
         "Name": "Test project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -214,7 +253,10 @@
         "FilePath": ".\\precondition-v1.1-test.mfproj",
         "Name": "New Project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -226,7 +268,10 @@
         "FilePath": ".\\merge-multiple.testmfproj.optimized.mfproj",
         "Name": "Test project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -238,7 +283,10 @@
         "FilePath": ".\\merge-multiple.testmfproj.mfproj",
         "Name": "Test project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -249,7 +297,10 @@
         "FilePath": ".\\precondition-v1.1-test-migrated.mfproj",
         "Name": "New Project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -278,7 +329,10 @@
         "FilePath": ".\\dnd.mfproj",
         "Name": "New Project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -289,7 +343,10 @@
         "FilePath": ".\\Test-Rename.mfproj",
         "Name": "Test",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -300,7 +357,10 @@
         "FilePath": ".\\New Project.mfproj",
         "Name": "New Project",
         "Sim": null,
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -311,7 +371,10 @@
         "FilePath": ".\\Honeycomb-Bravo-Template.mfproj",
         "Name": "Renamed project",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -322,7 +385,10 @@
         "FilePath": ".\\Shop-Test-Demo-Board.mfproj",
         "Name": "Shop Test",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     },
     {
         "Aircraft": [],
@@ -333,6 +399,9 @@
         "FilePath": ".\\Mini Overhead SMD - FBW.mcc",
         "Name": "Mini Overhead SMD - FBW",
         "Sim": "msfs",
-        "UseFsuipc": false
+        "Features": {
+            "FSUIPC": false,
+            "ProSim": false
+        }
     }
 ]

--- a/frontend/tests/fixtures/MobiFlightPage.ts
+++ b/frontend/tests/fixtures/MobiFlightPage.ts
@@ -114,7 +114,10 @@ export class MobiFlightPage {
         FilePath: "SomeFilePath.mfproj",
         ConfigFiles: [],
         Sim: "msfs",
-        UseFsuipc: false,
+        Features: {
+            "FSUIPC": false,
+            "ProSim": false
+        }
       } as Project,
     }
     await this.publishMessage(message)


### PR DESCRIPTION
https://github.com/user-attachments/assets/98ac2b20-33e3-467f-b84d-187de03b4340

https://github.com/user-attachments/assets/ce4e4cff-d049-4fb0-9bb8-557308bd5c5d

- [x] Output Config - Source options
- [x] Input Config - Relevant Input Actions for sims
  - [x] MSFS - MSFS
  - [x] FSUIPC - All FSUIPC Input Actions
  - [x] XPlane - XPlane Options
  - [x] ProSim - Prosim Datarefs
- [x] Added `ProSim` as sim option
- [x] Unit tests
- [x] Playwright tests
- [x] i18n

**Out Of Scope**
The sim status bar is still showing irrelevant information
<img width="337" height="134" alt="image" src="https://github.com/user-attachments/assets/52ee6c63-2420-47ea-b67d-6dababedfcc7" />

fixes #2504 
fixes #2510