### PR TITLE
Upgrade Test Framework to 4.0.2

### DIFF
--- a/MobiFlightUnitTests/Base/CmdLineParamsTests.cs
+++ b/MobiFlightUnitTests/Base/CmdLineParamsTests.cs
@@ -1,10 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MobiFlight.Tests
 {
@@ -18,14 +12,14 @@ namespace MobiFlight.Tests
             CmdLineParams clp = new CmdLineParams(cmdlineParams);
 
             Assert.IsNotNull(clp, "Object is null.");
-            Assert.AreEqual(true, clp.AutoRun, "AutoRun is not true.");
+            Assert.IsTrue(clp.AutoRun, "AutoRun is not true.");
             Assert.AreEqual("c:\\test\\my.mcc", clp.ConfigFile, "ConfigFile doesn't match.");
 
             cmdlineParams = new string[3] { "/foo", "/cfg1", "c:\\test\\my.mcc" };
             clp = new CmdLineParams(cmdlineParams);
 
             Assert.IsNotNull(clp, "Object is null.");
-            Assert.AreEqual(false, clp.AutoRun, "AutoRun is true.");
+            Assert.IsFalse(clp.AutoRun, "AutoRun is true.");
             Assert.IsNull(clp.ConfigFile, "ConfigFile is not null.");
         }
     }

--- a/MobiFlightUnitTests/Base/ComboBoxHelperTests.cs
+++ b/MobiFlightUnitTests/Base/ComboBoxHelperTests.cs
@@ -1,9 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace System.Tests
@@ -16,15 +11,15 @@ namespace System.Tests
         {
             ComboBox cb = generateTestObject();
 
-            Assert.AreNotEqual(cb.SelectedIndex, 1, "Selected index should not be 1");
+            Assert.AreNotEqual(1,cb.SelectedIndex, "Selected index should not be 1");
             ComboBoxHelper.SetSelectedItem(cb, "App");
-            Assert.AreNotEqual(cb.SelectedIndex, 1, "Selected index should not be 1");
+            Assert.AreNotEqual(1, cb.SelectedIndex, "Selected index should not be 1");
             ComboBoxHelper.SetSelectedItem(cb, "Apples");
-            Assert.AreEqual(cb.SelectedIndex, 0, "Selected index should be 0");
+            Assert.AreEqual(0, cb.SelectedIndex, "Selected index should be 0");
             ComboBoxHelper.SetSelectedItem(cb, "Cherries");
-            Assert.AreEqual(cb.SelectedIndex, 1, "Selected index should be 1");
+            Assert.AreEqual(1, cb.SelectedIndex, "Selected index should be 1");
             ComboBoxHelper.SetSelectedItem(cb, "Cheese");
-            Assert.AreEqual(cb.SelectedIndex, 2, "Selected index should be 2");
+            Assert.AreEqual(2, cb.SelectedIndex,"Selected index should be 2");
         }
 
         [TestMethod()]
@@ -35,13 +30,13 @@ namespace System.Tests
             cb.Items.Add("Cherries");
             cb.Items.Add("Cheese");
 
-            Assert.AreNotEqual(cb.SelectedIndex, 1, "Selected index should not be 1");
+            Assert.AreNotEqual(1, cb.SelectedIndex, "Selected index should not be 1");
             ComboBoxHelper.SetSelectedItemByPart(cb, "App");
-            Assert.AreEqual(cb.SelectedIndex, 0, "Selected index should be 0");
+            Assert.AreEqual(0, cb.SelectedIndex, "Selected index should be 0");
             ComboBoxHelper.SetSelectedItemByPart(cb, "Che");
-            Assert.AreEqual(cb.SelectedIndex, 1, "Selected index should be 1");
+            Assert.AreEqual(1, cb.SelectedIndex, "Selected index should be 1");
             ComboBoxHelper.SetSelectedItemByPart(cb, "Chee");
-            Assert.AreEqual(cb.SelectedIndex, 2, "Selected index should be 2");
+            Assert.AreEqual(2, cb.SelectedIndex, "Selected index should be 2");
         }
 
         public ComboBox generateTestObject()

--- a/MobiFlightUnitTests/Base/ConfigFileFactoryTests.cs
+++ b/MobiFlightUnitTests/Base/ConfigFileFactoryTests.cs
@@ -1,10 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.Base;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MobiFlight.Base.Tests
 {
@@ -18,12 +12,12 @@ namespace MobiFlight.Base.Tests
             var configFile = ConfigFileFactory.CreateConfigFile(testFile);
 
             configFile.OpenFile();
-            Assert.IsTrue(configFile.ConfigItems.Count > 0);
+            Assert.IsNotEmpty(configFile.ConfigItems);
 
             testFile = @"assets/Base/ConfigFile/Json/OpenConfig.mfjson";
             configFile = ConfigFileFactory.CreateConfigFile(testFile);
             configFile.OpenFile();
-            Assert.IsTrue(configFile.ConfigItems.Count == 3);
+            Assert.HasCount(3, configFile.ConfigItems);
         }
 
         [TestMethod]
@@ -63,7 +57,7 @@ namespace MobiFlight.Base.Tests
             Assert.AreEqual(configFile.ConfigItems[0].ModuleSerial, configFileOut.ConfigItems[0].ModuleSerial);
             Assert.AreEqual(configFile.ConfigItems[0].Preconditions, configFileOut.ConfigItems[0].Preconditions);
 
-            Assert.IsTrue(configFileOut.ConfigItems.Count > 0);
+            Assert.IsNotEmpty(configFileOut.ConfigItems);
             for (int i = 0; i < configFile.ConfigItems.Count; i++)
             {
                 Assert.AreEqual(configFile.ConfigItems[i], configFileOut.ConfigItems[i]);

--- a/MobiFlightUnitTests/Base/ConfigFileTests.cs
+++ b/MobiFlightUnitTests/Base/ConfigFileTests.cs
@@ -1,5 +1,4 @@
-﻿using MobiFlight.Base;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.OutputConfig;
 using Newtonsoft.Json;
 using System.Collections.Generic;
@@ -81,7 +80,7 @@ namespace MobiFlight.Base.Tests
             Assert.AreEqual(configFile.FileName, deserializedConfigFile.FileName);
             Assert.AreEqual(configFile.ReferenceOnly, deserializedConfigFile.ReferenceOnly);
             Assert.AreEqual(configFile.EmbedContent, deserializedConfigFile.EmbedContent);
-            Assert.AreEqual(configFile.ConfigItems.Count, deserializedConfigFile.ConfigItems.Count);
+            Assert.HasCount(configFile.ConfigItems.Count, deserializedConfigFile.ConfigItems);
 
             configFile.ConfigItems.Add(CreateOutputConfigItem());
             configFile.ConfigItems.Add(CreateInputConfigItem());
@@ -92,8 +91,8 @@ namespace MobiFlight.Base.Tests
             Assert.AreEqual(configFile.FileName, deserializedConfigFile.FileName);
             Assert.AreEqual(configFile.ReferenceOnly, deserializedConfigFile.ReferenceOnly);
             Assert.AreEqual(configFile.EmbedContent, deserializedConfigFile.EmbedContent);
-            Assert.AreEqual(configFile.ConfigItems.Count, deserializedConfigFile.ConfigItems.Count);
-            Assert.IsTrue(configFile.ConfigItems.Count == 2);
+            Assert.HasCount(configFile.ConfigItems.Count, deserializedConfigFile.ConfigItems);
+            Assert.HasCount(2, configFile.ConfigItems);
 
             Assert.AreEqual((configFile.ConfigItems[0] as OutputConfigItem).Device, (deserializedConfigFile.ConfigItems[0] as OutputConfigItem).Device);
             Assert.AreEqual((configFile.ConfigItems[1] as InputConfigItem).Device, (deserializedConfigFile.ConfigItems[1] as InputConfigItem).Device);
@@ -119,7 +118,7 @@ namespace MobiFlight.Base.Tests
             Assert.AreEqual(configFile.FileName, newConfigFile.FileName);
             Assert.AreEqual(configFile.ReferenceOnly, newConfigFile.ReferenceOnly);
             Assert.AreEqual(configFile.EmbedContent, newConfigFile.EmbedContent);
-            Assert.AreEqual(configFile.ConfigItems.Count, newConfigFile.ConfigItems.Count);
+            Assert.HasCount(configFile.ConfigItems.Count, newConfigFile.ConfigItems);
         }
 
         [TestMethod]
@@ -143,7 +142,7 @@ namespace MobiFlight.Base.Tests
             Assert.AreEqual(configFile.FileName, deserializedConfigFile.FileName);
             Assert.AreEqual(configFile.ReferenceOnly, deserializedConfigFile.ReferenceOnly);
             Assert.AreEqual(configFile.EmbedContent, deserializedConfigFile.EmbedContent);
-            Assert.AreEqual(configFile.ConfigItems.Count, deserializedConfigFile.ConfigItems.Count);
+            Assert.HasCount(configFile.ConfigItems.Count, deserializedConfigFile.ConfigItems);
         }
 
         [TestMethod()]
@@ -201,9 +200,9 @@ namespace MobiFlight.Base.Tests
             var cfgItem1 = CreateOutputConfigItem();
             var cfgItem2 = cfgItem1.Clone() as OutputConfigItem;
             var cfgFile = new ConfigFile() { ConfigItems = new List<IConfigItem>() { cfgItem1, cfgItem2 } };
-            
+
             Assert.IsTrue(cfgFile.HasDuplicateGuids());
-            
+
             cfgFile.RemoveDuplicateGuids();
 
             Assert.IsFalse(cfgFile.HasDuplicateGuids());

--- a/MobiFlightUnitTests/Base/ConfigFileUtilsTests.cs
+++ b/MobiFlightUnitTests/Base/ConfigFileUtilsTests.cs
@@ -15,10 +15,10 @@ namespace MobiFlight.Base.Tests
             ConfigFile2.ConfigItems.Add(new OutputConfigItem() {});
 
             var ConfigFile3 = new ConfigFile("file3.json");
-            Assert.AreEqual(0, ConfigFile3.ConfigItems.Count);
+            Assert.IsEmpty(ConfigFile3.ConfigItems);
 
             ConfigFileUtils.MergeConfigItems(ConfigFile3, ConfigFile1);
-            Assert.AreEqual(ConfigFile1.ConfigItems.Count, ConfigFile3.ConfigItems.Count);
+            Assert.HasCount(ConfigFile1.ConfigItems.Count, ConfigFile3.ConfigItems);
 
             // check the GUIDs of the items
             for (int i = 0; i < ConfigFile1.ConfigItems.Count; i++)
@@ -27,7 +27,7 @@ namespace MobiFlight.Base.Tests
             }
 
             ConfigFileUtils.MergeConfigItems(ConfigFile3, ConfigFile2);
-            Assert.AreEqual(ConfigFile1.ConfigItems.Count + ConfigFile2.ConfigItems.Count, ConfigFile3.ConfigItems.Count);
+            Assert.HasCount(ConfigFile1.ConfigItems.Count + ConfigFile2.ConfigItems.Count, ConfigFile3.ConfigItems);
 
             for (int i = ConfigFile1.ConfigItems.Count; i < ConfigFile3.ConfigItems.Count; i++)
             {

--- a/MobiFlightUnitTests/Base/ConfigRefTests.cs
+++ b/MobiFlightUnitTests/Base/ConfigRefTests.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.Base;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.Base.Tests
@@ -36,19 +31,19 @@ namespace MobiFlight.Base.Tests
             Assert.IsNull(o.Ref, "Ref is not null");
             Assert.IsNull(o.Placeholder, "Placeholder is not null");
             Assert.IsNotNull(o.TestValue, "TestValue is null");
-            Assert.AreEqual(o.TestValue, "1", "TestValue is not matching");
+            Assert.AreEqual("1", o.TestValue, "TestValue is not matching");
 
             o.ReadXml(xmlReader);
             // the second one is set so the values should be initialized
-            Assert.AreEqual(o.Ref, "d88beacf-a305-4964-a4be-caf6693e18eb", "Ref is not matching");
-            Assert.AreEqual(o.Placeholder, "?", "Placeholder is not matching");
-            Assert.AreEqual(o.TestValue, "1", "TestValue is not matching");
+            Assert.AreEqual("d88beacf-a305-4964-a4be-caf6693e18eb", o.Ref, "Ref is not matching");
+            Assert.AreEqual("?", o.Placeholder, "Placeholder is not matching");
+            Assert.AreEqual("1", o.TestValue, "TestValue is not matching");
 
             o.ReadXml(xmlReader);
             // the second one is set so the values should be initialized
-            Assert.AreEqual(o.Ref, "2ab3b1b5-fbd2-4b8c-9366-ad948fff8135", "Ref is not matching");
-            Assert.AreEqual(o.Placeholder, "#", "Placeholder is not matching");
-            Assert.AreEqual(o.TestValue, "5", "TestValue is not matching");
+            Assert.AreEqual("2ab3b1b5-fbd2-4b8c-9366-ad948fff8135", o.Ref, "Ref is not matching");
+            Assert.AreEqual("#", o.Placeholder, "Placeholder is not matching");
+            Assert.AreEqual("5", o.TestValue, "TestValue is not matching");
 
             o = new ConfigRef(); // we have to make sure to use a new one otherwise 
                                  // it would hold the information from last read
@@ -81,7 +76,7 @@ namespace MobiFlight.Base.Tests
 
             String result = System.IO.File.ReadAllText(@"assets\Base\ConfigRef\WriteXmlTest.1.xml");
 
-            Assert.AreEqual(s, result, "The both strings are not equal");
+            Assert.AreEqual(result, s, "The both strings are not equal");
         }
 
         [TestMethod()]
@@ -96,10 +91,10 @@ namespace MobiFlight.Base.Tests
             ConfigRef c = o.Clone() as ConfigRef;
 
             Assert.AreNotSame(o, c, "Clone is the same object");
-            Assert.AreEqual(o.Active, c.Active, "Active not the same");
-            Assert.AreEqual(o.Ref, c.Ref, "Ref not the same");
-            Assert.AreEqual(o.Placeholder, c.Placeholder, "Placeholder not the same");
-            Assert.AreEqual(o.TestValue, c.TestValue, "TestValue not the same");
+            Assert.AreEqual(c.Active, o.Active, "Active not the same");
+            Assert.AreEqual(c.Ref, o.Ref, "Ref not the same");
+            Assert.AreEqual(c.Placeholder, o.Placeholder, "Placeholder not the same");
+            Assert.AreEqual(c.TestValue, o.TestValue, "TestValue not the same");
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/Base/Deprecated/DeprecatedConfigFileTests.cs
+++ b/MobiFlightUnitTests/Base/Deprecated/DeprecatedConfigFileTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.OutputConfig;
 using System;
 using System.Text.RegularExpressions;
 
@@ -187,8 +186,8 @@ namespace MobiFlight.Base.Deprecated.Tests
                 o = new DeprecatedConfigFile(inFile);
                 o.OpenFile();
                 Assert.IsTrue(o.ConfigItems[0].Active);
-                Assert.IsTrue(o.ConfigItems[0].Name == "ConfigItem For Precondition");
-                Assert.IsTrue(o.ConfigItems[0].GUID == "bdd97308-b4f8-475c-a8c4-729e191101af");
+                Assert.AreEqual("ConfigItem For Precondition", o.ConfigItems[0].Name);
+                Assert.AreEqual("bdd97308-b4f8-475c-a8c4-729e191101af", o.ConfigItems[0].GUID);
             }
             catch (Exception)
             {
@@ -201,7 +200,6 @@ namespace MobiFlight.Base.Deprecated.Tests
         public void SaveFileTest()
         {
             // implicitly tested in OpenFileTest();
-            Assert.IsTrue(true);
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -120,7 +120,7 @@ namespace MobiFlight.Execution.Tests
             var result = _executor.Execute(inputEventArgs, isStarted: true);
 
             // Assert
-            Assert.AreEqual(0, result.Count);
+            Assert.IsEmpty(result);
         }
 
         [TestMethod]
@@ -148,7 +148,7 @@ namespace MobiFlight.Execution.Tests
             var result = _executor.Execute(inputEventArgs, isStarted: true);
 
             // Assert
-            Assert.AreEqual(0, result.Count);
+            Assert.IsEmpty(result);
 
             _mockLogAppender.Verify(
                 appender => appender.log(It.Is<string>(msg => msg.Contains($@"Skipping inactive config ""{inactiveConfigItem.Name}""")), LogSeverity.Warn),
@@ -182,7 +182,7 @@ namespace MobiFlight.Execution.Tests
             var result = _executor.Execute(inputEventArgs, isStarted: true);
 
             // Assert
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.IsTrue(result.ContainsKey(activeConfigItem.GUID));
 
             _mockLogAppender.Verify(
@@ -245,7 +245,7 @@ namespace MobiFlight.Execution.Tests
             var result = _executor.Execute(inputEventArgs, isStarted: true);
 
             // Assert
-            Assert.AreEqual(1, result.Count, "Only one item should be executed.");
+            Assert.HasCount(1, result, "Only one item should be executed.");
             Assert.IsTrue(result.ContainsKey(activeConfigItem.GUID), "The wrong config item was executed.");
 
             _mockLogAppender.Verify(
@@ -309,7 +309,7 @@ namespace MobiFlight.Execution.Tests
             var result = _executor.Execute(inputEventArgs, isStarted: true);
 
             // Assert
-            Assert.AreEqual(0, result.Count);
+            Assert.IsEmpty(result);
 
             _mockLogAppender.Verify(
                 appender => appender.log(It.Is<string>(msg => msg.Contains($@"Preconditions not satisfied for ""{configItem.Name}"".")), LogSeverity.Debug),
@@ -343,7 +343,7 @@ namespace MobiFlight.Execution.Tests
             var result = _executor.Execute(inputEventArgs, isStarted: false);
 
             // Assert
-            Assert.AreEqual(0, result.Count);
+            Assert.IsEmpty(result);
 
             _mockLogAppender.Verify(
                 appender => appender.log(It.Is<string>(msg => msg.Contains("skipping, MobiFlight not running.")), LogSeverity.Warn),

--- a/MobiFlightUnitTests/Base/Migration/Output_0_9_MigrationTests.cs
+++ b/MobiFlightUnitTests/Base/Migration/Output_0_9_MigrationTests.cs
@@ -35,17 +35,17 @@ namespace MobiFlightUnitTests.Base.Migration
 
             // Assert
             var device = result["ConfigFiles"][0]["ConfigItems"][0]["Device"];
-            
+
             // New properties should exist
             Assert.AreEqual("LED1", device["pin"].ToString());
             Assert.AreEqual(255, device["brightness"].Value<int>());
-            Assert.AreEqual(true, device["pwmMode"].Value<bool>());
-            
+            Assert.IsTrue(device["pwmMode"].Value<bool>());
+
             // Old properties should be removed
             Assert.IsNull(device["DisplayPin"]);
             Assert.IsNull(device["DisplayPinBrightness"]);
             Assert.IsNull(device["DisplayPinPWM"]);
-            
+
             // Non-migrated properties should remain
             Assert.AreEqual("Test Output", device["Name"].ToString());
             Assert.AreEqual("Output", device["Type"].ToString());
@@ -84,13 +84,13 @@ namespace MobiFlightUnitTests.Base.Migration
             // Assert
             var device1 = result["ConfigFiles"][0]["ConfigItems"][0]["Device"];
             var device2 = result["ConfigFiles"][0]["ConfigItems"][1]["Device"];
-            
+
             Assert.AreEqual("LED1", device1["pin"].ToString());
             Assert.AreEqual(200, device1["brightness"].Value<int>());
             Assert.IsNull(device1["DisplayPin"]);
-            
+
             Assert.AreEqual("LED2", device2["pin"].ToString());
-            Assert.AreEqual(false, device2["pwmMode"].Value<bool>());
+            Assert.IsFalse(device2["pwmMode"].Value<bool>());
             Assert.IsNull(device2["DisplayPin"]);
         }
 
@@ -119,7 +119,7 @@ namespace MobiFlightUnitTests.Base.Migration
 
             // Assert
             var device = result["ConfigFiles"][0]["ConfigItems"][0]["Device"];
-            
+
             Assert.AreEqual("LED1", device["pin"].ToString());
             Assert.IsNull(device["brightness"]); // Should not exist if not in source
             Assert.IsNull(device["pwmMode"]); // Should not exist if not in source
@@ -151,7 +151,7 @@ namespace MobiFlightUnitTests.Base.Migration
 
             // Assert
             var device = result["ConfigFiles"][0]["ConfigItems"][0]["Device"];
-            
+
             // Original properties should remain unchanged for non-Output devices
             Assert.AreEqual("BTN1", device["DisplayPin"].ToString());
             Assert.AreEqual(128, device["DisplayPinBrightness"].Value<int>());
@@ -245,7 +245,7 @@ namespace MobiFlightUnitTests.Base.Migration
             // Assert
             var device1 = result["ConfigFiles"][0]["ConfigItems"][0]["Device"];
             var device2 = result["ConfigFiles"][1]["ConfigItems"][0]["Device"];
-            
+
             Assert.AreEqual("LED1", device1["pin"].ToString());
             Assert.AreEqual(100, device2["brightness"].Value<int>());
         }
@@ -277,7 +277,7 @@ namespace MobiFlightUnitTests.Base.Migration
             // Assert - Original document should be unchanged
             Assert.AreEqual("LED1", originalPin);
             Assert.AreEqual("LED1", inputDocument["ConfigFiles"][0]["ConfigItems"][0]["Device"]["DisplayPin"].ToString());
-            
+
             // Result should be different
             Assert.IsNull(result["ConfigFiles"][0]["ConfigItems"][0]["Device"]["DisplayPin"]);
             Assert.AreEqual("LED1", result["ConfigFiles"][0]["ConfigItems"][0]["Device"]["pin"].ToString());

--- a/MobiFlightUnitTests/Base/Migration/ProjectMigrationTests.cs
+++ b/MobiFlightUnitTests/Base/Migration/ProjectMigrationTests.cs
@@ -43,7 +43,7 @@ namespace MobiFlight.Base.Migration.Tests
             }}");
 
             // Use reflection to access private method
-            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations", 
+            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
@@ -64,7 +64,7 @@ namespace MobiFlight.Base.Migration.Tests
                 ""ConfigFiles"": []
             }");
 
-            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations", 
+            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
@@ -121,16 +121,16 @@ namespace MobiFlight.Base.Migration.Tests
 
             // Assert
             Assert.AreEqual("Legacy Integration Project", project.Name);
-            Assert.AreEqual(1, project.ConfigFiles.Count);
-            
+            Assert.HasCount(1, project.ConfigFiles);
+
             var configFile = project.ConfigFiles[0];
             Assert.AreEqual("Integration Config", configFile.Label);
-            Assert.AreEqual(1, configFile.ConfigItems.Count);
-            
+            Assert.HasCount(1, configFile.ConfigItems);
+
             var configItem = configFile.ConfigItems[0];
             Assert.AreEqual("Integration Output", configItem.Name);
             Assert.AreEqual("test-guid-123", configItem.GUID);
-            
+
             // The deserialization should work because migration happened before JSON was processed
             // Note: The exact precondition validation would depend on your Precondition class implementation
             Assert.AreEqual(1, configItem.Preconditions.Count);
@@ -152,10 +152,10 @@ namespace MobiFlight.Base.Migration.Tests
 
             // Assert
             Assert.IsTrue(File.Exists(testProjectFile));
-            
+
             var savedContent = File.ReadAllText(testProjectFile);
             var savedDocument = JObject.Parse(savedContent);
-            
+
             Assert.AreEqual(project.SchemaVersion.ToString(), savedDocument["_version"].ToString());
             Assert.AreEqual("Version Test Project", savedDocument["Name"].ToString());
         }
