### PR TITLE
Fix config exception for old projects where no sim can be auto-detected

### DIFF
--- a/UI/Dialogs/ConfigWizard.cs
+++ b/UI/Dialogs/ConfigWizard.cs
@@ -123,7 +123,7 @@ namespace MobiFlight.UI.Dialogs
 
         private void ShowSourceOptionsBasedOnProjectInfo(ProjectInfo projectInfo)
         {
-            var sim = projectInfo.Sim.Trim().ToLower();
+            var sim = projectInfo.Sim?.Trim().ToLower();
             var useFsuipc = (projectInfo?.Features?.FSUIPC ?? false) || sim == "p3d" || sim == "fsx";
             var useProSim = (projectInfo?.Features?.ProSim ?? false);
 

--- a/UI/Panels/Config/ActionTypePanel.cs
+++ b/UI/Panels/Config/ActionTypePanel.cs
@@ -44,7 +44,7 @@ namespace MobiFlight.UI.Panels.Config
             ActionTypeComboBox.Items.Clear();
             ActionTypeComboBox.Items.Add(i18n._tr("none"));
 
-            var sim = projectInfo?.Sim.Trim().ToLower();
+            var sim = projectInfo?.Sim?.Trim().ToLower();
             var showAllOptions = projectInfo == null;
 
             var currentConfigUsesFsuipc = ConfigFile.ContainsConfigOfSourceType(new List<IConfigItem>() { CurrentConfig }, new FsuipcSource());


### PR DESCRIPTION
When the config is only using FSUIPC, it is impossible to tell for which sim (msfs, p3d, fsx) it was originally created.
This PR prevents an exception for those projects when opening a config (input or output).

fixes #2578 