### PR TITLE
Use text color for dashboard chevron icons on dark mode

### DIFF
--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -76,7 +76,7 @@ export const ProjectCardTitle = ({
           className={buttonClassName}
           onClick={navigateToProject}
         >
-          <IconChevronRight className={cn("text-primary", iconClassName)} />
+          <IconChevronRight className={cn("text-primary dark:text-foreground", iconClassName)} />
         </Button>
       )}
     </div>


### PR DESCRIPTION
The dark mode chevron icons for navigation are not very visible on dark mode, making them text color so they are easier to see.

Also consistent with config table view's return chevron. Once we have a bit better color design system, the chevrons could have a dash of accent color, but with enough contrast. But for now, text color will ensure it will be usable. I don't want to invent a custom color just for this right now until I have a chance to think the color set through.

before: 
<img width="796" height="347" alt="image" src="https://github.com/user-attachments/assets/a53ad109-596d-402d-b88e-1312777fd558" />

after:
<img width="787" height="328" alt="image" src="https://github.com/user-attachments/assets/23c25174-6e15-402a-9808-d0516ed7893b" />