@@ -210,11 +210,11 @@ namespace MobiFlight.Base.Migration.Tests
 
             // Assert
             Assert.AreEqual("Modern Project", project.Name);
-            Assert.AreEqual(1, project.ConfigFiles.Count);
-            
+            Assert.HasCount(1, project.ConfigFiles);
+
             var configFile = project.ConfigFiles[0];
             Assert.AreEqual("Modern Config", configFile.Label);
-            Assert.AreEqual(1, configFile.ConfigItems.Count);
+            Assert.HasCount(1, configFile.ConfigItems);
         }
 
         [TestMethod]
@@ -268,11 +268,11 @@ namespace MobiFlight.Base.Migration.Tests
 
             // Assert
             Assert.AreEqual("Modern Project", project.Name);
-            Assert.AreEqual(1, project.ConfigFiles.Count);
+            Assert.HasCount(1, project.ConfigFiles);
 
             var configFile = project.ConfigFiles[0];
             Assert.AreEqual("Modern Config", configFile.Label);
-            Assert.AreEqual(1, configFile.ConfigItems.Count);
+            Assert.HasCount(1, configFile.ConfigItems);
             Assert.AreEqual(0, configFile.ConfigItems[0].Preconditions.Count);
         }
 
@@ -464,12 +464,12 @@ namespace MobiFlight.Base.Migration.Tests
                 ]
             }");
 
-            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations", 
+            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act & Assert - Should not throw
             var result = applyMigrationsMethod.Invoke(project, new object[] { corruptedDocument, false }) as JObject;
-            
+
             // Verify version was still updated
             Assert.AreEqual(project.SchemaVersion.ToString(), result["_version"].ToString());
         }
@@ -485,7 +485,7 @@ namespace MobiFlight.Base.Migration.Tests
                 ""ConfigFiles"": []
             }");
 
-            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations", 
+            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
@@ -507,7 +507,7 @@ namespace MobiFlight.Base.Migration.Tests
                 ""ConfigFiles"": []
             }");
 
-            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations", 
+            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
@@ -529,7 +529,7 @@ namespace MobiFlight.Base.Migration.Tests
                 ""ConfigFiles"": []
             }");
 
-            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations", 
+            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
@@ -551,7 +551,7 @@ namespace MobiFlight.Base.Migration.Tests
             }");
 
             // Use reflection to access private method
-            var getVersionMethod = typeof(Project).GetMethod("GetDocumentSchemaVersion", 
+            var getVersionMethod = typeof(Project).GetMethod("GetDocumentSchemaVersion",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
@@ -571,7 +571,7 @@ namespace MobiFlight.Base.Migration.Tests
                 ""Name"": ""Complex Version Project""
             }");
 
-            var getVersionMethod = typeof(Project).GetMethod("GetDocumentSchemaVersion", 
+            var getVersionMethod = typeof(Project).GetMethod("GetDocumentSchemaVersion",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act
@@ -611,7 +611,7 @@ namespace MobiFlight.Base.Migration.Tests
                 ""ConfigFiles"": []
             }}");
 
-            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations", 
+            var applyMigrationsMethod = typeof(Project).GetMethod("ApplyMigrations",
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
 
             // Act

--- a/MobiFlightUnitTests/Base/PreconditionListTests.cs
+++ b/MobiFlightUnitTests/Base/PreconditionListTests.cs
@@ -1,5 +1,4 @@
-﻿using MobiFlight.Base;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -49,9 +48,9 @@ namespace MobiFlight.Base.Tests
         public void AddTest()
         {
             PreconditionList o = new PreconditionList();
-            Assert.IsTrue(o.Count == 0);
+            Assert.AreEqual(0, o.Count);
             o.Add(new Precondition());
-            Assert.IsTrue(o.Count == 1);
+            Assert.AreEqual(1, o.Count);
         }
 
         [TestMethod()]
@@ -60,9 +59,9 @@ namespace MobiFlight.Base.Tests
             PreconditionList o = new PreconditionList();
             Precondition p = new Precondition();
             o.Add(p);
-            Assert.IsTrue(o.Count == 1);
+            Assert.HasCount(1, o);
             o.Remove(p);
-            Assert.IsTrue(o.Count == 0);
+            Assert.HasCount(0, o);
         }
 
         [TestMethod()]
@@ -85,7 +84,7 @@ namespace MobiFlight.Base.Tests
             xmlReader.ReadToDescendant("preconditions");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.Count, 0);
+            Assert.AreEqual(0, o.Count);
 
             o = new PreconditionList();
             s = System.IO.File.ReadAllText(@"assets\Base\PreconditionList\ReadXmlTest.2.xml");
@@ -97,9 +96,9 @@ namespace MobiFlight.Base.Tests
             xmlReader.ReadToDescendant("preconditions");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.Count, 2);
-            Assert.AreEqual(o.ExecuteOnFalse, false);
-            Assert.AreEqual(o.FalseCaseValue, "");
+            Assert.AreEqual(2, o.Count);
+            Assert.IsFalse(o.ExecuteOnFalse);
+            Assert.AreEqual("", o.FalseCaseValue);
         }
 
         [TestMethod()]
@@ -132,7 +131,7 @@ namespace MobiFlight.Base.Tests
 
             String result = System.IO.File.ReadAllText(@"assets\Base\PreconditionList\WriteXmlTest.1.xml");
 
-            Assert.AreEqual(s, result, "The both strings are not equal");
+            Assert.AreEqual(result, s, "The both strings are not equal");
         }
 
         [TestMethod()]
@@ -227,7 +226,7 @@ namespace MobiFlight.Base.Tests
             var json = JsonConvert.SerializeObject(list, Newtonsoft.Json.Formatting.Indented, settings);
 
             // Assert
-            Assert.IsFalse(json.Contains("null"), "Serialized JSON should not contain 'null' for empty preconditions");
+            Assert.DoesNotContain("null", json, "Serialized JSON should not contain 'null' for empty preconditions");
             // Should serialize as empty array or with no preconditions
             Assert.IsTrue(json.Contains("[]") || !json.Contains("\"Preconditions\""),
                 "Empty preconditions should result in empty array or no Preconditions property");
@@ -266,8 +265,8 @@ namespace MobiFlight.Base.Tests
             var json = JsonConvert.SerializeObject(list, Newtonsoft.Json.Formatting.Indented, settings);
 
             // Assert
-            Assert.IsFalse(json.Contains("null"), "Serialized JSON should not contain 'null'");
-            Assert.IsTrue(json.Contains("TestRef"), "Valid precondition should be serialized");
+            Assert.DoesNotContain("null", json, "Serialized JSON should not contain 'null'");
+            Assert.Contains("TestRef", json, "Valid precondition should be serialized");
 
             // Count how many preconditions are in the output
             var deserializedList = JsonConvert.DeserializeObject<PreconditionList>(json);
@@ -291,7 +290,7 @@ namespace MobiFlight.Base.Tests
             var json = JsonConvert.SerializeObject(list, Newtonsoft.Json.Formatting.Indented, settings);
 
             // Assert
-            Assert.IsFalse(json.Contains("null"), "Serialized JSON should not contain 'null'");
+            Assert.DoesNotContain("null", json, "Serialized JSON should not contain 'null'");
         }
 
         [TestMethod()]
@@ -311,7 +310,7 @@ namespace MobiFlight.Base.Tests
             var json = configFile.ToJson();
 
             // Assert
-            Assert.IsFalse(json.Contains("null"), "ConfigFile JSON should not contain 'null' for empty preconditions");
+            Assert.DoesNotContain("null", json, "ConfigFile JSON should not contain 'null' for empty preconditions");
         }
     }
 }

--- a/MobiFlightUnitTests/Base/PreconditionTests.cs
+++ b/MobiFlightUnitTests/Base/PreconditionTests.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.Tests
@@ -19,10 +14,10 @@ namespace MobiFlight.Tests
         {
             Precondition o = new Precondition();
             Assert.IsNotNull(o, "Object is null");
-            Assert.AreEqual(o.Type, "none", "Type is not none");
-            Assert.AreEqual(o.Active, true, "Active is not true");
-            Assert.AreEqual(o.Logic, "and", "Precondition logic is not and");
-            Assert.AreEqual(o.Operand, Precondition.OPERAND_DEFAULT, "Precondition operand is not the OPERAND_DEFAULT");
+            Assert.AreEqual("none", o.Type, "Type is not none");
+            Assert.IsTrue(o.Active, "Active is not true");
+            Assert.AreEqual("and", o.Logic, "Precondition logic is not and");
+            Assert.AreEqual(Precondition.OPERAND_DEFAULT, o.Operand, "Precondition operand is not the OPERAND_DEFAULT");
         }
 
         [TestMethod()]
@@ -45,28 +40,28 @@ namespace MobiFlight.Tests
             xmlReader.ReadToDescendant("precondition");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.Active, true, "Active not the same");
-            Assert.AreEqual(o.Label, "TestLabel", "Label not the same");
-            Assert.AreEqual(o.Logic, "or", "Logic not the same");
-            Assert.AreEqual(o.Operand, "<", "Operand not the same");
-            Assert.AreEqual(o.Pin, null, "Pin not the same");
-            Assert.AreEqual(o.Ref, "TestRef", "Ref not the same");
-            Assert.AreEqual(o.Serial, null, "Serial not the same");
-            Assert.AreEqual(o.Type, "config", "Type not the same");
-            Assert.AreEqual(o.Value, "0", "Value not the same");
+            Assert.IsTrue(o.Active, "Active not the same");
+            Assert.AreEqual("TestLabel", o.Label, "Label not the same");
+            Assert.AreEqual("or", o.Logic, "Logic not the same");
+            Assert.AreEqual("<", o.Operand, "Operand not the same");
+            Assert.IsNull(o.Pin, "Pin not the same");
+            Assert.AreEqual("TestRef", o.Ref, "Ref not the same");
+            Assert.IsNull(o.Serial, "Serial not the same");
+            Assert.AreEqual("config", o.Type, "Type not the same");
+            Assert.AreEqual("0", o.Value, "Value not the same");
 
             o = new Precondition();
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.Active, true, "Active not the same");
-            Assert.AreEqual(o.Label, "TestLabel", "Label not the same");
-            Assert.AreEqual(o.Logic, "or", "Logic not the same");
-            Assert.AreEqual(o.Operand, "<", "Operand not the same");
-            Assert.AreEqual(o.Pin, "TestPin", "Pin not the same");
-            Assert.AreEqual(o.Ref, null, "Ref not the same");
-            Assert.AreEqual(o.Serial, "TestSerial", "Serial not the same");
-            Assert.AreEqual(o.Type, "pin", "Type not the same");
-            Assert.AreEqual(o.Value, "0", "Value not the same");
+            Assert.IsTrue(o.Active, "Active not the same");
+            Assert.AreEqual("TestLabel", o.Label, "Label not the same");
+            Assert.AreEqual("or", o.Logic, "Logic not the same");
+            Assert.AreEqual("<", o.Operand, "Operand not the same");
+            Assert.AreEqual("TestPin", o.Pin, "Pin not the same");
+            Assert.IsNull(o.Ref, "Ref not the same");
+            Assert.AreEqual("TestSerial", o.Serial, "Serial not the same");
+            Assert.AreEqual("pin", o.Type, "Type not the same");
+            Assert.AreEqual("0", o.Value, "Value not the same");
         }
 
         [TestMethod()]
@@ -90,7 +85,7 @@ namespace MobiFlight.Tests
 
             String result = System.IO.File.ReadAllText(@"assets\Base\Precondition\WriteXmlTest.1.xml");
 
-            Assert.AreEqual(s, result, "The both strings are not equal");
+            Assert.AreEqual(result, s, "The both strings are not equal");
         }
 
         [TestMethod()]
@@ -99,22 +94,22 @@ namespace MobiFlight.Tests
             Precondition o = _generateTestObject();
             Precondition c = (Precondition)o.Clone();
             Assert.AreNotSame(o, c, "Clone is the same object");
-            Assert.AreEqual(o.Active, c.Active, "Active not the same");
-            Assert.AreEqual(o.Label, c.Label, "Label not the same");
-            Assert.AreEqual(o.Logic, c.Logic, "Logic not the same");
-            Assert.AreEqual(o.Operand, c.Operand, "Operand not the same");
-            Assert.AreEqual(o.Pin, c.Pin, "Pin not the same");
-            Assert.AreEqual(o.Ref, c.Ref, "Ref not the same");
-            Assert.AreEqual(o.Serial, c.Serial, "Serial not the same");
-            Assert.AreEqual(o.Type, c.Type, "Type not the same");
-            Assert.AreEqual(o.Value, c.Value, "Value not the same");
+            Assert.AreEqual(c.Active, o.Active, "Active not the same");
+            Assert.AreEqual(c.Label, o.Label, "Label not the same");
+            Assert.AreEqual(c.Logic, o.Logic, "Logic not the same");
+            Assert.AreEqual(c.Operand, o.Operand, "Operand not the same");
+            Assert.AreEqual(c.Pin, o.Pin, "Pin not the same");
+            Assert.AreEqual(c.Ref, o.Ref, "Ref not the same");
+            Assert.AreEqual(c.Serial, o.Serial, "Serial not the same");
+            Assert.AreEqual(c.Type, o.Type, "Type not the same");
+            Assert.AreEqual(c.Value, o.Value, "Value not the same");
         }
 
         [TestMethod()]
         public void ToStringTest()
         {
             Precondition o = _generateTestObject();
-            Assert.AreEqual(o.ToString(), "TestPreCon", "String value is not correct");
+            Assert.AreEqual("TestPreCon", o.ToString(), "String value is not correct");
         }
 
         private Precondition _generateTestObject()

--- a/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.Base;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using System.IO;
 using System.Linq;
@@ -43,17 +42,17 @@ namespace MobiFlight.Base.Tests
             o.OpenFile();
 
             Assert.IsNotNull(o.ConfigFiles);
-            Assert.IsTrue(o.ConfigFiles.Count > 0);
+            Assert.IsNotEmpty(o.ConfigFiles);
 
             var config = o.ConfigFiles[0];
             var inputConfigs = config.ConfigItems.Where(i => i is InputConfigItem);
 
             Assert.IsNotNull(inputConfigs);
-            Assert.IsTrue(inputConfigs.Count() > 0);
+            Assert.IsGreaterThan(0, inputConfigs.Count());
 
             var outputConfigs = config.ConfigItems.Where(i => i is OutputConfigItem);
             Assert.IsNotNull(outputConfigs);
-            Assert.IsTrue(outputConfigs.Count() > 0);
+            Assert.IsGreaterThan(0, outputConfigs.Count());
         }
 
         [TestMethod()]
@@ -67,13 +66,13 @@ namespace MobiFlight.Base.Tests
             o.OpenFile();
 
             Assert.IsNotNull(o.ConfigFiles);
-            Assert.IsTrue(o.ConfigFiles.Count > 0);
+            Assert.IsNotEmpty(o.ConfigFiles);
 
             var config = o.ConfigFiles[0];
             var outputConfig = config.ConfigItems.Where(i => i is OutputConfigItem && i.Name == "COM1 Active").First();
 
             Assert.IsNotNull(outputConfig);
-            Assert.IsTrue(outputConfig as OutputConfigItem != null);
+            Assert.IsNotNull(outputConfig as OutputConfigItem);
             var preconditions = (outputConfig as OutputConfigItem).Preconditions;
 
             Assert.AreEqual(0, preconditions.Count);
@@ -90,13 +89,13 @@ namespace MobiFlight.Base.Tests
             o.OpenFile();
 
             Assert.IsNotNull(o.ConfigFiles);
-            Assert.IsTrue(o.ConfigFiles.Count > 0);
+            Assert.IsNotEmpty(o.ConfigFiles);
 
             var config = o.ConfigFiles[0];
             var outputConfig = config.ConfigItems.Where(i => i is OutputConfigItem && i.Name == "COM1 Standby").First();
 
             Assert.IsNotNull(outputConfig);
-            Assert.IsTrue(outputConfig as OutputConfigItem != null);
+            Assert.IsNotNull(outputConfig as OutputConfigItem);
             var preconditions = (outputConfig as OutputConfigItem).Preconditions;
 
             Assert.AreEqual(2, preconditions.Count);
@@ -113,17 +112,17 @@ namespace MobiFlight.Base.Tests
             o.OpenFile();
 
             Assert.IsNotNull(o.ConfigFiles);
-            Assert.IsTrue(o.ConfigFiles.Count > 0);
+            Assert.IsNotEmpty(o.ConfigFiles);
 
             var config = o.ConfigFiles[0];
             var inputConfigs = config.ConfigItems.Where(i => i is InputConfigItem);
 
             Assert.IsNotNull(inputConfigs);
-            Assert.IsTrue(inputConfigs.Count() > 0);
+            Assert.IsGreaterThan(0, inputConfigs.Count());
 
             var outputConfigs = config.ConfigItems.Where(i => i is OutputConfigItem);
             Assert.IsNotNull(outputConfigs);
-            Assert.IsTrue(outputConfigs.Count() > 0);
+            Assert.IsGreaterThan(0, outputConfigs.Count());
         }
 
         [TestMethod()]
@@ -158,7 +157,7 @@ namespace MobiFlight.Base.Tests
             o.SaveFile();
 
             string fileContent = File.ReadAllText(outFile);
-            Assert.IsFalse(fileContent.Contains("\"SchemaVersion\":"));
+            Assert.DoesNotContain("\"SchemaVersion\":", fileContent);
         }
 
         [TestMethod()]
@@ -174,7 +173,7 @@ namespace MobiFlight.Base.Tests
             o.SaveFile();
 
             string fileContent = File.ReadAllText(outFile);
-            Assert.IsFalse(fileContent.Contains("\"FilePath\":"));
+            Assert.DoesNotContain("\"FilePath\":", fileContent);
         }
 
         [TestMethod()]
@@ -226,7 +225,7 @@ namespace MobiFlight.Base.Tests
             targetProject.Merge(sourceProject);
 
             // Assert
-            Assert.AreEqual(originalCount + 2, targetProject.ConfigFiles.Count);
+            Assert.HasCount(originalCount + 2, targetProject.ConfigFiles);
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Source Config 1"));
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Source Config 2"));
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Original Config"));
@@ -249,7 +248,7 @@ namespace MobiFlight.Base.Tests
             targetProject.Merge(sourceProject);
 
             // Assert
-            Assert.AreEqual(originalCount, targetProject.ConfigFiles.Count);
+            Assert.HasCount(originalCount, targetProject.ConfigFiles);
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Original Config"));
         }
 
@@ -275,7 +274,7 @@ namespace MobiFlight.Base.Tests
 
             // Assert
             var totalItemsAfterMerge = targetProject.ConfigFiles.SelectMany(cf => cf.ConfigItems).Count();
-            Assert.IsTrue(totalItemsAfterMerge > originalItemCount);
+            Assert.IsGreaterThan(originalItemCount, totalItemsAfterMerge);
 
             // Verify original items are still there
             Assert.IsTrue(targetProject.ConfigFiles.SelectMany(cf => cf.ConfigItems).Any(item => item.GUID == "original-guid"));
@@ -299,7 +298,7 @@ namespace MobiFlight.Base.Tests
             targetProject.MergeFromProjectFile(sourceFile);
 
             // Assert
-            Assert.IsTrue(targetProject.ConfigFiles.Count > originalCount);
+            Assert.IsGreaterThan(originalCount, targetProject.ConfigFiles.Count);
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Config File 1"));
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Original Config"));
         }
@@ -319,7 +318,7 @@ namespace MobiFlight.Base.Tests
             targetProject.MergeFromProjectFile(sourceFile);
 
             // Assert
-            Assert.AreEqual(originalCount + 2, targetProject.ConfigFiles.Count);
+            Assert.HasCount(originalCount + 2, targetProject.ConfigFiles);
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Config File 2A"));
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Config File 2B"));
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Original Config"));
@@ -346,7 +345,7 @@ namespace MobiFlight.Base.Tests
             targetProject.MergeFromProjectFile(sourceFile);
 
             // Assert
-            Assert.AreEqual(originalCount, targetProject.ConfigFiles.Count);
+            Assert.HasCount(originalCount, targetProject.ConfigFiles);
             Assert.IsTrue(targetProject.ConfigFiles.Any(cf => cf.Label == "Original Config"));
         }
 
@@ -433,7 +432,7 @@ namespace MobiFlight.Base.Tests
             targetProject.Merge(sourceProject);
 
             // Assert
-            Assert.AreEqual(2, targetProject.ConfigFiles.Count);
+            Assert.HasCount(2, targetProject.ConfigFiles);
             Assert.AreEqual(2, targetProject.ConfigFiles.Count(cf => cf.Label == "Same Label"));
         }
 
