### PR TITLE
For Winctrl FCU and PAP 3 do not retrigger on connect

### DIFF
--- a/MobiFlight/Joysticks/Winwing/WinwingFcu.cs
+++ b/MobiFlight/Joysticks/Winwing/WinwingFcu.cs
@@ -165,9 +165,9 @@ namespace MobiFlight.Joysticks.Winwing
 
                 if (DoRetrigger)
                 {
-                    PreviousReport.ButtonState = ~PreviousReport.ButtonState; // to retrigger
-                    PreviousReport.ButtonState2 = ~PreviousReport.ButtonState2; // to retrigger
-                    PreviousReport.ButtonState3 = ~PreviousReport.ButtonState3; // to retrigger
+                    PreviousReport.ButtonState = ~CurrentReport.ButtonState; // to retrigger
+                    PreviousReport.ButtonState2 = ~CurrentReport.ButtonState2; // to retrigger
+                    PreviousReport.ButtonState3 = ~CurrentReport.ButtonState3; // to retrigger
                     DoRetrigger = false;
                 }
 

--- a/MobiFlight/Joysticks/Winwing/WinwingPap3.cs
+++ b/MobiFlight/Joysticks/Winwing/WinwingPap3.cs
@@ -161,9 +161,9 @@ namespace MobiFlight.Joysticks.Winwing
 
                 if (DoRetrigger)
                 {
-                    PreviousReport.ButtonState = ~PreviousReport.ButtonState; // to retrigger
-                    PreviousReport.ButtonState2 = ~PreviousReport.ButtonState2; // to retrigger
-                    PreviousReport.ButtonState3 = ~PreviousReport.ButtonState3; // to retrigger
+                    PreviousReport.ButtonState = ~CurrentReport.ButtonState; // to retrigger
+                    PreviousReport.ButtonState2 = ~CurrentReport.ButtonState2; // to retrigger
+                    PreviousReport.ButtonState3 = ~CurrentReport.ButtonState3; // to retrigger
                     DoRetrigger = false;
                 }
 


### PR DESCRIPTION
Fixes https://github.com/MobiFlight/MobiFlight-Connector/issues/2382 by preventing Winwing FCU and PAP 3 from implicitly retriggering all button states during initial connection/startup when Auto-retrigger is OFF.

**Changes:**

- Introduced a separate DoRetrigger flag to decouple first-report initialization from explicit retrigger behavior.
- Updated HID report handling so startup only initializes previous state (no forced edge generation).
- Changed Retrigger() to set DoRetrigger instead of reusing DoInitialize.