### PR TITLE
Fix issue with always using Fenix Script for CDU

### DIFF
--- a/MobiFlight/Scripts/ScriptRunner.cs
+++ b/MobiFlight/Scripts/ScriptRunner.cs
@@ -338,7 +338,6 @@ namespace MobiFlight.Scripts
             Log.Instance.log($"ScriptRunner - Start().", LogSeverity.Debug);
             IsInPlayMode = true;
             string currentAircraftDescription = MsfsCache.IsConnected() ? AircraftPath : AircraftName;
-            currentAircraftDescription = "_fnx_3_";
             NewAircraftRequestQueue.Enqueue(currentAircraftDescription);
             Task myTask = Task.Run(async () => { await ProcessAircraftRequests(CancellationTokenSource.Token); });
         }


### PR DESCRIPTION
This PR fixes a bug where the ScriptRunner was always using a hardcoded Fenix aircraft identifier (_fnx_3_), regardless of the actual aircraft being flown. The issue was caused by debug/test code that was accidentally left in the codebase.

fixes #2605 