@@ -465,8 +464,8 @@ namespace MobiFlight.Base.Tests
             var outputItems = allItems.Where(item => item is OutputConfigItem).ToList();
             var inputItems = allItems.Where(item => item is InputConfigItem).ToList();
 
-            Assert.IsTrue(outputItems.Count > 1); // Original + merged outputs
-            Assert.IsTrue(inputItems.Count > 1); // Original + merged inputs
+            Assert.IsGreaterThan(1, outputItems.Count); // Original + merged outputs
+            Assert.IsGreaterThan(1, inputItems.Count); // Original + merged inputs
 
             // Verify specific merged items
             Assert.IsTrue(allItems.Any(item => item.GUID == "merge-test-guid-2a"));
@@ -490,7 +489,7 @@ namespace MobiFlight.Base.Tests
 
             // Assert
             Assert.IsNotNull(project.Controllers);
-            Assert.AreEqual(0, project.Controllers.Count);
+            Assert.IsEmpty(project.Controllers);
             Assert.IsNull(project.Sim);
             Assert.IsFalse(project.Features.FSUIPC);
             Assert.IsFalse(project.Features.ProSim);
@@ -515,10 +514,10 @@ namespace MobiFlight.Base.Tests
             project.DetermineProjectInfos();
 
             // Assert
-            Assert.AreEqual(3, project.Controllers.Count);
-            Assert.IsTrue(project.Controllers.Contains("SN-123-456"));
-            Assert.IsTrue(project.Controllers.Contains("SN-789-012"));
-            Assert.IsTrue(project.Controllers.Contains("SN-345-678"));
+            Assert.HasCount(3, project.Controllers);
+            Assert.Contains("SN-123-456", project.Controllers);
+            Assert.Contains("SN-789-012", project.Controllers);
+            Assert.Contains("SN-345-678", project.Controllers);
         }
 
         [TestMethod()]
@@ -541,9 +540,9 @@ namespace MobiFlight.Base.Tests
             project.DetermineProjectInfos();
 
             // Assert
-            Assert.AreEqual(2, project.Controllers.Count);
-            Assert.IsTrue(project.Controllers.Contains("SN-AAA-111"));
-            Assert.IsTrue(project.Controllers.Contains("SN-BBB-222"));
+            Assert.HasCount(2, project.Controllers);
+            Assert.Contains("SN-AAA-111", project.Controllers);
+            Assert.Contains("SN-BBB-222", project.Controllers);
         }
 
         [TestMethod()]
@@ -568,9 +567,9 @@ namespace MobiFlight.Base.Tests
             project.DetermineProjectInfos();
 
             // Assert
-            Assert.AreEqual(1, project.Controllers.Count);
-            Assert.IsFalse(project.Controllers.Contains("SN-FIRST-001"));
-            Assert.IsTrue(project.Controllers.Contains("SN-SECOND-002"));
+            Assert.HasCount(1, project.Controllers);
+            Assert.DoesNotContain("SN-FIRST-001", project.Controllers);
+            Assert.Contains("SN-SECOND-002", project.Controllers);
         }
 
         [TestMethod()]
@@ -728,7 +727,7 @@ namespace MobiFlight.Base.Tests
             // Assert
             // Should only set the first sim found (MSFS in this case)
             Assert.AreEqual("msfs", project.Sim);
-            Assert.AreEqual(2, project.Controllers.Count);
+            Assert.HasCount(2, project.Controllers);
         }
 
         [TestMethod()]
@@ -759,7 +758,7 @@ namespace MobiFlight.Base.Tests
             // Assert
             Assert.AreEqual("msfs", project.Sim);
             Assert.IsTrue(project.Features.FSUIPC);
-            Assert.AreEqual(2, project.Controllers.Count);
+            Assert.HasCount(2, project.Controllers);
         }
 
         [TestMethod()]
@@ -801,7 +800,7 @@ namespace MobiFlight.Base.Tests
             // Assert
             Assert.AreEqual("msfs", project.Sim);
             Assert.IsTrue(project.Features.FSUIPC);
-            Assert.AreEqual(3, project.Controllers.Count);
+            Assert.HasCount(3, project.Controllers);
         }
 
         [TestMethod()]
@@ -830,7 +829,7 @@ namespace MobiFlight.Base.Tests
 
             // Assert
             Assert.AreEqual("xplane", project.Sim);
-            Assert.AreEqual(2, project.Controllers.Count);
+            Assert.HasCount(2, project.Controllers);
         }
         #endregion
 
@@ -855,7 +854,7 @@ namespace MobiFlight.Base.Tests
                 project.FilePath = ext;
                 var result = project.MigrateFileExtension();
                 Assert.AreEqual(mfprojExtension, project.FilePath, "Extension was not migrated to .mfproj");
-                Assert.AreEqual(project.FilePath, result, "Return value should be the same as FilePath value");
+                Assert.AreEqual(result, project.FilePath, "Return value should be the same as FilePath value");
             });
 
             var invalidExtensions = new[]
@@ -871,7 +870,7 @@ namespace MobiFlight.Base.Tests
                 project.FilePath = ext;
                 var result = project.MigrateFileExtension();
                 Assert.AreEqual(ext, project.FilePath, "Extension should not be changed for invalid extensions");
-                Assert.AreEqual(project.FilePath, result, "Return value should be the same as FilePath value");
+                Assert.AreEqual(result, project.FilePath, "Return value should be the same as FilePath value");
             });
         }
 

--- a/MobiFlightUnitTests/Base/SerialNumberTests.cs
+++ b/MobiFlightUnitTests/Base/SerialNumberTests.cs
@@ -1,10 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.Base;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MobiFlight.Base.Tests
 {
@@ -64,15 +58,15 @@ namespace MobiFlight.Base.Tests
         {
             var serial = "GMA345/ SN-b44-4c5";
             var result = SerialNumber.IsMobiFlightSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(true, result);
+            Assert.IsTrue(result);
 
             serial = "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000";
             result = SerialNumber.IsMobiFlightSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
 
             serial = "Arcaze v5.36/ 000393600000";
             result = SerialNumber.IsMobiFlightSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
         }
 
         [TestMethod()]
@@ -80,15 +74,15 @@ namespace MobiFlight.Base.Tests
         {
             var serial = "GMA345/ SN-b44-4c5";
             var result = SerialNumber.IsJoystickSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
 
             serial = "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000";
             result = SerialNumber.IsJoystickSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(true, result);
+            Assert.IsTrue(result);
 
             serial = "Arcaze v5.36/ 000393600000";
             result = SerialNumber.IsJoystickSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
         }
 
         [TestMethod()]
@@ -96,15 +90,15 @@ namespace MobiFlight.Base.Tests
         {
             var serial = "GMA345/ SN-b44-4c5";
             var result = SerialNumber.IsArcazeSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
 
             serial = "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000";
             result = SerialNumber.IsArcazeSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
 
             serial = "Arcaze v5.36/ 000393600000";
             result = SerialNumber.IsArcazeSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(true, result);
+            Assert.IsTrue(result);
         }
 
         [TestMethod()]
@@ -112,19 +106,19 @@ namespace MobiFlight.Base.Tests
         {
             var serial = "GMA345/ SN-b44-4c5";
             var result = SerialNumber.IsMidiBoardSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
 
             serial = "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000";
             result = SerialNumber.IsMidiBoardSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
 
             serial = "Arcaze v5.36/ 000393600000";
             result = SerialNumber.IsMidiBoardSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(false, result);
+            Assert.IsFalse(result);
 
             serial = "My MidiDevice/ MI-123456";
             result = SerialNumber.IsMidiBoardSerial(SerialNumber.ExtractSerial(serial));
-            Assert.AreEqual(true, result);
+            Assert.IsTrue(result);
         }
     }
 }

--- a/MobiFlightUnitTests/HubHop/Msfs2020HubhopPresetListTests.cs
+++ b/MobiFlightUnitTests/HubHop/Msfs2020HubhopPresetListTests.cs
@@ -17,7 +17,7 @@ namespace MobiFlight.HubHop.Tests
             Msfs2020HubhopPresetList list = new Msfs2020HubhopPresetList();
             String TestFile = @"assets\HubHop\Msfs2020HubhopPresetListTests\test01.json";
             list.Load(TestFile);
-            Assert.AreEqual(7, list.Items.Count);
+            Assert.HasCount(7, list.Items);
             Assert.AreEqual("Microsoft.Generic.Avionics.AS1000_PFD_VOL_1_INC", list.Items[0].path);
             Assert.AreEqual("Microsoft", list.Items[0].vendor);
             Assert.AreEqual("Generic", list.Items[0].aircraft);
@@ -42,7 +42,7 @@ namespace MobiFlight.HubHop.Tests
             String TestFile = @"assets\HubHop\Msfs2020HubhopPresetListTests\test01.json";
             list.Load(TestFile);
 
-            Assert.AreEqual(3, list.AllVendors(HubHopType.Input).Count);
+            Assert.HasCount(3, list.AllVendors(HubHopType.Input));
 
             // check for order
             Assert.AreEqual("Asobo", list.AllVendors(HubHopType.Input)[0]);
@@ -50,13 +50,13 @@ namespace MobiFlight.HubHop.Tests
             Assert.AreEqual("Microsoft", list.AllVendors(HubHopType.Input)[2]);
 
             // check for outputs
-            Assert.AreEqual(2, list.AllVendors(HubHopType.Output).Count);
+            Assert.HasCount(2, list.AllVendors(HubHopType.Output));
 
             // check for potentiometers
-            Assert.AreEqual(1, list.AllVendors(HubHopType.InputPotentiometer).Count);
+            Assert.HasCount(1, list.AllVendors(HubHopType.InputPotentiometer));
 
             // check for all inputs
-            Assert.AreEqual(3, list.AllVendors(HubHopType.InputPotentiometer | HubHopType.Input).Count);
+            Assert.HasCount(3, list.AllVendors(HubHopType.InputPotentiometer | HubHopType.Input));
         }
 
         [TestMethod()]
@@ -66,7 +66,7 @@ namespace MobiFlight.HubHop.Tests
             String TestFile = @"assets\HubHop\Msfs2020HubhopPresetListTests\test01.json";
             list.Load(TestFile);
 
-            Assert.AreEqual(3, list.AllAircraft(HubHopType.Input).Count);
+            Assert.HasCount(3, list.AllAircraft(HubHopType.Input));
 
             // check for order
             Assert.AreEqual("Generic", list.AllAircraft(HubHopType.Input)[0]);
@@ -74,13 +74,13 @@ namespace MobiFlight.HubHop.Tests
             Assert.AreEqual("TBM 580", list.AllAircraft(HubHopType.Input)[2]);
 
             // check for outputs
-            Assert.AreEqual(2, list.AllAircraft(HubHopType.Output).Count);
+            Assert.HasCount(2, list.AllAircraft(HubHopType.Output));
 
             // check for potentiometers
-            Assert.AreEqual(1, list.AllAircraft(HubHopType.InputPotentiometer).Count);
+            Assert.HasCount(1, list.AllAircraft(HubHopType.InputPotentiometer));
 
             // check for all inputs
-            Assert.AreEqual(4, list.AllAircraft(HubHopType.InputPotentiometer | HubHopType.Input).Count);
+            Assert.HasCount(4, list.AllAircraft(HubHopType.InputPotentiometer | HubHopType.Input));
         }
 
         [TestMethod()]
@@ -90,7 +90,7 @@ namespace MobiFlight.HubHop.Tests
             String TestFile = @"assets\HubHop\Msfs2020HubhopPresetListTests\test01.json";
             list.Load(TestFile);
 
-            Assert.AreEqual(3, list.AllSystems(HubHopType.Input).Count);
+            Assert.HasCount(3, list.AllSystems(HubHopType.Input));
 
             // check for order
             Assert.AreEqual("Avionics", list.AllSystems(HubHopType.Input)[0]);
@@ -98,13 +98,13 @@ namespace MobiFlight.HubHop.Tests
             Assert.AreEqual("Gear", list.AllSystems(HubHopType.Input)[2]);
 
             // check for outputs
-            Assert.AreEqual(2, list.AllSystems(HubHopType.Output).Count);
+            Assert.HasCount(2, list.AllSystems(HubHopType.Output));
 
             // check for potentiometers
-            Assert.AreEqual(1, list.AllSystems(HubHopType.InputPotentiometer).Count);
+            Assert.HasCount(1, list.AllSystems(HubHopType.InputPotentiometer));
 
             // check for all inputs
-            Assert.AreEqual(4, list.AllAircraft(HubHopType.InputPotentiometer | HubHopType.Input).Count);
+            Assert.HasCount(4, list.AllAircraft(HubHopType.InputPotentiometer | HubHopType.Input));
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/BoardTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/BoardTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight;
 using System.Collections.Generic;
 
 namespace MobiFlight.Tests
@@ -46,7 +45,7 @@ namespace MobiFlight.Tests
 
             // Assert
             Assert.IsNotNull(board.AvrDudeSettings.BaudRates);
-            Assert.AreEqual(1, board.AvrDudeSettings.BaudRates.Count);
+            Assert.HasCount(1, board.AvrDudeSettings.BaudRates);
             Assert.AreEqual("115200", board.AvrDudeSettings.BaudRates[0]);
         }
 
@@ -73,7 +72,7 @@ namespace MobiFlight.Tests
 
             // Assert
             Assert.AreEqual(existingBaudRates, board.AvrDudeSettings.BaudRates);
-            Assert.AreEqual(2, board.AvrDudeSettings.BaudRates.Count);
+            Assert.HasCount(2, board.AvrDudeSettings.BaudRates);
             Assert.AreEqual("9600", board.AvrDudeSettings.BaudRates[0]);
             Assert.AreEqual("57600", board.AvrDudeSettings.BaudRates[1]);
         }
@@ -476,7 +475,7 @@ namespace MobiFlight.Tests
 
             // Assert
             Assert.IsNotNull(board.AvrDudeSettings.BaudRates);
-            Assert.AreEqual(1, board.AvrDudeSettings.BaudRates.Count);
+            Assert.HasCount(1, board.AvrDudeSettings.BaudRates);
             Assert.AreEqual("57600", board.AvrDudeSettings.BaudRates[0]);
             Assert.AreEqual("reset.hex", board.Info.ResetFirmwareFile);
             Assert.AreEqual("legacy_firmware", board.Info.FirmwareBaseName);
@@ -514,7 +513,7 @@ namespace MobiFlight.Tests
 
             // Assert
             // BaudRates should not be overwritten
-            Assert.AreEqual(1, board.AvrDudeSettings.BaudRates.Count);
+            Assert.HasCount(1, board.AvrDudeSettings.BaudRates);
             Assert.AreEqual("9600", board.AvrDudeSettings.BaudRates[0]);
             
             // ResetFirmwareFile should not be overwritten
@@ -561,7 +560,7 @@ namespace MobiFlight.Tests
             board.Migrate();
 
             // Assert - Results should be the same after multiple calls
-            Assert.AreEqual(1, board.AvrDudeSettings.BaudRates.Count);
+            Assert.HasCount(1, board.AvrDudeSettings.BaudRates);
             Assert.AreEqual("115200", board.AvrDudeSettings.BaudRates[0]);
             Assert.AreEqual("reset.hex", board.Info.ResetFirmwareFile);
             Assert.AreEqual("firmware_base", board.Info.FirmwareBaseName);

--- a/MobiFlightUnitTests/MobiFlight/Config/ConfigTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Config/ConfigTests.cs
@@ -1,11 +1,8 @@
-﻿using MobiFlight.Config;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.Config.Compatibility;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MobiFlight.Config.Tests
 {
@@ -15,18 +12,18 @@ namespace MobiFlight.Config.Tests
         [TestMethod()]
         public void invalidFormatDeserializeTest()
         {
-            Assert.AreEqual(0, new Config().FromInternal("").Items.Count);
-            Assert.AreEqual(0, new Config().FromInternal("invalid").Items.Count);
-            Assert.AreEqual(0, new Config().FromInternal(":").Items.Count);
-            Assert.AreEqual(0, new Config().FromInternal("1:").Items.Count);
-            Assert.AreEqual(0, new Config().FromInternal("invalid:").Items.Count);
+            Assert.IsEmpty(new Config().FromInternal("").Items);
+            Assert.IsEmpty(new Config().FromInternal("invalid").Items);
+            Assert.IsEmpty(new Config().FromInternal(":").Items);
+            Assert.IsEmpty(new Config().FromInternal("1:").Items);
+            Assert.IsEmpty(new Config().FromInternal("invalid:").Items);
         }
 
         [TestMethod()]
         public void invalidDeviceDeserializeTest()
         {
-            Assert.AreEqual(0, new Config().FromInternal("0.0.Device:").Items.Count);
-            Assert.AreEqual(0, new Config().FromInternal("99.0.Device:").Items.Count);
+            Assert.IsEmpty(new Config().FromInternal("0.0.Device:").Items);
+            Assert.IsEmpty(new Config().FromInternal("99.0.Device:").Items);
         }
 
         [TestMethod()]
@@ -34,7 +31,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("1.0.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("1.0.Device:").Items);
 
             Button expected = new Button();
             expected.Name = "Device";
@@ -48,7 +45,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("2.0.1.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("2.0.1.Device:").Items);
 
             Encoder expected = new Encoder();
             expected.Name = "Device";
@@ -63,7 +60,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("3.0.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("3.0.Device:").Items);
 
             Output expected = new Output();
             expected.Name = "Device";
@@ -77,7 +74,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("16.0.0.1.2.3.4.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("16.0.0.1.2.3.4.Device:").Items);
 
             LedModule expected = new LedModule();
             expected.Name = "Device";
@@ -95,7 +92,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("5.0.1.2.3.4.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("5.0.1.2.3.4.Device:").Items);
 
             StepperDeprecatedV2 deprecated = new StepperDeprecatedV2();
             Stepper expected = new Stepper(deprecated);
@@ -114,7 +111,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("6.0.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("6.0.Device:").Items);
 
             Servo expected = new Servo();
             expected.Name = "Device";
@@ -128,7 +125,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("7.0.1.2.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("7.0.1.2.Device:").Items);
 
             LcdDisplay expected = new LcdDisplay();
             expected.Name = "Device";
@@ -144,7 +141,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("8.0.1.2.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("8.0.1.2.Device:").Items);
 
             Encoder expected = new Encoder();
             expected.Name = "Device";
@@ -160,7 +157,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(1, o.FromInternal("9.0.1.2.3.4.Device:").Items.Count);
+            Assert.HasCount(1, o.FromInternal("9.0.1.2.3.4.Device:").Items);
 
             Stepper expected = new Stepper();
             expected.Name = "Device";
@@ -178,7 +175,7 @@ namespace MobiFlight.Config.Tests
         {
             Config o = new Config();
 
-            Assert.AreEqual(9, o.FromInternal(
+            Assert.HasCount(9, o.FromInternal(
                 "1.0.Device1:"
                 + "2.0.1.Device2:"
                 + "3.0.Device3:"
@@ -187,7 +184,7 @@ namespace MobiFlight.Config.Tests
                 + "6.0.Device6:"
                 + "7.0.1.2.Device7:"
                 + "8.0.1.2.Device8:"
-                + "9.0.1.2.3.4.Device9:").Items.Count);
+                + "9.0.1.2.3.4.Device9:").Items);
 
             Button expected1 = new Button();
             expected1.Name = "Device1";
@@ -260,7 +257,7 @@ namespace MobiFlight.Config.Tests
             Config o = new Config();
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("", actual.ElementAt(0));
         }
 
@@ -275,7 +272,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("1.0.Device:", actual.ElementAt(0));
         }
 
@@ -291,7 +288,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("8.0.1.0.Device:", actual.ElementAt(0));
         }
 
@@ -306,7 +303,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("3.0.Device:", actual.ElementAt(0));
         }
 
@@ -325,7 +322,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("16.0.0.1.2.3.4.Device:", actual.ElementAt(0));
         }
 
@@ -344,7 +341,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("15.0.1.2.3.0.0.0.0.0.Device:", actual.ElementAt(0));
         }
 
@@ -359,7 +356,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("6.0.Device:", actual.ElementAt(0));
         }
 
@@ -376,7 +373,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("7.0.1.2.Device:", actual.ElementAt(0));
         }
 
@@ -393,7 +390,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("8.0.1.2.Device:", actual.ElementAt(0));
         }
 
@@ -412,7 +409,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device);
 
             List<String> actual = o.ToInternal(100);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual("15.0.1.2.3.4.0.0.0.0.Device:", actual.ElementAt(0));
         }
 
@@ -484,7 +481,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device9);
 
             List<String> actual = o.ToInternal(1000);
-            Assert.AreEqual(1, actual.Count);
+            Assert.HasCount(1, actual);
             Assert.AreEqual(
                 "1.0.Device1:"
                 + "8.0.1.0.Device2:"
@@ -564,7 +561,7 @@ namespace MobiFlight.Config.Tests
             o.Items.Add(device9);
 
             List<String> actual = o.ToInternal(1);
-            Assert.AreEqual(9, actual.Count);
+            Assert.HasCount(9, actual);
             Assert.AreEqual("1.0.Device1:", actual.ElementAt(0));
             Assert.AreEqual("8.0.1.0.Device2:", actual.ElementAt(1));
             Assert.AreEqual("3.0.Device3:", actual.ElementAt(2));
@@ -584,7 +581,7 @@ namespace MobiFlight.Config.Tests
 
             Assert.AreEqual("UnitTest", config.ModuleName);
             Assert.AreEqual("MobiFlight Mega", config.ModuleType);
-            Assert.AreEqual(11, config.Items.Count);
+            Assert.HasCount(11, config.Items);
         }
 
         [TestMethod()]
@@ -598,7 +595,7 @@ namespace MobiFlight.Config.Tests
             var savedConfig = Config.LoadFromFile(tmpFileName);
             Assert.AreEqual(config.ModuleName, savedConfig.ModuleName);
             Assert.AreEqual(config.ModuleType, savedConfig.ModuleType);
