### PR TITLE
ini a340: Add special character mapping for 'p'

### DIFF
--- a/Scripts/Winwing/ini_a340_winwing_cdu.py
+++ b/Scripts/Winwing/ini_a340_winwing_cdu.py
@@ -11,7 +11,7 @@ FO_MCDU_URL = "ws://localhost:8320/winwing/cdu-co-pilot"
 MCDU_FLAG_SMALL_FONT = 0x01
 
 MCDU_COLOR_MAP = {0:"w",1:"c",2:"a",3:"g",4:"e",5:"r",6:"y",7:"m"}
-special_chars = {'a':'←','b':'→','e':'↑','f':'↓','o':'☐','d':'°','c':'Δ'}
+special_chars = {'a':'←','b':'→','e':'↑','f':'↓','o':'☐','d':'°','c':'Δ','p':'■'}
 
 MCDU_COLUMNS, MCDU_ROWS = 24, 14
 MCDU_CHARS = MCDU_COLUMNS * MCDU_ROWS


### PR DESCRIPTION
This is used during brightness adjustment.

Ingame: 
<img width="433" height="339" alt="image" src="https://github.com/user-attachments/assets/a5733758-ead3-455a-892d-9172cac3f666" />

Now:
<img width="673" height="812" alt="image" src="https://github.com/user-attachments/assets/20c1adb0-6217-4294-a588-9bac6b8b374e" />


Fixed:
<img width="683" height="671" alt="image" src="https://github.com/user-attachments/assets/37e6f3b2-82f6-4288-b79f-9a0074dee6f1" />
