### PR TITLE
Fix issue with missing Community Info

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -255,7 +255,6 @@ namespace MobiFlight
                 connectedControllers.Add(new Controller()
                 {
                     Name = module.Name,
-                    Vendor = module.Board.Info.Community.Project,
                     Connected = true,
                     Serial = module.Serial
                 });


### PR DESCRIPTION
Remove the unused vendor information when sending the connected controller information.

part of #2634 