-            Assert.AreEqual(config.Items.Count, savedConfig.Items.Count);  
+            Assert.HasCount(config.Items.Count, savedConfig.Items);  
             for(var i = 0; i < config.Items.Count; i++)
             {
                 Assert.IsTrue(config.Items[i].Equals(savedConfig.Items[i]));

--- a/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -73,7 +73,7 @@ namespace MobiFlight.Tests
             executor.Execute(cfg, updatedValues);
 
             // Assert
-            Assert.AreEqual(0, updatedValues.Count);
+            Assert.IsEmpty(updatedValues);
         }
 
         [TestMethod]
@@ -98,8 +98,8 @@ namespace MobiFlight.Tests
 
             // Assert
             // verify that are status is cleared
-            Assert.AreEqual(1, updatedValues.Count);
-            Assert.AreEqual(0, cfg.Status.Count);
+            Assert.HasCount(1, updatedValues);
+            Assert.IsEmpty(cfg.Status);
         }
 
         [TestMethod]
@@ -124,8 +124,8 @@ namespace MobiFlight.Tests
 
             // Assert
             // verify that are status is cleared
-            Assert.AreEqual(1, updatedValues.Count);
-            Assert.AreEqual(0, cfg.Status.Count);
+            Assert.HasCount(1, updatedValues);
+            Assert.IsEmpty(cfg.Status);
         }
 
         [TestMethod]
@@ -140,7 +140,7 @@ namespace MobiFlight.Tests
             executor.Execute(cfg, updatedValues);
 
             // Assert
-            Assert.AreEqual(1, updatedValues.Count);
+            Assert.HasCount(1, updatedValues);
             Assert.AreEqual("XPLANE_NOT_AVAILABLE", cfg.Status[ConfigItemStatusType.Source]);
 
             
@@ -152,8 +152,8 @@ namespace MobiFlight.Tests
 
             // Assert
             // verify that are status is cleared
-            Assert.AreEqual(1, updatedValues.Count);
-            Assert.AreEqual(0, cfg.Status.Count);
+            Assert.HasCount(1, updatedValues);
+            Assert.IsEmpty(cfg.Status);
         }
 
         [TestMethod]
@@ -185,8 +185,8 @@ namespace MobiFlight.Tests
 
             // Assert
             // verify that are status is cleared
-            Assert.AreEqual(1, updatedValues.Count);
-            Assert.AreEqual(0, cfg.Status.Count);
+            Assert.HasCount(1, updatedValues);
+            Assert.IsEmpty(cfg.Status);
         }
 
         [TestMethod]
@@ -210,8 +210,8 @@ namespace MobiFlight.Tests
             executor.Execute(cfg, updatedValues);
 
             // Assert
-            Assert.AreEqual(1, updatedValues.Count);
-            Assert.IsTrue(cfg.Status[ConfigItemStatusType.Modifier].Contains("error occurred on parsing your value formula"));
+            Assert.HasCount(1, updatedValues);
+            Assert.Contains("error occurred on parsing your value formula", cfg.Status[ConfigItemStatusType.Modifier]);
 
             cfg.Modifiers.Items.Clear();
             cfg.Modifiers.Items.Add(new Transformation() { Active = true, Expression = "$+1" });
@@ -219,8 +219,8 @@ namespace MobiFlight.Tests
             executor.Execute(cfg, updatedValues);
 
             // Assert
-            Assert.AreEqual(1, updatedValues.Count);
-            Assert.AreEqual(0, cfg.Status.Count);
+            Assert.HasCount(1, updatedValues);
+            Assert.IsEmpty(cfg.Status);
         }
 
         [TestMethod]
@@ -267,7 +267,7 @@ namespace MobiFlight.Tests
             executor.Execute(cfg, updatedValues);
 
             // Assert
-            Assert.AreEqual(1, updatedValues.Count);
+            Assert.HasCount(1, updatedValues);
             Assert.AreEqual("not satisfied", cfg.Status[ConfigItemStatusType.Precondition]);
             precondition.Value = "100";
 
@@ -275,8 +275,8 @@ namespace MobiFlight.Tests
             updatedValues.Clear();
             executor.Execute(cfg, updatedValues);
             // Assert
-            Assert.AreEqual(1, updatedValues.Count);
-            Assert.AreEqual(false, cfg.Status.ContainsKey(ConfigItemStatusType.Precondition));
+            Assert.HasCount(1, updatedValues);
+            Assert.IsFalse(cfg.Status.ContainsKey(ConfigItemStatusType.Precondition));
         }
 
         [TestMethod]

--- a/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.Base;
 using MobiFlight.BrowserMessages;
 using MobiFlight.BrowserMessages.Incoming;
@@ -102,8 +102,8 @@ namespace MobiFlight.Tests
             MessageExchange.Instance.Publish(message);
 
             // Assert
-            Assert.IsFalse(_executionManager.ConfigItems.Contains(configItem1));
-            Assert.IsTrue(_executionManager.ConfigItems.Contains(configItem2));
+            Assert.DoesNotContain(configItem1, _executionManager.ConfigItems);
+            Assert.Contains(configItem2, _executionManager.ConfigItems);
         }
 
         [TestMethod]
@@ -193,7 +193,7 @@ namespace MobiFlight.Tests
             project.ConfigFiles.Add(new ConfigFile() { ConfigItems = { configItem1, configItem2 } });
             _executionManager.Project = project;
 
-            Assert.AreEqual(_executionManager.ActiveConfigIndex, 0);
+            Assert.AreEqual(0, _executionManager.ActiveConfigIndex);
 
             var message = new CommandActiveConfigFile
             {
@@ -204,7 +204,7 @@ namespace MobiFlight.Tests
             MessageExchange.Instance.Publish(message);
 
             // Assert
-            Assert.AreEqual(_executionManager.ActiveConfigIndex, 1);
+            Assert.AreEqual(1, _executionManager.ActiveConfigIndex);
         }
 
         [TestMethod]
@@ -227,7 +227,7 @@ namespace MobiFlight.Tests
 
             _executionManager.Project = project;
 
-            Assert.AreEqual(_executionManager.ActiveConfigIndex, 0);
+            Assert.AreEqual(0, _executionManager.ActiveConfigIndex);
 
             var message = new CommandFileContextMenu
             {
@@ -240,8 +240,8 @@ namespace MobiFlight.Tests
             MessageExchange.Instance.Publish(message);
 
             // Assert
-            Assert.AreEqual(project.ConfigFiles.Count, 1);
-            Assert.AreEqual(project.ConfigFiles[0].Label, "First Config");
+            Assert.HasCount(1, project.ConfigFiles);
+            Assert.AreEqual("First Config", project.ConfigFiles[0].Label);
         }
 
         [TestMethod]
@@ -264,7 +264,7 @@ namespace MobiFlight.Tests
 
             _executionManager.Project = project;
 
-            Assert.AreEqual(_executionManager.ActiveConfigIndex, 0);
+            Assert.AreEqual(0, _executionManager.ActiveConfigIndex);
 
             var message = new CommandFileContextMenu
             {
@@ -281,8 +281,8 @@ namespace MobiFlight.Tests
             MessageExchange.Instance.Publish(message);
 
             // Assert
-            Assert.AreEqual(project.ConfigFiles.Count, 2);
-            Assert.AreEqual(project.ConfigFiles[1].Label, "Renamed Config");
+            Assert.HasCount(2, project.ConfigFiles);
+            Assert.AreEqual("Renamed Config", project.ConfigFiles[1].Label);
         }
 
         [TestMethod]
@@ -346,7 +346,7 @@ namespace MobiFlight.Tests
             var result = _executionManager.GetAvailableVariables();
 
             // Assert
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.IsTrue(result.ContainsKey("varA"));
 
             var message = new CommandActiveConfigFile
@@ -360,7 +360,7 @@ namespace MobiFlight.Tests
             result = _executionManager.GetAvailableVariables();
 
             // Assert
-            Assert.AreEqual(1, result.Count);
+            Assert.HasCount(1, result);
             Assert.IsTrue(result.ContainsKey("varB"));
         }
 
@@ -620,7 +620,7 @@ namespace MobiFlight.Tests
                             ex.Message.Contains("Collection was modified"))
                 .ToList();
 
-            Assert.AreEqual(0, collectionModifiedExceptions.Count,
+            Assert.IsEmpty(collectionModifiedExceptions,
                 $"Should not throw 'Collection was modified' InvalidOperationException. " +
                 $"Found {collectionModifiedExceptions.Count} such exceptions. " +
                 $"This indicates the ToList() operation is not properly protected by the lock.");
@@ -725,12 +725,12 @@ namespace MobiFlight.Tests
             MessageExchange.Instance.Publish(message);
 
             // Assert
-            Assert.AreEqual(1, sourceFile.ConfigItems.Count, "Source file should have one less item");
-            Assert.AreEqual(2, targetFile.ConfigItems.Count, "Target file should have one more item");
-            Assert.AreEqual(configItem1.GUID, targetFile.ConfigItems[0].GUID, "Item should be moved to target file at correct index");
-            Assert.AreEqual(configItem3.GUID, targetFile.ConfigItems[1].GUID, "Existing item should be shifted down");
-            Assert.IsFalse(sourceFile.ConfigItems.Contains(configItem1), "Item should be removed from source file");
-            Assert.IsTrue(sourceFile.ConfigItems.Contains(configItem2), "Other items should remain in source file");
+            Assert.HasCount(1, sourceFile.ConfigItems, "Source file should have one less item");
+            Assert.HasCount(2, targetFile.ConfigItems, "Target file should have one more item");
+            Assert.AreEqual(targetFile.ConfigItems[0].GUID, configItem1.GUID, "Item should be moved to target file at correct index");
+            Assert.AreEqual(targetFile.ConfigItems[1].GUID, configItem3.GUID, "Existing item should be shifted down");
+            Assert.DoesNotContain(configItem1, sourceFile.ConfigItems, "Item should be removed from source file");
+            Assert.Contains(configItem2, sourceFile.ConfigItems, "Other items should remain in source file");
         }
 
         [TestMethod]
@@ -760,10 +760,10 @@ namespace MobiFlight.Tests
             MessageExchange.Instance.Publish(message);
 
             // Assert
-            Assert.AreEqual(3, configFile.ConfigItems.Count, "File should still have same number of items");
-            Assert.AreEqual(configItem2.GUID, configFile.ConfigItems[0].GUID, "Item2 should be moved to position 0");
-            Assert.AreEqual(configItem1.GUID, configFile.ConfigItems[1].GUID, "Item1 should be shifted to position 1");
-            Assert.AreEqual(configItem3.GUID, configFile.ConfigItems[2].GUID, "Item3 should remain at position 2");
+            Assert.HasCount(3, configFile.ConfigItems, "File should still have same number of items");
+            Assert.AreEqual(configFile.ConfigItems[0].GUID, configItem2.GUID, "Item2 should be moved to position 0");
+            Assert.AreEqual(configFile.ConfigItems[1].GUID, configItem1.GUID, "Item1 should be shifted to position 1");
+            Assert.AreEqual(configFile.ConfigItems[2].GUID, configItem3.GUID, "Item3 should remain at position 2");
         }
 
         [TestMethod]
@@ -800,13 +800,13 @@ namespace MobiFlight.Tests
             MessageExchange.Instance.Publish(message);
 
             // Assert
-            Assert.AreEqual(1, sourceFile.ConfigItems.Count, "Source file should have 2 less items");
-            Assert.AreEqual(configItem2.GUID, sourceFile.ConfigItems[0].GUID, "Only item2 should remain in source file");
+            Assert.HasCount(1, sourceFile.ConfigItems, "Source file should have 2 less items");
+            Assert.AreEqual(sourceFile.ConfigItems[0].GUID, configItem2.GUID, "Only item2 should remain in source file");
             
-            Assert.AreEqual(3, targetFile.ConfigItems.Count, "Target file should have 2 more items");
-            Assert.AreEqual(configItem4.GUID, targetFile.ConfigItems[0].GUID, "Original target item should remain at position 0");
-            Assert.AreEqual(configItem1.GUID, targetFile.ConfigItems[1].GUID, "First moved item should be at position 1");
-            Assert.AreEqual(configItem3.GUID, targetFile.ConfigItems[2].GUID, "Second moved item should be at position 2");
+            Assert.HasCount(3, targetFile.ConfigItems, "Target file should have 2 more items");
+            Assert.AreEqual(targetFile.ConfigItems[0].GUID, configItem4.GUID, "Original target item should remain at position 0");
+            Assert.AreEqual(targetFile.ConfigItems[1].GUID, configItem1.GUID, "First moved item should be at position 1");
+            Assert.AreEqual(targetFile.ConfigItems[2].GUID, configItem3.GUID, "Second moved item should be at position 2");
         }
     }
 }

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/AnalogInputConfigTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/AnalogInputConfigTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.BrowserMessages.Incoming.Converter;
 using Newtonsoft.Json;
 using System;
@@ -97,14 +97,14 @@ namespace MobiFlight.InputConfig.Tests
             cfg.onChange = new VariableInputAction();
             
             var result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 1);
-            Assert.AreEqual(result[0].GetType(), typeof(VariableInputAction));
+            Assert.HasCount(1, result);
+            Assert.AreEqual(typeof(VariableInputAction), result[0].GetType());
 
 
             cfg.onChange = new MSFS2020CustomInputAction();
 
             result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 0);
+            Assert.HasCount(0, result);
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.BrowserMessages.Incoming.Converter;
 using Newtonsoft.Json;
 using System;
@@ -22,9 +22,9 @@ namespace MobiFlight.InputConfig.Tests
             Assert.AreEqual((o.onRelease as JeehellInputAction).EventId, (c.onRelease as JeehellInputAction).EventId, "OnRelease is not correct");
             Assert.AreEqual((o.onLongRelease as MSFS2020CustomInputAction).PresetId, (c.onLongRelease as MSFS2020CustomInputAction).PresetId, "OnLongRelase is not correct");
             Assert.AreEqual((o.onHold as XplaneInputAction).Path, (c.onHold as XplaneInputAction).Path, "onHold is not correct");
-            Assert.AreEqual(o.RepeatDelay, c.RepeatDelay, "RepeatDelay is not correct");
-            Assert.AreEqual(o.HoldDelay, c.HoldDelay, "HoldDelay is not correct");
-            Assert.AreEqual(o.LongReleaseDelay, c.LongReleaseDelay, "LongReleaseDelay is not correct");
+            Assert.AreEqual(c.RepeatDelay, o.RepeatDelay, "RepeatDelay is not correct");
+            Assert.AreEqual(c.HoldDelay, o.HoldDelay, "HoldDelay is not correct");
+            Assert.AreEqual(c.LongReleaseDelay, o.LongReleaseDelay, "LongReleaseDelay is not correct");
         }
 
         private ButtonInputConfig generateTestObject()
@@ -75,8 +75,8 @@ namespace MobiFlight.InputConfig.Tests
             o.ReadXml(xmlReader);
 
             Assert.AreEqual(12345, (o.onPress as EventIdInputAction).EventId, "EventId not the same");
-            Assert.AreEqual(null, o.onRelease, "onRelease not null");
-            Assert.AreEqual(null, o.onLongRelease, "onLongRelease not null");
+            Assert.IsNull(o.onRelease, "onRelease not null");
+            Assert.IsNull(o.onLongRelease, "onLongRelease not null");
 
             o = new ButtonInputConfig();
             s = File.ReadAllText(@"assets\MobiFlight\InputConfig\ButtonInputConfig\ReadXmlTest.3.xml");
@@ -89,8 +89,8 @@ namespace MobiFlight.InputConfig.Tests
             o.ReadXml(xmlReader);
 
             Assert.AreEqual(12345, (o.onPress as EventIdInputAction).EventId, "EventId not the same");
-            Assert.AreEqual(null, o.onRelease, "onRelease not null");
-            Assert.AreEqual(null, o.onLongRelease, "onLongRelease not null");
+            Assert.IsNull(o.onRelease, "onRelease not null");
+            Assert.IsNull(o.onLongRelease, "onLongRelease not null");
 
             o = new ButtonInputConfig();
             s = File.ReadAllText(@"assets\MobiFlight\InputConfig\ButtonInputConfig\ReadXmlTest.4.xml");
@@ -103,7 +103,7 @@ namespace MobiFlight.InputConfig.Tests
             o.ReadXml(xmlReader);
 
             Assert.AreEqual(12345, (o.onPress as EventIdInputAction).EventId, "EventId not the same");
-            Assert.AreEqual(null, o.onRelease, "onRelease not null");
+            Assert.IsNull(o.onRelease, "onRelease not null");
             Assert.AreEqual("c1cb32b4-fd35-41ab-8ff7-c407bd407998", (o.onLongRelease as MSFS2020CustomInputAction).PresetId, "PresetId not the same");
 
             o = new ButtonInputConfig();
@@ -116,9 +116,9 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("button");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(null, o.onPress, "onPress not null");
-            Assert.AreEqual(null, o.onRelease, "onRelease not null");
-            Assert.AreEqual(null, o.onLongRelease, "onLongRelease not null");
+            Assert.IsNull(o.onPress, "onPress not null");
+            Assert.IsNull(o.onRelease, "onRelease not null");
+            Assert.IsNull(o.onLongRelease, "onLongRelease not null");
         }
 
         [TestMethod()]
@@ -168,33 +168,33 @@ namespace MobiFlight.InputConfig.Tests
             cfg.onLongRelease = new XplaneInputAction();
 
             var result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 1);
-            Assert.AreEqual(result[0].GetType(), typeof(VariableInputAction));
+            Assert.HasCount(1, result);
+            Assert.AreEqual(typeof(VariableInputAction), result[0].GetType());
 
             cfg.onPress = new MSFS2020CustomInputAction();
             cfg.onRelease = new VariableInputAction();
             cfg.onLongRelease = new XplaneInputAction();
 
             result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 1);
-            Assert.AreEqual(result[0].GetType(), typeof(VariableInputAction));
+            Assert.HasCount(1, result);
+            Assert.AreEqual(typeof(VariableInputAction), result[0].GetType());
 
             cfg.onPress = new MSFS2020CustomInputAction();
             cfg.onRelease = new MSFS2020CustomInputAction();
             cfg.onLongRelease = new XplaneInputAction();
 
             result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 0);
+            Assert.HasCount(0, result);
 
             cfg.onPress = new VariableInputAction();
             cfg.onRelease = new VariableInputAction();
             cfg.onLongRelease = new VariableInputAction();
 
             result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 3);
-            Assert.AreEqual(result[0].GetType(), typeof(VariableInputAction));
-            Assert.AreEqual(result[1].GetType(), typeof(VariableInputAction));
-            Assert.AreEqual(result[2].GetType(), typeof(VariableInputAction));
+            Assert.HasCount(3, result);
+            Assert.AreEqual(typeof(VariableInputAction), result[0].GetType());
+            Assert.AreEqual(typeof(VariableInputAction), result[1].GetType());
+            Assert.AreEqual(typeof(VariableInputAction), result[2].GetType());
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/EncoderInputConfigTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/EncoderInputConfigTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.BrowserMessages.Incoming.Converter;
 using Newtonsoft.Json;
 using System;
@@ -44,10 +44,10 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("encoder");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual((o.onLeft as EventIdInputAction).EventId, 12345, "EventId not the same");
-            Assert.AreEqual((o.onLeftFast as JeehellInputAction).EventId, 127, "EventId not the same");
-            Assert.AreEqual((o.onRight as JeehellInputAction).EventId, 126, "EventId not the same");
-            Assert.AreEqual((o.onRightFast as JeehellInputAction).EventId, 125, "EventId not the same");
+            Assert.AreEqual(12345, (o.onLeft as EventIdInputAction).EventId, "EventId not the same");
+            Assert.AreEqual(127, (o.onLeftFast as JeehellInputAction).EventId, "EventId not the same");
+            Assert.AreEqual(126, (o.onRight as JeehellInputAction).EventId, "EventId not the same");
+            Assert.AreEqual(125, (o.onRightFast as JeehellInputAction).EventId, "EventId not the same");
         }
 
         [TestMethod()]
@@ -109,8 +109,8 @@ namespace MobiFlight.InputConfig.Tests
             cfg.onRightFast = new MSFS2020CustomInputAction();
 
             var result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 1);
-            Assert.AreEqual(result[0].GetType(), typeof(VariableInputAction));
+            Assert.HasCount(1, result);
+            Assert.AreEqual(typeof(VariableInputAction), result[0].GetType());
 
             cfg.onLeft = new VariableInputAction();
             cfg.onLeftFast = new VariableInputAction();
@@ -118,9 +118,9 @@ namespace MobiFlight.InputConfig.Tests
             cfg.onRightFast = new MSFS2020CustomInputAction();
 
             result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 2);
-            Assert.AreEqual(result[0].GetType(), typeof(VariableInputAction));
-            Assert.AreEqual(result[1].GetType(), typeof(VariableInputAction));
+            Assert.HasCount(2, result);
+            Assert.AreEqual(typeof(VariableInputAction), result[0].GetType());
+            Assert.AreEqual(typeof(VariableInputAction), result[1].GetType());
 
             cfg.onLeft = new VariableInputAction();
             cfg.onLeftFast = new VariableInputAction();
@@ -128,10 +128,10 @@ namespace MobiFlight.InputConfig.Tests
             cfg.onRightFast = new MSFS2020CustomInputAction();
 
             result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 3);
-            Assert.AreEqual(result[0].GetType(), typeof(VariableInputAction));
-            Assert.AreEqual(result[1].GetType(), typeof(VariableInputAction));
-            Assert.AreEqual(result[2].GetType(), typeof(VariableInputAction));
+            Assert.HasCount(3, result);
+            Assert.AreEqual(typeof(VariableInputAction), result[0].GetType());
+            Assert.AreEqual(typeof(VariableInputAction), result[1].GetType());
+            Assert.AreEqual(typeof(VariableInputAction), result[2].GetType());
 
             cfg.onLeft = new VariableInputAction();
             cfg.onLeftFast = new VariableInputAction();
@@ -139,11 +139,11 @@ namespace MobiFlight.InputConfig.Tests
             cfg.onRightFast = new VariableInputAction();
 
             result = cfg.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 4);
