### PR TITLE
Smart Auto-Binding for Controllers & improved UX for missing controllers

### DIFF
--- a/Base/Project.cs
+++ b/Base/Project.cs
@@ -1,4 +1,5 @@
 ﻿using MobiFlight.Base.Migration;
+using MobiFlight.Controllers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -23,6 +24,13 @@ namespace MobiFlight.Base
         public List<string> Controllers { get; set; }
         public string FilePath { get; set; }
         public bool Favorite { get; set; } = false;
+        /// <summary>
+        /// Binding status for controllers in this project
+        /// Key: ModuleSerial, Value: ControllerBindingStatus
+        /// Only populated when analyzing binding status
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public Dictionary<string, (ControllerBindingStatus, string)> ControllerBindings { get; set; }
     }
 
 
@@ -281,7 +289,7 @@ namespace MobiFlight.Base
             Name = "New MobiFlight Project";
         }
 
-        public ProjectInfo ToProjectInfo()
+        public ProjectInfo ToProjectInfo(ControllerBindingService bindingService = null)
         {
             if (string.IsNullOrEmpty(Sim))
             {
@@ -297,6 +305,12 @@ namespace MobiFlight.Base
                 Controllers = Controllers?.ToList() ?? new List<string>(),
                 FilePath = FilePath
             };
+
+            // Optional: Analyze binding status if service provided
+            if (bindingService != null)
+            {
+                projectInfo.ControllerBindings = bindingService.AnalyzeProjectBindings(this);
+            }
 
             return projectInfo;
         }

--- a/Base/Project.cs
+++ b/Base/Project.cs
@@ -21,7 +21,6 @@ namespace MobiFlight.Base
         public string Sim { get; set; }
         public ProjectFeatures Features { get; set; }
         public List<string> Aircraft { get; set; }
-        public List<string> Controllers { get; set; }
         public string FilePath { get; set; }
         public bool Favorite { get; set; } = false;
         /// <summary>
@@ -30,7 +29,7 @@ namespace MobiFlight.Base
         /// Only populated when analyzing binding status
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public Dictionary<string, (ControllerBindingStatus, string)> ControllerBindings { get; set; }
+        public List<ControllerBinding> ControllerBindings { get; set; }
     }
 
 
@@ -219,35 +218,6 @@ namespace MobiFlight.Base
             }
         }
 
-        private ObservableCollection<string> _controllers = new ObservableCollection<string>();
-        /// <summary>
-        /// Gets or sets the name of the project.
-        /// </summary>
-        public ObservableCollection<string> Controllers
-        {
-            get => _controllers;
-            set
-            {
-                if (_aircraft != value)
-                {
-                    if (_controllers != null)
-                    {
-                        _controllers.CollectionChanged -= CollectionChanged;
-                    }
-
-                    _controllers = value;
-
-                    if (_controllers != null)
-                    {
-                        _controllers.CollectionChanged += CollectionChanged;
-                    }
-
-                    OnPropertyChanged(nameof(Controllers));
-                    OnProjectChanged();
-                }
-            }
-        }
-
         private ProjectFeatures _features = new ProjectFeatures();
 
         /// <summary>
@@ -285,7 +255,7 @@ namespace MobiFlight.Base
         /// Key: ModuleSerial, Value: ControllerBindingStatus
         /// Only populated when analyzing binding status
         /// </summary>
-        public virtual Dictionary<string, (ControllerBindingStatus, string)> ControllerBindings { get; set; }
+        public virtual List<ControllerBinding> ControllerBindings { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Project"/> class with default values.
@@ -314,7 +284,6 @@ namespace MobiFlight.Base
                 Sim = Sim,
                 Features = Features,
                 Aircraft = Aircraft?.ToList() ?? new List<string>(),
-                Controllers = Controllers?.ToList() ?? new List<string>(),
                 FilePath = FilePath,
                 ControllerBindings = ControllerBindings
             };
@@ -347,13 +316,6 @@ namespace MobiFlight.Base
 
                 item.GetIUniqueControllerSerials().ForEach(c => controllerSerials.Add(c));
             }
-
-            Controllers.Clear();
-
-            controllerSerials.Distinct().ToList().ForEach(c =>
-            {
-                Controllers.Add(c);
-            });
         }
 
         /// <summary>
@@ -461,9 +423,7 @@ namespace MobiFlight.Base
                 ConfigFiles.CollectionChanged -= CollectionChanged;
             if (Aircraft != null)
                 Aircraft.CollectionChanged -= CollectionChanged;
-            if (Controllers != null)
-                Controllers.CollectionChanged -= CollectionChanged;
-
+            
             this.Name = project.Name;
             this.FilePath = project.FilePath;
             this.OriginalSchemaVersion = project.OriginalSchemaVersion;
@@ -472,17 +432,14 @@ namespace MobiFlight.Base
             this.Features = project.Features.Clone();
             this.Aircraft = project.Aircraft != null ?
                                 new ObservableCollection<string>(project.Aircraft) :
-                                new ObservableCollection<string>();
+                                null;
 
             this.ConfigFiles = project.ConfigFiles != null ?
                                 new ObservableCollection<ConfigFile>(project.ConfigFiles) :
-                                new ObservableCollection<ConfigFile>();
-            this.Controllers = project.Controllers != null ?
-                                new ObservableCollection<string>(project.Controllers) :
-                                new ObservableCollection<string>();
+                                null;
             this.ControllerBindings = project.ControllerBindings != null ?
-                                        new Dictionary<string, (ControllerBindingStatus, string)>(project.ControllerBindings) :
-                                        new Dictionary<string, (ControllerBindingStatus, string)>();
+                                        new List<ControllerBinding>(project.ControllerBindings) :
+                                        null;
         }
 
         /// <summary>
@@ -700,7 +657,7 @@ namespace MobiFlight.Base
     public class PersistedProject : Project
     {
         [JsonIgnore]
-        public override Dictionary<string, (ControllerBindingStatus, string)> ControllerBindings { get; set; }
+        public override List<ControllerBinding> ControllerBindings { get; set; }
 
         public PersistedProject(Project project) : base(project) { }
     }

--- a/Base/Project.cs
+++ b/Base/Project.cs
@@ -281,6 +281,14 @@ namespace MobiFlight.Base
         }
 
         /// <summary>
+        /// Binding status for controllers in this project
+        /// Key: ModuleSerial, Value: ControllerBindingStatus
+        /// Only populated when analyzing binding status
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary<string, (ControllerBindingStatus, string)> ControllerBindings { get; set; }
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="Project"/> class with default values.
         /// </summary>
         public Project()
@@ -289,7 +297,7 @@ namespace MobiFlight.Base
             Name = "New MobiFlight Project";
         }
 
-        public ProjectInfo ToProjectInfo(ControllerBindingService bindingService = null)
+        public ProjectInfo ToProjectInfo()
         {
             if (string.IsNullOrEmpty(Sim))
             {
@@ -303,14 +311,9 @@ namespace MobiFlight.Base
                 Features = Features,
                 Aircraft = Aircraft?.ToList() ?? new List<string>(),
                 Controllers = Controllers?.ToList() ?? new List<string>(),
-                FilePath = FilePath
+                FilePath = FilePath,
+                ControllerBindings = ControllerBindings
             };
-
-            // Optional: Analyze binding status if service provided
-            if (bindingService != null)
-            {
-                projectInfo.ControllerBindings = bindingService.AnalyzeProjectBindings(this);
-            }
 
             return projectInfo;
         }

--- a/Base/Project.cs
+++ b/Base/Project.cs
@@ -374,6 +374,13 @@ namespace MobiFlight.Base
                     Log.Instance.log("Project could not be loaded", LogSeverity.Error);
                     throw new InvalidDataException("Failed to deserialize project file.");
                 }
+
+                // Set FilePath so that CopyFrom keeps it
+                project.FilePath = FilePath;
+
+                // Set OriginalSchemaVersion so that CopyFrom keeps it
+                project.OriginalSchemaVersion = OriginalSchemaVersion;
+
                 this.CopyFrom(project);
 
                 foreach (var configFile in ConfigFiles)

--- a/Base/SerialNumber.cs
+++ b/Base/SerialNumber.cs
@@ -34,10 +34,10 @@ namespace MobiFlight.Base
         }
 
         /// <summary>
-        /// Extracts the device type prefix from a serial number (e.g., "SN", "JS", "MI")
+        /// Extracts the device type prefix from a serial number (e.g., "SN-", "JS-", "MI-")
         /// If no match - returns null
         /// </summary>
-        /// <returns>Device type prefix from a serial number (e.g., "SN", "JS", "MI") or null if no match</returns>
+        /// <returns>Device type prefix from a serial number (e.g., "SN-", "JS-", "MI-") or null if no match</returns>
         public static string ExtractPrefix(string fullString)
         {
             var serial = ExtractSerial(fullString);

--- a/Base/SerialNumber.cs
+++ b/Base/SerialNumber.cs
@@ -33,6 +33,20 @@ namespace MobiFlight.Base
             return String.Join("", tokens).Trim();
         }
 
+        /// <summary>
+        /// Extracts the device type prefix from a serial number (e.g., "SN", "JS", "MI")
+        /// If no match - returns null
+        /// </summary>
+        /// <returns>Device type prefix from a serial number (e.g., "SN", "JS", "MI") or null if no match</returns>
+        public static string ExtractPrefix(string fullString)
+        {
+            var serial = ExtractSerial(fullString);
+            if (serial.StartsWith(MobiFlightModule.SerialPrefix)) return MobiFlightModule.SerialPrefix;
+            else if (serial.StartsWith(Joystick.SerialPrefix)) return Joystick.SerialPrefix;
+            else if (serial.StartsWith(MidiBoard.SerialPrefix)) return MidiBoard.SerialPrefix;
+            return null;
+        }
+
         public static bool IsArcazeSerial(string serial)
         {
             if (serial == null || serial == "") return false;

--- a/MobiFlight/Controllers/ControllerAutoBinder.cs
+++ b/MobiFlight/Controllers/ControllerAutoBinder.cs
@@ -175,16 +175,6 @@ namespace MobiFlight.Controllers
             return new ControllerBinding() { Status = ControllerBindingStatus.Missing, BoundController = null, OriginalController = configSerial };
         }
 
-        private string FindNewSerial(string originalSerial)
-        {
-            var configTypeAndName = GetTypeAndName(originalSerial);
-            var potentialMatches = _connectedControllers
-                .Where(c => GetTypeAndName(c) == configTypeAndName)
-                .ToList();
-
-            return potentialMatches.FirstOrDefault();
-        }
-
         public static string GetTypeAndName(string fullSerial)
         {
             var parts = fullSerial.Split(new[] { SerialNumber.SerialSeparator }, StringSplitOptions.None);

--- a/MobiFlight/Controllers/ControllerAutoBinder.cs
+++ b/MobiFlight/Controllers/ControllerAutoBinder.cs
@@ -1,0 +1,180 @@
+﻿using MobiFlight.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MobiFlight.Controllers
+{
+    /// <summary>
+    /// Performs auto-binding analysis and application for controller serials
+    /// </summary>
+    public class ControllerAutoBinder
+    {
+        private readonly List<string> _connectedControllers;
+        private readonly Dictionary<string, int> _controllerTypeCount = new Dictionary<string, int>();
+
+        public ControllerAutoBinder(List<string> connectedControllers)
+        {
+            _connectedControllers = connectedControllers ?? new List<string>();
+
+            // Count controllers by type:name
+            foreach (var controllerSerial in _connectedControllers)
+            {
+                var deviceName = SerialNumber.ExtractDeviceName(controllerSerial);
+                var deviceSerialPrefix = SerialNumber.ExtractPrefix(controllerSerial);
+                var deviceIdentifier = GetDeviceIdentifier(controllerSerial);
+
+                if (!_controllerTypeCount.ContainsKey(deviceIdentifier))
+                    _controllerTypeCount[deviceIdentifier] = 0;
+ 
+                _controllerTypeCount[deviceIdentifier]++;
+            }
+        }
+
+        /// <summary>
+        /// Gets a unique key combining device name and serial prefix for matching
+        /// </summary>
+        private static string GetDeviceIdentifier(string controllerSerial)
+        {
+            var deviceName = SerialNumber.ExtractDeviceName(controllerSerial);
+            var deviceSerialPrefix = SerialNumber.ExtractPrefix(controllerSerial);
+            return $"{deviceSerialPrefix}:{deviceName}";
+        }
+
+        /// <summary>
+        /// Analyzes binding status for all config items without modifying them
+        /// Returns a dictionary mapping original serial -> binding status
+        /// </summary>
+        public Dictionary<string, (ControllerBindingStatus, string)> AnalyzeBindings(List<IConfigItem> configItems)
+        {
+            var results = new Dictionary<string, (ControllerBindingStatus, string)>();
+            var uniqueSerials = configItems
+                .Where(c => !string.IsNullOrEmpty(c.ModuleSerial) && c.ModuleSerial != "-")
+                .Select(c => c.ModuleSerial)
+                .Distinct()
+                .ToList();
+
+            var availableControllers = new List<string>(_connectedControllers);
+
+            foreach (var serial in uniqueSerials)
+            {
+                var (status, boundController) = AnalyzeSingleBinding(serial, availableControllers);
+
+                results[serial] = (status, boundController);
+                if (status == ControllerBindingStatus.Match)
+                {
+                    // Remove from available controllers to prevent multiple bindings
+                    availableControllers.Remove(serial);
+                }
+
+                if (status == ControllerBindingStatus.AutoBind)
+                {
+                    availableControllers.Remove(boundController);
+                }
+            }
+
+            return results;
+        }
+
+        /// <summary>
+        /// Applies auto-binding updates to config items based on analysis results
+        /// </summary>
+        /// <returns>Dictionary mapping original serial -> new serial (only for AutoBound items)</returns>
+        public Dictionary<string, string> ApplyAutoBinding(
+            List<IConfigItem> configItems,
+            Dictionary<string, (ControllerBindingStatus, string)> bindingStatus)
+        {
+            var serialMappings = new Dictionary<string, string>();
+
+            // First, determine which serials need to be updated
+            foreach (var kvp in bindingStatus)
+            {
+                var (status, boundController) = kvp.Value;
+                if (status == ControllerBindingStatus.AutoBind)
+                {
+                    var originalSerial = kvp.Key;
+                    var newSerial = boundController;
+                    serialMappings[originalSerial] = newSerial;
+                }
+            }
+
+            // Apply the mappings to config items
+            foreach (var item in configItems)
+            {
+                if (string.IsNullOrEmpty(item.ModuleSerial) || item.ModuleSerial == "-")
+                    continue;
+
+                if (serialMappings.ContainsKey(item.ModuleSerial))
+                {
+                    item.ModuleSerial = serialMappings[item.ModuleSerial];
+                }
+            }
+
+            return serialMappings;
+        }
+
+        private (ControllerBindingStatus status, string claimedController) AnalyzeSingleBinding(string configSerial, List<string> availableControllers)
+        {
+            // Scenario 1: Exact match
+            if (availableControllers.Contains(configSerial))
+            {
+                return (ControllerBindingStatus.Match, configSerial);
+            }
+
+            var deviceTypeName = GetDeviceIdentifier(configSerial);
+            var potentialTypeNameMatches = availableControllers
+                .Where(c => GetDeviceIdentifier(c) == deviceTypeName)
+                .ToList();
+
+            var deviceSerial = SerialNumber.ExtractSerial(configSerial);
+            var potentialSerialMatches = availableControllers
+                .Where(c => SerialNumber.ExtractSerial(c) == deviceSerial)
+                .ToList();
+
+            // Scenario 4: Missing
+            if (potentialTypeNameMatches.Count == 0 && potentialSerialMatches.Count == 0)
+            {
+                return (ControllerBindingStatus.Missing, null);
+            }
+
+            var configsWithSameIdentifier = availableControllers
+                .Where(s => GetDeviceIdentifier(s) == deviceTypeName)
+                .Count();
+
+            // Scenario 5: Multiple matches, need user selection
+            if (potentialTypeNameMatches.Count > 1)
+            {
+                return (ControllerBindingStatus.RequiresManualBind, null);
+            }
+
+            // Scenarios 2, 3, 6: Auto-bind
+            // - Scenario 2: Serial differs but device name/type match (single match)
+            // - Scenario 3: Name differs but serial matches (single match)  
+            // - Scenario 6: Multiple matches exist, but multiple configs also exist (1:1 mapping)
+            if (potentialTypeNameMatches.Count == 1 || potentialSerialMatches.Count == 1)
+            {
+                var autoBindSerial = potentialTypeNameMatches.Count == 1 ? potentialTypeNameMatches.First() : potentialSerialMatches.First();
+                return (ControllerBindingStatus.AutoBind, autoBindSerial);
+            }
+
+            // Fallback
+            return (ControllerBindingStatus.Missing, null);
+        }
+
+        private string FindNewSerial(string originalSerial)
+        {
+            var configTypeAndName = GetTypeAndName(originalSerial);
+            var potentialMatches = _connectedControllers
+                .Where(c => GetTypeAndName(c) == configTypeAndName)
+                .ToList();
+
+            return potentialMatches.FirstOrDefault();
+        }
+
+        public static string GetTypeAndName(string fullSerial)
+        {
+            var parts = fullSerial.Split(new[] { SerialNumber.SerialSeparator }, StringSplitOptions.None);
+            return parts.Length > 0 ? parts[0].Trim() : fullSerial;
+        }
+    }
+}

--- a/MobiFlight/Controllers/ControllerAutoBinder.cs
+++ b/MobiFlight/Controllers/ControllerAutoBinder.cs
@@ -84,20 +84,11 @@ namespace MobiFlight.Controllers
             List<IConfigItem> configItems,
             Dictionary<string, (ControllerBindingStatus, string)> bindingStatus)
         {
-            var serialMappings = new Dictionary<string, string>();
+            var serialMappings = bindingStatus.Where((status) => status.Value.Item1 == ControllerBindingStatus.AutoBind)
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Item2);
 
