### PR TITLE
Make "add config" buttons solid also in dark mode for consistency

### DIFF
--- a/frontend/src/components/tables/config-item-table/config-item-table.tsx
+++ b/frontend/src/components/tables/config-item-table/config-item-table.tsx
@@ -338,13 +338,13 @@ export function ConfigItemTable<TValue>({
         )}
         <div className="flex justify-start gap-2">
           <Button
-            className="bg-pink-600 dark:bg-pink-900 text-white hover:bg-pink-600 dark:hover:bg-pink-700"
+            className="bg-pink-600 dark:bg-pink-900 text-white hover:bg-pink-500 dark:hover:bg-pink-700"
             onClick={handleAddOutputConfig}
           >
             {t("ConfigList.Actions.OutputConfigItem.Add")}
           </Button>
           <Button
-            className="bg-teal-600 dark:bg-teal-900 text-white hover:bg-teal-600 dark:hover:bg-teal-700"
+            className="bg-teal-600 dark:bg-teal-900 text-white hover:bg-teal-500 dark:hover:bg-teal-700"
             onClick={handleAddInputConfig}
           >
             {t("ConfigList.Actions.InputConfigItem.Add")}


### PR DESCRIPTION
We use solid buttons for action things (like the + for tabs and for creating new project etc) - style the "add new input/output config" -buttons the same way. This is less distracting especially on dark mode where one migh seek for a muted visual style.

Light:
<img width="371" height="220" alt="image" src="https://github.com/user-attachments/assets/64d6b0a9-0a21-4128-b0f6-72c370196ff9" />

Dark:
<img width="321" height="120" alt="image" src="https://github.com/user-attachments/assets/dcfb2c6a-ae67-4531-82c3-131f70b82779" />

Using the -900 variant of the pink and teal colors for muted appearance on dark mode.