-            Assert.AreEqual(result[0].GetType(), typeof(VariableInputAction));
-            Assert.AreEqual(result[1].GetType(), typeof(VariableInputAction));
-            Assert.AreEqual(result[2].GetType(), typeof(VariableInputAction));
-            Assert.AreEqual(result[3].GetType(), typeof(VariableInputAction));
+            Assert.HasCount(4, result);
+            Assert.AreEqual(typeof(VariableInputAction), result[0].GetType());
+            Assert.AreEqual(typeof(VariableInputAction), result[1].GetType());
+            Assert.AreEqual(typeof(VariableInputAction), result[2].GetType());
+            Assert.AreEqual(typeof(VariableInputAction), result[3].GetType());
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/EventIdInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/EventIdInputActionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.InputConfig;
 using System;
 using System.Collections.Generic;
@@ -19,8 +19,8 @@ namespace MobiFlight.InputConfig.Tests
             EventIdInputAction o = generateTestObject();
             EventIdInputAction c = (EventIdInputAction)o.Clone();
             Assert.AreNotSame(o, c, "Clone is the same object");
-            Assert.AreEqual(o.EventId, c.EventId, "EventId not the same");
-            Assert.AreEqual(o.Param, c.Param, "Param not the same");
+            Assert.AreEqual(c.EventId, o.EventId, "EventId not the same");
+            Assert.AreEqual(c.Param, o.Param, "Param not the same");
         }
 
         private EventIdInputAction generateTestObject()
@@ -44,8 +44,8 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("onPress");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.EventId, Int32.MaxValue, "EventId not the same");
-            Assert.AreEqual(o.Param, (Int32.MaxValue - 1).ToString(), "Param not the same");
+            Assert.AreEqual(Int32.MaxValue, o.EventId, "EventId not the same");
+            Assert.AreEqual((Int32.MaxValue - 1).ToString(), o.Param, "Param not the same");
         }
 
         [TestMethod()]
@@ -87,7 +87,7 @@ namespace MobiFlight.InputConfig.Tests
             };
 
             o.execute(cacheCollection, null, new List<ConfigRefValue>());
-            Assert.AreEqual(1, mock.Writes.Count, "The message count is not as expected");
+            Assert.HasCount(1, mock.Writes, "The message count is not as expected");
             Assert.AreEqual("SetEventID>" + o.EventId + ">" + o.Param, mock.Writes[0].Value, "The Write Value is wrong");
 
             mock.Clear();
@@ -97,7 +97,7 @@ namespace MobiFlight.InputConfig.Tests
             configrefs.Add(new ConfigRefValue() { ConfigRef = new Base.ConfigRef() { Active = true, Placeholder = "#" }, Value = "1" });
             o.execute(cacheCollection, null, configrefs);
 
-            Assert.AreEqual(1, mock.Writes.Count, "The message count is not as expected");
+            Assert.HasCount(1, mock.Writes, "The message count is not as expected");
             Assert.AreEqual("SetEventID>" + o.EventId + ">" + 2, mock.Writes[0].Value, "The Write Value is wrong");
         }
 

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/FsuipcOffsetInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/FsuipcOffsetInputActionTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.InputConfig;
 using MobiFlight.OutputConfig;
 using System;
@@ -18,12 +18,12 @@ namespace MobiFlight.InputConfig.Tests
         public void FsuipcOffsetInputActionTest()
         {
             FsuipcOffsetInputAction o = new FsuipcOffsetInputAction();
-            Assert.AreEqual(o.FSUIPC.Offset, FsuipcOffset.OffsetNull, "FSUIPCOffset is not FSUIPCOffsetNull");
-            Assert.AreEqual(o.FSUIPC.Mask, 0xFF, "FSUIPCMask is not 0xFF");
-            Assert.AreEqual(o.FSUIPC.OffsetType, FSUIPCOffsetType.Integer, "FSUIPCOffsetType not correct");
-            Assert.AreEqual(o.FSUIPC.Size, 1, "FSUIPCSize not correct");
-            Assert.AreEqual(o.FSUIPC.BcdMode, false, "Not correct");
-            Assert.AreEqual(o.Value, "", "Value not correct");
+            Assert.AreEqual(FsuipcOffset.OffsetNull, o.FSUIPC.Offset, "FSUIPCOffset is not FSUIPCOffsetNull");
+            Assert.AreEqual(0xFF, o.FSUIPC.Mask, "FSUIPCMask is not 0xFF");
+            Assert.AreEqual(FSUIPCOffsetType.Integer, o.FSUIPC.OffsetType, "FSUIPCOffsetType not correct");
+            Assert.AreEqual(1, o.FSUIPC.Size, "FSUIPCSize not correct");
+            Assert.IsFalse(o.FSUIPC.BcdMode, "Not correct");
+            Assert.AreEqual("", o.Value, "Value not correct");
             Assert.IsNotNull(o.Modifiers.Transformation, "Transform not initialized");
         }
 
@@ -39,7 +39,7 @@ namespace MobiFlight.InputConfig.Tests
             Assert.AreEqual(o.FSUIPC.Offset, c.FSUIPC.Offset, "FSUIPCOffset are not the same");
             Assert.AreEqual(o.FSUIPC.OffsetType, c.FSUIPC.OffsetType, "FSUIPCOffsetType are not the same");
             Assert.AreEqual(o.FSUIPC.Size, c.FSUIPC.Size, "FSUIPCSize are not the same");
-            Assert.AreEqual(o.Value, c.Value, "Value are not the same");
+            Assert.AreEqual(c.Value, o.Value, "Value are not the same");
             Assert.AreEqual(o.Modifiers.Transformation.Expression, c.Modifiers.Transformation.Expression, "Value are not the same");
         }
 
@@ -91,12 +91,12 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("onPress");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.FSUIPC.BcdMode, true, "FSUIPCBcdMode are not the same");
-            Assert.AreEqual(o.FSUIPC.Mask, 0xFFFFFFFF, "FSUIPCMask are not the same");
-            Assert.AreEqual(o.FSUIPC.Offset, 0x1234, "FSUIPCOffset are not the same");
-            Assert.AreEqual(o.FSUIPC.OffsetType, FSUIPCOffsetType.Float, "FSUIPCOffsetType are not the same");
-            Assert.AreEqual(o.FSUIPC.Size, 4, "FSUIPCSize are not the same");
-            Assert.AreEqual(o.Value, "$-1", "Value are not the same");
+            Assert.IsTrue(o.FSUIPC.BcdMode, "FSUIPCBcdMode are not the same");
+            Assert.AreEqual(0xFFFFFFFF, o.FSUIPC.Mask, "FSUIPCMask are not the same");
+            Assert.AreEqual(0x1234, o.FSUIPC.Offset, "FSUIPCOffset are not the same");
+            Assert.AreEqual(FSUIPCOffsetType.Float, o.FSUIPC.OffsetType, "FSUIPCOffsetType are not the same");
+            Assert.AreEqual(4, o.FSUIPC.Size, "FSUIPCSize are not the same");
+            Assert.AreEqual("$-1", o.Value, "Value are not the same");
         }
 
         [TestMethod()]
@@ -119,9 +119,9 @@ namespace MobiFlight.InputConfig.Tests
             o.FSUIPC.BcdMode = false;
             o.Value = "12";
             o.execute(cacheCollection, null, new List<ConfigRefValue>());
-            Assert.AreEqual(mock.Writes.Count, 2, "The message count is not as expected"); // there is one write in the mock for setting the offset and one write for writing to the cache.
-            Assert.AreEqual(mock.Writes[0].Offset, 0x1234, "The Offset is wrong");
-            Assert.AreEqual(mock.Writes[0].Value, "12", "The Param Value is wrong");
+            Assert.HasCount(2, mock.Writes, "The message count is not as expected"); // there is one write in the mock for setting the offset and one write for writing to the cache.
+            Assert.AreEqual(0x1234, mock.Writes[0].Offset, "The Offset is wrong");
+            Assert.AreEqual("12", mock.Writes[0].Value, "The Param Value is wrong");
 
             mock.Clear();
             // validate config references work
@@ -130,8 +130,8 @@ namespace MobiFlight.InputConfig.Tests
             configrefs.Add(new ConfigRefValue() { ConfigRef = new Base.ConfigRef() { Active = true, Placeholder = "#" }, Value = "1" });
             o.execute(cacheCollection, null, configrefs);
 
-            Assert.AreEqual(2, mock.Writes.Count, "The message count is not as expected");
-            Assert.AreEqual("2", mock.Writes[0].Value, mock.Writes[0].Value, "The Write Value is wrong");
+            Assert.HasCount(2, mock.Writes, "The message count is not as expected");
+            Assert.AreEqual("2", mock.Writes[0].Value, "The Write Value is wrong");
 
             // test https://github.com/Mobiflight/MobiFlight-Connector/issues/438
             mock.Clear();
@@ -139,8 +139,8 @@ namespace MobiFlight.InputConfig.Tests
             configrefs = new List<ConfigRefValue>();
             o.execute(cacheCollection, new InputEventArgs() { Value = 359 }, configrefs);
 
-            Assert.AreEqual(2, mock.Writes.Count, "The message count is not as expected");
-            Assert.AreEqual(Math.Round((359 * 359 / 1023f), 0).ToString(), mock.Writes[0].Value, mock.Writes[0].Value, "The Write Value is wrong");
+            Assert.HasCount(2, mock.Writes, "The message count is not as expected");
+            Assert.AreEqual(Math.Round((359 * 359 / 1023f), 0).ToString(), mock.Writes[0].Value, "The Write Value is wrong");
 
             // test https://github.com/Mobiflight/MobiFlight-Connector/issues/438
             mock.Clear();
@@ -148,8 +148,8 @@ namespace MobiFlight.InputConfig.Tests
             configrefs = new List<ConfigRefValue>();
             o.execute(cacheCollection, new InputEventArgs() { Value = 359 }, configrefs);
 
-            Assert.AreEqual(2, mock.Writes.Count, "The message count is not as expected");
-            Assert.AreEqual(Math.Floor((359 * 359 / 1023f)).ToString(), mock.Writes[0].Value, mock.Writes[0].Value, "The Write Value is wrong");
+            Assert.HasCount(2, mock.Writes, "The message count is not as expected");
+            Assert.AreEqual(Math.Floor((359 * 359 / 1023f)).ToString(), mock.Writes[0].Value, "The Write Value is wrong");
 
             // test https://github.com/Mobiflight/MobiFlight-Connector/issues/340
             mock.Clear();
@@ -163,7 +163,7 @@ namespace MobiFlight.InputConfig.Tests
             }
             catch (FormatException)
             {
-                Assert.AreEqual(0, mock.Writes.Count, "The message count is not as expected");
+                Assert.HasCount(0, mock.Writes, "The message count is not as expected");
             }
         }
 

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/InputMultiplexerConfigTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/InputMultiplexerConfigTests.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.InputConfig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.InputConfig.Tests
@@ -23,9 +18,9 @@ namespace MobiFlight.InputConfig.Tests
             Assert.AreEqual((o.onPress as EventIdInputAction).EventId, (c.onPress as EventIdInputAction).EventId, "OnPress is not correct");
             Assert.AreEqual((o.onRelease as JeehellInputAction).EventId, (c.onRelease as JeehellInputAction).EventId, "OnRelase is not correct");
             Assert.AreEqual((o.onHold as VariableInputAction).Variable.Name, (c.onHold as VariableInputAction).Variable.Name, "onHold is not correct");
-            Assert.AreEqual(o.HoldDelay, c.HoldDelay, "HoldDelay is not correct");
-            Assert.AreEqual(o.LongReleaseDelay, c.LongReleaseDelay, "LongReleaseDelay is not correct");
-            Assert.AreEqual(o.RepeatDelay, c.RepeatDelay, "RepeatDelay is not correct");
+            Assert.AreEqual(c.HoldDelay, o.HoldDelay, "HoldDelay is not correct");
+            Assert.AreEqual(c.LongReleaseDelay, o.LongReleaseDelay, "LongReleaseDelay is not correct");
+            Assert.AreEqual(c.RepeatDelay, o.RepeatDelay, "RepeatDelay is not correct");
         }
 
         private InputMultiplexerConfig generateTestObject()

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/JeehellInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/JeehellInputActionTests.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.InputConfig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.InputConfig.Tests
@@ -19,8 +15,8 @@ namespace MobiFlight.InputConfig.Tests
             JeehellInputAction o = generateTestObject();
             JeehellInputAction c = (JeehellInputAction)o.Clone();
             Assert.AreNotSame(o, c, "Clone is the same object");
-            Assert.AreEqual(o.EventId, c.EventId, "EventId not the same");
-            Assert.AreEqual(o.Param, c.Param, "Param not the same");
+            Assert.AreEqual(c.EventId, o.EventId, "EventId not the same");
+            Assert.AreEqual(c.Param, o.Param, "Param not the same");
         }
 
         [TestMethod()]
@@ -36,8 +32,8 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("onPress");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.EventId, 13, "EventId not the same");
-            Assert.AreEqual(o.Param, Int16.MaxValue.ToString(), "Param not the same");
+            Assert.AreEqual(13, o.EventId, "EventId not the same");
+            Assert.AreEqual(Int16.MaxValue.ToString(), o.Param, "Param not the same");
         }
 
         [TestMethod()]
@@ -78,12 +74,12 @@ namespace MobiFlight.InputConfig.Tests
                 xplaneCache = xplaneCacheMock
             };
             o.execute(cacheCollection, null, new List<ConfigRefValue>());
-            Assert.AreEqual(mock.Writes.Count, 3, "The message count is not as expected");
-            Assert.AreEqual(mock.Writes[0].Offset, 0x73CD, "The Param Offset is wrong");
-            Assert.AreEqual(mock.Writes[0].Value, Int16.MaxValue.ToString(), "The Param Value is wrong");
-            Assert.AreEqual(mock.Writes[1].Offset, 0x73CC, "The Base Offset is wrong");
-            Assert.AreEqual(mock.Writes[1].Value, "13", "The Base Value is wrong");
-            Assert.AreEqual(mock.Writes[2].Value, "Write", "The Write Value is wrong");
+            Assert.HasCount(3, mock.Writes, "The message count is not as expected");
+            Assert.AreEqual(0x73CD, mock.Writes[0].Offset,"The Param Offset is wrong");
+            Assert.AreEqual(Int16.MaxValue.ToString(), mock.Writes[0].Value, "The Param Value is wrong");
+            Assert.AreEqual(0x73CC, mock.Writes[1].Offset, "The Base Offset is wrong");
+            Assert.AreEqual("13", mock.Writes[1].Value, "The Base Value is wrong");
+            Assert.AreEqual("Write", mock.Writes[2].Value, "The Write Value is wrong");
         }
 
         JeehellInputAction generateTestObject()

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/KeyInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/KeyInputActionTests.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.InputConfig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
 
@@ -20,10 +15,10 @@ namespace MobiFlight.InputConfig.Tests
             KeyInputAction o = generateTestObject();
 
             KeyInputAction i = (KeyInputAction)o.Clone();
-            Assert.AreEqual(o.Shift, i.Shift, "SHIFT value differs");
-            Assert.AreEqual(o.Alt, i.Alt, "ALT value differs");
-            Assert.AreEqual(o.Control, i.Control, "CONTROL value differs");
-            Assert.AreEqual(o.Key, i.Key, "Key value differs");
+            Assert.AreEqual(i.Shift, o.Shift, "SHIFT value differs");
+            Assert.AreEqual(i.Alt, o.Alt, "ALT value differs");
+            Assert.AreEqual(i.Control, o.Control, "CONTROL value differs");
+            Assert.AreEqual(i.Key, o.Key, "Key value differs");
         }
 
         [TestMethod()]
@@ -61,10 +56,10 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("onPress");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.Alt, true, "Alt modifier not the same");
-            Assert.AreEqual(o.Shift, true, "Shift modifier not the same");
-            Assert.AreEqual(o.Control, true, "Ctrl modifier not the same");
-            Assert.AreEqual(o.Key, Keys.A, "Key not the same");
+            Assert.IsTrue(o.Alt, "Alt modifier not the same");
+            Assert.IsTrue(o.Shift, "Shift modifier not the same");
+            Assert.IsTrue(o.Control, "Ctrl modifier not the same");
+            Assert.AreEqual(Keys.A, o.Key, "Key not the same");
         }
 
         [TestMethod()]
@@ -87,8 +82,8 @@ namespace MobiFlight.InputConfig.Tests
             MobiFlightUnitTests.mock.Base.KeyboardInputMock keybMock = new MobiFlightUnitTests.mock.Base.KeyboardInputMock();
             o.Keyboard = keybMock;
             o.execute(cacheCollection, null, null);
-            Assert.AreEqual(keybMock.Writes.Count, 1, "The message count is not as expected");
-            Assert.AreEqual(keybMock.Writes[0], "Ctrl+Shift+Alt+A", "The sent string is wrong");
+            Assert.HasCount(1, keybMock.Writes, "The message count is not as expected");
+            Assert.AreEqual("Ctrl+Shift+Alt+A", keybMock.Writes[0], "The sent string is wrong");
         }
 
         private KeyInputAction generateTestObject()

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/MSFS2020CustomInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/MSFS2020CustomInputActionTests.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.InputConfig;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MobiFlight.InputConfig.Tests
 {
@@ -58,8 +53,8 @@ namespace MobiFlight.InputConfig.Tests
 
             o.execute(cacheCollection, new InputEventArgs() { Value = 359 }, configrefs);
             
-            Assert.AreEqual(simConnectMock.Writes.Count, 1, "The message count is not as expected");
-            Assert.AreEqual(simConnectMock.Writes[0], "359 (>K:THROTTLE_SET)", "The Write Value is wrong");
+            Assert.HasCount(1, simConnectMock.Writes, "The message count is not as expected");
+            Assert.AreEqual("359 (>K:THROTTLE_SET)", simConnectMock.Writes[0], "The Write Value is wrong");
         }
     }
 }

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/MSFS2020EventIdInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/MSFS2020EventIdInputActionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Xml;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -15,7 +15,7 @@ namespace MobiFlight.InputConfig.Tests
             MSFS2020EventIdInputAction o = generateTestObject();
             MSFS2020EventIdInputAction c = (MSFS2020EventIdInputAction)o.Clone();
             Assert.AreNotSame(o, c, "Clone is the same object");
-            Assert.AreEqual(o.EventId, c.EventId, "EventId not the same");
+            Assert.AreEqual(c.EventId, o.EventId, "EventId not the same");
         }
 
         private MSFS2020EventIdInputAction generateTestObject()
@@ -39,7 +39,7 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("onPress");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.EventId, "ReadTestEvent", "EventId not the same");
+            Assert.AreEqual("ReadTestEvent", o.EventId, "EventId not the same");
         }
 
         [TestMethod()]
@@ -83,8 +83,8 @@ namespace MobiFlight.InputConfig.Tests
             };
 
             o.execute(cacheCollection, null, null);
-            Assert.AreEqual(simConnectMock.Writes.Count, 1, "The message count is not as expected");
-            Assert.AreEqual(simConnectMock.Writes[0], "SetEventID>MyEventId", "The Write Value is wrong");
+            Assert.HasCount(1, simConnectMock.Writes, "The message count is not as expected");
+            Assert.AreEqual("SetEventID>MyEventId", simConnectMock.Writes[0], "The Write Value is wrong");
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/PmdgEventIdInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/PmdgEventIdInputActionTests.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.InputConfig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.InputConfig.Tests
@@ -19,9 +15,9 @@ namespace MobiFlight.InputConfig.Tests
             PmdgEventIdInputAction o = generateTestObject();
             PmdgEventIdInputAction c = (PmdgEventIdInputAction)o.Clone();
             Assert.AreNotSame(o, c, "Clone is the same object");
-            Assert.AreEqual(o.EventId, c.EventId, "EventId not the same");
-            Assert.AreEqual(o.Param, c.Param, "Param not the same");
-            Assert.AreEqual(o.AircraftType, c.AircraftType, "Param not the same");
+            Assert.AreEqual(c.EventId, o.EventId, "EventId not the same");
+            Assert.AreEqual(c.Param, o.Param, "Param not the same");
+            Assert.AreEqual(c.AircraftType, o.AircraftType, "Param not the same");
         }
 
         private PmdgEventIdInputAction generateTestObject()
@@ -47,9 +43,9 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("onPress");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.EventId, Int32.MaxValue, "EventId not the same");
-            Assert.AreEqual(o.Param, (UInt32.MaxValue - 1).ToString(), "Param not the same");
-            Assert.AreEqual(o.AircraftType, PmdgEventIdInputAction.PmdgAircraftType.B777);
+            Assert.AreEqual(Int32.MaxValue, o.EventId, "EventId not the same");
+            Assert.AreEqual((UInt32.MaxValue - 1).ToString(), o.Param, "Param not the same");
+            Assert.AreEqual(PmdgEventIdInputAction.PmdgAircraftType.B777, o.AircraftType);
         }
 
         [TestMethod()]
@@ -91,7 +87,7 @@ namespace MobiFlight.InputConfig.Tests
             };
 
             o.execute(cacheCollection, null, new List<ConfigRefValue>());
-            Assert.AreEqual(1, mock.Writes.Count, "The message count is not as expected");
+            Assert.HasCount(1, mock.Writes, "The message count is not as expected");
             Assert.AreEqual("SetEventID>" + o.EventId + ">-2", mock.Writes[0].Value, "The Write Value is wrong");
 
             mock.Clear();
@@ -101,7 +97,7 @@ namespace MobiFlight.InputConfig.Tests
             configrefs.Add(new ConfigRefValue() { ConfigRef = new Base.ConfigRef() { Active = true, Placeholder = "#" }, Value = "1" });
             o.execute(cacheCollection, null, configrefs);
 
-            Assert.AreEqual(1, mock.Writes.Count, "The message count is not as expected");
+            Assert.HasCount(1, mock.Writes, "The message count is not as expected");
             Assert.AreEqual("SetEventID>" + o.EventId + ">" + 2, mock.Writes[0].Value, "The Write Value is wrong");
         }
 

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/ProSimInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/ProSimInputActionTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.InputConfig;
-using System;
 using System.IO;
 using System.Xml;
 
@@ -148,8 +147,8 @@ namespace MobiFlight.Tests.ProSim
             string result = sw.ToString();
             
             // Verify the XML contains the expected attributes