-            // First, determine which serials need to be updated
-            foreach (var kvp in bindingStatus)
-            {
-                var (status, boundController) = kvp.Value;
-                if (status == ControllerBindingStatus.AutoBind)
-                {
-                    var originalSerial = kvp.Key;
-                    var newSerial = boundController;
-                    serialMappings[originalSerial] = newSerial;
-                }
-            }
-
+            if (serialMappings.Count == 0) return serialMappings;
+            
             // Apply the mappings to config items
             foreach (var item in configItems)
             {

--- a/MobiFlight/Controllers/ControllerAutoBinder.cs
+++ b/MobiFlight/Controllers/ControllerAutoBinder.cs
@@ -54,7 +54,7 @@ namespace MobiFlight.Controllers
                 .Where(c => !string.IsNullOrEmpty(c.ModuleSerial) && c.ModuleSerial != "-")
                 .Select(c => c.ModuleSerial)
                 .Distinct()
-                .OrderByDescending(serial => availableControllers.Contains(serial) || (existingBindings?.First(b => b.OriginalController == serial) != null))
+                .OrderByDescending(serial => availableControllers.Contains(serial) || (existingBindings?.FirstOrDefault(b => b.OriginalController == serial) != null))
                 .ToList();
 
             foreach (var serial in uniqueSerials)

--- a/MobiFlight/Controllers/ControllerAutoBinder.cs
+++ b/MobiFlight/Controllers/ControllerAutoBinder.cs
@@ -20,8 +20,6 @@ namespace MobiFlight.Controllers
             // Count controllers by type:name
             foreach (var controllerSerial in _connectedControllers)
             {
-                var deviceName = SerialNumber.ExtractDeviceName(controllerSerial);
-                var deviceSerialPrefix = SerialNumber.ExtractPrefix(controllerSerial);
                 var deviceIdentifier = GetDeviceIdentifier(controllerSerial);
 
                 if (!_controllerTypeCount.ContainsKey(deviceIdentifier))
@@ -68,12 +66,16 @@ namespace MobiFlight.Controllers
                     if (!availableControllers.Contains(previouslyBoundController.BoundController)) continue;
 
                     // Reuse the same binding
-                    // Reuse the same binding
                     var previousStatus = previouslyBoundController.BoundController == serial
                         ? ControllerBindingStatus.Match
                         : ControllerBindingStatus.AutoBind;
 
-                    results.Add(new ControllerBinding() { Status = previousStatus, BoundController = previouslyBoundController.BoundController, OriginalController = serial });
+                    results.Add(new ControllerBinding() { 
+                        Status = previousStatus, 
+                        BoundController = previouslyBoundController.BoundController, 
+                        OriginalController = serial 
+                    });
+
                     availableControllers.Remove(previouslyBoundController.BoundController);
                     continue;
                 }

--- a/MobiFlight/Controllers/ControllerAutoBinder.cs
+++ b/MobiFlight/Controllers/ControllerAutoBinder.cs
@@ -154,7 +154,7 @@ namespace MobiFlight.Controllers
                 return new ControllerBinding() { Status = ControllerBindingStatus.RequiresManualBind, BoundController = null, OriginalController = configSerial };
             }
 
-            // Senario 7: Multiple configs exist for same type:name, need user selection
+            // Senario 6: Multiple configs exist in same profile for same type:name, need user selection
             var configsWithTypeNameMatch = uniqueSerials
                 .Where(s => GetDeviceIdentifier(s) == deviceTypeName);
             if (configsWithTypeNameMatch.Count() > 1)
@@ -162,10 +162,9 @@ namespace MobiFlight.Controllers
                 return new ControllerBinding() { Status = ControllerBindingStatus.RequiresManualBind, BoundController = null, OriginalController = configSerial };
             }
 
-            // Scenarios 2, 3, 6: Auto-bind
+            // Scenarios 2, 3: Auto-bind
             // - Scenario 2: Serial differs but device name/type match (single match)
-            // - Scenario 3: Name differs but serial matches (single match)  
-            // - Scenario 6: Multiple matches exist, but multiple configs also exist (1:1 mapping)
+            // - Scenario 3: Name differs but serial matches (single match)
             if (potentialTypeNameMatches.Count == 1 || potentialSerialMatches.Count == 1)
             {
                 var autoBindSerial = potentialTypeNameMatches.Count == 1 ? potentialTypeNameMatches.First() : potentialSerialMatches.First();

--- a/MobiFlight/Controllers/ControllerBinding.cs
+++ b/MobiFlight/Controllers/ControllerBinding.cs
@@ -1,0 +1,9 @@
+﻿namespace MobiFlight.Controllers
+{
+    public class ControllerBinding
+    {
+        public string BoundController { get; set; }
+        public ControllerBindingStatus Status { get; set; }
+        public string OriginalController { get; set; }
+    }
+}

--- a/MobiFlight/Controllers/ControllerBindingService.cs
+++ b/MobiFlight/Controllers/ControllerBindingService.cs
@@ -63,18 +63,17 @@ namespace MobiFlight.Controllers
 
                 foreach (var binding in results)
                 {
-                    var bindingExists = allResults.FirstOrDefault(b => b.BoundController == binding.BoundController);
+                    var bindingExists = allResults.FirstOrDefault(b => b.OriginalController == binding.OriginalController);
                     // Only add if not already present (first occurrence wins)
                     if (bindingExists != null) continue;
                     
                     allResults.Add(binding);
-                    break;
                 }
 
                 // Update binding mappings for next config file
                 foreach (var mapping in serialMappings)
                 {
-                    if (appliedBindingMappings.First(b => b.BoundController == mapping.BoundController) != null) continue;
+                    if (appliedBindingMappings.FirstOrDefault(b => b.BoundController == mapping.BoundController) != null) continue;
 
                     appliedBindingMappings.Add(mapping);
                 }

--- a/MobiFlight/Controllers/ControllerBindingService.cs
+++ b/MobiFlight/Controllers/ControllerBindingService.cs
@@ -1,0 +1,91 @@
+﻿using MobiFlight.Base;
+using System.Collections.Generic;
+
+namespace MobiFlight.Controllers
+{
+    /// <summary>
+    /// High-level service for controller binding operations
+    /// </summary>
+    public class ControllerBindingService
+    {
+        private readonly IExecutionManager _executionManager;
+
+        public ControllerBindingService(IExecutionManager executionManager)
+        {
+            _executionManager = executionManager;
+        }
+
+        /// <summary>
+        /// Analyzes binding status WITHOUT modifying the project
+        /// Returns: Dictionary mapping ModuleSerial -> ControllerBindingStatus
+        /// </summary>
+        public Dictionary<string, (ControllerBindingStatus, string)> AnalyzeProjectBindings(Project project)
+        {
+            var connectedControllers = GetAllConnectedControllers();
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            var allResults = new Dictionary<string, (ControllerBindingStatus, string)>();
+
+            foreach (var configFile in project.ConfigFiles)
+            {
+                var results = binder.AnalyzeBindings(configFile.ConfigItems);
+                foreach (var kvp in results)
+                {
+                    allResults[kvp.Key] = kvp.Value;
+                }
+            }
+
+            return allResults;
+        }
+
+        /// <summary>
+        /// Performs auto-binding and modifies config items
+        /// Returns: Dictionary mapping ModuleSerial -> ControllerBindingStatus
+        /// </summary>
+        public Dictionary<string, (ControllerBindingStatus, string)> PerformAutoBinding(Project project)
+        {
+            var connectedControllers = GetAllConnectedControllers();
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            var allResults = new Dictionary<string, (ControllerBindingStatus, string)>();
+
+            foreach (var configFile in project.ConfigFiles)
+            {
+                var results = binder.AnalyzeBindings(configFile.ConfigItems);
+                var serialMappings = binder.ApplyAutoBinding(configFile.ConfigItems, results);
+
+                foreach (var kvp in results)
+                {
+                    allResults[kvp.Key] = kvp.Value;
+                }
+            }
+
+            // Update project metadata with new controller serials
+            project.DetermineProjectInfos();
+
+            return allResults;
+        }
+
+        private List<string> GetAllConnectedControllers()
+        {
+            var serials = new List<string>();
+
+            foreach (var module in _executionManager.getMobiFlightModuleCache().GetModules())
+            {
+                serials.Add($"{module.Name}{SerialNumber.SerialSeparator}{module.Serial}");
+            }
+
+            foreach (var joystick in _executionManager.GetJoystickManager().GetJoysticks())
+            {
+                serials.Add($"{joystick.Name} {SerialNumber.SerialSeparator}{joystick.Serial}");
+            }
+
+            foreach (var midiBoard in _executionManager.GetMidiBoardManager().GetMidiBoards())
+            {
+                serials.Add($"{midiBoard.Name} {SerialNumber.SerialSeparator}{midiBoard.Serial}");
+            }
+
+            return serials;
+        }
+    }
+}

--- a/MobiFlight/Controllers/ControllerBindingService.cs
+++ b/MobiFlight/Controllers/ControllerBindingService.cs
@@ -34,7 +34,7 @@ namespace MobiFlight.Controllers
                 results.ForEach(b =>
                 {
                     // Only add if not already present (first occurrence wins)
-                    if (!allResults.Any(existing => existing.BoundController == b.BoundController))
+                    if (!allResults.Any(existing => existing.OriginalController == b.OriginalController))
                     {
                         allResults.Add(b);
                     }

--- a/MobiFlight/Controllers/ControllerBindingService.cs
+++ b/MobiFlight/Controllers/ControllerBindingService.cs
@@ -62,6 +62,7 @@ namespace MobiFlight.Controllers
 
             // Update project metadata with new controller serials
             project.DetermineProjectInfos();
+            project.ControllerBindings = allResults;
 
             return allResults;
         }

--- a/MobiFlight/Controllers/ControllerBindingStatus.cs
+++ b/MobiFlight/Controllers/ControllerBindingStatus.cs
@@ -1,28 +1,37 @@
-﻿namespace MobiFlight.Controllers
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
+
+namespace MobiFlight.Controllers
 {
     /// <summary>
     /// Represents the binding status of a controller
     /// </summary>
+    [JsonConverter(typeof(StringEnumConverter))] 
     public enum ControllerBindingStatus
     {
         /// <summary>
         /// Controller is connected with exact serial match (Scenario 1)
         /// </summary>
+        [EnumMember(Value = "Match")]
         Match,
 
         /// <summary>
         /// Controller was automatically bound (Scenarios 2, 3, 6)
         /// </summary>
+        [EnumMember(Value = "AutoBind")]
         AutoBind,
 
         /// <summary>
         /// Controller is not connected (Scenario 4)
         /// </summary>
+        [EnumMember(Value = "Missing")]
         Missing,
 
         /// <summary>
         /// Multiple controllers found, requires manual selection (Scenario 5)
         /// </summary>
+        [EnumMember(Value = "RequiresManualBind")]
         RequiresManualBind
     }
 }

--- a/MobiFlight/Controllers/ControllerBindingStatus.cs
+++ b/MobiFlight/Controllers/ControllerBindingStatus.cs
@@ -1,0 +1,28 @@
+﻿namespace MobiFlight.Controllers
+{
+    /// <summary>
+    /// Represents the binding status of a controller
+    /// </summary>
+    public enum ControllerBindingStatus
+    {
+        /// <summary>
+        /// Controller is connected with exact serial match (Scenario 1)
+        /// </summary>
+        Match,
+
+        /// <summary>
+        /// Controller was automatically bound (Scenarios 2, 3, 6)
+        /// </summary>
+        AutoBind,
+
+        /// <summary>
+        /// Controller is not connected (Scenario 4)
+        /// </summary>
+        Missing,
+
+        /// <summary>
+        /// Multiple controllers found, requires manual selection (Scenario 5)
+        /// </summary>
+        RequiresManualBind
+    }
+}

--- a/MobiFlight/Joysticks/JoystickManager.cs
+++ b/MobiFlight/Joysticks/JoystickManager.cs
@@ -169,7 +169,7 @@ namespace MobiFlight
         /// Returns the list of Joysticks sorted by name
         /// </summary>
         /// <returns>List of currently connected joysticks</returns>
-        public List<Joystick> GetJoysticks()
+        public virtual List<Joystick> GetJoysticks()
         {
             return Joysticks.Values.OrderBy(j => j.Name).ToList();
         }

--- a/MobiFlight/MidiBoard/MidiBoard.cs
+++ b/MobiFlight/MidiBoard/MidiBoard.cs
@@ -46,11 +46,11 @@ namespace MobiFlight
             return (serial != null && serial.Contains(SerialPrefix));
         }
 
-        public string Name { 
+        public virtual string Name { 
             get { return this.name; }  
         }
 
-        public string Serial
+        public virtual string Serial
         {
             get { return SerialPrefix + this.serial; }
         }

--- a/MobiFlight/MidiBoard/MidiBoardManager.cs
+++ b/MobiFlight/MidiBoard/MidiBoardManager.cs
@@ -169,7 +169,7 @@ namespace MobiFlight
             ExcludedMidiBoards.Clear();
         }
 
-        public List<MidiBoard> GetMidiBoards()
+        public virtual List<MidiBoard> GetMidiBoards()
         {
             return MidiBoards;
         }

--- a/MobiFlight/MobiFlightCache.cs
+++ b/MobiFlight/MobiFlightCache.cs
@@ -329,7 +329,7 @@ namespace MobiFlight
             return AvailableComModules;
         }
 
-        public IEnumerable<MobiFlightModule> GetModules()
+        public virtual IEnumerable<MobiFlightModule> GetModules()
         {
             if (!Available())
                 return new List<MobiFlightModule>();

--- a/MobiFlight/MobiFlightModule.cs
+++ b/MobiFlight/MobiFlightModule.cs
@@ -91,7 +91,7 @@ namespace MobiFlight
         public String Port { get { return _comPort; } }
 
         private string _name;
-        public String Name
+        public virtual String Name
         {
             get
             {
@@ -126,7 +126,7 @@ namespace MobiFlight
                 }
             }
         }
-        public String Serial { get; set; }
+        public virtual String Serial { get; set; }
         public String Version { get; set; }
         public string CoreVersion { get; set; }
 

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -357,6 +357,9 @@
     <Compile Include="MobiFlight\Config\ShiftRegister.cs" />
     <Compile Include="MobiFlight\Config\IConfigRefConfigItem.cs" />
     <Compile Include="MobiFlight\Config\AnalogInput.cs" />
+    <Compile Include="MobiFlight\Controllers\ControllerAutoBinder.cs" />
+    <Compile Include="MobiFlight\Controllers\ControllerBindingService.cs" />
+    <Compile Include="MobiFlight\Controllers\ControllerBindingStatus.cs" />
     <Compile Include="MobiFlight\CustomDevices\CustomDevice.cs" />
     <Compile Include="MobiFlight\CustomDevices\CustomDeviceDefinitions.cs" />
     <Compile Include="MobiFlight\DeviceType.cs" />

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -358,6 +358,7 @@
     <Compile Include="MobiFlight\Config\IConfigRefConfigItem.cs" />
     <Compile Include="MobiFlight\Config\AnalogInput.cs" />
     <Compile Include="MobiFlight\Controllers\ControllerAutoBinder.cs" />
+    <Compile Include="MobiFlight\Controllers\ControllerBinding.cs" />
     <Compile Include="MobiFlight\Controllers\ControllerBindingService.cs" />
     <Compile Include="MobiFlight\Controllers\ControllerBindingStatus.cs" />
     <Compile Include="MobiFlight\CustomDevices\CustomDevice.cs" />

--- a/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -488,106 +488,9 @@ namespace MobiFlight.Base.Tests
             project.DetermineProjectInfos();
 
             // Assert
-            Assert.IsNotNull(project.Controllers);
-            Assert.IsEmpty(project.Controllers);
             Assert.IsNull(project.Sim);
             Assert.IsFalse(project.Features.FSUIPC);
             Assert.IsFalse(project.Features.ProSim);
