### PR TITLE
Output Input Action correctly displays only sim specific options

### DIFF
--- a/UI/Panels/OutputWizard/DisplayPanel.cs
+++ b/UI/Panels/OutputWizard/DisplayPanel.cs
@@ -162,7 +162,10 @@ namespace MobiFlight.UI.Panels.OutputWizard
             }
             else
             {
+                analogPanel1.ProjectInfo = _execManager.Project.ToProjectInfo();
                 analogPanel1.syncFromConfig(config.AnalogInputConfig);
+
+                buttonPanel1.ProjectInfo = _execManager.Project.ToProjectInfo();
                 buttonPanel1.syncFromConfig(config.ButtonInputConfig);
 
                 InputTypeButtonRadioButton.Checked = config.AnalogInputConfig?.onChange == null;


### PR DESCRIPTION
This PR fixes issue https://github.com/MobiFlight/MobiFlight-Connector/issues/2569 by ensuring that the Output Input Action configuration panels correctly display only simulator-specific options. The fix sets the ProjectInfo property on both button and analog input panels when users toggle between input types, enabling the action panels to filter available actions based on the project's configured simulator.

Key Changes:
- initialize the action type panel correctly with the current project settings information

fixes #2569 