-            Assert.IsTrue(result.Contains("path=\"test/dataref/path\""), "XML should contain path attribute");
-            Assert.IsTrue(result.Contains("expression=\"$ * 2\""), "XML should contain expression attribute");
+            Assert.Contains("path=\"test/dataref/path\"", result, "XML should contain path attribute");
+            Assert.Contains("expression=\"$ * 2\"", result, "XML should contain expression attribute");
         }
 
         [TestMethod()]
@@ -173,8 +172,8 @@ namespace MobiFlight.Tests.ProSim
             string result = sw.ToString();
             
             // Verify the XML contains the expected attributes
-            Assert.IsTrue(result.Contains("path=\"\""), "XML should contain empty path attribute");
-            Assert.IsTrue(result.Contains("expression=\"\""), "XML should contain empty expression attribute");
+            Assert.Contains("path=\"\"", result, "XML should contain empty path attribute");
+            Assert.Contains("expression=\"\"", result, "XML should contain empty expression attribute");
         }
 
         [TestMethod()]
@@ -254,7 +253,7 @@ namespace MobiFlight.Tests.ProSim
             XmlReader xmlReader = XmlReader.Create(sr, readerSettings);
             xmlReader.ReadToDescendant("ProSimInputAction");
             deserialized.ReadXml(xmlReader);
-            
+
             // Verify round trip
             Assert.AreEqual(original.Path, deserialized.Path, "Path should be preserved through XML round trip");
             Assert.AreEqual(original.Expression, deserialized.Expression, "Expression should be preserved through XML round trip");
@@ -290,10 +289,10 @@ namespace MobiFlight.Tests.ProSim
             XmlReader xmlReader = XmlReader.Create(sr, readerSettings);
             xmlReader.ReadToDescendant("ProSimInputAction");
             deserialized.ReadXml(xmlReader);
-            
+
             // Verify round trip
             Assert.AreEqual(original.Path, deserialized.Path, "Path should be preserved through XML round trip");
             Assert.AreEqual(original.Expression, deserialized.Expression, "Expression should be preserved through XML round trip");
         }
     }
-} 
+}

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/VariableInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/VariableInputActionTests.cs
@@ -1,11 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.InputConfig;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.InputConfig.Tests
@@ -47,8 +43,8 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("onPress");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.Variable.TYPE, "string", "Variable.TYPE are not the same");
-            Assert.AreEqual(o.Variable.Name, "VariableInputActionReadXMLTests", "Param not the same");
+            Assert.AreEqual("string", o.Variable.TYPE, "Variable.TYPE are not the same");
+            Assert.AreEqual("VariableInputActionReadXMLTests", o.Variable.Name, "Param not the same");
         }
 
         [TestMethod()]
@@ -95,7 +91,7 @@ namespace MobiFlight.InputConfig.Tests
             o.Variable.Expression = "$+1";
 
             o.execute(cacheCollection, null, new List<ConfigRefValue>());
-            Assert.AreEqual(mobiflightCacheMock.GetMobiFlightVariable("VariableInputActionTests").Number, 1, "The number is not correct.");
+            Assert.AreEqual(1, mobiflightCacheMock.GetMobiFlightVariable("VariableInputActionTests").Number, "The number is not correct.");
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/InputConfig/XplaneInputActionTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfig/XplaneInputActionTests.cs
@@ -1,11 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.InputConfig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.InputConfig.Tests
@@ -19,9 +15,9 @@ namespace MobiFlight.InputConfig.Tests
             XplaneInputAction o = generateTestObject();
             XplaneInputAction c = (XplaneInputAction)o.Clone();
             Assert.AreNotSame(o, c, "Clone is the same object");
-            Assert.AreEqual(o.InputType, c.InputType, "InputType not the same");
-            Assert.AreEqual(o.Path, c.Path, "Path not the same");
-            Assert.AreEqual(o.Expression, c.Expression, "Expression not the same");
+            Assert.AreEqual(c.InputType, o.InputType, "InputType not the same");
+            Assert.AreEqual(c.Path, o.Path, "Path not the same");
+            Assert.AreEqual(c.Expression, o.Expression, "Expression not the same");
         }
 
         private XplaneInputAction generateTestObject()
@@ -47,9 +43,9 @@ namespace MobiFlight.InputConfig.Tests
             xmlReader.ReadToDescendant("onPress");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.InputType, "DataRef", "InputType not the same");
-            Assert.AreEqual(o.Path,"/my/test/path1", "Path not the same");
-            Assert.AreEqual(o.Expression, "$+2");
+            Assert.AreEqual("DataRef", o.InputType, "InputType not the same");
+            Assert.AreEqual("/my/test/path1", o.Path, "Path not the same");
+            Assert.AreEqual("$+2", o.Expression);
         }
 
         [TestMethod()]
@@ -91,7 +87,7 @@ namespace MobiFlight.InputConfig.Tests
             };
 
             o.execute(cacheCollection, null, new List<ConfigRefValue>());
-            Assert.AreEqual(1, xplaneCacheMock.Writes.Count, "The message count is not as expected");
+            Assert.HasCount(1, xplaneCacheMock.Writes, "The message count is not as expected");
 
             xplaneCacheMock.Clear();
             // validate config references work
@@ -100,7 +96,7 @@ namespace MobiFlight.InputConfig.Tests
             configrefs.Add(new ConfigRefValue() { ConfigRef = new Base.ConfigRef() { Active = true, Placeholder = "#" }, Value = "1" });
             o.execute(cacheCollection, null, configrefs);
 
-            Assert.AreEqual(1, xplaneCacheMock.Writes.Count, "The message count is not as expected");
+            Assert.HasCount(1, xplaneCacheMock.Writes, "The message count is not as expected");
             Assert.AreEqual(2, xplaneCacheMock.Writes[0].Value, "The Write Value is wrong");
         }
 

--- a/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
@@ -1,4 +1,4 @@
-﻿using MobiFlight;
+using MobiFlight;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.InputConfig;
 using MobiFlight.OutputConfig;
@@ -19,8 +19,8 @@ namespace MobiFlight.Tests
         {
             InputConfigItem o = new InputConfigItem();
             Assert.IsInstanceOfType(o, typeof(InputConfigItem), "Not of type InputConfigItem");
-            Assert.AreEqual(o.Preconditions.Count, 0, "Preconditions Count other than 0");
-            Assert.AreEqual(o.DeviceType, InputConfigItem.TYPE_NOTSET, "Type other than NOTSET");
+            Assert.AreEqual(0, o.Preconditions.Count, "Preconditions Count other than 0");
+            Assert.AreEqual(InputConfigItem.TYPE_NOTSET, o.DeviceType, "Type other than NOTSET");
         }
 
         [TestMethod()]
@@ -43,14 +43,14 @@ namespace MobiFlight.Tests
             xmlReader.ReadToDescendant("settings");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.ModuleSerial, "TestSerial", "ModuleSerial not the same");
-            Assert.AreEqual(o.DeviceName, "TestName", "Name not the same");
-            Assert.AreEqual(o.Preconditions.Count, 0, "Preconditions Count not the same");
-            Assert.AreEqual(o.DeviceType, "Button", "Type not the same");
+            Assert.AreEqual("TestSerial", o.ModuleSerial, "ModuleSerial not the same");
+            Assert.AreEqual("TestName", o.DeviceName, "Name not the same");
+            Assert.AreEqual(0, o.Preconditions.Count, "Preconditions Count not the same");
+            Assert.AreEqual("Button", o.DeviceType, "Type not the same");
             Assert.IsNull(o.button.onPress, "button onpress not null");
             Assert.IsNotNull(o.button.onRelease, "button onRelease is null");
             Assert.IsNotNull(o.ConfigRefs, "ConfigRefs is null");
-            Assert.AreEqual(o.ConfigRefs.Count, 2, "ConfigRefs.Count is not 2");
+            Assert.HasCount(2, o.ConfigRefs);
 
             o = new InputConfigItem();
             s = System.IO.File.ReadAllText(@"assets\MobiFlight\InputConfig\InputConfigItem\ReadXmlTest.2.xml");
@@ -62,10 +62,10 @@ namespace MobiFlight.Tests
             xmlReader.ReadToDescendant("settings");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.ModuleSerial, "TestSerial", "ModuleSerial not the same");
-            Assert.AreEqual(o.Preconditions.Count, 0, "Preconditions Count not the same");
-            Assert.AreEqual(o.DeviceName, "TestName", "Name not the same");
-            Assert.AreEqual(o.DeviceType, "Button", "Type not the same");
+            Assert.AreEqual("TestSerial", o.ModuleSerial, "ModuleSerial not the same");
+            Assert.HasCount(0, o.Preconditions, "Preconditions Count not the same");
+            Assert.AreEqual("TestName", o.DeviceName, "Name not the same");
+            Assert.AreEqual("Button", o.DeviceType, "Type not the same");
             Assert.IsNull(o.button.onPress, "button onpress not null");
             Assert.IsNotNull(o.button.onRelease, "button onRelease is null");
             Assert.IsNull(o.encoder.onLeft, "encoder onLeft not null");
@@ -73,7 +73,7 @@ namespace MobiFlight.Tests
             Assert.IsNull(o.encoder.onRight, "encoder onRight not null");
             Assert.IsNotNull(o.encoder.onRightFast, "encoder onRightFast is null");
             Assert.IsNotNull(o.ConfigRefs, "ConfigRefs is null");
-            Assert.AreEqual(o.ConfigRefs.Count, 0, "ConfigRefs.Count is not 2");
+            Assert.HasCount(0, o.ConfigRefs, "ConfigRefs.Count is not 2");
 
             o = new InputConfigItem();
             s = System.IO.File.ReadAllText(@"assets\MobiFlight\InputConfig\InputConfigItem\ReadXmlTest.InputShiftRegister.xml");
@@ -85,10 +85,10 @@ namespace MobiFlight.Tests
             xmlReader.ReadToDescendant("settings");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.ModuleSerial, "TestSerial", "ModuleSerial not the same");
-            Assert.AreEqual(o.Preconditions.Count, 0, "Preconditions Count not the same");
-            Assert.AreEqual(o.DeviceName, "TestName", "Name not the same");
-            Assert.AreEqual(o.DeviceType, "Button", "Type not the same");
+            Assert.AreEqual("TestSerial", o.ModuleSerial, "ModuleSerial not the same");
+            Assert.HasCount(0, o.Preconditions, "Preconditions Count not the same");
+            Assert.AreEqual("TestName", o.DeviceName, "Name not the same");
+            Assert.AreEqual("Button", o.DeviceType, "Type not the same");
             Assert.IsNull(o.inputShiftRegister.onPress, "button onpress not null");
             Assert.IsNotNull(o.inputShiftRegister.onRelease, "button onRelease is null");
             Assert.IsNotNull(o.inputShiftRegister.onRelease as JeehellInputAction, "OnRelease is not of type JeehellInputAction");
@@ -103,10 +103,10 @@ namespace MobiFlight.Tests
             xmlReader.ReadToDescendant("settings");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.ModuleSerial, "TestSerial", "ModuleSerial not the same");
-            Assert.AreEqual(o.Preconditions.Count, 0, "Preconditions Count not the same");
-            Assert.AreEqual(o.DeviceName, "TestName", "Name not the same");
-            Assert.AreEqual(o.DeviceType, "Button", "Type not the same");
+            Assert.AreEqual("TestSerial", o.ModuleSerial, "ModuleSerial not the same");
+            Assert.HasCount(0, o.Preconditions, "Preconditions Count not the same");
+            Assert.AreEqual("TestName", o.DeviceName, "Name not the same");
+            Assert.AreEqual("Button", o.DeviceType, "Type not the same");
             Assert.IsNull(o.inputMultiplexer.onPress, "button onpress not null");
             Assert.IsNotNull(o.inputMultiplexer.onRelease, "button onRelease is null");
             Assert.IsNotNull(o.inputMultiplexer.onRelease as JeehellInputAction, "OnRelease is not of type JeehellInputAction");
@@ -121,10 +121,10 @@ namespace MobiFlight.Tests
             xmlReader.ReadToDescendant("settings");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.ModuleSerial, "737PEDESTAL1/ SN-769-a6a", "ModuleSerial not the same");
-            Assert.AreEqual(o.DeviceName, "Analog 67 A13", "Name not the same");
-            Assert.AreEqual(o.Preconditions.Count, 1, "Preconditions Count not the same");
-            Assert.AreEqual(o.ConfigRefs.Count, 1, "Config ref count is not correct");
+            Assert.AreEqual("737PEDESTAL1/ SN-769-a6a", o.ModuleSerial, "ModuleSerial not the same");
+            Assert.AreEqual("Analog 67 A13", o.DeviceName, "Name not the same");
+            Assert.HasCount(1, o.Preconditions, "Preconditions Count not the same");
+            Assert.HasCount(1, o.ConfigRefs, "Config ref count is not correct");
         }
 
         [TestMethod()]
@@ -183,9 +183,9 @@ namespace MobiFlight.Tests
 
             Assert.IsNotNull(c.button, "Button is null");
             Assert.IsNull(c.encoder, "Encoder is not null");
-            Assert.AreEqual(o.ModuleSerial, c.ModuleSerial, "Module Serial not the same");
-            Assert.AreEqual(o.Name, c.Name, "Name not the same");
-            Assert.AreEqual(c.Preconditions.Count, 1, "Precondition Count is not 1");
+            Assert.AreEqual(c.ModuleSerial, o.ModuleSerial, "Module Serial not the same");
+            Assert.AreEqual(c.Name, o.Name, "Name not the same");
+            Assert.HasCount(1, c.Preconditions, "Precondition Count is not 1");
         }
 
         private InputConfigItem generateTestObject()
@@ -256,12 +256,12 @@ namespace MobiFlight.Tests
 
             var statistics = o.GetStatistics();
             Assert.IsNotNull(statistics, "Statistics should be always an empty Dictionary<String, int>");
-            Assert.AreEqual(0, statistics.Count);
+            Assert.HasCount(0, statistics);
 
             o.analog = new InputConfig.AnalogInputConfig();
             o.analog.onChange = new InputConfig.MSFS2020CustomInputAction();
             statistics = o.GetStatistics();
-            Assert.AreEqual(o.analog.GetStatistics().Count, statistics.Count);
+            Assert.HasCount(o.analog.GetStatistics().Count, statistics);
         }
 
         [TestMethod()]
@@ -272,25 +272,25 @@ namespace MobiFlight.Tests
             o.analog.onChange = new VariableInputAction();
 
             var result = o.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 1);
+            Assert.HasCount(1, result);
 
             o.encoder = new InputConfig.EncoderInputConfig();
             o.encoder.onLeft = new VariableInputAction();
 
             result = o.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 2);
+            Assert.HasCount(2, result);
 
             o.button = new InputConfig.ButtonInputConfig();
             o.button.onPress = new VariableInputAction();
 
             result = o.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 3);
+            Assert.HasCount(3, result);
 
             o.inputShiftRegister = new InputConfig.InputShiftRegisterConfig();
             o.inputShiftRegister.onPress = new VariableInputAction();
 
             result = o.GetInputActionsByType(typeof(VariableInputAction));
-            Assert.AreEqual(result.Count, 4);
+            Assert.HasCount(4, result);
         }
     }
 }

--- a/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickDefinitionMigratorTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickDefinitionMigratorTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.Joysticks;
 using System;
 using System.IO;
 using System.Linq;
@@ -151,7 +150,7 @@ namespace MobiFlight.Joysticks.Tests
             Assert.IsTrue(Directory.Exists(conflictFolder), "_CONFLICT_ folder should exist");
             
             var conflictFiles = Directory.GetFiles(conflictFolder);
-            Assert.IsTrue(conflictFiles.Length > 0, "_CONFLICT_ folder should contain files");
+            Assert.IsNotEmpty(conflictFiles, "_CONFLICT_ folder should contain files");
             
             var conflictFile = conflictFiles.FirstOrDefault(f => Path.GetFileName(f).StartsWith("conflict_test.joystick.json_"));
             Assert.IsNotNull(conflictFile, "Should have a conflict file starting with 'conflict_test.joystick.json_'");
@@ -171,7 +170,7 @@ namespace MobiFlight.Joysticks.Tests
             // Assert
             var conflictFolder = Path.Combine(_joysticksDirectory, "_CONFLICT_");
             var conflictFiles = Directory.GetFiles(conflictFolder, "*.bak");
-            Assert.AreEqual(2, conflictFiles.Length, "Should have two conflict backup files");
+            Assert.HasCount(2, conflictFiles, "Should have two conflict backup files");
         }
 
         [TestMethod]
@@ -188,11 +187,11 @@ namespace MobiFlight.Joysticks.Tests
             // Assert
             var conflictFolder = Path.Combine(_joysticksDirectory, "_CONFLICT_");
             var conflictFiles = Directory.GetFiles(conflictFolder, "timestamp_test.joystick.json_*.bak");
-            Assert.AreEqual(1, conflictFiles.Length, "Should have one conflict file");
+            Assert.HasCount(1, conflictFiles, "Should have one conflict file");
             
             var fileName = Path.GetFileName(conflictFiles[0]);
-            Assert.IsTrue(fileName.StartsWith("timestamp_test.joystick.json_"), "File should start with full filename");
-            Assert.IsTrue(fileName.EndsWith(".bak"), "File should end with .bak");
+            Assert.StartsWith("timestamp_test.joystick.json_", fileName, "File should start with full filename");
+            Assert.EndsWith(".bak", fileName, "File should end with .bak");
             
             // Extract timestamp from filename (format: fullfilename_yyyyMMddHHmmss.bak)
             var timestampPart = fileName.Substring("timestamp_test.joystick.json_".Length, 12); // YYYYMMDDHHMM
@@ -235,7 +234,7 @@ namespace MobiFlight.Joysticks.Tests
             
             // Check conflict backup
             var conflictFiles = Directory.GetFiles(Path.Combine(_joysticksDirectory, "_CONFLICT_"), "conflict.joystick.json_*.bak");
-            Assert.AreEqual(1, conflictFiles.Length, "Conflict should be backed up");
+            Assert.HasCount(1, conflictFiles, "Conflict should be backed up");
         }
 
         #endregion
@@ -251,7 +250,6 @@ namespace MobiFlight.Joysticks.Tests
             try
             {
                 ControllerDefinitionMigrator.MigrateDefinitions(_joysticksDirectory, "*.joystick.json");
-                Assert.IsTrue(true, "Should complete without throwing");
             }
             catch (Exception ex)
             {
@@ -269,7 +267,6 @@ namespace MobiFlight.Joysticks.Tests
             try
             {
                 ControllerDefinitionMigrator.MigrateDefinitions(_joysticksDirectory, "*.joystick.json");
-                Assert.IsTrue(true, "Should complete without throwing");
             }
             catch (Exception ex)
             {
@@ -300,7 +297,7 @@ namespace MobiFlight.Joysticks.Tests
                 if (Directory.Exists(conflictFolder))
                 {
                     var conflictFiles = Directory.GetFiles(conflictFolder, "readonly*");
-                    Assert.AreEqual(0, conflictFiles.Length, "Read-only file should not be in conflict folder");
+                    Assert.IsEmpty(conflictFiles, "Read-only file should not be in conflict folder");
                 }
             }
             finally

--- a/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/FcuCubeReportTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/FcuCubeReportTests.cs
@@ -77,7 +77,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert
             Assert.IsNotNull(result);
-            Assert.IsTrue(result.Length >= 23, "Output buffer should be at least 23 bytes");
+            Assert.IsGreaterThanOrEqualTo(23, result.Length, "Output buffer should be at least 23 bytes");
 
             // Check header bytes (with report ID offset)
             Assert.AreEqual(0xF2, result[0], "Header byte 0 should be 0xF2");
@@ -365,7 +365,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             byte byteValue = (byte)positiveValue;
 
             Assert.AreEqual(5, byteValue, "Positive value should remain unchanged");
-            Assert.IsTrue(positiveValue > 0, "Should be detected as positive");
+            Assert.IsGreaterThan(0, positiveValue, "Should be detected as positive");
         }
 
         [TestMethod]
@@ -376,7 +376,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             byte byteValue = (byte)negativeValue;
 
             Assert.AreEqual(251, byteValue, "Negative value should be 251 in two's complement"); // 256 - 5 = 251
-            Assert.IsTrue(((sbyte)byteValue) < 0, "Should be detected as negative when cast back to sbyte");
+            Assert.IsLessThan(0, (sbyte)byteValue, "Should be detected as negative when cast back to sbyte");
         }
 
         [TestMethod]
@@ -389,8 +389,8 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(127, (byte)maxPositive, "Max positive should be 127");
             Assert.AreEqual(128, (byte)maxNegative, "Max negative should be 128");
 
-            Assert.IsTrue(((sbyte)(byte)maxPositive) > 0, "Max positive should remain positive");
-            Assert.IsTrue(((sbyte)(byte)maxNegative) < 0, "Max negative should remain negative");
+            Assert.IsGreaterThan(0, (sbyte)(byte)maxPositive, "Max positive should remain positive");
+            Assert.IsLessThan(0, (sbyte)(byte)maxNegative, "Max negative should remain negative");
         }
 
         #endregion

--- a/MobiFlightUnitTests/MobiFlight/JsonDefinitionFilesTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/JsonDefinitionFilesTests.cs
@@ -14,13 +14,13 @@ namespace MobiFlight.Tests
             Assert.IsFalse(BoardDefinitions.LoadingError);
 
             var coreBoard = BoardDefinitions.GetBoardByMobiFlightType("MobiFlight Mega");
-            Assert.IsTrue(coreBoard.PartnerLevel == BoardPartnerLevel.Core);
+            Assert.AreEqual(BoardPartnerLevel.Core, coreBoard.PartnerLevel);
 
             var partnerBoard = BoardDefinitions.GetBoardByMobiFlightType("Kav Mega");
-            Assert.IsTrue(partnerBoard.PartnerLevel == BoardPartnerLevel.Partner);
+            Assert.AreEqual(BoardPartnerLevel.Partner, partnerBoard.PartnerLevel);
 
             var communityBoard = BoardDefinitions.GetBoardByMobiFlightType("MobiFlight GenericI2C Mega");