-        }
-
-        [TestMethod()]
-        public void DetermineProjectInfos_WithMultipleConfigFiles_ShouldCollectUniqueControllers()
-        {
-            // Arrange
-            var project = new Project();
-            var config1 = new ConfigFile();
-            config1.ConfigItems.Add(new OutputConfigItem { ModuleSerial = "SN-123-456" });
-            config1.ConfigItems.Add(new OutputConfigItem { ModuleSerial = "SN-123-456" }); // Duplicate
-            var config2 = new ConfigFile();
-            config2.ConfigItems.Add(new InputConfigItem { ModuleSerial = "SN-789-012" });
-            config2.ConfigItems.Add(new OutputConfigItem { ModuleSerial = "SN-345-678" });
-
-            project.ConfigFiles.Add(config1);
-            project.ConfigFiles.Add(config2);
-
-            // Act
-            project.DetermineProjectInfos();
-
-            // Assert
-            Assert.HasCount(3, project.Controllers);
-            Assert.Contains("SN-123-456", project.Controllers);
-            Assert.Contains("SN-789-012", project.Controllers);
-            Assert.Contains("SN-345-678", project.Controllers);
-        }
-
-        [TestMethod()]
-        public void DetermineProjectInfos_WithDuplicateSerials_ShouldOnlyIncludeUnique()
-        {
-            // Arrange
-            var project = new Project();
-            var config1 = new ConfigFile();
-            config1.ConfigItems.Add(new OutputConfigItem { ModuleSerial = "SN-AAA-111" });
-            config1.ConfigItems.Add(new InputConfigItem { ModuleSerial = "SN-AAA-111" });
-
-            var config2 = new ConfigFile();
-            config2.ConfigItems.Add(new OutputConfigItem { ModuleSerial = "SN-AAA-111" });
-            config2.ConfigItems.Add(new InputConfigItem { ModuleSerial = "SN-BBB-222" });
-
-            project.ConfigFiles.Add(config1);
-            project.ConfigFiles.Add(config2);
-
-            // Act
-            project.DetermineProjectInfos();
-
-            // Assert
-            Assert.HasCount(2, project.Controllers);
-            Assert.Contains("SN-AAA-111", project.Controllers);
-            Assert.Contains("SN-BBB-222", project.Controllers);
-        }
-
-        [TestMethod()]
-        public void DetermineProjectInfos_CalledMultipleTimes_ShouldClearPreviousControllers()
-        {
-            // Arrange
-            var project = new Project();
-            var config = new ConfigFile();
-            config.ConfigItems.Add(new OutputConfigItem { ModuleSerial = "SN-FIRST-001" });
-            project.ConfigFiles.Add(config);
-
-            // Act - First call
-            project.DetermineProjectInfos();
-
-            // Modify project
-            project.ConfigFiles.Clear();
-            var newConfig = new ConfigFile();
-            newConfig.ConfigItems.Add(new OutputConfigItem { ModuleSerial = "SN-SECOND-002" });
-            project.ConfigFiles.Add(newConfig);
-
-            // Act - Second call
-            project.DetermineProjectInfos();
-
-            // Assert
-            Assert.HasCount(1, project.Controllers);
-            Assert.DoesNotContain("SN-FIRST-001", project.Controllers);
-            Assert.Contains("SN-SECOND-002", project.Controllers);
-        }
-
-        [TestMethod()]
-        public void DetermineProjectInfos_WithNoModuleSerials_ShouldHaveEmptyControllersList()
-        {
-            // Arrange
-            var project = new Project();
-            var config = new ConfigFile();
-            config.ConfigItems.Add(new OutputConfigItem { ModuleSerial = null });
-            config.ConfigItems.Add(new InputConfigItem { ModuleSerial = "" });
-            project.ConfigFiles.Add(config);
-
-            // Act
-            project.DetermineProjectInfos();
-
-            // Assert
-            // The method doesn't filter out null/empty serials, it just collects distinct values
-            Assert.IsNotNull(project.Controllers);
         }
 
         [TestMethod()]
@@ -727,7 +630,6 @@ namespace MobiFlight.Base.Tests
             // Assert
             // Should only set the first sim found (MSFS in this case)
             Assert.AreEqual("msfs", project.Sim);
-            Assert.HasCount(2, project.Controllers);
         }
 
         [TestMethod()]
@@ -758,7 +660,6 @@ namespace MobiFlight.Base.Tests
             // Assert
             Assert.AreEqual("msfs", project.Sim);
             Assert.IsTrue(project.Features.FSUIPC);
-            Assert.HasCount(2, project.Controllers);
         }
 
         [TestMethod()]
@@ -800,7 +701,6 @@ namespace MobiFlight.Base.Tests
             // Assert
             Assert.AreEqual("msfs", project.Sim);
             Assert.IsTrue(project.Features.FSUIPC);
-            Assert.HasCount(3, project.Controllers);
         }
 
         [TestMethod()]
@@ -829,7 +729,6 @@ namespace MobiFlight.Base.Tests
 
             // Assert
             Assert.AreEqual("xplane", project.Sim);
-            Assert.HasCount(2, project.Controllers);
         }
         #endregion
 

--- a/MobiFlightUnitTests/Base/SerialNumberTests.cs
+++ b/MobiFlightUnitTests/Base/SerialNumberTests.cs
@@ -54,6 +54,25 @@ namespace MobiFlight.Base.Tests
         }
 
         [TestMethod()]
+        public void ExtractPrefixTest() {
+            var serial = "GMA345/ SN-b44-4c5";
+            var result = SerialNumber.ExtractPrefix(serial);
+            Assert.AreEqual(MobiFlightModule.SerialPrefix, result);
+
+            serial = "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000";
+            result = SerialNumber.ExtractPrefix(serial);
+            Assert.AreEqual(Joystick.SerialPrefix, result);
+
+            serial = "My MidiDevice/ MI-123456";
+            result = SerialNumber.ExtractPrefix(serial);
+            Assert.AreEqual(MidiBoard.SerialPrefix, result);
+
+            serial = "Arcaze v5.36/ 000393600000";
+            result = SerialNumber.ExtractPrefix(serial);
+            Assert.IsNull(result);
+        }
+
+        [TestMethod()]
         public void IsMobiFlightSerialTest()
         {
             var serial = "GMA345/ SN-b44-4c5";

--- a/MobiFlightUnitTests/MobiFlight/Controllers/ControllerAutoBinderTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Controllers/ControllerAutoBinderTests.cs
@@ -55,7 +55,7 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(1, results);
-            var binding = results.Find(b => b.OriginalController == "X1-Pro # / SN-NEW456");
+            var binding = results.Find(b => b.OriginalController == "X1-Pro # / SN-OLD123");
             Assert.AreEqual(ControllerBindingStatus.AutoBind, binding.Status);
             Assert.HasCount(1, serialMappings);
             Assert.AreEqual("X1-Pro # / SN-OLD123", serialMappings[0].OriginalController);
@@ -274,7 +274,7 @@ namespace MobiFlight.Tests.Controllers
             {
                 new ControllerBinding()
                 {
-                    OriginalController = "Board1 # / SN-222", BoundController = "Board1 # / SN-111", Status = ControllerBindingStatus.AutoBind
+                    OriginalController = "Board1 # / SN-333", BoundController = "Board1 # / SN-111", Status = ControllerBindingStatus.AutoBind
                 }
             };
             var binder = new ControllerAutoBinder(connectedControllers);

--- a/MobiFlightUnitTests/MobiFlight/Controllers/ControllerAutoBinderTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Controllers/ControllerAutoBinderTests.cs
@@ -112,17 +112,17 @@ namespace MobiFlight.Tests.Controllers
         }
 
         [TestMethod]
-        public void Scenario5_MultipleMatches_RequiresManualBindAndNoChanges()
+        public void Scenario5_MultipleControllerMatches_RequiresManualBindAndNoChanges()
         {
             // Arrange
             var connectedControllers = new List<string>
             {
-                "Joystick X #/JS-111111",
-                "Joystick X #/JS-222222"
+                "Joystick X # / JS-111111",
+                "Joystick X # / JS-222222"
             };
             var configItems = new List<IConfigItem>
             {
-                CreateConfigItem("Joystick X #/JS-999999")
+                CreateConfigItem("Joystick X # / JS-999999")
             };
             var binder = new ControllerAutoBinder(connectedControllers);
             var existingBindings = new List<ControllerBinding>();
@@ -133,10 +133,43 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(1, results);
-            var binding = results.Find(b => b.OriginalController == "Joystick X #/JS-999999");
+            var binding = results.Find(b => b.OriginalController == "Joystick X # / JS-999999");
             Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, binding.Status);
             Assert.IsEmpty(serialMappings);
-            Assert.AreEqual("Joystick X #/JS-999999", configItems[0].ModuleSerial);
+            Assert.AreEqual("Joystick X # / JS-999999", configItems[0].ModuleSerial);
+        }
+
+        [TestMethod]
+        public void Scenario5_MultipleConfigMatches_RequiresManualBindAndNoChanges()
+        {
+            // Arrange
+            var connectedControllers = new List<string>
+            {
+                "Joystick X # / JS-111111"
+            };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("Joystick X # / JS-222222"),
+                CreateConfigItem("Joystick X # / JS-333333")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+            var existingBindings = new List<ControllerBinding>();
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems, existingBindings);
+            var serialMappings = binder.ApplyAutoBinding(configItems, results);
+
+            // Assert
+            Assert.HasCount(2, results);
+            var binding = results.Find(b => b.OriginalController == "Joystick X # / JS-222222");
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, binding.Status);
+            Assert.IsEmpty(serialMappings);
+            Assert.AreEqual("Joystick X # / JS-222222", configItems[0].ModuleSerial);
+            
+            binding = results.Find(b => b.OriginalController == "Joystick X # / JS-333333");
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, binding.Status);
+            Assert.IsEmpty(serialMappings);
+            Assert.AreEqual("Joystick X # / JS-333333", configItems[1].ModuleSerial);
         }
 
         #endregion
@@ -309,7 +342,7 @@ namespace MobiFlight.Tests.Controllers
             var configItems = new List<IConfigItem>
             {
                 CreateConfigItem("Board1 # / SN-222"),
-                CreateConfigItem("Board1 # / SN-333")
+                CreateConfigItem("Board2 # / SN-333")
             };
 
             var existingBindings = new List<ControllerBinding>()
@@ -328,13 +361,13 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             var binding1 = bindingStatus.Find(b => b.OriginalController == "Board1 # / SN-222");
-            var binding2 = bindingStatus.Find(b => b.OriginalController == "Board1 # / SN-333");
+            var binding2 = bindingStatus.Find(b => b.OriginalController == "Board2 # / SN-333");
 
             Assert.AreEqual(ControllerBindingStatus.AutoBind, binding1.Status);
             Assert.AreEqual(ControllerBindingStatus.Missing, binding2.Status);
             Assert.HasCount(1, serialMappings);
             Assert.AreEqual("Board1 # / SN-111", configItems[0].ModuleSerial, "Missing unchanged");
-            Assert.AreEqual("Board1 # / SN-333", configItems[1].ModuleSerial, "Auto-bind changed");
+            Assert.AreEqual("Board2 # / SN-333", configItems[1].ModuleSerial, "Auto-bind changed");
         }
 
         #endregion

--- a/MobiFlightUnitTests/MobiFlight/Controllers/ControllerAutoBinderTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Controllers/ControllerAutoBinderTests.cs
@@ -1,0 +1,451 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.Base;
+using MobiFlight.Controllers;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MobiFlight.Tests.Controllers
+{
+    [TestClass]
+    public class ControllerAutoBinderTests
+    {
+        #region Scenario Tests
+
+        [TestMethod]
+        public void Scenario1_ExactMatch_ReturnsMatchAndNoChanges()
+        {
+            // Arrange
+            var connectedControllers = new List<string> { "MyBoard # / SN-1234567890" };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("MyBoard # / SN-1234567890")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+            var serialMappings = binder.ApplyAutoBinding(configItems, results);
+
+            // Assert
+            Assert.HasCount(1, results);
+            var (status, boundController) = results["MyBoard # / SN-1234567890"];
+            Assert.AreEqual(ControllerBindingStatus.Match, status);
+            Assert.IsEmpty(serialMappings);
+            Assert.AreEqual("MyBoard # / SN-1234567890", configItems[0].ModuleSerial);
+            Assert.AreEqual("MyBoard # / SN-1234567890", boundController);
+        }
+
+        [TestMethod]
+        public void Scenario2_SerialDiffers_ReturnsAutoBoundAndUpdatesSerial()
+        {
+            // Arrange
+            var connectedControllers = new List<string> { "X1-Pro # / SN-NEW456" };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("X1-Pro # / SN-OLD123")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+            var serialMappings = binder.ApplyAutoBinding(configItems, results);
+
+            // Assert
+            Assert.HasCount(1, results);
+            var (status, boundController) = results["X1-Pro # / SN-OLD123"];
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+            Assert.HasCount(1, serialMappings);
+            Assert.AreEqual("X1-Pro # / SN-NEW456", serialMappings["X1-Pro # / SN-OLD123"]);
+            Assert.AreEqual("X1-Pro # / SN-NEW456", configItems[0].ModuleSerial);
+        }
+
+        [TestMethod]
+        public void Scenario3_NameDiffers_ReturnsAutoBoundAndUpdatesName()
+        {
+            // Arrange
+            var connectedControllers = new List<string> { "NewBoardName # / SN-1234567890" };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("OldBoardName # / SN-1234567890")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+            var serialMappings = binder.ApplyAutoBinding(configItems, results);
+
+            // Assert
+            Assert.HasCount(1, results);
+            var (status, boundController) = results["OldBoardName # / SN-1234567890"];
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+            Assert.HasCount(1, serialMappings);
+            Assert.AreEqual("NewBoardName # / SN-1234567890", serialMappings["OldBoardName # / SN-1234567890"]);
+            Assert.AreEqual("NewBoardName # / SN-1234567890", configItems[0].ModuleSerial);
+        }
+
+        [TestMethod]
+        public void Scenario4_Missing_ReturnsMissingAndNoChanges()
+        {
+            // Arrange
+            var connectedControllers = new List<string> { "DifferentBoard # / SN-9999" };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("X1-Pro # / SN-1234")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+            var serialMappings = binder.ApplyAutoBinding(configItems, results);
+
+            // Assert
+            Assert.HasCount(1, results);
+            var (status, boundController) = results["X1-Pro # / SN-1234"];
+            Assert.AreEqual(ControllerBindingStatus.Missing, status);
+            Assert.IsEmpty(serialMappings);
+            Assert.AreEqual("X1-Pro # / SN-1234", configItems[0].ModuleSerial);
+        }
+
+        [TestMethod]
+        public void Scenario5_MultipleMatches_RequiresManualBindAndNoChanges()
+        {
+            // Arrange
+            var connectedControllers = new List<string>
+            {
+                "Joystick X #/JS-111111",
+                "Joystick X #/JS-222222"
+            };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("Joystick X #/JS-999999")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+            var serialMappings = binder.ApplyAutoBinding(configItems, results);
+
+            // Assert
+            Assert.HasCount(1, results);
+            var (status, boundController) = results["Joystick X #/JS-999999"];
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, status);
+            Assert.IsEmpty(serialMappings);
+            Assert.AreEqual("Joystick X #/JS-999999", configItems[0].ModuleSerial);
+        }
+
+        #endregion
+
+        #region Multiple Config Items Tests
+
+        [TestMethod]
+        public void AnalyzeBindings_MultipleConfigItems_AnalyzesAll()
+        {
+            // Arrange
+            var connectedControllers = new List<string>
+            {
+                "Board1 # / SN-111",
+                "Board2 # / SN-222"
+            };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("Board1 # / SN-111"),
+                CreateConfigItem("Board2 # / SN-OLD"),
+                CreateConfigItem("Board3 # / SN-333")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+
+            // Assert
+            Assert.HasCount(3, results);
+            var (status1, _) = results["Board1 # / SN-111"];
+            var (status2, _) = results["Board2 # / SN-OLD"];
+            var (status3, _) = results["Board3 # / SN-333"];
+
+            Assert.AreEqual(ControllerBindingStatus.Match, status1);
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status2);
+            Assert.AreEqual(ControllerBindingStatus.Missing, status3);
+        }
+
+        [TestMethod]
+        public void ApplyAutoBinding_MultipleConfigItems_UpdatesOnlyAutoBound()
+        {
+            // Arrange
+            var connectedControllers = new List<string>
+            {
+                "Board1 # / SN-111",
+                "Board2 # / SN-222"
+            };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("Board1 # / SN-111"),
+                CreateConfigItem("Board2 # / SN-OLD"),
+                CreateConfigItem("Board3 # / SN-333")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+            var bindingStatus = binder.AnalyzeBindings(configItems);
+
+            // Act
+            var serialMappings = binder.ApplyAutoBinding(configItems, bindingStatus);
+
+            // Assert
+            Assert.HasCount(1, serialMappings);
+            Assert.AreEqual("Board1 # / SN-111", configItems[0].ModuleSerial, "Exact match unchanged");
+            Assert.AreEqual("Board2 # / SN-222", configItems[1].ModuleSerial, "Auto-bound updated");
+            Assert.AreEqual("Board3 # / SN-333", configItems[2].ModuleSerial, "Missing unchanged");
+        }
+
+        [TestMethod]
+        public void ApplyAutoBinding_MultipleConfigItems_IgnoreMissingMatch()
+        {
+            // Arrange
+            var connectedControllers = new List<string>
+            {
+                "Board1 # / SN-111",
+            };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("Board1 # / SN-111"),
+                CreateConfigItem("Board1 # / SN-OTHER")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+            var bindingStatus = binder.AnalyzeBindings(configItems);
+
+            // Act
+            var serialMappings = binder.ApplyAutoBinding(configItems, bindingStatus);
+
+            // Assert
+            Assert.HasCount(0, serialMappings);
+            Assert.AreEqual("Board1 # / SN-111", configItems[0].ModuleSerial, "Exact match unchanged");
+            Assert.AreEqual("Board1 # / SN-OTHER", configItems[1].ModuleSerial, "Missing unchanged");
+        }
+
+        public void ApplyAutoBinding_MultipleConfigItems_IgnoreMissingMatchAndOrder()
+        {
+            // Arrange
+            var connectedControllers = new List<string>
+            {
+                "Board1 # / SN-111",
+            };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("Board1 # / SN-OTHER"),
+                CreateConfigItem("Board1 # / SN-111")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+            var bindingStatus = binder.AnalyzeBindings(configItems);
+
+            // Act
+            var serialMappings = binder.ApplyAutoBinding(configItems, bindingStatus);
+
+            // Assert
+            Assert.HasCount(1, serialMappings);
+            Assert.AreEqual("Board1 # / SN-111", configItems[0].ModuleSerial, "Exact match unchanged");
+            Assert.AreEqual("Board1 # / SN-OTHER", configItems[1].ModuleSerial, "Missing unchanged");
+        }
+
+        #endregion
+
+        #region Duplicate Serials Tests
+
+        [TestMethod]
+        public void AnalyzeBindings_DuplicateSerials_ReturnsOnlyUnique()
+        {
+            // Arrange
+            var connectedControllers = new List<string> { "Board # / SN-NEW" };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("Board # / SN-OLD"),
+                CreateConfigItem("Board # / SN-OLD"),  // Duplicate
+                CreateConfigItem("Board # / SN-OLD")   // Duplicate
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+
+            // Assert
+            Assert.HasCount(1, results, "Should only analyze unique serials");
+            var (status, _) = results["Board # / SN-OLD"];
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+        }
+
+        [TestMethod]
+        public void ApplyAutoBinding_DuplicateSerials_UpdatesAllInstances()
+        {
+            // Arrange
+            var connectedControllers = new List<string> { "Board # / SN-NEW" };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem("Board # / SN-OLD"),
+                CreateConfigItem("Board # / SN-OLD"),
+                CreateConfigItem("Board # / SN-OLD")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+            var bindingStatus = binder.AnalyzeBindings(configItems);
+
+            // Act
+            binder.ApplyAutoBinding(configItems, bindingStatus);
+
+            // Assert
+            Assert.IsTrue(configItems.All(c => c.ModuleSerial == "Board # / SN-NEW"),
+                "All duplicate serials should be updated");
+        }
+
+        #endregion
+
+        #region Empty and Null Tests
+
+        [TestMethod]
+        public void AnalyzeBindings_EmptyConfigItems_ReturnsEmptyDictionary()
+        {
+            // Arrange
+            var connectedControllers = new List<string> { "Board # / SN-123" };
+            var configItems = new List<IConfigItem>();
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+
+            // Assert
+            Assert.IsEmpty(results);
+        }
+
+        [TestMethod]
+        public void AnalyzeBindings_IgnoresEmptyAndDashSerials()
+        {
+            // Arrange
+            var connectedControllers = new List<string> { "Board # / SN-123" };
+            var configItems = new List<IConfigItem>
+            {
+                CreateConfigItem(""),
+                CreateConfigItem("-"),
+                CreateConfigItem(null),
+                CreateConfigItem("Board # / SN-123")
+            };
+            var binder = new ControllerAutoBinder(connectedControllers);
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+
+            // Assert
+            Assert.HasCount(1, results);
+            Assert.IsTrue(results.ContainsKey("Board # / SN-123"));
+        }
+
+        [TestMethod]
+        public void Constructor_NullConnectedControllers_HandlesGracefully()
+        {
+            // Arrange & Act
+            var binder = new ControllerAutoBinder(null);
+            var configItems = new List<IConfigItem> { CreateConfigItem("Board # / SN-123") };
+
+            // Act
+            var results = binder.AnalyzeBindings(configItems);
+
+            // Assert
+            Assert.HasCount(1, results);
+            var (status, _) = results["Board # / SN-123"];
+            Assert.AreEqual(ControllerBindingStatus.Missing, status);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private IConfigItem CreateConfigItem(string moduleSerial)
+        {
+            return new OutputConfigItem
+            {
+                ModuleSerial = moduleSerial,
+                Active = true,
+                GUID = System.Guid.NewGuid().ToString()
+            };
+        }
+
+        #endregion
+
+        #region GetTypeAndName Tests
+
+        [TestMethod]
+        public void GetTypeAndName_StandardFormat_ReturnsTypeAndName()
+        {
+            // Arrange
+            var serial = "Board #/ SN-1234567890";
+
+            // Act
+            var result = ControllerAutoBinder.GetTypeAndName(serial);
+
+            // Assert
+            Assert.AreEqual("Board #", result);
+        }
+
+        [TestMethod]
+        public void GetTypeAndName_WithWhitespace_TrimsProperly()
+        {
+            // Arrange
+            var serial = "  X1-Pro #  / SN-ABC123  ";
+
+            // Act
+            var result = ControllerAutoBinder.GetTypeAndName(serial);
+
+            // Assert
+            Assert.AreEqual("X1-Pro #", result);
+        }
+
+        [TestMethod]
+        public void GetTypeAndName_NoSeparator_ReturnsFullString()
+        {
+            // Arrange
+            var serial = "BoardWithoutSeparator";
+
+            // Act
+            var result = ControllerAutoBinder.GetTypeAndName(serial);
+
+            // Assert
+            Assert.AreEqual("BoardWithoutSeparator", result);
+        }
+
+        [TestMethod]
+        public void GetTypeAndName_EmptyString_ReturnsEmptyString()
+        {
+            // Arrange
+            var serial = "";
+
+            // Act
+            var result = ControllerAutoBinder.GetTypeAndName(serial);
+
+            // Assert
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void GetTypeAndName_OnlySeparator_ReturnsEmptyString()
+        {
+            // Arrange
+            var serial = "/ ";
+
+            // Act
+            var result = ControllerAutoBinder.GetTypeAndName(serial);
+
+            // Assert
+            Assert.AreEqual("", result);
+        }
+
+        [TestMethod]
+        public void GetTypeAndName_MultipleSeparators_ReturnFirstPart()
+        {
+            // Arrange
+            var serial = "Board #/ SN-123/ Extra";
+
+            // Act
+            var result = ControllerAutoBinder.GetTypeAndName(serial);
+
+            // Assert
+            Assert.AreEqual("Board #", result);
+        }
+
+        #endregion
+    }
+}

