### PR TITLE
Downgrade Newtonsoft JSON to 13.0.3

### DIFF
--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -165,7 +165,7 @@
       <HintPath>lib\NCalc.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json.Schema, Version=4.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
       <HintPath>packages\Newtonsoft.Json.Schema.4.0.1\lib\net45\Newtonsoft.Json.Schema.dll</HintPath>

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -140,7 +140,7 @@
       <HintPath>..\packages\MSTest.TestFramework.4.0.2\lib\net462\MSTest.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.13.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.13.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX, Version=4.2.0.0, Culture=neutral, PublicKeyToken=b4dcf0f35e5521f1, processorArchitecture=MSIL">
       <HintPath>..\packages\SharpDX.4.2.0\lib\net45\SharpDX.dll</HintPath>

--- a/MobiFlightUnitTests/packages.config
+++ b/MobiFlightUnitTests/packages.config
@@ -20,7 +20,7 @@
   <package id="MSTest.Analyzers" version="4.0.2" targetFramework="net48" developmentDependency="true" />
   <package id="MSTest.TestAdapter" version="4.0.2" targetFramework="net48" />
   <package id="MSTest.TestFramework" version="4.0.2" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net48" />

--- a/packages.config
+++ b/packages.config
@@ -12,7 +12,7 @@
   <package id="Microsoft.ApplicationInsights" version="2.23.0" targetFramework="net48" />
   <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.23.0" targetFramework="net48" />
   <package id="Microsoft.Web.WebView2" version="1.0.3650.58" targetFramework="net48" />
-  <package id="Newtonsoft.Json" version="13.0.4" targetFramework="net48" />
+  <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net48" />
   <package id="Newtonsoft.Json.Schema" version="4.0.1" targetFramework="net48" />
   <package id="protobuf-net" version="3.2.56" targetFramework="net48" />
   <package id="protobuf-net.Core" version="3.2.56" targetFramework="net48" />


### PR DESCRIPTION
This PR downgrades the Newtonsoft.Json dependency from version 13.0.4 to 13.0.3 to resolve a compatibility issue with older Newtonsoft.Json versions installed in the Windows Global Assembly Cache (GAC), which was causing exceptions when saving configurations.

We are waiting for 13.0.5 which will likely fix the issue. See: 
- https://github.com/JamesNK/Newtonsoft.Json/issues/3084
- https://github.com/JamesNK/Newtonsoft.Json/pull/3092

fixes #2602 