-            Assert.IsTrue(communityBoard.PartnerLevel == BoardPartnerLevel.Community);
+            Assert.AreEqual(BoardPartnerLevel.Community, communityBoard.PartnerLevel);
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/MobiFlightModuleTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/MobiFlightModuleTests.cs
@@ -1,10 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MobiFlight.Tests
 {
@@ -219,24 +216,24 @@ namespace MobiFlight.Tests
             MobiFlightModule o = new MobiFlightModule("COM1", board);
             o.Config = new Config.Config();
 
-            Assert.AreEqual(board.Pins.Count(), o.GetFreePins().Count, "Number of free pins is wrong");
+            Assert.HasCount(board.Pins.Count(), o.GetFreePins(), "Number of free pins is wrong");
             o.Config.Items.Add(new Config.Button() { Name = "Test", Pin = "2" });
             o.Config.Items.Add(new Config.Button() { Name = "Test", Pin = "5" });
 
-            Assert.AreEqual(board.Pins.Count() - o.Config.Items.Count, o.GetFreePins().Count, "Number of free pins is wrong");
-            Assert.AreEqual(false, o.GetFreePins().Exists(x => x.Pin == 2), "Used pin still available");
-            Assert.AreEqual(false, o.GetFreePins().Exists(x => x.Pin == 5), "Used pin still available");
-            Assert.AreEqual(true, o.GetFreePins().Exists(x => x.Pin == 52), "Free pin not available");
+            Assert.HasCount(board.Pins.Count() - o.Config.Items.Count, o.GetFreePins(), "Number of free pins is wrong");
+            Assert.IsFalse(o.GetFreePins().Exists(x => x.Pin == 2), "Used pin still available");
+            Assert.IsFalse(o.GetFreePins().Exists(x => x.Pin == 5), "Used pin still available");
+            Assert.IsTrue(o.GetFreePins().Exists(x => x.Pin == 52), "Free pin not available");
 
             (o.Config.Items[0] as Config.Button).Pin = "3";
-            Assert.AreEqual(false, o.GetFreePins().Exists(x => x.Pin == 3), "Used pin still available");
-            Assert.AreEqual(true, o.GetFreePins().Exists(x => x.Pin == 2), "Free pin not available");
+            Assert.IsFalse(o.GetFreePins().Exists(x => x.Pin == 3), "Used pin still available");
+            Assert.IsTrue(o.GetFreePins().Exists(x => x.Pin == 2), "Free pin not available");
 
             board = BoardDefinitions.GetBoardByMobiFlightType("MobiFlight Uno");
             o = new MobiFlightModule("COM1", board);
             o.Config = new Config.Config();
-            Assert.AreEqual(true, o.GetFreePins().Exists(x => x.Pin == 13), "Free pin not available");
-            Assert.AreEqual(false, o.GetFreePins().Exists(x => x.Pin == 52), "Invalid pin available");
+            Assert.IsTrue(o.GetFreePins().Exists(x => x.Pin == 13), "Free pin not available");
+            Assert.IsFalse(o.GetFreePins().Exists(x => x.Pin == 52), "Invalid pin available");
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
@@ -1,12 +1,7 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.Modifier;
-using MobiFlight.OutputConfig;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.Modifier.Tests
@@ -19,7 +14,7 @@ namespace MobiFlight.Modifier.Tests
         {
             Comparison o = new Comparison();
             Assert.IsNotNull(o, "Object is null");
-            Assert.AreEqual(false, o.Active, "Active not true");
+            Assert.IsFalse(o.Active, "Active not true");
             Assert.AreEqual("", o.Value, "Value not empty");
             Assert.AreEqual(Comparison.OPERAND_EQUAL, o.Operand, "Operand not empty");
             Assert.AreEqual("", o.IfValue, "IfValue not empty");

--- a/MobiFlightUnitTests/MobiFlight/Modifier/InterpolationTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Modifier/InterpolationTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Xml;
@@ -167,7 +167,7 @@ namespace MobiFlight.Modifier.Tests
             Interpolation i = new Interpolation();
             xmlReader.ReadToDescendant("interpolation");
             i.ReadXml(xmlReader);
-            Assert.AreEqual(true, i.Active, "Interpolation is not active");
+            Assert.IsTrue(i.Active, "Interpolation is not active");
             Assert.AreEqual(3, i.Count, "Number of items in Interpolation wrong");
             Assert.AreEqual(0, i.Value(0), "Value of interpolation is wrong");
             Assert.AreEqual(2, i.Value(0.5f), "Value of interpolation is wrong");

--- a/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -80,8 +80,8 @@ namespace MobiFlight.Modifier.Tests
             xmlReader.ReadToDescendant("transformation");
             o.ReadXml(xmlReader);
 
-            Assert.AreEqual(o.Active, true, "Active value differs");
-            Assert.AreEqual(o.Expression, "$+2", "Expression value differs");
+            Assert.IsTrue(o.Active, "Active value differs");
+            Assert.AreEqual("$+2", o.Expression, "Expression value differs");
         }
 
         [TestMethod()]
@@ -112,8 +112,8 @@ namespace MobiFlight.Modifier.Tests
             Transformation o = generateTestObject();
 
             Transformation c = (Transformation)o.Clone();
-            Assert.AreEqual(o.Active, c.Active, "Active value differs");
-            Assert.AreEqual(o.Expression, c.Expression, "Expression value differs");
+            Assert.AreEqual(c.Active, o.Active, "Active value differs");
+            Assert.AreEqual(c.Expression, o.Expression, "Expression value differs");
         }
 
         private Transformation generateTestObject()

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/CustomDeviceTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/CustomDeviceTests.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.OutputConfig;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.OutputConfig.Tests
@@ -18,9 +13,9 @@ namespace MobiFlight.OutputConfig.Tests
         {
             var o = new CustomDevice();
             Assert.IsNotNull(o);
-            Assert.AreEqual(null, o.CustomName);
-            Assert.AreEqual(null, o.CustomType);
-            Assert.AreEqual(null, o.Value);
+            Assert.IsNull(o.CustomName);
+            Assert.IsNull(o.CustomType);
+            Assert.IsNull(o.Value);
             Assert.AreEqual(0, o.MessageType);
         }
 

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/FsuipcOffsetTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/FsuipcOffsetTests.cs
@@ -1,10 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.OutputConfig;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace MobiFlight.OutputConfig.Tests
 {
@@ -20,7 +14,7 @@ namespace MobiFlight.OutputConfig.Tests
             Assert.AreEqual(0xFF, o.Mask);
             Assert.AreEqual(FSUIPCOffsetType.Integer, o.OffsetType);
             Assert.AreEqual(1, o.Size);
-            Assert.AreEqual(false, o.BcdMode);
+            Assert.IsFalse(o.BcdMode);
         }
 
         [TestMethod()]
@@ -53,10 +47,10 @@ namespace MobiFlight.OutputConfig.Tests
             FsuipcOffset clone = o.Clone() as FsuipcOffset;
 
 
-            Assert.AreEqual(o.Offset, clone.Offset, "Mask is not the same");
-            Assert.AreEqual(o.OffsetType, clone.OffsetType, "OffsetType is not the same");
-            Assert.AreEqual(o.Size, clone.Size, "Size is not the same");
-            Assert.AreEqual(o.BcdMode, clone.BcdMode, "BcdMode is not the same");
+            Assert.AreEqual(clone.Offset, o.Offset, "Mask is not the same");
+            Assert.AreEqual(clone.OffsetType, o.OffsetType, "OffsetType is not the same");
+            Assert.AreEqual(clone.Size, o.Size, "Size is not the same");
+            Assert.AreEqual(clone.BcdMode, o.BcdMode, "BcdMode is not the same");
         }
     }
 }

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/LcdDisplayTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/LcdDisplayTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.OutputConfig;
 using System;
 using System.Collections.Generic;
@@ -20,7 +20,7 @@ namespace MobiFlight.OutputConfig.Tests
             Assert.IsNotNull(o, "Object is null");
 
             Assert.IsNull(o.Address, "Address is not null");
-            Assert.AreEqual(0, o.Lines.Count, "Line Count not 0");
+            Assert.IsEmpty(o.Lines, "Line Count not 0");
         }
 
         [TestMethod()]
@@ -31,8 +31,8 @@ namespace MobiFlight.OutputConfig.Tests
             o.Lines.Add("TestLine1");
             Assert.IsNotNull(o, "Object is null");
             LcdDisplay c = o.Clone() as LcdDisplay;
-            Assert.AreEqual(o.Address, c.Address, "Address are not the same");
-            Assert.AreEqual(o.Lines.Count, c.Lines.Count, "Line.Count not the same");
+            Assert.AreEqual(c.Address, o.Address, "Address are not the same");
+            Assert.HasCount(o.Lines.Count, c.Lines, "Line.Count not the same");
             Assert.AreEqual(o.Lines[0], c.Lines[0], "Lines[0] not the same");
         }
 
@@ -59,7 +59,7 @@ namespace MobiFlight.OutputConfig.Tests
             o.ReadXml(xmlReader);
 
             Assert.AreEqual("LCDDisplay", o.Address, "Address does not match.");
-            Assert.AreEqual(1, o.Lines.Count, "Lines.Count does not match.");
+            Assert.HasCount(1, o.Lines, "Lines.Count does not match.");
             Assert.AreEqual("Read Test Line 1", o.Lines[0]);
 
             s = System.IO.File.ReadAllText(@"assets\MobiFlight\OutputConfig\LcdDisplay\ReadXmlTest.2.xml");
@@ -71,7 +71,7 @@ namespace MobiFlight.OutputConfig.Tests
             o.ReadXml(xmlReader);
 
             Assert.AreEqual("LCDDisplay", o.Address, "Address does not match.");
-            Assert.AreEqual(4, o.Lines.Count, "Lines.Count does not match.");
+            Assert.HasCount(4, o.Lines, "Lines.Count does not match.");
             Assert.AreEqual("Read Test Line 1", o.Lines[0]);
             Assert.AreEqual("", o.Lines[1]); // no space was used in the node
             Assert.AreEqual("", o.Lines[2]); // 20 spaces were used, but it cant get loaded again, that is what XML does 

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/LedModuleTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/LedModuleTests.cs
@@ -1,10 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.OutputConfig;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace MobiFlight.OutputConfig.Tests
 {
@@ -18,8 +13,8 @@ namespace MobiFlight.OutputConfig.Tests
             Assert.IsNotNull(o);
             Assert.AreEqual(1,o.DisplayLedConnector);
             Assert.AreEqual("0",o.DisplayLedAddress);
-            Assert.AreEqual(false,o.DisplayLedPadding);
-            Assert.AreEqual(false,o.DisplayLedReverseDigits);
+            Assert.IsFalse(o.DisplayLedPadding);
+            Assert.IsFalse(o.DisplayLedReverseDigits);
             Assert.AreEqual(string.Empty, o.DisplayLedBrightnessReference);
             Assert.AreEqual("0",o.DisplayLedPaddingChar);
             Assert.AreEqual(8, o.DisplayLedModuleSize);

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/OutputTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/OutputTests.cs
@@ -14,7 +14,7 @@ namespace MobiFlight.OutputConfig.Tests
             Output o = new Output();
             Assert.IsNotNull(o);
             Assert.AreEqual(byte.MaxValue, o.Brightness);
-            Assert.AreEqual(false, o.PwmMode);
+            Assert.IsFalse(o.PwmMode);
         }
 
         [TestMethod()]
@@ -65,7 +65,7 @@ namespace MobiFlight.OutputConfig.Tests
 
             Assert.AreEqual("Pin", o.Pin);
             Assert.AreEqual(128, o.Brightness);
-            Assert.AreEqual(true, o.PwmMode);
+            Assert.IsTrue(o.PwmMode);
         }
 
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/ShiftRegisterTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/ShiftRegisterTests.cs
@@ -1,9 +1,7 @@
-﻿using MobiFlight.OutputConfig;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
-using System.Net;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 using System.IO;
 using System.Xml;
-using System;
 
 namespace MobiFlight.OutputConfig.Tests
 {
@@ -69,7 +67,7 @@ namespace MobiFlight.OutputConfig.Tests
 
             Assert.AreEqual("Output 4", o.Pin);
             Assert.AreEqual(128, o.Brightness);
-            Assert.AreEqual(true, o.PWM);
+            Assert.IsTrue(o.PWM);
         }
         
         [TestMethod()]

--- a/MobiFlightUnitTests/MobiFlight/OutputConfig/StepperTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfig/StepperTests.cs
@@ -1,11 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.OutputConfig;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml;
 
 namespace MobiFlight.OutputConfig.Tests
@@ -79,7 +74,7 @@ namespace MobiFlight.OutputConfig.Tests
             o.ReadXml(xmlReader);
 
             Assert.AreEqual("Address", o.Address);
-            Assert.AreEqual(true, o.CompassMode);
+            Assert.IsTrue(o.CompassMode);
             Assert.AreEqual(1000, o.InputRev);
             Assert.AreEqual(2040, o.OutputRev);
             Assert.AreEqual(1024, o.TestValue);

--- a/MobiFlightUnitTests/MobiFlight/OutputConfigItemTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/OutputConfigItemTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.Base;
 using MobiFlight.Modifier;
 using MobiFlight.OutputConfig;
@@ -38,22 +38,22 @@ namespace MobiFlight.Tests
             System.Xml.XmlReader xmlReader = System.Xml.XmlReader.Create(sr, settings);
             oci.ReadXml(xmlReader);
             Assert.IsTrue(oci.Source is FsuipcSource);
-            Assert.AreEqual((oci.Source as FsuipcSource).FSUIPC.OffsetType, FSUIPCOffsetType.Integer);
-            Assert.AreEqual((oci.Source as FsuipcSource).FSUIPC.Offset, 0x034E);
-            Assert.AreEqual((oci.Source as FsuipcSource).FSUIPC.Size, 2);
-            Assert.AreEqual((oci.Source as FsuipcSource).FSUIPC.Mask, 0xFFFF);
-            Assert.AreEqual((oci.Source as FsuipcSource).FSUIPC.BcdMode, true);
-            Assert.AreEqual(oci.Modifiers.Transformation.Expression, "$+123");
+            Assert.AreEqual(FSUIPCOffsetType.Integer, (oci.Source as FsuipcSource).FSUIPC.OffsetType);
+            Assert.AreEqual(0x034E, (oci.Source as FsuipcSource).FSUIPC.Offset);
+            Assert.AreEqual(2, (oci.Source as FsuipcSource).FSUIPC.Size);
+            Assert.AreEqual(0xFFFF, (oci.Source as FsuipcSource).FSUIPC.Mask);
+            Assert.IsTrue((oci.Source as FsuipcSource).FSUIPC.BcdMode);
+            Assert.AreEqual("$+123", oci.Modifiers.Transformation.Expression);
 
             // read backward compatible
             s = System.IO.File.ReadAllText(@"assets\MobiFlight\OutputConfig\OutputConfigItem\ReadXmlTest.2.xml");
             sr = new StringReader(s);
             xmlReader = System.Xml.XmlReader.Create(sr, settings);
             oci.ReadXml(xmlReader);
-            Assert.AreEqual(oci.Modifiers.Transformation.Active, true);
-            Assert.AreEqual(oci.Modifiers.Transformation.Expression, "$*123");
+            Assert.IsTrue(oci.Modifiers.Transformation.Active);
+            Assert.AreEqual("$*123", oci.Modifiers.Transformation.Expression);
             Assert.IsTrue(oci.Device is LedModule);
-            Assert.AreEqual((oci.Device as LedModule).DisplayLedBrightnessReference, "CF057791-E133-4638-A99E-FEF9B187C4DB");
+            Assert.AreEqual("CF057791-E133-4638-A99E-FEF9B187C4DB", (oci.Device as LedModule).DisplayLedBrightnessReference);
 
             // read problem with missing configrefs
             s = System.IO.File.ReadAllText(@"assets\MobiFlight\OutputConfig\OutputConfigItem\ReadXmlTest.3.xml");
@@ -68,7 +68,7 @@ namespace MobiFlight.Tests
             sr = new StringReader(s);
             xmlReader = System.Xml.XmlReader.Create(sr, settings);
             oci.ReadXml(xmlReader);
-            Assert.AreEqual(true, oci.Modifiers.Interpolation.Active, "Interpolation is supposed to be active");
+            Assert.IsTrue(oci.Modifiers.Interpolation.Active, "Interpolation is supposed to be active");
             Assert.AreEqual(5, oci.Modifiers.Interpolation.Count);
 
             // read problem with interpolation OUTSIDE of display node
@@ -76,7 +76,7 @@ namespace MobiFlight.Tests
             sr = new StringReader(s);
             xmlReader = System.Xml.XmlReader.Create(sr, settings);
             oci.ReadXml(xmlReader);
-            Assert.AreEqual(true, oci.Modifiers.Interpolation.Active, "Interpolation is supposed to be active");
+            Assert.IsTrue(oci.Modifiers.Interpolation.Active, "Interpolation is supposed to be active");
             Assert.AreEqual(5, oci.Modifiers.Interpolation.Count);
 
             // read buttoninputaction
@@ -136,7 +136,7 @@ namespace MobiFlight.Tests
             oci = new OutputConfigItem();
             oci.ReadXml(xmlReader);
             Assert.AreEqual("Display Module", oci.DeviceType, "Display Type not Display Module");
-            Assert.AreEqual(true, oci.Modifiers.Interpolation.Active, "AnalogInputConfig.onPress null");
+            Assert.IsTrue(oci.Modifiers.Interpolation.Active, "AnalogInputConfig.onPress null");
             Assert.AreEqual(5, oci.Modifiers.Interpolation.Count, "Interpolation Count is not 5");
         }
 
@@ -190,10 +190,10 @@ namespace MobiFlight.Tests
             OutputConfigItem o = _generateConfigItem();
 
             OutputConfigItem c = (OutputConfigItem)o.Clone();
-            Assert.AreEqual(o.Name, c.Name, "clone: Name not the same");
-            Assert.AreEqual(o.Active, c.Active, "clone: Active not the same");
-            Assert.AreEqual(o.GUID, c.GUID, "clone: GUID not the same");
-            Assert.AreEqual(o.Type, c.Type, "clone: Type not the same");
+            Assert.AreEqual(c.Name, o.Name, "clone: Name not the same");
+            Assert.AreEqual(c.Active, o.Active, "clone: Active not the same");
+            Assert.AreEqual(c.GUID, o.GUID, "clone: GUID not the same");
+            Assert.AreEqual(c.Type, o.Type, "clone: Type not the same");
 
             Assert.AreEqual((o.Source as FsuipcSource).FSUIPC.Offset, (c.Source as FsuipcSource).FSUIPC.Offset, "clone: FSUIPCOffset not the same");
             Assert.AreEqual((o.Source as FsuipcSource).FSUIPC.Mask, (c.Source as FsuipcSource).FSUIPC.Mask, " clone: FSUIPCMask not the same");
@@ -208,8 +208,8 @@ namespace MobiFlight.Tests
             Assert.AreEqual(o.Modifiers.Comparison.ElseValue, c.Modifiers.Comparison.ElseValue, "clone: ComparisonElseValue not the same");
             Assert.AreEqual(o.Modifiers.Interpolation.Count, c.Modifiers.Interpolation.Count, "clone: Interpolation count not right");
 
-            Assert.AreEqual(o.DeviceType, c.DeviceType, "clone: DisplayType not the same");
-            Assert.AreEqual(o.ModuleSerial, c.ModuleSerial, "clone: DisplaySerial not the same");
+            Assert.AreEqual(c.DeviceType, o.DeviceType, "clone: DisplayType not the same");
+            Assert.AreEqual(c.ModuleSerial, o.ModuleSerial, "clone: DisplaySerial not the same");
 
             if (o.DeviceType == MobiFlight.DeviceType.Output.ToString("F"))
             {
@@ -236,20 +236,20 @@ namespace MobiFlight.Tests
                 var oServo = o.Device as Servo;
                 var cServo = c.Device as Servo;
 
-                Assert.AreEqual(oServo.Address, cServo.Address, "clone: ServoAddress not the same");
-                Assert.AreEqual(oServo.Max, cServo.Max, "clone: ServoMax not the same");
-                Assert.AreEqual(oServo.Min, cServo.Min, "clone: ServoMin not the same");
-                Assert.AreEqual(oServo.MaxRotationPercent, cServo.MaxRotationPercent, "clone: ServoMaxRotationPercent not the same");
+                Assert.AreEqual(cServo.Address, oServo.Address, "clone: ServoAddress not the same");
+                Assert.AreEqual(cServo.Max, oServo.Max, "clone: ServoMax not the same");
+                Assert.AreEqual(cServo.Min, oServo.Min, "clone: ServoMin not the same");
+                Assert.AreEqual(cServo.MaxRotationPercent, oServo.MaxRotationPercent, "clone: ServoMaxRotationPercent not the same");
             }
 
             if (o.Device is Stepper) {
                 var oStepper = o.Device as Stepper;
                 var cStepper = c.Device as Stepper;
 
-                Assert.AreEqual(oStepper.Address, cStepper.Address, "clone: StepperAddress not the same");
-                Assert.AreEqual(oStepper.InputRev, cStepper.InputRev, "clone: StepperInputRev not the same");
-                Assert.AreEqual(oStepper.OutputRev, cStepper.OutputRev, "clone: StepperOutputRev not the same");
-                Assert.AreEqual(oStepper.TestValue, cStepper.TestValue, "clone: StepperTestValue not the same");
+                Assert.AreEqual(cStepper.Address, oStepper.Address, "clone: StepperAddress not the same");
+                Assert.AreEqual(cStepper.InputRev, oStepper.InputRev, "clone: StepperInputRev not the same");
+                Assert.AreEqual(cStepper.OutputRev, oStepper.OutputRev, "clone: StepperOutputRev not the same");
+                Assert.AreEqual(cStepper.TestValue, oStepper.TestValue, "clone: StepperTestValue not the same");
             }
 
             if (o.Device is ShiftRegister)
@@ -257,8 +257,8 @@ namespace MobiFlight.Tests
                 var oShiftRegister = o.Device as ShiftRegister;
                 var cShiftRegister = c.Device as ShiftRegister;
                 // Shift Register