--- a/MobiFlightUnitTests/MobiFlight/Controllers/ControllerBindingServiceTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Controllers/ControllerBindingServiceTests.cs
@@ -91,7 +91,7 @@ namespace MobiFlight.Tests.Controllers
             // Assert
             Assert.HasCount(1, result);
             var binding = result.Find(b => b.OriginalController == "X1-Pro/ SN-OLD123");
-            Assert.AreEqual(ControllerBindingStatus.Match, binding.Status);
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, binding.Status);
             Assert.AreEqual("X1-Pro/ SN-NEW456", binding.BoundController);
             Assert.AreEqual("X1-Pro/ SN-OLD123", binding.OriginalController);
         }

--- a/MobiFlightUnitTests/MobiFlight/Controllers/ControllerBindingServiceTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Controllers/ControllerBindingServiceTests.cs
@@ -50,8 +50,10 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(1, result);
-            var (status, _) = result["MyBoard/ SN-1234567890"];
-            Assert.AreEqual(ControllerBindingStatus.Match, status);
+            var binding = result.Find(b => b.OriginalController == "MyBoard/ SN-1234567890");
+            Assert.AreEqual(ControllerBindingStatus.Match, binding.Status);
+            Assert.AreEqual("MyBoard/ SN-1234567890", binding.BoundController);
+            Assert.AreEqual("MyBoard/ SN-1234567890", binding.OriginalController);
         }
 
         [TestMethod]
@@ -66,8 +68,8 @@ namespace MobiFlight.Tests.Controllers
             var result = service.PerformAutoBinding(project);
 
             // Assert
-            var (status, _) = result["MyBoard/ SN-1234567890"];
-            Assert.AreEqual(ControllerBindingStatus.Match, status);
+            var binding = result.Find(b => b.OriginalController == "MyBoard/ SN-1234567890");
+            Assert.AreEqual(ControllerBindingStatus.Match, binding.Status);
             Assert.AreEqual(originalSerial, project.ConfigFiles[0].ConfigItems[0].ModuleSerial, 
                 "Serial should not change for exact match");
         }
@@ -88,8 +90,10 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(1, result);
-            var (status, _) = result["X1-Pro/ SN-OLD123"];
-            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+            var binding = result.Find(b => b.OriginalController == "X1-Pro/ SN-OLD123");
+            Assert.AreEqual(ControllerBindingStatus.Match, binding.Status);
+            Assert.AreEqual("X1-Pro/ SN-NEW456", binding.BoundController);
+            Assert.AreEqual("X1-Pro/ SN-OLD123", binding.OriginalController);
         }
 
         [TestMethod]
@@ -103,8 +107,8 @@ namespace MobiFlight.Tests.Controllers
             var result = service.PerformAutoBinding(project);
 
             // Assert
-            var (status, _) = result["X1-Pro/ SN-OLD123"];
-            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+            var binding = result.Find(b => b.OriginalController == "X1-Pro/ SN-OLD123");
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, binding.Status);
             Assert.AreEqual("X1-Pro/ SN-NEW456", project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
                 "Serial should be updated to new serial");
         }
@@ -125,8 +129,10 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(1, result);
-            var (status, _) = result["OldBoardName/ SN-1234567890"];
-            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+            var binding = result.Find(b => b.OriginalController == "OldBoardName/ SN-1234567890");
+            Assert.AreEqual("NewBoardName/ SN-1234567890", binding.BoundController);
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, binding.Status);
+            Assert.AreEqual("OldBoardName/ SN-1234567890", binding.OriginalController);
         }
 
         [TestMethod]
@@ -140,8 +146,8 @@ namespace MobiFlight.Tests.Controllers
             var result = service.PerformAutoBinding(project);
 
             // Assert
-            var (status, _) = result["OldBoardName/ SN-1234567890"];
-            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+            var binding = result.Find(b => b.OriginalController == "OldBoardName/ SN-1234567890");
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, binding.Status);
             Assert.AreEqual("NewBoardName/ SN-1234567890", project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
                 "Name should be updated");
         }
@@ -162,8 +168,8 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(1, result);
-            var (status, _) = result["X1-Pro/ SN-1234567890"];
-            Assert.AreEqual(ControllerBindingStatus.Missing, status);
+            var binding = result.Find(b => b.OriginalController == "X1-Pro/ SN-1234567890");
+            Assert.AreEqual(ControllerBindingStatus.Missing, binding.Status);
         }
 
         [TestMethod]
@@ -179,8 +185,8 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
 
-            var (status, _) = result["X1-Pro/ SN-1234567890"];
-            Assert.AreEqual(ControllerBindingStatus.Missing, status);
+            var binding = result.Find(b => b.OriginalController == "X1-Pro/ SN-1234567890");
+            Assert.AreEqual(ControllerBindingStatus.Missing, binding.Status);
             Assert.AreEqual(originalSerial, project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
                 "Serial should not change when missing");
         }
@@ -205,8 +211,8 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(1, result);
-            var (status, _) = result["Joystick X / JS-999999"];
-            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, status);
+            var binding = result.Find(b => b.OriginalController == "Joystick X / JS-999999");
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, binding.Status);
         }
 
         [TestMethod]
@@ -225,8 +231,8 @@ namespace MobiFlight.Tests.Controllers
             var result = service.PerformAutoBinding(project);
 
             // Assert
-            var (status, _) = result["Joystick X / JS-999999"];
-            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, status);
+            var binding = result.Find(b => b.OriginalController == "Joystick X / JS-999999");
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, binding.Status);
             Assert.AreEqual(originalSerial, project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
                 "Serial should not auto-bind when multiple matches exist");
         }
@@ -251,10 +257,10 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(2, result);
-            var (status1, _) = result["X1-Pro/ SN-1111111111"];
-            var (status2, _) = result["X1-Pro/ SN-2222222222"];
-            Assert.AreEqual(ControllerBindingStatus.AutoBind, status1);
-            Assert.AreEqual(ControllerBindingStatus.Missing, status2);
+            var binding1 = result.Find(b => b.OriginalController == "X1-Pro/ SN-1111111111");
+            var binding2 = result.Find(b => b.OriginalController == "X1-Pro/ SN-2222222222");
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, binding1.Status);
+            Assert.AreEqual(ControllerBindingStatus.Missing, binding2.Status);
 
             // Act
             var bindingResult = service.PerformAutoBinding(project);
@@ -283,10 +289,10 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(2, result);
-            var (status1, _) = result["X1-Pro/ SN-1111111111"];
-            var (status2, _) = result["X1-Pro/ SN-2222222222"];
-            Assert.AreEqual(ControllerBindingStatus.Match, status1);
-            Assert.AreEqual(ControllerBindingStatus.Missing, status2);
+            var binding1 = result.Find(b => b.OriginalController == "X1-Pro/ SN-1111111111");
+            var binding2 = result.Find(b => b.OriginalController == "X1-Pro/ SN-2222222222");
+            Assert.AreEqual(ControllerBindingStatus.Match, binding1.Status);
+            Assert.AreEqual(ControllerBindingStatus.Missing, binding2.Status);
         }
 
         [TestMethod]
@@ -333,10 +339,10 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(2, result);
-            var (status1, _) = result["Board1/ SN-111"];
-            var (status2, _) = result["Board2/ SN-222"];
-            Assert.AreEqual(ControllerBindingStatus.Match, status1);
-            Assert.AreEqual(ControllerBindingStatus.AutoBind, status2);
+            var binding1 = result.Find(b => b.OriginalController == "Board1/ SN-111");
+            var binding2 = result.Find(b => b.OriginalController == "Board2/ SN-222");
+            Assert.AreEqual(ControllerBindingStatus.Match, binding1.Status);
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, binding2.Status);
         }
 
         [TestMethod]
@@ -394,10 +400,10 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(2, result);
-            var (status1, _) = result["Board1/ SN-111"];
-            var (status2, _) = result["Board2/ SN-222"];
-            Assert.AreEqual(ControllerBindingStatus.Missing, status1);
-            Assert.AreEqual(ControllerBindingStatus.Missing, status2);
+            var binding1 = result.Find(b => b.OriginalController == "Board1/ SN-111");
+            var binding2 = result.Find(b => b.OriginalController == "Board2/ SN-222");
+            Assert.AreEqual(ControllerBindingStatus.Missing, binding1.Status);
+            Assert.AreEqual(ControllerBindingStatus.Missing, binding2.Status);
         }
 
         [TestMethod]
@@ -417,26 +423,7 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(1, result);
-            Assert.IsTrue(result.ContainsKey("ValidBoard/ SN-123"));
-        }
-
-        [TestMethod]
-        public void PerformAutoBinding_CallsDetermineProjectInfos()
-        {
-            // Arrange
-            var project = CreateProjectWithController("Board/ SN-OLD");
-            SetupConnectedController("Board", "SN-NEW");
-
-            // Verify Controllers list is empty before auto-binding
-            Assert.IsEmpty(project.Controllers);
-
-            // Act
-            service.PerformAutoBinding(project);
-
-            // Assert
-            // DetermineProjectInfos should populate Controllers
-            Assert.HasCount(1, project.Controllers);
-            Assert.AreEqual("Board/ SN-NEW", project.Controllers[0]);
+            Assert.AreEqual("ValidBoard/ SN-123", result[0].OriginalController);
         }
 
         #endregion
@@ -475,12 +462,12 @@ namespace MobiFlight.Tests.Controllers
 
             // Assert
             Assert.HasCount(3, result);
-            var (status1, _) = result["MyBoard/ SN-111"];
-            var (status2, _) = result["Joystick X / JS-222"];
-            var (status3, _) = result["MIDI Controller / MI-333"];
-            Assert.AreEqual(ControllerBindingStatus.Match, status1);
-            Assert.AreEqual(ControllerBindingStatus.Match, status2);
-            Assert.AreEqual(ControllerBindingStatus.Match, status3);
+            var binding1 = result.Find(b => b.OriginalController == "MyBoard/ SN-111");
+            var binding2 = result.Find(b => b.OriginalController == "Joystick X / JS-222");
+            var binding3 = result.Find(b => b.OriginalController == "MIDI Controller / MI-333");
+            Assert.AreEqual(ControllerBindingStatus.Match, binding1.Status);
+            Assert.AreEqual(ControllerBindingStatus.Match, binding2.Status);
+            Assert.AreEqual(ControllerBindingStatus.Match, binding3.Status);
         }
 
         #endregion
@@ -497,6 +484,7 @@ namespace MobiFlight.Tests.Controllers
             var project = new Project();
             var configFile = CreateConfigFileWithControllers(moduleSerials);
             project.ConfigFiles.Add(configFile);
+            project.Sim = "msfs";
             return project;
         }
 

--- a/MobiFlightUnitTests/MobiFlight/Controllers/ControllerBindingServiceTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Controllers/ControllerBindingServiceTests.cs
@@ -1,0 +1,562 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.Base;
+using MobiFlight.Controllers;
+using Moq;
+using System.Collections.Generic;
+
+namespace MobiFlight.Tests.Controllers
+{
+    [TestClass]
+    public class ControllerBindingServiceTests
+    {
+        private Mock<IExecutionManager> mockExecutionManager;
+        private Mock<MobiFlightCache> mockMobiFlightCache;
+        private Mock<JoystickManager> mockJoystickManager;
+        private Mock<MidiBoardManager> mockMidiBoardManager;
+        private ControllerBindingService service;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            mockExecutionManager = new Mock<IExecutionManager>();
+            mockMobiFlightCache = new Mock<MobiFlightCache>();
+            mockJoystickManager = new Mock<JoystickManager>();
+            mockMidiBoardManager = new Mock<MidiBoardManager>();
+
+            // Setup execution manager to return mocked caches
+            mockExecutionManager.Setup(m => m.getMobiFlightModuleCache()).Returns(mockMobiFlightCache.Object);
+            mockExecutionManager.Setup(m => m.GetJoystickManager()).Returns(mockJoystickManager.Object);
+            mockExecutionManager.Setup(m => m.GetMidiBoardManager()).Returns(mockMidiBoardManager.Object);
+
+            //// Default: no connected controllers
+            mockMobiFlightCache.Setup(m => m.GetModules()).Returns(new List<MobiFlightModule>());
+            mockJoystickManager.Setup(j => j.GetJoysticks()).Returns(new List<Joystick>());
+            mockMidiBoardManager.Setup(m => m.GetMidiBoards()).Returns(new List<MidiBoard>());
+
+            service = new ControllerBindingService(mockExecutionManager.Object);
+        }
+
+        #region Scenario 1: Exact Match Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_Scenario1_ExactMatch_ReturnsMatch()
+        {
+            // Arrange
+            var project = CreateProjectWithController("MyBoard/ SN-1234567890");
+            SetupConnectedController("MyBoard", "SN-1234567890");
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(1, result);
+            var (status, _) = result["MyBoard/ SN-1234567890"];
+            Assert.AreEqual(ControllerBindingStatus.Match, status);
+        }
+
+        [TestMethod]
+        public void PerformAutoBinding_Scenario1_ExactMatch_NoChanges()
+        {
+            // Arrange
+            var project = CreateProjectWithController("MyBoard/ SN-1234567890");
+            var originalSerial = project.ConfigFiles[0].ConfigItems[0].ModuleSerial;
+            SetupConnectedController("MyBoard", "SN-1234567890");
+
+            // Act
+            var result = service.PerformAutoBinding(project);
+
+            // Assert
+            var (status, _) = result["MyBoard/ SN-1234567890"];
+            Assert.AreEqual(ControllerBindingStatus.Match, status);
+            Assert.AreEqual(originalSerial, project.ConfigFiles[0].ConfigItems[0].ModuleSerial, 
+                "Serial should not change for exact match");
+        }
+
+        #endregion
+
+        #region Scenario 2: Partial Match - Serial Differs Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_Scenario2_SerialDiffers_ReturnsAutoBound()
+        {
+            // Arrange
+            var project = CreateProjectWithController("X1-Pro/ SN-OLD123");
+            SetupConnectedController("X1-Pro", "SN-NEW456");
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(1, result);
+            var (status, _) = result["X1-Pro/ SN-OLD123"];
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+        }
+
+        [TestMethod]
+        public void PerformAutoBinding_Scenario2_SerialDiffers_UpdatesSerial()
+        {
+            // Arrange
+            var project = CreateProjectWithController("X1-Pro/ SN-OLD123");
+            SetupConnectedController("X1-Pro", "SN-NEW456");
+
+            // Act
+            var result = service.PerformAutoBinding(project);
+
+            // Assert
+            var (status, _) = result["X1-Pro/ SN-OLD123"];
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+            Assert.AreEqual("X1-Pro/ SN-NEW456", project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
+                "Serial should be updated to new serial");
+        }
+
+        #endregion
+
+        #region Scenario 3: Partial Match - Name Differs Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_Scenario3_NameDiffers_ReturnsAutoBound()
+        {
+            // Arrange - name changed but serial is same
+            var project = CreateProjectWithController("OldBoardName/ SN-1234567890");
+            SetupConnectedController("NewBoardName", "SN-1234567890");
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(1, result);
+            var (status, _) = result["OldBoardName/ SN-1234567890"];
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+        }
+
+        [TestMethod]
+        public void PerformAutoBinding_Scenario3_NameDiffers_UpdatesName()
+        {
+            // Arrange
+            var project = CreateProjectWithController("OldBoardName/ SN-1234567890");
+            SetupConnectedController("NewBoardName", "SN-1234567890");
+
+            // Act
+            var result = service.PerformAutoBinding(project);
+
+            // Assert
+            var (status, _) = result["OldBoardName/ SN-1234567890"];
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status);
+            Assert.AreEqual("NewBoardName/ SN-1234567890", project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
+                "Name should be updated");
+        }
+
+        #endregion
+
+        #region Scenario 4: Missing Controller Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_Scenario4_Missing_ReturnsMissing()
+        {
+            // Arrange
+            var project = CreateProjectWithController("X1-Pro/ SN-1234567890");
+            SetupConnectedController("DifferentBoard", "SN-9999999999");
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(1, result);
+            var (status, _) = result["X1-Pro/ SN-1234567890"];
+            Assert.AreEqual(ControllerBindingStatus.Missing, status);
+        }
+
+        [TestMethod]
+        public void PerformAutoBinding_Scenario4_Missing_NoChanges()
+        {
+            // Arrange
+            var project = CreateProjectWithController("X1-Pro/ SN-1234567890");
+            var originalSerial = project.ConfigFiles[0].ConfigItems[0].ModuleSerial;
+            SetupConnectedController("DifferentBoard", "SN-9999999999");
+
+            // Act
+            var result = service.PerformAutoBinding(project);
+
+            // Assert
+
+            var (status, _) = result["X1-Pro/ SN-1234567890"];
+            Assert.AreEqual(ControllerBindingStatus.Missing, status);
+            Assert.AreEqual(originalSerial, project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
+                "Serial should not change when missing");
+        }
+
+        #endregion
+
+        #region Scenario 5: Multiple Devices - Requires Manual Bind Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_Scenario5_MultipleDevices_RequiresManualBind()
+        {
+            // Arrange
+            var project = CreateProjectWithController("Joystick X / JS-999999");
+            SetupConnectedJoysticks(new[]
+            {
+                ("Joystick X", "JS-111111"),
+                ("Joystick X", "JS-222222")
+            });
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(1, result);
+            var (status, _) = result["Joystick X / JS-999999"];
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, status);
+        }
+
+        [TestMethod]
+        public void PerformAutoBinding_Scenario5_MultipleDevices_NoAutoBind()
+        {
+            // Arrange
+            var project = CreateProjectWithController("Joystick X / JS-999999");
+            var originalSerial = project.ConfigFiles[0].ConfigItems[0].ModuleSerial;
+            SetupConnectedJoysticks(new[]
+            {
+                ("Joystick X", "JS-111111"),
+                ("Joystick X", "JS-222222")
+            });
+
+            // Act
+            var result = service.PerformAutoBinding(project);
+
+            // Assert
+            var (status, _) = result["Joystick X / JS-999999"];
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, status);
+            Assert.AreEqual(originalSerial, project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
+                "Serial should not auto-bind when multiple matches exist");
+        }
+
+        #endregion
+
+        #region Scenario 6: Multiple Profiles - One Connected Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_Scenario6_MultipleProfiles_OneConnected_AutoBindsBoth()
+        {
+            // Arrange
+            var project = CreateProjectWithControllers(new[]
+            {
+                "X1-Pro/ SN-1111111111",
+                "X1-Pro/ SN-2222222222"
+            });
+            SetupConnectedController("X1-Pro", "SN-9876543210");
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(2, result);
+            var (status1, _) = result["X1-Pro/ SN-1111111111"];
+            var (status2, _) = result["X1-Pro/ SN-2222222222"];
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status1);
+            Assert.AreEqual(ControllerBindingStatus.Missing, status2);
+
+            // Act
+            var bindingResult = service.PerformAutoBinding(project);
+            Assert.HasCount(2, bindingResult);
+            Assert.AreEqual("X1-Pro/ SN-9876543210", project.ConfigFiles[0].ConfigItems[0].ModuleSerial);
+            Assert.AreEqual("X1-Pro/ SN-2222222222", project.ConfigFiles[0].ConfigItems[1].ModuleSerial);
+        }
+
+        #endregion
+
+        #region Scenario 7: Two Controllers - One Missing Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_Scenario7_TwoControllers_OneMissing()
+        {
+            // Arrange
+            var project = CreateProjectWithControllers(new[]
+            {
+                "X1-Pro/ SN-1111111111",
+                "X1-Pro/ SN-2222222222"
+            });
+            SetupConnectedController("X1-Pro", "SN-1111111111");
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(2, result);
+            var (status1, _) = result["X1-Pro/ SN-1111111111"];
+            var (status2, _) = result["X1-Pro/ SN-2222222222"];
+            Assert.AreEqual(ControllerBindingStatus.Match, status1);
+            Assert.AreEqual(ControllerBindingStatus.Missing, status2);
+        }
+
+        [TestMethod]
+        public void PerformAutoBinding_Scenario7_TwoControllers_OneMissing_NoChanges()
+        {
+            // Arrange
+            var project = CreateProjectWithControllers(new[]
+            {
+                "X1-Pro/ SN-1111111111",
+                "X1-Pro/ SN-2222222222"
+            });
+            SetupConnectedController("X1-Pro", "SN-1111111111");
+
+            // Act
+            var result = service.PerformAutoBinding(project);
+
+            // Assert
+            Assert.AreEqual("X1-Pro/ SN-1111111111", project.ConfigFiles[0].ConfigItems[0].ModuleSerial,
+                "Connected controller should not change");
+            Assert.AreEqual("X1-Pro/ SN-2222222222", project.ConfigFiles[0].ConfigItems[1].ModuleSerial,
+                "Missing controller should not change");
+        }
+
+        #endregion
+
+        #region Multiple Config Files Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_MultipleConfigFiles_AnalyzesAll()
+        {
+            // Arrange
+            var project = new Project();
+            project.ConfigFiles.Add(CreateConfigFileWithController("Board1/ SN-111"));
+            project.ConfigFiles.Add(CreateConfigFileWithController("Board2/ SN-222"));
+            
+            SetupConnectedControllers(new[]
+            {
+                ("Board1", "SN-111"),
+                ("Board2", "SN-333")
+            });
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(2, result);
+            var (status1, _) = result["Board1/ SN-111"];
+            var (status2, _) = result["Board2/ SN-222"];
+            Assert.AreEqual(ControllerBindingStatus.Match, status1);
+            Assert.AreEqual(ControllerBindingStatus.AutoBind, status2);
+        }
+
+        [TestMethod]
+        public void PerformAutoBinding_MultipleConfigFiles_UpdatesAll()
+        {
+            // Arrange
+            var project = new Project();
+            project.ConfigFiles.Add(CreateConfigFileWithController("Board1/ SN-111"));
+            project.ConfigFiles.Add(CreateConfigFileWithController("Board2/ SN-222"));
+            
+            SetupConnectedControllers(new[]
+            {
+                ("Board1", "SN-111"),
+                ("Board2", "SN-333")
+            });
+
+            // Act
+            service.PerformAutoBinding(project);
+
+            // Assert
+            Assert.AreEqual("Board1/ SN-111", project.ConfigFiles[0].ConfigItems[0].ModuleSerial);
+            Assert.AreEqual("Board2/ SN-333", project.ConfigFiles[1].ConfigItems[0].ModuleSerial);
+        }
+
+        #endregion
+
+        #region Edge Cases Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_EmptyProject_ReturnsEmptyDictionary()
+        {
+            // Arrange
+            var project = new Project();
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.IsEmpty(result);
+        }
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_NoConnectedControllers_AllMissing()
+        {
+            // Arrange
+            var project = CreateProjectWithControllers(new[]
+            {
+                "Board1/ SN-111",
+                "Board2/ SN-222"
+            });
+            // No controllers connected (default mock setup)
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(2, result);
+            var (status1, _) = result["Board1/ SN-111"];
+            var (status2, _) = result["Board2/ SN-222"];
+            Assert.AreEqual(ControllerBindingStatus.Missing, status1);
+            Assert.AreEqual(ControllerBindingStatus.Missing, status2);
+        }
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_IgnoresEmptySerials()
+        {
+            // Arrange
+            var project = CreateProjectWithControllers(new[]
+            {
+                "",
+                "-",
+                "ValidBoard/ SN-123"
+            });
+            SetupConnectedController("ValidBoard", "SN-123");
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(1, result);
+            Assert.IsTrue(result.ContainsKey("ValidBoard/ SN-123"));
+        }
+
+        [TestMethod]
+        public void PerformAutoBinding_CallsDetermineProjectInfos()
+        {
+            // Arrange
+            var project = CreateProjectWithController("Board/ SN-OLD");
+            SetupConnectedController("Board", "SN-NEW");
+
+            // Verify Controllers list is empty before auto-binding
+            Assert.IsEmpty(project.Controllers);
+
+            // Act
+            service.PerformAutoBinding(project);
+
+            // Assert
+            // DetermineProjectInfos should populate Controllers
+            Assert.HasCount(1, project.Controllers);
+            Assert.AreEqual("Board/ SN-NEW", project.Controllers[0]);
+        }
+
+        #endregion
+
+        #region Mixed Controller Types Tests
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_MixedControllerTypes_AnalyzesAll()
+        {
+            // Arrange
+            var project = CreateProjectWithControllers(new[]
+            {
+                "MyBoard/ SN-111",           // MobiFlight
+                "Joystick X / JS-222",        // Joystick
+                "MIDI Controller / MI-333"    // MIDI
+            });
+
+            var module = new Mock<MobiFlightModule>("COM1", new Board() { Info = new Info() { FriendlyName = "MyBoard" } });
+            module.Setup(m => m.Name).Returns("MyBoard");
+            module.Setup(m => m.Serial).Returns("SN-111");
+
+            var joystick = new Mock<Joystick>(null, new JoystickDefinition() { InstanceName = "Joystick X" });
+            joystick.Setup(j => j.Name).Returns("Joystick X");
+            joystick.Setup(j => j.Serial).Returns("JS-222");
+
+            var midiBoard = new Mock<MidiBoard>(null, null, "MIDI Controller", new MidiBoardDefinition() { InstanceName = "MIDI Controller"});
+            midiBoard.Setup(m => m.Name).Returns("MIDI Controller");
+            midiBoard.Setup(m => m.Serial).Returns("MI-333");
+
+            mockMobiFlightCache.Setup(m => m.GetModules()).Returns(new List<MobiFlightModule> { module.Object });
+            mockJoystickManager.Setup(j => j.GetJoysticks()).Returns(new List<Joystick> { joystick.Object });
+            mockMidiBoardManager.Setup(m => m.GetMidiBoards()).Returns(new List<MidiBoard> { midiBoard.Object });
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(3, result);
+            var (status1, _) = result["MyBoard/ SN-111"];
+            var (status2, _) = result["Joystick X / JS-222"];
+            var (status3, _) = result["MIDI Controller / MI-333"];
+            Assert.AreEqual(ControllerBindingStatus.Match, status1);
+            Assert.AreEqual(ControllerBindingStatus.Match, status2);
+            Assert.AreEqual(ControllerBindingStatus.Match, status3);
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private Project CreateProjectWithController(string moduleSerial)
+        {
+            return CreateProjectWithControllers(new[] { moduleSerial });
+        }
+
+        private Project CreateProjectWithControllers(string[] moduleSerials)
+        {
+            var project = new Project();
+            var configFile = CreateConfigFileWithControllers(moduleSerials);
+            project.ConfigFiles.Add(configFile);
+            return project;
+        }
+
+        private ConfigFile CreateConfigFileWithController(string moduleSerial)
+        {
+            return CreateConfigFileWithControllers(new[] { moduleSerial });
+        }
+
+        private ConfigFile CreateConfigFileWithControllers(string[] moduleSerials)
+        {
+            var configFile = new ConfigFile
+            {
+                Label = "Test Config",
+                EmbedContent = true
+            };
+
+            foreach (var serial in moduleSerials)
+            {
+                configFile.ConfigItems.Add(new OutputConfigItem
+                {
+                    ModuleSerial = serial,
+                    Active = true,
+                    GUID = System.Guid.NewGuid().ToString()
+                });
+            }
+
+            return configFile;
+        }
+
+        private void SetupConnectedController(string name, string serial)
+        {
+            SetupConnectedControllers(new[] { (name, serial) });
+        }
+
+        private void SetupConnectedControllers((string name, string serial)[] controllers)
+        {
+            var modules = new List<MobiFlightModule>();
+            foreach (var (name, serial) in controllers)
+            {
+                var module = new Mock<MobiFlightModule>("com5", new Board() { Info = new Info() { FriendlyName = name } });
+                module.Setup(m => m.Name).Returns(name);
+                module.Setup(m => m.Serial).Returns(serial);
+                modules.Add(module.Object);
+            }
+            mockMobiFlightCache.Setup(m => m.GetModules()).Returns(modules);
+        }
+
+        private void SetupConnectedJoysticks((string name, string serial)[] joysticks)
+        {
+            var joystickList = new List<Joystick>();
+            foreach (var (name, serial) in joysticks)
+            {
+                var joystick = new Mock<Joystick>(null, new JoystickDefinition() { InstanceName = name });
+                joystick.Setup(j => j.Name).Returns(name);
+                joystick.Setup(j => j.Serial).Returns(serial);
+                joystickList.Add(joystick.Object);
+            }
+            mockJoystickManager.Setup(j => j.GetJoysticks()).Returns(joystickList);
+        }
+
+        #endregion
+    }
+}

--- a/MobiFlightUnitTests/MobiFlight/Controllers/ControllerBindingServiceTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Controllers/ControllerBindingServiceTests.cs
@@ -270,7 +270,36 @@ namespace MobiFlight.Tests.Controllers
         }
 
         [TestMethod]