-                Assert.AreEqual(oShiftRegister.Address, cShiftRegister.Address, "clone: ShiftRegister.Address not the same");
-                Assert.AreEqual(oShiftRegister.Pin, cShiftRegister.Pin, "clone: ShiftRegister.Address not the same");
+                Assert.AreEqual(cShiftRegister.Address, oShiftRegister.Address, "clone: ShiftRegister.Address not the same");
+                Assert.AreEqual(cShiftRegister.Pin, oShiftRegister.Pin, "clone: ShiftRegister.Address not the same");
             }
 
             if (o.Device is CustomDevice)
@@ -266,10 +266,10 @@ namespace MobiFlight.Tests
                 var oCustomDevice = o.Device as CustomDevice;
                 var cCustomDevice = c.Device as CustomDevice;
                 // Custom Device
-                Assert.AreEqual(oCustomDevice.CustomType, cCustomDevice.CustomType, "clone: CustomDevice.CustomType not the same");
-                Assert.AreEqual(oCustomDevice.CustomName, cCustomDevice.CustomName, "clone: CustomDevice.CustomName not the same");
-                Assert.AreEqual(oCustomDevice.MessageType, cCustomDevice.MessageType, "clone: CustomDevice.MessageType not the same");
-                Assert.AreEqual(oCustomDevice.Value, cCustomDevice.Value, "clone: CustomDevice.Value not the same");
+                Assert.AreEqual(cCustomDevice.CustomType, oCustomDevice.CustomType, "clone: CustomDevice.CustomType not the same");
+                Assert.AreEqual(cCustomDevice.CustomName, oCustomDevice.CustomName, "clone: CustomDevice.CustomName not the same");
+                Assert.AreEqual(cCustomDevice.MessageType, oCustomDevice.MessageType, "clone: CustomDevice.MessageType not the same");
+                Assert.AreEqual(cCustomDevice.Value, oCustomDevice.Value, "clone: CustomDevice.Value not the same");
             }
 
             //o. = new Interpolation();

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.4.0.2\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.4.0.2\build\net462\MSTest.TestAdapter.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.0.2\build\Microsoft.Testing.Platform.MSBuild.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.0.2\build\Microsoft.Testing.Platform.MSBuild.props')" />
   <Import Project="..\packages\Microsoft.Testing.Extensions.Telemetry.2.0.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props" Condition="Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.0.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.2.0.2\build\netstandard2.0\Microsoft.Testing.Platform.props" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.0.2\build\netstandard2.0\Microsoft.Testing.Platform.props')" />
-  <Import Project="..\packages\MSTest.TestAdapter.3.10.2\build\net462\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.3.10.2\build\net462\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -130,14 +130,14 @@
       <HintPath>..\packages\Microsoft.TestPlatform.ObjectModel.18.0.1\lib\net462\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.3.10.2\lib\net462\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.3.10.2\lib\net462\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="Moq, Version=4.20.72.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.20.72\lib\net462\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="MSTest.TestFramework, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.4.0.2\lib\net462\MSTest.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="MSTest.TestFramework.Extensions, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.4.0.2\lib\net462\MSTest.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
       <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -758,8 +758,8 @@
     <Folder Include="MobiFlight\SimConnectMSFS\" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\MSTest.Analyzers.3.10.2\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\MSTest.Analyzers.3.10.2\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
+    <Analyzer Include="..\packages\MSTest.Analyzers.4.0.2\analyzers\dotnet\cs\MSTest.Analyzers.CodeFixes.dll" />
+    <Analyzer Include="..\packages\MSTest.Analyzers.4.0.2\analyzers\dotnet\cs\MSTest.Analyzers.dll" />
   </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
@@ -785,23 +785,23 @@
     <PreBuildEvent>xcopy "$(SolutionDir)examples\*.mcc" "$(TargetDir)assets\Base\ConfigFile\" /Y /I
 xcopy /R /Y "$(SolutionDir)\lib\x86\SimConnect.dll" "$(TargetDir)"</PreBuildEvent>
   </PropertyGroup>
-  <Import Project="..\packages\MSTest.TestFramework.3.10.2\build\net462\MSTest.TestFramework.targets" Condition="Exists('..\packages\MSTest.TestFramework.3.10.2\build\net462\MSTest.TestFramework.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestFramework.3.10.2\build\net462\MSTest.TestFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestFramework.3.10.2\build\net462\MSTest.TestFramework.targets'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.3.10.2\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.3.10.2\build\net462\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.3.10.2\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.3.10.2\build\net462\MSTest.TestAdapter.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Platform.2.0.2\build\netstandard2.0\Microsoft.Testing.Platform.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.2.0.2\build\netstandard2.0\Microsoft.Testing.Platform.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Platform.2.0.2\build\netstandard2.0\Microsoft.Testing.Platform.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.2.0.2\build\netstandard2.0\Microsoft.Testing.Platform.targets'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Extensions.Telemetry.2.0.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Extensions.Telemetry.2.0.2\build\netstandard2.0\Microsoft.Testing.Extensions.Telemetry.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.0.2\build\Microsoft.Testing.Platform.MSBuild.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.MSBuild.2.0.2\build\Microsoft.Testing.Platform.MSBuild.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.0.2\build\Microsoft.Testing.Platform.MSBuild.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Testing.Platform.MSBuild.2.0.2\build\Microsoft.Testing.Platform.MSBuild.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestFramework.4.0.2\build\net462\MSTest.TestFramework.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestFramework.4.0.2\build\net462\MSTest.TestFramework.targets'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.0.2\build\net462\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.0.2\build\net462\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.4.0.2\build\net462\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.4.0.2\build\net462\MSTest.TestAdapter.targets'))" />
   </Target>
-  <Import Project="..\packages\MSTest.TestAdapter.3.10.2\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.3.10.2\build\net462\MSTest.TestAdapter.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.2.0.2\build\netstandard2.0\Microsoft.Testing.Platform.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.2.0.2\build\netstandard2.0\Microsoft.Testing.Platform.targets')" />
   <Import Project="..\packages\Microsoft.Testing.Platform.MSBuild.2.0.2\build\Microsoft.Testing.Platform.MSBuild.targets" Condition="Exists('..\packages\Microsoft.Testing.Platform.MSBuild.2.0.2\build\Microsoft.Testing.Platform.MSBuild.targets')" />
+  <Import Project="..\packages\MSTest.TestFramework.4.0.2\build\net462\MSTest.TestFramework.targets" Condition="Exists('..\packages\MSTest.TestFramework.4.0.2\build\net462\MSTest.TestFramework.targets')" />
+  <Import Project="..\packages\MSTest.TestAdapter.4.0.2\build\net462\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.4.0.2\build\net462\MSTest.TestAdapter.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/MobiFlightUnitTests/ProSim/ProSimCacheTests.cs
+++ b/MobiFlightUnitTests/ProSim/ProSimCacheTests.cs
@@ -1,14 +1,10 @@
+using GraphQL;
+using GraphQL.Client.Abstractions.Websocket;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.ProSim;
-using System;
+using Moq;
 using System.Collections.Generic;
 using System.Reflection;
-using System.Threading.Tasks;
-using Moq;
-using GraphQL.Client.Http;
-using GraphQL;
-using GraphQL.Client.Serializer.Newtonsoft;
-using GraphQL.Client.Abstractions.Websocket;
 
 namespace MobiFlight.Tests.ProSim
 {
@@ -147,8 +143,9 @@ namespace MobiFlight.Tests.ProSim
 
             // Assert
             Assert.IsNotNull(capturedRequest, "Expected a GraphQL request to be sent");
-            Assert.IsTrue(capturedRequest.Query.Contains("writeBool"),
-                $"Expected mutation to contain 'writeBool', but got: {capturedRequest.Query}");
+            Assert.Contains("writeBool",
+                            capturedRequest.Query, 
+                            $"Expected mutation to contain 'writeBool', but got: {capturedRequest.Query}");
             Assert.IsTrue(capturedRequest.Query.Contains("$name") && capturedRequest.Query.Contains("$value"),
                 $"Expected mutation to use variables, but got: {capturedRequest.Query}");
             Assert.IsNotNull(capturedRequest.Variables, "Expected variables to be set");
@@ -190,8 +187,9 @@ namespace MobiFlight.Tests.ProSim
 
             // Assert
             Assert.IsNotNull(capturedRequest, "Expected a GraphQL request to be sent");
-            Assert.IsTrue(capturedRequest.Query.Contains("writeInt"),
-                $"Expected mutation to contain 'writeInt', but got: {capturedRequest.Query}");
+            Assert.Contains("writeInt",
+                            capturedRequest.Query, 
+                            $"Expected mutation to contain 'writeInt', but got: {capturedRequest.Query}");
             Assert.IsTrue(capturedRequest.Query.Contains("$name") && capturedRequest.Query.Contains("$value"),
                 $"Expected mutation to use variables, but got: {capturedRequest.Query}");
             Assert.IsNotNull(capturedRequest.Variables, "Expected variables to be set");
@@ -233,8 +231,9 @@ namespace MobiFlight.Tests.ProSim
 
             // Assert
             Assert.IsNotNull(capturedRequest, "Expected a GraphQL request to be sent");
-            Assert.IsTrue(capturedRequest.Query.Contains("writeFloat"),
-                $"Expected mutation to contain 'writeFloat', but got: {capturedRequest.Query}");
+            Assert.Contains("writeFloat",
+                            capturedRequest.Query, 
+                            $"Expected mutation to contain 'writeFloat', but got: {capturedRequest.Query}");
             Assert.IsTrue(capturedRequest.Query.Contains("$name") && capturedRequest.Query.Contains("$value"),
                 $"Expected mutation to use variables, but got: {capturedRequest.Query}");
             Assert.IsNotNull(capturedRequest.Variables, "Expected variables to be set");
@@ -276,8 +275,9 @@ namespace MobiFlight.Tests.ProSim
 
             // Assert
             Assert.IsNotNull(capturedRequest, "Expected a GraphQL request to be sent");
-            Assert.IsTrue(capturedRequest.Query.Contains("writeBool"),
-                $"Expected mutation to contain 'writeBool', but got: {capturedRequest.Query}");
+            Assert.Contains("writeBool",
+                            capturedRequest.Query, 
+                            $"Expected mutation to contain 'writeBool', but got: {capturedRequest.Query}");
             Assert.IsNotNull(capturedRequest.Variables, "Expected variables to be set");
         }
 
@@ -317,8 +317,9 @@ namespace MobiFlight.Tests.ProSim
 
             // Assert
             Assert.IsNotNull(capturedRequest, "Expected a GraphQL request to be sent");
-            Assert.IsTrue(capturedRequest.Query.Contains("writeBool"),
-                $"Expected mutation to contain 'writeBool', but got: {capturedRequest.Query}");
+            Assert.Contains("writeBool",
+                            capturedRequest.Query, 
+                            $"Expected mutation to contain 'writeBool', but got: {capturedRequest.Query}");
             Assert.IsNotNull(capturedRequest.Variables, "Expected variables to be set");
         }
 
@@ -358,8 +359,9 @@ namespace MobiFlight.Tests.ProSim
 
             // Assert
             Assert.IsNotNull(capturedRequest, "Expected a GraphQL request to be sent");
-            Assert.IsTrue(capturedRequest.Query.Contains("writeInt"),
-                $"Expected mutation to contain 'writeInt', but got: {capturedRequest.Query}");
+            Assert.Contains("writeInt",
+                            capturedRequest.Query, 
+                            $"Expected mutation to contain 'writeInt', but got: {capturedRequest.Query}");
             Assert.IsNotNull(capturedRequest.Variables, "Expected variables to be set");
         }
 

--- a/MobiFlightUnitTests/ProSim/ProSimSerializationIntegrationTests.cs
+++ b/MobiFlightUnitTests/ProSim/ProSimSerializationIntegrationTests.cs
@@ -3,7 +3,6 @@ using MobiFlight.Base;
 using MobiFlight.InputConfig;
 using MobiFlight.ProSim;
 using Newtonsoft.Json;
-using System;
 using System.IO;
 using System.Xml;
 
@@ -48,10 +47,10 @@ namespace MobiFlight.Tests.ProSim
             string json = JsonConvert.SerializeObject(source);
             
             // Verify both serializations work correctly
-            Assert.IsTrue(xml.Contains("path=\"test/dataref/path\""), "XML should contain path attribute");
-            Assert.IsTrue(xml.Contains("expression=\"$ * 2 + @\""), "XML should contain expression attribute");
-            Assert.IsTrue(json.Contains("\"Type\":\"ProSimSource\""), "JSON should contain Type");
-            Assert.IsTrue(json.Contains("\"Path\":\"test/dataref/path\""), "JSON should contain Path");
+            Assert.Contains("path=\"test/dataref/path\"", xml, "XML should contain path attribute");
+            Assert.Contains("expression=\"$ * 2 + @\"", xml, "XML should contain expression attribute");
+            Assert.Contains("\"Type\":\"ProSimSource\"", json, "JSON should contain Type");
+            Assert.Contains("\"Path\":\"test/dataref/path\"", json, "JSON should contain Path");
         }
 
         [TestMethod()]
@@ -101,7 +100,7 @@ namespace MobiFlight.Tests.ProSim
             
             // Deserialize ProSimSource from JSON
             var deserializedSource = JsonConvert.DeserializeObject<ProSimSource>(json);
-            
+
             // Verify round trips work correctly
             Assert.AreEqual(originalInputAction.Path, deserializedInputAction.Path, "ProSimInputAction Path should be preserved through XML round trip");
             Assert.AreEqual(originalInputAction.Expression, deserializedInputAction.Expression, "ProSimInputAction Expression should be preserved through XML round trip");
@@ -134,7 +133,7 @@ namespace MobiFlight.Tests.ProSim
             // Verify clones are not the same references
             Assert.AreNotSame(originalInputAction, clonedInputAction, "Cloned ProSimInputAction should not be the same reference");
             Assert.AreNotSame(originalSource, clonedSource, "Cloned ProSimSource should not be the same reference");
-            
+
             // Verify clone values are the same
             Assert.AreEqual(originalInputAction.Path, clonedInputAction.Path, "Cloned ProSimInputAction Path should be the same");
             Assert.AreEqual(originalInputAction.Expression, clonedInputAction.Expression, "Cloned ProSimInputAction Expression should be the same");
@@ -218,7 +217,7 @@ namespace MobiFlight.Tests.ProSim
             XmlReader xmlReader = XmlReader.Create(sr, readerSettings);
             xmlReader.ReadToDescendant("ProSimInputAction");
             deserialized.ReadXml(xmlReader);
-            
+
             // Verify special characters are handled correctly
             Assert.AreEqual(inputAction.Path, deserialized.Path, "Path with special characters should be preserved");
             Assert.AreEqual(inputAction.Expression, deserialized.Expression, "Expression with special characters should be preserved");
@@ -240,7 +239,7 @@ namespace MobiFlight.Tests.ProSim
             
             // Deserialize from JSON
             var deserialized = JsonConvert.DeserializeObject<ProSimSource>(json);
-            
+
             // Verify special characters are handled correctly
             Assert.AreEqual(source.SourceType, deserialized.SourceType, "SourceType should be preserved");
             Assert.AreEqual(source.ProSimDataRef.Path, deserialized.ProSimDataRef.Path, "Path with special characters should be preserved");
@@ -303,10 +302,10 @@ namespace MobiFlight.Tests.ProSim
             Assert.AreNotEqual(json1, json2, "Different ProSimSource objects should produce different JSON");
 
             // Verify each serialization contains the correct data
-            Assert.IsTrue(xml1.Contains("path=\"test/dataref/path1\""), "First XML should contain first path");
-            Assert.IsTrue(xml2.Contains("path=\"test/dataref/path2\""), "Second XML should contain second path");
-            Assert.IsTrue(json1.Contains("\"Path\":\"test/dataref/path1\""), "First JSON should contain first path");
-            Assert.IsTrue(json2.Contains("\"Path\":\"test/dataref/path2\""), "Second JSON should contain second path");
+            Assert.Contains("path=\"test/dataref/path1\"", xml1, "First XML should contain first path");
+            Assert.Contains("path=\"test/dataref/path2\"", xml2, "Second XML should contain second path");
+            Assert.Contains("\"Path\":\"test/dataref/path1\"", json1, "First JSON should contain first path");
+            Assert.Contains("\"Path\":\"test/dataref/path2\"", json2, "Second JSON should contain second path");
         }
     }
-} 
+}

--- a/MobiFlightUnitTests/ProSim/ProSimSourceTests.cs
+++ b/MobiFlightUnitTests/ProSim/ProSimSourceTests.cs
@@ -2,7 +2,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.Base;
 using MobiFlight.ProSim;
 using Newtonsoft.Json;
-using System;
 
 namespace MobiFlight.Tests.ProSim
 {
@@ -223,4 +222,4 @@ namespace MobiFlight.Tests.ProSim
             Assert.AreEqual("", deserialized.ProSimDataRef.Path, "Default ProSimDataRef Path should be empty string");
         }
     }
-} 
+}

--- a/MobiFlightUnitTests/Properties/AssemblyInfo.cs
+++ b/MobiFlightUnitTests/Properties/AssemblyInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -34,3 +35,6 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// MSTest parallelization settings
+[assembly: DoNotParallelize()]

--- a/MobiFlightUnitTests/UI/Dialogs/InputConfigWizardTests.cs
+++ b/MobiFlightUnitTests/UI/Dialogs/InputConfigWizardTests.cs
@@ -85,7 +85,7 @@ namespace MobiFlight.UI.Dialogs.Tests
                 null,
                 null,
                 new List<OutputConfigItem>(),
-                availableVariables, 
+                availableVariables,
                 null);
 
             // Get private fields using reflection
@@ -127,7 +127,7 @@ namespace MobiFlight.UI.Dialogs.Tests
                 methodInfo.Invoke(wizard, new object[] { inputTypeComboBox, EventArgs.Empty });
 
                 // Assert: Check that a panel was created and it implements IInputPanel
-                Assert.AreEqual(1, groupBoxInputSettings.Controls.Count, $"Expected 1 control for {testCase.DeviceType}, got {groupBoxInputSettings.Controls.Count}");
+                Assert.HasCount(1, groupBoxInputSettings.Controls, $"Expected 1 control for {testCase.DeviceType}, got {groupBoxInputSettings.Controls.Count}");
 
                 var panel = groupBoxInputSettings.Controls[0];
                 Assert.IsInstanceOfType(panel, typeof(IInputPanel), $"Panel for {testCase.DeviceType} should implement IInputPanel");
@@ -184,6 +184,5 @@ namespace MobiFlight.UI.Dialogs.Tests
                 return (obj.Label, obj.Value).GetHashCode();
             }
         }
-
     }
 }

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -96,7 +96,7 @@ namespace MobiFlight.UI.Tests
             // Assert
             var mainFormTitle = _mainForm.Text;
             Assert.IsTrue(_mainForm.ProjectHasUnsavedChanges, "ProjectHasUnsavedChanges should be true after adding a new file.");
-            Assert.IsTrue(mainFormTitle.Contains("*"), "Project title should indicate that there are unsaved changes.");
+            Assert.Contains("*", mainFormTitle, "Project title should indicate that there are unsaved changes.");
         }
 
         [TestMethod()]
@@ -168,10 +168,10 @@ namespace MobiFlight.UI.Tests
 
             // Assert
             var recentFiles = Properties.Settings.Default.RecentFiles;
-            Assert.AreEqual(2, recentFiles.Count, "Should have 2 files remaining");
+            Assert.HasCount(2, recentFiles, "Should have 2 files remaining");
             Assert.AreEqual("C:\\project1.mfproj", recentFiles[0]);
             Assert.AreEqual("C:\\project3.mfproj", recentFiles[1]);
-            Assert.IsFalse(recentFiles.Contains("C:\\project2.mfproj"), "Removed file should not be in the list");
+            Assert.DoesNotContain("C:\\project2.mfproj", recentFiles, "Removed file should not be in the list");
         }
 
         [TestMethod]
@@ -185,10 +185,10 @@ namespace MobiFlight.UI.Tests
                 var result = MainForm.CheckForMissingFiles(inputs);
 
                 // missing path and whitespace entry are reported missing
-                Assert.IsTrue(result.Contains(missing), "Expected missing file to be reported.");
+                Assert.Contains(missing, result, "Expected missing file to be reported.");
                 Assert.IsTrue(result.Any(x => string.IsNullOrWhiteSpace(x)), "Expected whitespace entry to be reported as missing.");
                 // existing file should not be reported missing
-                Assert.IsFalse(result.Contains(existing), "Existing file should not be reported missing.");
+                Assert.DoesNotContain(existing, result, "Existing file should not be reported missing.");
             }
             finally
             {
@@ -221,8 +221,8 @@ namespace MobiFlight.UI.Tests
 
                 var current = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
 
-                Assert.IsTrue(current.Contains(existing), "Existing file should remain in settings.");
-                Assert.IsFalse(current.Contains(missing), "Missing file should have been removed from settings.");
+                Assert.Contains(existing, current, "Existing file should remain in settings.");
+                Assert.DoesNotContain(missing, current, "Missing file should have been removed from settings.");
             }
             finally
             {

--- a/MobiFlightUnitTests/packages.config
+++ b/MobiFlightUnitTests/packages.config
@@ -17,9 +17,9 @@
   <package id="Microsoft.TestPlatform.AdapterUtilities" version="18.0.1" targetFramework="net48" />
   <package id="Microsoft.TestPlatform.ObjectModel" version="18.0.1" targetFramework="net48" />
   <package id="Moq" version="4.20.72" targetFramework="net48" />
-  <package id="MSTest.Analyzers" version="3.10.2" targetFramework="net48" developmentDependency="true" />
-  <package id="MSTest.TestAdapter" version="3.10.2" targetFramework="net48" />
-  <package id="MSTest.TestFramework" version="3.10.2" targetFramework="net48" />
+  <package id="MSTest.Analyzers" version="4.0.2" targetFramework="net48" developmentDependency="true" />
+  <package id="MSTest.TestAdapter" version="4.0.2" targetFramework="net48" />
+  <package id="MSTest.TestFramework" version="4.0.2" targetFramework="net48" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net48" />


### PR DESCRIPTION
New version of MS Test Framework comes with stricter warnings and errors. The required changes are applied across the existing test cases. For example: many times the order of the parameters for  `Assert.AreEqual` was flipped, expected vs actual.

part of #2434