-        public void AnalyzeProjectBindings_Scenario6_TwoProfiles_TwoController_OneConnected_AutoBindsBoth()
+        public void AnalyzeProjectBindings_Scenario6_OneProfile_TwoController_TwoConnected_RequiresManualBind()
+        {
+            // Arrange
+            var project = CreateProjectWithControllers(new[]
+            {
+                "X1-Pro/ SN-1111111111",
+                "X1-Pro/ SN-2222222222"
+            });
+            SetupConnectedController("X1-Pro", "SN-9876543210");
+            SetupConnectedController("X1-Pro", "SN-0123456789");
+
+            // Act
+            var result = service.AnalyzeProjectBindings(project);
+
+            // Assert
+            Assert.HasCount(2, result);
+            var binding1 = result.Find(b => b.OriginalController == "X1-Pro/ SN-1111111111");
+            var binding2 = result.Find(b => b.OriginalController == "X1-Pro/ SN-2222222222");
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, binding1.Status);
+            Assert.AreEqual(ControllerBindingStatus.RequiresManualBind, binding2.Status);
+
+            // Act
+            var bindingResult = service.PerformAutoBinding(project);
+            Assert.HasCount(2, bindingResult);
+            Assert.AreEqual("X1-Pro/ SN-1111111111", project.ConfigFiles[0].ConfigItems[0].ModuleSerial);
+            Assert.AreEqual("X1-Pro/ SN-2222222222", project.ConfigFiles[0].ConfigItems[1].ModuleSerial);
+        }
+
+        [TestMethod]
+        public void AnalyzeProjectBindings_Scenario6_TwoProfiles_OneController_OneConnected_AutoBindsBoth()
         {
             // Arrange
             var project = CreateProjectWithControllers(new[]

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -241,6 +241,8 @@
     <Compile Include="MobiFlight\BrowserMessages\Incoming\Handler\CommandProjectToolbarHandlerTests.cs" />
     <Compile Include="MobiFlight\BrowserMessages\MessageExchangeTests.cs" />
     <Compile Include="MobiFlight\BrowserMessages\MessageTests.cs" />
+    <Compile Include="MobiFlight\Controllers\ControllerAutoBinderTests.cs" />
+    <Compile Include="MobiFlight\Controllers\ControllerBindingServiceTests.cs" />
     <Compile Include="MobiFlight\ExecutionManagerTests.cs" />
     <Compile Include="MobiFlight\Execution\ConfigItemExecutorTests.cs" />
     <Compile Include="MobiFlight\InputEventArgsTests.cs" />

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -423,6 +423,7 @@ namespace MobiFlight.UI
             if (bindings == null) return;
 
             var autoBoundControllers = bindings.Where(b => b.Status == ControllerBindingStatus.AutoBind).ToList();
+            var manualRebindRequiredControllers = bindings.Where(b => b.Status == ControllerBindingStatus.RequiresManualBind).ToList();
 
             if (autoBoundControllers.Count > 0)
             {
@@ -433,6 +434,19 @@ namespace MobiFlight.UI
                     {
                         { "Count", autoBoundControllers.Count.ToString() },
                         { "Controllers", string.Join(", ", autoBoundControllers.Select(c => SerialNumber.ExtractDeviceName(c.BoundController))) }
+                    }
+                });
+            }
+
+            if (manualRebindRequiredControllers.Count > 0)
+            {
+                MessageExchange.Instance.Publish(new Notification()
+                {
+                    Event = "ControllerManualBindRequired",
+                    Context = new Dictionary<string, string>()
+                    {
+                        { "Count", manualRebindRequiredControllers.Count.ToString() },
+                        { "Controllers", string.Join(", ", manualRebindRequiredControllers.Select(c => SerialNumber.ExtractDeviceName(c.OriginalController)).Distinct()) }
                     }
                 });
             }

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2053,7 +2053,7 @@ namespace MobiFlight.UI
                     execManager.Project.MergeFromProjectFile(fileName);
                 }
 
-                var bindingStatus = controllerBindingService.PerformAutoBinding(execManager.Project);
+                controllerBindingService.PerformAutoBinding(execManager.Project);
 
                 execManager.Project.ConfigFiles.ToList().ForEach(configFile =>
                 {

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -389,6 +389,7 @@ namespace MobiFlight.UI
             {
                 StopExecution();
                 MessageExchange.Instance.Publish(project);
+                CreateBindingStatusNotification(project);
             };
 
             PropertyChanged += (s, e) =>
@@ -413,6 +414,25 @@ namespace MobiFlight.UI
             };
 
             RestoreWindowsPositionAndZoomLevel();
+        }
+
+        private void CreateBindingStatusNotification(Project project)
+        {
+            var bindings = project.ControllerBindings;
+            var autoBoundControllers = bindings.Where(b => b.Status == ControllerBindingStatus.AutoBind).ToList();
+
+            if (autoBoundControllers.Count > 0)
+            {
+                MessageExchange.Instance.Publish(new Notification()
+                {
+                    Event = "ControllerAutoBindSuccessful",
+                    Context = new Dictionary<string, string>()
+                    {
+                        { "Count", autoBoundControllers.Count.ToString() },
+                        { "Controllers", string.Join(", ", autoBoundControllers.Select(c => SerialNumber.ExtractDeviceName(c.BoundController))) }
+                    }
+                });
+            }
         }
 
         private async void MainForm_Shown(object sender, EventArgs e)

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -570,7 +570,6 @@ namespace MobiFlight.UI
                         p.FilePath = project;
                         p.OpenFile(suppressMigrationLogging: true);
                         p.DetermineProjectInfos();
-
                         controllerBindingService.PerformAutoBinding(p);
 
                         recentProjects.Add(p.ToProjectInfo());

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -419,6 +419,9 @@ namespace MobiFlight.UI
         private void CreateBindingStatusNotification(Project project)
         {
             var bindings = project.ControllerBindings;
+
+            if (bindings == null) return;
+
             var autoBoundControllers = bindings.Where(b => b.Status == ControllerBindingStatus.AutoBind).ToList();
 
             if (autoBoundControllers.Count > 0)

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -110,7 +110,7 @@ namespace MobiFlight.UI
             }
         }
 
-        public ControllerBindingService controllerBindingService { get; private set; }
+        public ControllerBindingService ControllerBindingService { get; private set; }
 
         private void InitializeLogging()
         {
@@ -475,7 +475,7 @@ namespace MobiFlight.UI
             cmdLineParams = new CmdLineParams(Environment.GetCommandLineArgs());
             InitializeExecutionManager();
 
-            controllerBindingService = new ControllerBindingService(execManager);
+            ControllerBindingService = new ControllerBindingService(execManager);
 
             connectedDevicesToolStripDropDownButton.DropDownDirection = ToolStripDropDownDirection.AboveRight;
             simStatusToolStripDropDownButton1.DropDownDirection = ToolStripDropDownDirection.AboveRight;
@@ -607,7 +607,7 @@ namespace MobiFlight.UI
                         p.FilePath = project;
                         p.OpenFile(suppressMigrationLogging: true);
                         p.DetermineProjectInfos();
-                        controllerBindingService.PerformAutoBinding(p);
+                        ControllerBindingService.PerformAutoBinding(p);
 
                         recentProjects.Add(p.ToProjectInfo());
                     }
@@ -2053,7 +2053,7 @@ namespace MobiFlight.UI
                     execManager.Project.MergeFromProjectFile(fileName);
                 }
 
-                controllerBindingService.PerformAutoBinding(execManager.Project);
+                ControllerBindingService.PerformAutoBinding(execManager.Project);
 
                 execManager.Project.ConfigFiles.ToList().ForEach(configFile =>
                 {

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -237,6 +237,12 @@
       }
     }
   },
+  "Notifications": {
+    "ControllerAutoBindSuccessful": {
+      "Title": "Gute Nachricht!",
+      "Description": "Wir haben Dein Projekt für die Verwendung von ‘{{controllerName}}’ aktualisiert — Dein Projekt ist nun startklar."
+    }
+  },
   "Feed": {
     "Title": "Community Feed",
     "Description": "Neuigkeiten und Updates aus der MobiFlight-Community.",

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -247,6 +247,11 @@
     "ControllerAutoBindSuccessful": {
       "Title": "Gute Nachricht!",
       "Description": "Wir haben Dein Projekt für die Verwendung von ‘{{controllerName}}’ aktualisiert — Dein Projekt ist nun startklar."
+    },
+    "ControllerManualBindRequired": {
+      "Title": "Deine Hilfe ist gefragt!",
+      "Description": "{{controllerName}} wird in diesem Profil verwendet und erfordert eine manuelle Zuordnung, damit Dein Projekt korrekt funktioniert.",
+      "Action": "Controller zuordnen"
     }
   },
   "Feed": {

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -78,6 +78,12 @@
       "prosim": "ProSim",
       "none": "Kein Simulator"
     },
+    "BindingStatus": {
+      "Match": "Controller vorhanden",
+      "AutoBind": "Automatisch zugeordneter Controller",
+      "Missing": "Controller fehlt",
+      "RequiresManualBind": "Manuelle Zurodnung erforderlich"
+    },
     "Card": {
       "Main": {
         "Title": "Meine Projekte",

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -114,6 +114,12 @@
         "UseProSim": "ProSim - Schnittstelle für ProSim Flugzeuge",
         "Feature": "Zusätzliche Funktionen"
       },
+      "BindingStatus": {
+        "Match": "Controller angeschlossen",
+        "AutoBind": "Automatisch gebundener Controller",
+        "Missing": "Controller fehlt",
+        "RequiresManualBind": "Manuelle Bindung erforderlich"
+      },
       "Aircraft": {
         "Label": "Flugzeug",
         "HelpText": "Wähle das Flugzeug für dieses Projekt aus."

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -122,9 +122,9 @@
       },
       "BindingStatus": {
         "Match": "Controller angeschlossen",
-        "AutoBind": "Automatisch gebundener Controller",
+        "AutoBind": "Automatisch zugeordneter Controller",
         "Missing": "Controller fehlt",
-        "RequiresManualBind": "Manuelle Bindung erforderlich"
+        "RequiresManualBind": "Manuelle Zuordnung erforderlich"
       },
       "Aircraft": {
         "Label": "Flugzeug",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -241,6 +241,11 @@
     "ControllerAutoBindSuccessful": {
       "Title": "Great news!",
       "Description": "We've updated your project to work with ‘{{controllerName}}’ — everything’s ready to go!."
+    },
+    "ControllerManualBindRequired": {
+      "Title": "Your input is needed!",
+      "Description": "{{controllerName}} used in this profile requires manual binding to make your project work correctly.",
+      "Action": "Bind controllers"
     }
   },
   "Feed": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -240,7 +240,7 @@
   "Notifications": {
     "ControllerAutoBindSuccessful": {
       "Title": "Great news!",
-      "Description": "We've updated your project to work with ‘{{controllerName}}’ — everything’s ready to go!."
+      "Description": "We've updated your project to work with ‘{{controllerName}}’ — everything’s ready to go!"
     },
     "ControllerManualBindRequired": {
       "Title": "Your input is needed!",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -237,6 +237,12 @@
       }
     }
   },
+  "Notifications": {
+    "ControllerAutoBindSuccessful": {
+      "Title": "Great news!",
+      "Description": "We've updated your project to work with ‘{{controllerName}}’ — everything’s ready to go!."
+    }
+  },
   "Feed": {
     "Title": "Community Feed",
     "Description": "News and updates from the MobiFlight community.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -78,6 +78,12 @@
       "prosim": "ProSim",
       "none": "No simulator"
     },
+    "BindingStatus": {
+      "Match": "Controller connected",
+      "AutoBind": "Auto-bound controller",
+      "Missing": "Controller missing",
+      "RequiresManualBind": "Manual binding required"
+    },
     "Card": {
       "Main": {
         "Title": "My Projects",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -78,6 +78,12 @@
       "prosim": "ProSim",
       "none": "Ningún simulador"
     },
+    "BindingStatus": {
+      "Match": "Controlador conectado",
+      "AutoBind": "Controlador vinculado automáticamente",
+      "Missing": "Controlador ausente",
+      "RequiresManualBind": "Vinculación manual requerida"
+    },
     "Card": {
       "Main": {
         "Title": "Mis Proyectos",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -237,6 +237,12 @@
       }
     }
   },
+  "Notifications": {
+    "ControllerAutoBindSuccessful": {
+      "Title": "¡Buenas noticias!",
+      "Description": "Hemos actualizado el proyecto para funcionar con ‘{{controllerName}}’ — está listo para usar."
+    }
+  },
   "Feed": {
     "Title": "Community Feed",
     "Description": "Noticias y novedades de la comunidad de MobiFlight.",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -247,6 +247,11 @@
     "ControllerAutoBindSuccessful": {
       "Title": "¡Buenas noticias!",
       "Description": "Hemos actualizado el proyecto para funcionar con ‘{{controllerName}}’ — está listo para usar."
+    },
+    "ControllerManualBindRequired": {
+      "Title": "¡Necesitamos tu ayuda!",
+      "Description": "{{controllerName}} usado en este perfil requiere una vinculación manual para que tu proyecto funcione correctamente.",
+      "Action": "Vincular controladores"
     }
   },
   "Feed": {

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -114,6 +114,12 @@
         "UseProSim": "ProSim - interfaz para aviones ProSim",
         "Feature": "Funciones adicionales"
       },
+      "BindingStatus": {
+        "Match": "Controlador conectado",
+        "AutoBind": "Controlador vinculado automáticamente",
+        "Missing": "Controlador ausente",
+        "RequiresManualBind": "Vinculación manual requerida"
+      },
       "Aircraft": {
         "Label": "Avión",
         "HelpText": "Selecciona el avión para este proyecto."

--- a/frontend/src/components/modals/ProjectFormModal.tsx
+++ b/frontend/src/components/modals/ProjectFormModal.tsx
@@ -20,7 +20,6 @@ export default function NewProjectModalRoute() {
         if (!open) close()
       }}
       onSave={async (values) => {
-        console.log("ProjectFormModal onSave", values)
         publish({
           key: "CommandMainMenu",
           payload: {

--- a/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -53,7 +53,7 @@ export const ToastNotificationHandler = () => {
         break
 
       default:
-        console.log("Unhandled notification event:", notification.Event)
+        console.error("Unhandled notification event:", notification.Event)
         break
     }
   })

--- a/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -12,7 +12,7 @@ export const ToastNotificationHandler = () => {
   useAppMessage("Notification", (message) => {
     const notification = message.payload as Notification
     const controllerType = notification.Context?.Type ?? "Board"
-    
+
     switch (notification.Event) {
       case "MissingControllerDetected":
         toast({
@@ -30,6 +30,17 @@ export const ToastNotificationHandler = () => {
           },
         })
         break
+
+      case "ControllerAutoBindSuccessful": {
+        const controllerName =
+          notification?.Context?.Controllers ?? "Unknown Controller"
+        toast({
+          id: "autobind-controllers-successful",
+          title: t("Notifications.ControllerAutoBindSuccessful.Title"),
+          description: t("Notifications.ControllerAutoBindSuccessful.Description", { controllerName }),
+        })
+        break
+      }
 
       case "ProjectFileExtensionMigrated":
         toast({
@@ -51,8 +62,7 @@ export const ToastNotificationHandler = () => {
       toast({
         id: "hubhop-auto-update",
         title: t("General.HubHopUpdate.Title"),
-        description:
-          t("General.HubHopUpdate.Description", { days: 7 }),
+        description: t("General.HubHopUpdate.Description", { days: 7 }),
         button: {
           label: "Update Now",
           onClick: () => {
@@ -65,14 +75,18 @@ export const ToastNotificationHandler = () => {
       })
     }
 
-    if (status.ShouldUpdate && status.Result === "InProgress" && status.UpdateProgress === 0) {
+    if (
+      status.ShouldUpdate &&
+      status.Result === "InProgress" &&
+      status.UpdateProgress === 0
+    ) {
       toast({
         id: "hubhop-auto-update",
         title: t("General.HubHopUpdate.Title.Downloading"),
         description: <HubHopUpdateToast timeout={2000} />,
         options: {
           duration: Infinity, // Keep it open until completed
-        }
+        },
       })
     }
   })

--- a/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -24,6 +24,26 @@ export const ToastNotificationHandler = () => {
         break
       }
 
+      case "ManualBindingRequired": {
+        const controllerName =
+          notification?.Context?.Controllers ?? "Unknown Controller"
+        toast({
+          id: "manual-binding-required",
+          title: "Your input is needed!",
+          description: `${controllerName} used in this profile require manual binding to make them work.`,
+          button: {
+            label: `Rebind now`,
+            onClick: () => {
+              publish({
+                key: "CommandMainMenu",
+                payload: { action: "extras.serials" },
+              } as CommandMainMenu)
+            },
+          },
+        })
+        break
+      }
+
       case "ProjectFileExtensionMigrated":
         toast({
           id: "file-extension-migrated",

--- a/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -11,26 +11,8 @@ export const ToastNotificationHandler = () => {
 
   useAppMessage("Notification", (message) => {
     const notification = message.payload as Notification
-    const controllerType = notification.Context?.Type ?? "Board"
-
+    
     switch (notification.Event) {
-      case "MissingControllerDetected":
-        toast({
-          id: "missing-controllers-detected",
-          title: "Missing Controllers Detected",
-          description: `Some ${controllerType} controllers used in this profile are currently not connected.`,
-          button: {
-            label: `Reassign ${controllerType}`,
-            onClick: () => {
-              publish({
-                key: "CommandMainMenu",
-                payload: { action: "extras.serials" },
-              } as CommandMainMenu)
-            },
-          },
-        })
-        break
-
       case "ControllerAutoBindSuccessful": {
         const controllerName =
           notification?.Context?.Controllers ?? "Unknown Controller"

--- a/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -24,15 +24,15 @@ export const ToastNotificationHandler = () => {
         break
       }
 
-      case "ManualBindingRequired": {
+      case "ControllerManualBindRequired": {
         const controllerName =
           notification?.Context?.Controllers ?? "Unknown Controller"
         toast({
           id: "manual-binding-required",
-          title: "Your input is needed!",
-          description: `${controllerName} used in this profile require manual binding to make them work.`,
+          title: t("Notifications.ControllerManualBindRequired.Title"),
+          description: t("Notifications.ControllerManualBindRequired.Description", { controllerName }),
           button: {
-            label: `Rebind now`,
+            label: t("Notifications.ControllerManualBindRequired.Action"),
             onClick: () => {
               publish({
                 key: "CommandMainMenu",

--- a/frontend/src/components/project/ControllerIcon.tsx
+++ b/frontend/src/components/project/ControllerIcon.tsx
@@ -1,8 +1,10 @@
 import { cn } from "@/lib/utils"
+import { ControllerBinding, ControllerBindingStatus } from "@/types/controller"
 import { HtmlHTMLAttributes } from "react"
+import { useTranslation } from "react-i18next"
 
 export type ControllerIconProps = {
-  serial: string
+  controllerBinding: ControllerBinding
 }
 
 const ControllerIconPath = {
@@ -18,7 +20,7 @@ const ControllerIconPath = {
   },
   joystick: {
     authentikit: {
-      "AuthentiKit": "/controller/authentikit/atk-orange-button-logo.png",
+      AuthentiKit: "/controller/authentikit/atk-orange-button-logo.png",
     },
     honeycomb: {
       "Alpha Flight Controls": "/controller/honeycomb/alpha-yoke.jpg",
@@ -85,10 +87,17 @@ const FindControllerIconPath = (controllerType: string, deviceName: string) => {
 }
 
 const ControllerIcon = ({
-  serial,
+  controllerBinding,
   className,
   ...props
 }: HtmlHTMLAttributes<HTMLDivElement> & ControllerIconProps) => {
+  const serial =
+    controllerBinding.BoundController ||
+    controllerBinding.OriginalController ||
+    ""
+  const status = controllerBinding.Status
+  const { t } = useTranslation()
+
   console.log("ControllerIcon serial:", serial)
   const controllerType = serial.includes("SN-")
     ? "mobiflight"
@@ -102,12 +111,22 @@ const ControllerIcon = ({
   const deviceName = serial.split("/")[0].trim() || ""
   const controllerIconUrl = FindControllerIconPath(controllerType, deviceName)
 
+  const variant = {
+    Match: "",
+    AutoBind: "outline-blue-500 outline-1 shadow-sm",
+    Missing: "outline-amber-500 outline-1 shadow-sm",
+    RequiresManualBind: "outline-red-500 outline-1 shadow-sm",
+  } as Record<ControllerBindingStatus, string>
+
+  const titleStatus = t(`Project.BindingStatus.${status}`)
+
   return usingController ? (
     <div
       data-testid="controller-icon"
-      title={deviceName}
+      title={`${deviceName} - ${titleStatus}`}
       className={cn(
-        `bg-background border-background flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border-2 shadow-sm`,
+        `border-card bg-card flex h-10 w-10 items-center justify-center overflow-hidden rounded-full border-2 shadow-sm`,
+        variant[status],
         className,
       )}
       {...props}

--- a/frontend/src/components/project/ControllerIcon.tsx
+++ b/frontend/src/components/project/ControllerIcon.tsx
@@ -58,7 +58,6 @@ const ControllerIconPath = {
 }
 
 const FindControllerIconPath = (controllerType: string, deviceName: string) => {
-  console.log(`FindControllerIconPath: ${controllerType} > ${deviceName}`)
   const controllerIconPathSection =
     ControllerIconPath[controllerType as keyof typeof ControllerIconPath]
 
@@ -98,7 +97,6 @@ const ControllerIcon = ({
   const status = controllerBinding.Status
   const { t } = useTranslation()
 
-  console.log("ControllerIcon serial:", serial)
   const controllerType = serial.includes("SN-")
     ? "mobiflight"
     : serial.includes("JS-")

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -193,15 +193,17 @@ const ProjectCard = ({
                   className="flex flex-row -space-x-4 hover:space-x-0"
                   data-testid="controller-icons"
                 >
-                  {summary.Controllers?.map(
-                    (controllerName, index) =>
-                      controllerName != "-" && (
+                  {summary.ControllerBindings?.map(
+                    (controllerBinding, index) => {
+                      console.log("Rendering ControllerIcon for binding:", controllerBinding)
+                      return controllerBinding.BoundController != "-" && (
                         <ControllerIcon
                           className="transition-all ease-in-out"
-                          key={`${controllerName}-${index}`}
-                          serial={controllerName}
+                          key={`${controllerBinding.BoundController}-${index}`}
+                          serial={controllerBinding.BoundController || controllerBinding.OriginalController || ""}
                         />
-                      ),
+                      )
+                    },
                   )}
                 </div>
               </div>

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -88,7 +88,7 @@ export const ProjectCardImage = ({
   className,
 }: HtmlHTMLAttributes<HTMLDivElement> & { summary: ProjectInfo }) => {
   const imageUrl = summary.Thumbnail || `/sim/${summary.Sim?.toLowerCase()}.jpg`
-  console.log("ProjectCardImage imageUrl:", imageUrl, import.meta.url)
+
   return summary.Sim ? (
     <div className={cn("bg-accent rounded-lg", className)}>
       <img
@@ -195,7 +195,6 @@ const ProjectCard = ({
                 >
                   {summary.ControllerBindings?.map(
                     (controllerBinding, index) => {
-                      console.log("Rendering ControllerIcon for binding:", controllerBinding)
                       return controllerBinding.BoundController != "-" && (
                         <ControllerIcon
                           className="transition-all ease-in-out"

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -200,7 +200,7 @@ const ProjectCard = ({
                         <ControllerIcon
                           className="transition-all ease-in-out"
                           key={`${controllerBinding.BoundController}-${index}`}
-                          serial={controllerBinding.BoundController || controllerBinding.OriginalController || ""}
+                          controllerBinding={controllerBinding}
                         />
                       )
                     },

--- a/frontend/src/components/project/ProjectForm.tsx
+++ b/frontend/src/components/project/ProjectForm.tsx
@@ -62,7 +62,7 @@ const ProjectForm = ({
       return
     }
     setHasError(false)
-    console.log("Saving")
+
     onSave({
       Name: trimmedName,
       Sim: simulator,

--- a/frontend/src/components/tables/config-item-table/config-item-table.tsx
+++ b/frontend/src/components/tables/config-item-table/config-item-table.tsx
@@ -172,10 +172,6 @@ export function ConfigItemTable<TValue>({
   })
 
   useEffect(() => {
-    console.log("added item", addedItem.current)
-  }, [addedItem])
-
-  useEffect(() => {
     if (addedItem.current && data.length === prevDataLength.current + 1) {
       addedItem.current = false
       const lastItem = data[data.length - 1] as IConfigItem

--- a/frontend/src/types/controller.d.ts
+++ b/frontend/src/types/controller.d.ts
@@ -12,4 +12,10 @@ export type Controller = {
   firmwareUpdate?: boolean
 }
 
+export type ControllerBinding = {
+  BoundController: string
+  Status: ControllerBindingStatus
+  OriginalController: string | null
+}
+
 export type ControllerBindingStatus = "Match" | "AutoBind" | "Missing" | "RequiresManualBind"

--- a/frontend/src/types/controller.d.ts
+++ b/frontend/src/types/controller.d.ts
@@ -11,3 +11,5 @@ export type Controller = {
   certified: boolean
   firmwareUpdate?: boolean
 }
+
+export type ControllerBindingStatus = "Match" | "AutoBind" | "Missing" | "RequiresManualBind"

--- a/frontend/src/types/messages.d.ts
+++ b/frontend/src/types/messages.d.ts
@@ -103,7 +103,7 @@ export interface OverlayState {
 }
 
 export interface Notification {
-  Event: string
+  Event: "ControllerAutoBindSuccessful" | "ControllerManualBindRequired" | "ProjectFileExtensionMigrated"
   Guid?: string
   Context: Record<string, string> | null
 }

--- a/frontend/src/types/project.d.ts
+++ b/frontend/src/types/project.d.ts
@@ -25,7 +25,7 @@ export interface ProjectInfo {
   Favorite?: boolean
   Features: ProjectFeatures
   Controllers?: string[]
-
+  ControllerBindings?: Record<string, { Item1: string; Item2: string }>[]
   Aircraft?: {
     Name: string
     Filter: string

--- a/frontend/src/types/project.d.ts
+++ b/frontend/src/types/project.d.ts
@@ -1,4 +1,4 @@
-import { ControllerBindingStatus } from "@/types/controller"
+import { ControllerBinding } from "@/types/controller"
 import { ConfigFile } from "./config"
 
 export interface Project {
@@ -8,7 +8,7 @@ export interface Project {
   Thumbnail?: string
   Sim: "msfs" | "xplane" | "p3d" | "fsx" | "none"
   Features: ProjectFeatures
-  ControllerBindings: Record<string, { Item1: ControllerBindingStatus; Item2: string }>
+  ControllerBindings: ControllerBinding[]
   Aircraft?: {
     Name: string
     Filter: string
@@ -24,7 +24,7 @@ export interface ProjectInfo {
   Sim: string
   Favorite?: boolean
   Features: ProjectFeatures
-  ControllerBindings: Record<string, { Item1: ControllerBindingStatus; Item2: string }>
+  ControllerBindings: ControllerBinding[]
   Aircraft?: {
     Name: string
     Filter: string

--- a/frontend/src/types/project.d.ts
+++ b/frontend/src/types/project.d.ts
@@ -1,3 +1,4 @@
+import { ControllerBindingStatus } from "@/types/controller"
 import { ConfigFile } from "./config"
 
 export interface Project {
@@ -25,7 +26,7 @@ export interface ProjectInfo {
   Favorite?: boolean
   Features: ProjectFeatures
   Controllers?: string[]
-  ControllerBindings?: Record<string, { Item1: string; Item2: string }>[]
+  ControllerBindings: Record<string, { Item1: ControllerBindingStatus; Item2: string }>
   Aircraft?: {
     Name: string
     Filter: string

--- a/frontend/src/types/project.d.ts
+++ b/frontend/src/types/project.d.ts
@@ -8,8 +8,7 @@ export interface Project {
   Thumbnail?: string
   Sim: "msfs" | "xplane" | "p3d" | "fsx" | "none"
   Features: ProjectFeatures
-  Controllers?: string[]
-
+  ControllerBindings: Record<string, { Item1: ControllerBindingStatus; Item2: string }>
   Aircraft?: {
     Name: string
     Filter: string
@@ -25,7 +24,6 @@ export interface ProjectInfo {
   Sim: string
   Favorite?: boolean
   Features: ProjectFeatures
-  Controllers?: string[]
   ControllerBindings: Record<string, { Item1: ControllerBindingStatus; Item2: string }>
   Aircraft?: {
     Name: string

--- a/frontend/tests/Dashboard.spec.ts
+++ b/frontend/tests/Dashboard.spec.ts
@@ -28,12 +28,12 @@ test.describe("Project view tests", () => {
     await dashboardPage.mobiFlightPage.initWithTestDataAndSpecificProjectProps({
       Name: "Test Project",
       Sim: "msfs",
-      Controllers: [
-        "ProtoBoard-v2/ SN-3F1-FDD",
-        "MobiFlight Board / SN-12345",
-        "Alpha Flight Controls / JS-67890",
-        "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000",
-        "miniCOCKPIT miniFCU/ SN-E98-277",
+      ControllerBindings: [
+        { "BoundController": "ProtoBoard-v2/ SN-3F1-FDD", "OriginalController": "ProtoBoard-v2/ SN-3F1-FDD", "Status": "Match" },
+        { "BoundController": "MobiFlight Board / SN-12345", "OriginalController": "MobiFlight Board / SN-12345", "Status": "Match" },
+        { "BoundController": "Alpha Flight Controls / JS-67890", "OriginalController": "Alpha Flight Controls / JS-67890", "Status": "Match" },
+        { "BoundController": "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000", "OriginalController": "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000", "Status": "Match" },
+        { "BoundController": "miniCOCKPIT miniFCU/ SN-E98-277", "OriginalController": "miniCOCKPIT miniFCU/ SN-E98-277", "Status": "Match" },
       ],
     })
 

--- a/frontend/tests/Dashboard.spec.ts
+++ b/frontend/tests/Dashboard.spec.ts
@@ -30,8 +30,8 @@ test.describe("Project view tests", () => {
       Sim: "msfs",
       ControllerBindings: [
         { "BoundController": "ProtoBoard-v2/ SN-3F1-FDD", "OriginalController": "ProtoBoard-v2/ SN-3F1-FDD", "Status": "Match" },
-        { "BoundController": "MobiFlight Board / SN-12345", "OriginalController": "MobiFlight Board / SN-12345", "Status": "Match" },
-        { "BoundController": "Alpha Flight Controls / JS-67890", "OriginalController": "Alpha Flight Controls / JS-67890", "Status": "Match" },
+        { "BoundController": null, "OriginalController": "MobiFlight Board / SN-12345", "Status": "Missing" },
+        { "BoundController": "Alpha Flight Controls / JS-67890", "OriginalController": "Alpha Flight Controls / JS-67891", "Status": "AutoBind" },
         { "BoundController": "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000", "OriginalController": "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000", "Status": "Match" },
         { "BoundController": "miniCOCKPIT miniFCU/ SN-E98-277", "OriginalController": "miniCOCKPIT miniFCU/ SN-E98-277", "Status": "Match" },
       ],
@@ -49,23 +49,23 @@ test.describe("Project view tests", () => {
     await expect(controllerIcons).toHaveCount(5)
     await expect(controllerIcons.nth(0)).toHaveAttribute(
       "title",
-      "ProtoBoard-v2",
+      "ProtoBoard-v2 - Controller connected",
     )
     await expect(controllerIcons.nth(1)).toHaveAttribute(
       "title",
-      "MobiFlight Board",
+      "MobiFlight Board - Controller missing",
     )
     await expect(controllerIcons.nth(2)).toHaveAttribute(
       "title",
-      "Alpha Flight Controls",
+      "Alpha Flight Controls - Auto-bound controller",
     )
     await expect(controllerIcons.nth(3)).toHaveAttribute(
       "title",
-      "Bravo Throttle Quadrant",
+      "Bravo Throttle Quadrant - Controller connected",
     )
     await expect(controllerIcons.nth(4)).toHaveAttribute(
       "title",
-      "miniCOCKPIT miniFCU",
+      "miniCOCKPIT miniFCU - Controller connected",
     )
   })
 

--- a/frontend/tests/General.spec.ts
+++ b/frontend/tests/General.spec.ts
@@ -83,6 +83,29 @@ test.describe("Generic Notifications tests", () => {
     await expect(toastAutoBindControllerSuccessful).toBeVisible()
   })
 
+  test("Confirm Manual Binding Required Notification shows correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData()
+
+    const toastManualBindingRequired  = page.getByTestId(
+      "toast-manual-binding-required",
+    )
+    await expect(toastManualBindingRequired).not.toBeVisible()
+
+    await configListPage.mobiFlightPage.publishMessage({
+      key: "Notification",
+      payload: {
+        Event: "ManualBindingRequired",
+        Context: { Count: "2", Controllers: "Alpha Flight Controls"},
+      },
+    })
+
+    await expect(toastManualBindingRequired).toBeVisible()
+  })
+
   test("Confirm Project File Extension Migrated Notification shows correctly", async ({
     configListPage,
     page,

--- a/frontend/tests/General.spec.ts
+++ b/frontend/tests/General.spec.ts
@@ -98,7 +98,7 @@ test.describe("Generic Notifications tests", () => {
     await configListPage.mobiFlightPage.publishMessage({
       key: "Notification",
       payload: {
-        Event: "ManualBindingRequired",
+        Event: "ControllerManualBindRequired",
         Context: { Count: "2", Controllers: "Alpha Flight Controls"},
       },
     })

--- a/frontend/tests/General.spec.ts
+++ b/frontend/tests/General.spec.ts
@@ -60,27 +60,27 @@ test("Confirm HubHop update notifications show correctly", async ({
 })
 
 test.describe("Generic Notifications tests", () => {
-  test("Confirm Missing Controller Detected Notification shows correctly", async ({
+  test("Confirm Auto-Bind Controller Notification shows correctly", async ({
     configListPage,
     page,
   }) => {
     await configListPage.gotoPage()
     await configListPage.mobiFlightPage.initWithTestData()
 
-    const toastMissingControllerDetected = page.getByTestId(
-      "toast-missing-controllers-detected",
+    const toastAutoBindControllerSuccessful  = page.getByTestId(
+      "toast-autobind-controllers-successful",
     )
-    await expect(toastMissingControllerDetected).not.toBeVisible()
+    await expect(toastAutoBindControllerSuccessful).not.toBeVisible()
 
     await configListPage.mobiFlightPage.publishMessage({
       key: "Notification",
       payload: {
-        Event: "MissingControllerDetected",
-        Context: { Type: "Board" },
+        Event: "ControllerAutoBindSuccessful",
+        Context: { Count: "1", Controllers: "Alpha Flight Controls"},
       },
     })
 
-    await expect(toastMissingControllerDetected).toBeVisible()
+    await expect(toastAutoBindControllerSuccessful).toBeVisible()
   })
 
   test("Confirm Project File Extension Migrated Notification shows correctly", async ({

--- a/frontend/tests/data/project.testdata.json
+++ b/frontend/tests/data/project.testdata.json
@@ -548,13 +548,25 @@
   "FilePath": "tests/data/project.testdata.json",
   "Sim": "msfs",
   "Aircraft": [],
-  "Controllers": [
-    "miniCOCKPIT miniFCU/ SN-E98-277",
-    "ProtoBoard-v2/ SN-3F1-FDD",
-    "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000"
+  "ControllerBindings": [
+    {
+      "BoundController": "miniCOCKPIT miniFCU/ SN-E98-277",
+      "Status": "Match",
+      "OriginalController": null
+    },
+    {
+      "BoundController": "ProtoBoard-v2/ SN-5FC-1CF",
+      "Status": "AutoBind",
+      "OriginalController": "ProtoBoard-v2/ SN-3F1-FDD"
+    },
+    {
+      "BoundController": "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000",
+      "Status": "Missing",
+      "OriginalController": "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000"
+    }
   ],
   "Features": {
-      "FSUIPC": false,
-      "ProSim": false
+    "FSUIPC": false,
+    "ProSim": false
   }
 }

--- a/frontend/tests/data/project.testdata.json
+++ b/frontend/tests/data/project.testdata.json
@@ -552,7 +552,7 @@
     {
       "BoundController": "miniCOCKPIT miniFCU/ SN-E98-277",
       "Status": "Match",
-      "OriginalController": null
+      "OriginalController": "miniCOCKPIT miniFCU/ SN-E98-277"
     },
     {
       "BoundController": "ProtoBoard-v2/ SN-5FC-1CF",
@@ -560,7 +560,12 @@
       "OriginalController": "ProtoBoard-v2/ SN-3F1-FDD"
     },
     {
-      "BoundController": "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000",
+      "BoundController": "Alpha Flight Controls / JS-b0875190-3b89-11ed-8007-444553540000",
+      "Status": "RequiresManualBind",
+      "OriginalController": "Alpha Flight Controls / JS-b0875190-3b89-11ed-8007-444553540000"
+    },
+    {
+      "BoundController": null,
       "Status": "Missing",
       "OriginalController": "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000"
     }

--- a/frontend/tests/data/recentProjects.testdata.json
+++ b/frontend/tests/data/recentProjects.testdata.json
@@ -1,287 +1,326 @@
 [
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Starship-MiniFCU-MiniEFIS-V2.mfproj",
-        "Name": "Starship-MiniFCU+miniEFIS-V1",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Starship-MiniFCU-MiniEFIS-V2.mfproj",
+    "Name": "Starship-MiniFCU+miniEFIS-V1",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\FBW-A320DEV.mfproj",
-        "Name": "FBW-A320DEV",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\FBW-A320DEV.mfproj",
+    "Name": "FBW-A320DEV",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\New Project.mfproj",
-        "Name": "Test",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\New Project.mfproj",
+    "Name": "Test",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\precondition-v1.1-test-migrated-optimized.mfproj",
-        "Name": "New Project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\precondition-v1.1-test-migrated-optimized.mfproj",
+    "Name": "New Project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\CRJ_PUCDUV2_CPT_PROFILE_737NG_KP_9RKoh\\CRJ PU AIR KOREA MCDU  737NG KP CAPTAIN.mcc",
-        "Name": "Air Korea MCDU",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\CRJ_PUCDUV2_CPT_PROFILE_737NG_KP_9RKoh\\CRJ PU AIR KOREA MCDU  737NG KP CAPTAIN.mcc",
+    "Name": "Air Korea MCDU",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Delta_Force_bug_minimum_example_AdvWS.mfproj",
-        "Name": "unsaved",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Delta_Force_bug_minimum_example_AdvWS.mfproj",
+    "Name": "unsaved",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\test-orphaned.mfproj",
-        "Name": "unsaved",
-        "Sim": "msfs",
-        "UseFsuipc": true
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\test-orphaned.mfproj",
+    "Name": "unsaved",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": true,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Mini Overhead SMD - FBW.mfproj",
-        "Name": "Mini Overhead SMD - FBW",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Mini Overhead SMD - FBW.mfproj",
+    "Name": "Mini Overhead SMD - FBW",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\aero2023-combined-display.mfproj",
-        "Name": "aero2023-combined-display",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\aero2023-combined-display.mfproj",
+    "Name": "aero2023-combined-display",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\joystick-workaround.mcc",
-        "Name": "joystick-workaround",
-        "Sim": "msfs",
-        "UseFsuipc": true
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\joystick-workaround.mcc",
+    "Name": "joystick-workaround",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": true,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Homecockpit_C172_v0.9.mfproj",
-        "Name": "Homecockpit_C172",
-        "Sim": "msfs",
-        "UseFsuipc": true
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Homecockpit_C172_v0.9.mfproj",
+    "Name": "Homecockpit_C172",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": true,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\A321 Toliss Extra.mfproj",
-        "Name": "MobiFlight Project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\A321 Toliss Extra.mfproj",
+    "Name": "MobiFlight Project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Saitek-Multi-Panel.mfproj",
-        "Name": "New Project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Saitek-Multi-Panel.mfproj",
+    "Name": "New Project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\flitesim-FFB.mfproj",
-        "Name": "FliteSim FFB Complete Config",
-        "Sim": "xplane",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\flitesim-FFB.mfproj",
+    "Name": "FliteSim FFB Complete Config",
+    "Sim": "xplane",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\wingflex-fcu.mfproj",
-        "Name": "Test project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\wingflex-fcu.mfproj",
+    "Name": "Test project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\wingflex-fcu.migrate.mfproj",
-        "Name": "Test project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\wingflex-fcu.migrate.mfproj",
+    "Name": "Test project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\precondition-v1.1-test.mfproj",
-        "Name": "New Project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\precondition-v1.1-test.mfproj",
+    "Name": "New Project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\merge-multiple.testmfproj.optimized.mfproj",
-        "Name": "Test project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\merge-multiple.testmfproj.optimized.mfproj",
+    "Name": "Test project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\merge-multiple.testmfproj.mfproj",
-        "Name": "Test project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\merge-multiple.testmfproj.mfproj",
+    "Name": "Test project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\precondition-v1.1-test-migrated.mfproj",
-        "Name": "New Project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\precondition-v1.1-test-migrated.mfproj",
+    "Name": "New Project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\aero2023-combined-display.mcc",
-        "Name": "aero2023-combined-display",
-        "Sim": "msfs",
-        "UseFsuipc": true
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\aero2023-combined-display.mcc",
+    "Name": "aero2023-combined-display",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": true,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\dnd.mfproj",
-        "Name": "New Project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\dnd.mfproj",
+    "Name": "New Project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Test-Rename.mfproj",
-        "Name": "Test",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Test-Rename.mfproj",
+    "Name": "Test",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\New Project.mfproj",
-        "Name": "New Project",
-        "Sim": null,
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\New Project.mfproj",
+    "Name": "New Project",
+    "Sim": null,
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Honeycomb-Bravo-Template.mfproj",
-        "Name": "Renamed project",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Honeycomb-Bravo-Template.mfproj",
+    "Name": "Renamed project",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Shop-Test-Demo-Board.mfproj",
-        "Name": "Shop Test",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Shop-Test-Demo-Board.mfproj",
+    "Name": "Shop Test",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
     },
-    {
-        "Aircraft": [],
-        "Favorite": false,
-        "FilePath": ".\\Mini Overhead SMD - FBW.mcc",
-        "Name": "Mini Overhead SMD - FBW",
-        "Sim": "msfs",
-        "Features": {
-            "FSUIPC": false,
-            "ProSim": false
-        }
-    }
+    "ControllerBindings": []
+  },
+  {
+    "Aircraft": [],
+    "Favorite": false,
+    "FilePath": ".\\Mini Overhead SMD - FBW.mcc",
+    "Name": "Mini Overhead SMD - FBW",
+    "Sim": "msfs",
+    "Features": {
+      "FSUIPC": false,
+      "ProSim": false
+    },
+    "ControllerBindings": []
+  }
 ]

--- a/frontend/tests/data/recentProjects.testdata.json
+++ b/frontend/tests/data/recentProjects.testdata.json
@@ -1,10 +1,6 @@
 [
     {
         "Aircraft": [],
-        "Controllers": [
-            "miniCOCKPIT miniFCU/ SN-FF7-AF3",
-            "-"
-        ],
         "Favorite": false,
         "FilePath": ".\\Starship-MiniFCU-MiniEFIS-V2.mfproj",
         "Name": "Starship-MiniFCU+miniEFIS-V1",
@@ -16,12 +12,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "miniCOCKPIT miniFCU/ SN-E98-277",
-            "Spektrum Radio / JS-05727530-0203-11f0-8001-444553540000",
-            "TCA Sidestick X Pilot / JS-70fad9d0-f2e3-11ee-8001-444553540000",
-            "TCA  Quadrant Airbus Pilot / JS-70fb00e0-f2e3-11ee-8002-444553540000"
-        ],
         "Favorite": false,
         "FilePath": ".\\FBW-A320DEV.mfproj",
         "Name": "FBW-A320DEV",
@@ -33,10 +23,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "",
-            "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000"
-        ],
         "Favorite": false,
         "FilePath": ".\\New Project.mfproj",
         "Name": "Test",
@@ -48,9 +34,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-"
-        ],
         "Favorite": false,
         "FilePath": ".\\precondition-v1.1-test-migrated-optimized.mfproj",
         "Name": "New Project",
@@ -62,10 +45,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "PU CDU V2 / JS-1daec020-eca7-11ef-8001-444553540000",
-            ""
-        ],
         "Favorite": false,
         "FilePath": ".\\CRJ_PUCDUV2_CPT_PROFILE_737NG_KP_9RKoh\\CRJ PU AIR KOREA MCDU  737NG KP CAPTAIN.mcc",
         "Name": "Air Korea MCDU",
@@ -77,11 +56,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-",
-            "ProtoBoard-v2/ SN-3F1-FDD",
-            "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000"
-        ],
         "Favorite": false,
         "FilePath": ".\\Delta_Force_bug_minimum_example_AdvWS.mfproj",
         "Name": "unsaved",
@@ -93,9 +67,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "WINWING Orion Joystick Base 2 + JGRIP-F16 / JS-3145ad90-c6f2-11ef-8001-444553540000"
-        ],
         "Favorite": false,
         "FilePath": ".\\test-orphaned.mfproj",
         "Name": "unsaved",
@@ -104,9 +75,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "Mini OverheadSMD/ SN-E46454936324482F"
-        ],
         "Favorite": false,
         "FilePath": ".\\Mini Overhead SMD - FBW.mfproj",
         "Name": "Mini Overhead SMD - FBW",
@@ -118,15 +86,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "",
-            "-",
-            "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000",
-            "Alpha Flight Controls / JS-9da32d30-41e0-11ed-8001-444553540000",
-            "MCDU 1_5/ SN-aaa-15c",
-            "CORE_MCP_v17_3/ SN-ffb-7e7",
-            "CPT_EFIS_v5_3/ SN-a1e-039"
-        ],
         "Favorite": false,
         "FilePath": ".\\aero2023-combined-display.mfproj",
         "Name": "aero2023-combined-display",
@@ -138,11 +97,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-",
-            "ProtoBoard-v2/ SN-777-0BC",
-            "MobiFlight Mega/ SN-B1C-682"
-        ],
         "Favorite": false,
         "FilePath": ".\\joystick-workaround.mcc",
         "Name": "joystick-workaround",
@@ -151,12 +105,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-",
-            "C172RadioStack/ SN-c2b-a22",
-            "C172Left/ SN-33a-cbd",
-            ""
-        ],
         "Favorite": false,
         "FilePath": ".\\Homecockpit_C172_v0.9.mfproj",
         "Name": "Homecockpit_C172",
@@ -165,15 +113,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "WINWING FCU-320 / JS-8f2dfb10-fd8f-11ee-8001-444553540000",
-            "-",
-            "PFC Radio Module/ SN-777-0BC",
-            "Cessna Panel 2855 / JS-cb4c6870-85f8-11ee-8004-444553540000",
-            "T.A320 Pilot / JS-4e284670-85f8-11ee-8002-444553540000",
-            "Warning Panel/ SN-6GD-1BB",
-            ""
-        ],
         "Favorite": false,
         "FilePath": ".\\A321 Toliss Extra.mfproj",
         "Name": "MobiFlight Project",
@@ -185,10 +124,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-",
-            "Pro Flight Multi Panel / JS-\\\\?\\hid#vid_06a3&pid_0d06#a&27a27da8&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}"
-        ],
         "Favorite": false,
         "FilePath": ".\\Saitek-Multi-Panel.mfproj",
         "Name": "New Project",
@@ -200,9 +135,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "FliteSim FFB (UDP) / JS-UDP-FFB"
-        ],
         "Favorite": false,
         "FilePath": ".\\flitesim-FFB.mfproj",
         "Name": "FliteSim FFB Complete Config",
@@ -214,11 +146,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-",
-            "FCU Cube / JS-5CEE68613138",
-            ""
-        ],
         "Favorite": false,
         "FilePath": ".\\wingflex-fcu.mfproj",
         "Name": "Test project",
@@ -230,11 +157,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-",
-            "FCU Cube / JS-5CEE68613138",
-            ""
-        ],
         "Favorite": false,
         "FilePath": ".\\wingflex-fcu.migrate.mfproj",
         "Name": "Test project",
@@ -246,9 +168,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-"
-        ],
         "Favorite": false,
         "FilePath": ".\\precondition-v1.1-test.mfproj",
         "Name": "New Project",
@@ -260,10 +179,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "",
-            "FCU Cube / JS-5CEE68613138"
-        ],
         "Favorite": false,
         "FilePath": ".\\merge-multiple.testmfproj.optimized.mfproj",
         "Name": "Test project",
@@ -275,10 +190,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "",
-            "FCU Cube / JS-5CEE68613138"
-        ],
         "Favorite": false,
         "FilePath": ".\\merge-multiple.testmfproj.mfproj",
         "Name": "Test project",
@@ -290,9 +201,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-"
-        ],
         "Favorite": false,
         "FilePath": ".\\precondition-v1.1-test-migrated.mfproj",
         "Name": "New Project",
@@ -304,15 +212,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "MCDU 1_5/ SN-aaa-15c",
-            "CORE_MCP_v17_3/ SN-ffb-7e7",
-            "CPT_EFIS_v5_3/ SN-a1e-039",
-            "-",
-            "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000",
-            "Alpha Flight Controls / JS-9da32d30-41e0-11ed-8001-444553540000",
-            ""
-        ],
         "Favorite": false,
         "FilePath": ".\\aero2023-combined-display.mcc",
         "Name": "aero2023-combined-display",
@@ -321,10 +220,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "-",
-            ""
-        ],
         "Favorite": false,
         "FilePath": ".\\dnd.mfproj",
         "Name": "New Project",
@@ -336,9 +231,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            ""
-        ],
         "Favorite": false,
         "FilePath": ".\\Test-Rename.mfproj",
         "Name": "Test",
@@ -350,9 +242,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "MPK mini 3 / MI-163179739"
-        ],
         "Favorite": false,
         "FilePath": ".\\New Project.mfproj",
         "Name": "New Project",
@@ -364,9 +253,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "Bravo Throttle Quadrant / JS-b0875190-3b89-11ed-8007-444553540000"
-        ],
         "Favorite": false,
         "FilePath": ".\\Honeycomb-Bravo-Template.mfproj",
         "Name": "Renamed project",
@@ -378,9 +264,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "ProtoBoard-v2/ SN-3F1-FDD"
-        ],
         "Favorite": false,
         "FilePath": ".\\Shop-Test-Demo-Board.mfproj",
         "Name": "Shop Test",
@@ -392,9 +275,6 @@
     },
     {
         "Aircraft": [],
-        "Controllers": [
-            "Mini OverheadSMD/ SN-E4627CA7130D1D33"
-        ],
         "Favorite": false,
         "FilePath": ".\\Mini Overhead SMD - FBW.mcc",
         "Name": "Mini Overhead SMD - FBW",

--- a/frontend/tests/fixtures/MobiFlightPage.ts
+++ b/frontend/tests/fixtures/MobiFlightPage.ts
@@ -117,7 +117,8 @@ export class MobiFlightPage {
         Features: {
             "FSUIPC": false,
             "ProSim": false
-        }
+        },
+        ControllerBindings: [],
       } as Project,
     }
     await this.publishMessage(message)


### PR DESCRIPTION
<img width="530" height="742" alt="image" src="https://github.com/user-attachments/assets/919c1e40-012c-4b94-b0e8-5c8ffd5174a6" />

<img width="1477" height="215" alt="image" src="https://github.com/user-attachments/assets/60156337-811f-4db8-abaf-0f1898d687e9" />

<img width="845" height="166" alt="image" src="https://github.com/user-attachments/assets/107a771d-03be-484c-a1ba-9977c782308e" />

### Scenarios
- [x] 1 - Exact match: Controller type, name and serial match
- [x] 2 - Partial match: Controller type and name matches, but serial doesn't
  - [x] Toast  - **Auto-bind**
  - [x] Controller Icon Indication - **Auto-bind**
- [x] 3 - Partial match: Controller type and serial matches, but name doesn't
  - [x] Toast  - **Auto-bind**
  - [x] Controller Icon Indication
- [x] 4 - Missing: Type and name in profile not found among connected devices.
  - [x] Controller Icon Indication - **Missing**
- [x] 5 - Multiple devices of the same type and name connected, but no serial match for any.
- [x] 6: Multiple Type and name matches, but serial differs, and only one device of that type is connected.
  - [x] Toast  - **Auto-bind**
  - [x] Controller Icon Indication - **Auto-bind**
- [x] 7: A profile contains multiple controllers with same type and name/serial, and now one of them is missing.
  - [x] Controller Icon Indication - **Missing**

### DoD

- [x] i18n
- [x] unit tests
- [x] frontend tests

fixes #2535 