### PR TITLE
Improve Project List behavior

### DIFF
--- a/Base/ProjectListManager.cs
+++ b/Base/ProjectListManager.cs
@@ -1,6 +1,7 @@
 ﻿using MobiFlight.Controllers;
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -21,7 +22,7 @@ namespace MobiFlight.Base
         /// <summary>
         /// Cache of ProjectInfo objects to avoid redundant disk I/O
         /// </summary>
-        private Dictionary<string, ProjectInfo> projectInfoCache = new Dictionary<string, ProjectInfo>();
+        private readonly Dictionary<string, ProjectInfo> projectInfoCache = new Dictionary<string, ProjectInfo>();
 
         /// <summary>
         /// Event raised when the project list changes
@@ -53,7 +54,7 @@ namespace MobiFlight.Base
             }
             catch (Exception ex)
             {
-                Log.Instance.log($"Exception during fetching project info for project list", LogSeverity.Error);
+                Log.Instance.log($"Exception during fetching project info for project list. {ex.Message}", LogSeverity.Error);
             }
 
             // Notify that initialization is complete

--- a/Base/ProjectListManager.cs
+++ b/Base/ProjectListManager.cs
@@ -1,0 +1,132 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MobiFlight.Base
+{
+    /// <summary>
+    /// Manages both the MRU RecentFiles list and the stable ProjectList for UI display
+    /// </summary>
+    public class ProjectListManager
+    {
+        /// <summary>
+        /// Stable list for UI - new projects added at top, existing items never reordered
+        /// </summary>
+        private List<string> projectListFiles = new List<string>();
+
+        /// <summary>
+        /// Initializes both lists from the RecentFiles setting
+        /// </summary>
+        public void InitializeFromSettings()
+        {
+            projectListFiles = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
+        }
+
+        /// <summary>
+        /// Adds a project to both the MRU RecentFiles and the stable project list
+        /// </summary>
+        public void OpenProject(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath?.Trim())) return;
+
+            // Update MRU RecentFiles (always reorder)
+            if (Properties.Settings.Default.RecentFiles.Contains(filePath))
+            {
+                Properties.Settings.Default.RecentFiles.Remove(filePath);
+            }
+            Properties.Settings.Default.RecentFiles.Insert(0, filePath);
+
+            // Update stable project list (no reorder, only add if new)
+            if (!projectListFiles.Contains(filePath))
+            {
+                projectListFiles.Insert(0, filePath);
+            }
+
+            Properties.Settings.Default.Save();
+        }
+
+        /// <summary>
+        /// Removes a project from both lists by file path
+        /// </summary>
+        public void RemoveProject(string filePath)
+        {
+            if (string.IsNullOrEmpty(filePath)) return;
+
+            Properties.Settings.Default.RecentFiles.Remove(filePath);
+            projectListFiles.Remove(filePath);
+            Properties.Settings.Default.Save();
+        }
+
+        internal void RemoveProjectByIndex(int index)
+        {
+            if (index < 0 || index >= projectListFiles.Count) return;
+
+            var filePath = projectListFiles[index];
+            RemoveProject(filePath);
+        }
+
+        /// <summary>
+        /// Removes missing files from both lists
+        /// </summary>
+        public void RemoveMissingFiles(IEnumerable<string> missingFiles)
+        {
+            if (missingFiles == null) return;
+
+            foreach (var file in missingFiles)
+            {
+                Properties.Settings.Default.RecentFiles.Remove(file);
+                projectListFiles.Remove(file);
+            }
+
+            Properties.Settings.Default.Save();
+        }
+
+        /// <summary>
+        /// Gets the stable project list as file paths
+        /// </summary>
+        public List<string> GetProjectFiles()
+        {
+            return projectListFiles.ToList();
+        }
+
+        /// <summary>
+        /// Removes non-existing files from both lists asynchronously
+        /// </summary>
+        public async Task CleanMissingFilesAsync()
+        {
+            var snapshot = projectListFiles.ToList();
+            var missingFiles = await Task.Run(() => CheckForMissingFiles(snapshot)).ConfigureAwait(false);
+
+            if (missingFiles.Count == 0) return;
+
+            RemoveMissingFiles(missingFiles);
+        }
+
+        /// <summary>
+        /// Checks which files from the provided list don't exist or are inaccessible
+        /// </summary>
+        public static List<string> CheckForMissingFiles(IEnumerable<string> files)
+        {
+            var missingFiles = new List<string>();
+            if (files == null) return missingFiles;
+
+            foreach (var f in files)
+            {
+                try
+                {
+                    if (string.IsNullOrWhiteSpace(f) || !File.Exists(f))
+                        missingFiles.Add(f);
+                }
+                catch
+                {
+                    // Treat IO errors as missing; keep scanning
+                    missingFiles.Add(f);
+                }
+            }
+
+            return missingFiles;
+        }
+    }
+}

--- a/Base/ProjectListManager.cs
+++ b/Base/ProjectListManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MobiFlight.Controllers;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,7 +8,8 @@ using System.Threading.Tasks;
 namespace MobiFlight.Base
 {
     /// <summary>
-    /// Manages both the MRU RecentFiles list and the stable ProjectList for UI display
+    /// Manages both the MRU RecentFiles list and the stable ProjectList for UI display,
+    /// with caching to avoid redundant disk I/O
     /// </summary>
     public class ProjectListManager
     {
@@ -17,19 +19,90 @@ namespace MobiFlight.Base
         private List<string> projectListFiles = new List<string>();
 
         /// <summary>
-        /// Initializes both lists from the RecentFiles setting
+        /// Cache of ProjectInfo objects to avoid redundant disk I/O
         /// </summary>
-        public void InitializeFromSettings()
+        private Dictionary<string, ProjectInfo> projectInfoCache = new Dictionary<string, ProjectInfo>();
+
+        /// <summary>
+        /// Event raised when the project list changes
+        /// </summary>
+        public event EventHandler ProjectListChanged;
+
+        /// <summary>
+        /// Initializes the project list from settings, cleans missing files, and loads project infos into cache
+        /// </summary>
+        public async Task InitializeFromSettingsAsync(ControllerBindingService controllerBindingService = null)
         {
-            projectListFiles = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
+            projectListFiles = Properties.Settings.Default.RecentFiles?.Cast<string>().ToList() ?? new List<string>();
+            projectInfoCache.Clear();
+
+            // Clean missing files
+            try
+            {
+                await CleanMissingFilesAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log($"Exception cleaning project files: {ex.Message}", LogSeverity.Error);
+            }
+
+            try
+            {
+                // Load all project infos in parallel to populate cache
+                await LoadAllProjectInfosAsync(controllerBindingService).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log($"Exception during fetching project info for project list", LogSeverity.Error);
+            }
+
+            // Notify that initialization is complete
+            ProjectListChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Loads all project files and populates the cache in parallel
+        /// </summary>
+        private async Task LoadAllProjectInfosAsync(ControllerBindingService controllerBindingService)
+        {
+            if (projectListFiles.Count == 0) return;
+
+            var loadTasks = projectListFiles.Select(async projectPath =>
+            {
+                try
+                {
+                    var p = new Project();
+                    p.FilePath = projectPath;
+                    p.OpenFile(suppressMigrationLogging: true);
+                    p.DetermineProjectInfos();
+                    controllerBindingService?.PerformAutoBinding(p);
+
+                    var projectInfo = p.ToProjectInfo();
+                    projectInfoCache[projectPath] = projectInfo;
+
+                    return projectInfo;
+                }
+                catch (Exception ex)
+                {
+                    Log.Instance.log($"Could not load recent project file {projectPath}: {ex.Message}", LogSeverity.Warn);
+                    return null;
+                }
+            }).ToList();
+
+            await Task.WhenAll(loadTasks);
         }
 
         /// <summary>
         /// Adds a project to both the MRU RecentFiles and the stable project list
         /// </summary>
-        public void OpenProject(string filePath)
+        public void OpenProject(ProjectInfo projectInfo)
         {
+            var filePath = projectInfo?.FilePath;
+
             if (string.IsNullOrEmpty(filePath?.Trim())) return;
+
+            // Update cache with the loaded project
+            projectInfoCache[filePath] = projectInfo;
 
             // Update MRU RecentFiles (always reorder)
             if (Properties.Settings.Default.RecentFiles.Contains(filePath))
@@ -45,10 +118,42 @@ namespace MobiFlight.Base
             }
 
             Properties.Settings.Default.Save();
+
+            ProjectListChanged?.Invoke(this, EventArgs.Empty);
         }
 
         /// <summary>
-        /// Removes a project from both lists by file path
+        /// Updates the cached ProjectInfo for a specific project
+        /// </summary>
+        public void UpdateProjectInfo(ProjectInfo projectInfo)
+        {
+            if (projectInfo == null || string.IsNullOrEmpty(projectInfo.FilePath)) return;
+
+            projectInfoCache[projectInfo.FilePath] = projectInfo;
+
+            ProjectListChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        /// <summary>
+        /// Gets the stable project list as ProjectInfo objects (from cache)
+        /// </summary>
+        public List<ProjectInfo> GetProjects()
+        {
+            var result = new List<ProjectInfo>();
+
+            foreach (var filePath in projectListFiles)
+            {
+                if (projectInfoCache.TryGetValue(filePath, out var projectInfo))
+                {
+                    result.Add(projectInfo);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Removes a project from both lists and cache by file path
         /// </summary>
         public void RemoveProject(string filePath)
         {
@@ -56,7 +161,10 @@ namespace MobiFlight.Base
 
             Properties.Settings.Default.RecentFiles.Remove(filePath);
             projectListFiles.Remove(filePath);
+            projectInfoCache.Remove(filePath);
             Properties.Settings.Default.Save();
+
+            ProjectListChanged?.Invoke(this, EventArgs.Empty);
         }
 
         internal void RemoveProjectByIndex(int index)
@@ -68,27 +176,26 @@ namespace MobiFlight.Base
         }
 
         /// <summary>
-        /// Removes missing files from both lists
+        /// Removes missing files from both lists and cache
         /// </summary>
         public void RemoveMissingFiles(IEnumerable<string> missingFiles)
         {
             if (missingFiles == null) return;
 
+            bool changed = false;
             foreach (var file in missingFiles)
             {
                 Properties.Settings.Default.RecentFiles.Remove(file);
                 projectListFiles.Remove(file);
+                projectInfoCache.Remove(file);
+                changed = true;
             }
 
-            Properties.Settings.Default.Save();
-        }
-
-        /// <summary>
-        /// Gets the stable project list as file paths
-        /// </summary>
-        public List<string> GetProjectFiles()
-        {
-            return projectListFiles.ToList();
+            if (changed)
+            {
+                Properties.Settings.Default.Save();
+                ProjectListChanged?.Invoke(this, EventArgs.Empty);
+            }
         }
 
         /// <summary>

--- a/Base/ProjectListManager.cs
+++ b/Base/ProjectListManager.cs
@@ -67,29 +67,27 @@ namespace MobiFlight.Base
         {
             if (projectListFiles.Count == 0) return;
 
-            var loadTasks = projectListFiles.Select(async projectPath =>
+            foreach (var projectPath in projectListFiles)
             {
-                try
+                await Task.Run(() =>
                 {
-                    var p = new Project();
-                    p.FilePath = projectPath;
-                    p.OpenFile(suppressMigrationLogging: true);
-                    p.DetermineProjectInfos();
-                    controllerBindingService?.PerformAutoBinding(p);
+                    try
+                    {
+                        var p = new Project();
+                        p.FilePath = projectPath;
+                        p.OpenFile(suppressMigrationLogging: true);
+                        p.DetermineProjectInfos();
+                        controllerBindingService?.PerformAutoBinding(p);
 
-                    var projectInfo = p.ToProjectInfo();
-                    projectInfoCache[projectPath] = projectInfo;
-
-                    return projectInfo;
-                }
-                catch (Exception ex)
-                {
-                    Log.Instance.log($"Could not load recent project file {projectPath}: {ex.Message}", LogSeverity.Warn);
-                    return null;
-                }
-            }).ToList();
-
-            await Task.WhenAll(loadTasks);
+                        var projectInfo = p.ToProjectInfo();
+                        projectInfoCache[projectPath] = projectInfo;
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Instance.log($"Could not load recent project file {projectPath}: {ex.Message}", LogSeverity.Warn);
+                    }
+                }).ConfigureAwait(false);
+            }
         }
 
         /// <summary>

--- a/MobiFlight/Controllers/ControllerBindingService.cs
+++ b/MobiFlight/Controllers/ControllerBindingService.cs
@@ -46,9 +46,10 @@ namespace MobiFlight.Controllers
 
         /// <summary>
         /// Performs auto-binding and modifies config items
+        /// it is virtual for mocking in unit tests
         /// Returns: Dictionary mapping ModuleSerial -> ControllerBindingStatus
         /// </summary>
-        public List<ControllerBinding> PerformAutoBinding(Project project)
+        public virtual List<ControllerBinding> PerformAutoBinding(Project project)
         {
             var connectedControllers = GetAllConnectedControllers();
             var binder = new ControllerAutoBinder(connectedControllers);

--- a/MobiFlight/Controllers/ControllerBindingService.cs
+++ b/MobiFlight/Controllers/ControllerBindingService.cs
@@ -45,9 +45,11 @@ namespace MobiFlight.Controllers
         }
 
         /// <summary>
-        /// Performs auto-binding and modifies config items
-        /// it is virtual for mocking in unit tests
-        /// Returns: Dictionary mapping ModuleSerial -> ControllerBindingStatus
+        /// Performs auto-binding for all config files in the given project and
+        /// modifies the corresponding config items. This method is virtual to
+        /// simplify mocking in unit tests.
+        /// Returns: List of ControllerBinding results for the entire project and
+        /// updates project.ControllerBindings with the same list.
         /// </summary>
         public virtual List<ControllerBinding> PerformAutoBinding(Project project)
         {

--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -304,6 +304,7 @@
     <Compile Include="Base\Migration\Precondition_V_0_9_Migration.cs" />
     <Compile Include="Base\ObservableObject.cs" />
     <Compile Include="Base\Project.cs" />
+    <Compile Include="Base\ProjectListManager.cs" />
     <Compile Include="Base\Serialization\Json\DeviceConfigConverter.cs" />
     <Compile Include="Base\Serialization\Json\ConfigValueOnlyItemConverter.cs" />
     <Compile Include="Base\Serialization\Json\PreconditionConverter.cs" />

--- a/MobiFlightUnitTests/Base/ProjectListManagerTests.cs
+++ b/MobiFlightUnitTests/Base/ProjectListManagerTests.cs
@@ -1,6 +1,10 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.Controllers;
+using Moq;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -10,6 +14,8 @@ namespace MobiFlight.Base.Tests
     public class ProjectListManagerTests
     {
         private StringCollection originalRecentFiles;
+        private Mock<ControllerBindingService> mockBindingService;
+        private string _tempDirectory;
 
         [TestInitialize]
         public void Setup()
@@ -17,8 +23,15 @@ namespace MobiFlight.Base.Tests
             // Save original RecentFiles
             originalRecentFiles = Properties.Settings.Default.RecentFiles;
 
+            mockBindingService = new Mock<ControllerBindingService>(null);
+            mockBindingService.Setup(x => x.PerformAutoBinding(It.IsAny<Project>())).Returns(new List<ControllerBinding>());
+
             // Initialize with clean state
             Properties.Settings.Default.RecentFiles = new StringCollection();
+
+            // Create a temporary test directory
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "ProjectMigrationTests", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_tempDirectory);
         }
 
         [TestCleanup]
@@ -27,313 +40,369 @@ namespace MobiFlight.Base.Tests
             // Restore original RecentFiles
             Properties.Settings.Default.RecentFiles = originalRecentFiles;
             Properties.Settings.Default.Save();
+
+            try
+            {
+                // Clean up test directory
+                if (Directory.Exists(_tempDirectory))
+                {
+                    Directory.Delete(_tempDirectory, true);
+                }
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Helper method to create a temporary test file
+        /// </summary>
+        private string CreateTestFile(string fileName)
+        {
+            var filePath = Path.Combine(_tempDirectory, fileName);
+            var testProject = new Project() { FilePath = filePath };
+            testProject.SaveFile();
+            return filePath;
         }
 
         [TestMethod()]
-        public void InitializeFromSettings_WithEmptyRecentFiles_ShouldCreateEmptyList()
+        public async Task InitializeFromSettings_WithEmptyRecentFiles_ShouldCreateEmptyList()
         {
             // Arrange
             var manager = new ProjectListManager();
 
             // Act
-            manager.InitializeFromSettings();
-            var result = manager.GetProjectFiles();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
+            var result = manager.GetProjects();
 
             // Assert
             Assert.IsEmpty(result, "Project list should be empty");
         }
 
         [TestMethod()]
-        public void InitializeFromSettings_WithExistingFiles_ShouldCopyToProjectList()
+        public async Task InitializeFromSettings_WithExistingFiles_ShouldCopyToProjectList()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            var project2 = CreateTestFile("project2.mfproj");
+            Properties.Settings.Default.RecentFiles.Add(project1);
+            Properties.Settings.Default.RecentFiles.Add(project2);
             var manager = new ProjectListManager();
 
             // Act
-            manager.InitializeFromSettings();
-            var result = manager.GetProjectFiles();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
+            var result = manager.GetProjects();
 
             // Assert
             Assert.HasCount(2, result, "Should have 2 projects");
-            Assert.AreEqual("C:\\project1.mfproj", result[0]);
-            Assert.AreEqual("C:\\project2.mfproj", result[1]);
+            Assert.AreEqual(project1, result[0].FilePath);
+            Assert.AreEqual(project2, result[1].FilePath);
         }
 
         [TestMethod()]
-        public void OpenProject_WithNewFile_ShouldAddToTopOfBothLists()
+        public async Task OpenProject_WithNewFile_ShouldAddToTopOfBothLists()
         {
             // Arrange
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
+            var newFile = CreateTestFile("new.mfproj");
 
             // Act
-            manager.OpenProject("C:\\new.mfproj");
+            manager.OpenProject(new ProjectInfo() { FilePath = newFile });
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(1, projectFiles, "Should have 1 project in stable list");
-            Assert.AreEqual("C:\\new.mfproj", projectFiles[0]);
+            Assert.AreEqual(newFile, projectFiles[0].FilePath);
 
             Assert.HasCount(1, Properties.Settings.Default.RecentFiles, "Should have 1 in RecentFiles");
-            Assert.AreEqual("C:\\new.mfproj", Properties.Settings.Default.RecentFiles[0]);
+            Assert.AreEqual(newFile, Properties.Settings.Default.RecentFiles[0]);
         }
 
         [TestMethod()]
-        public void OpenProject_WithExistingFileInRecentFiles_ShouldReorderRecentFilesButNotProjectList()
+        public async Task OpenProject_WithExistingFileInRecentFiles_ShouldReorderRecentFilesButNotProjectList()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project3.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            var project2 = CreateTestFile("project2.mfproj");
+            var project3 = CreateTestFile("project3.mfproj");
+
+            Properties.Settings.Default.RecentFiles.Add(project1);
+            Properties.Settings.Default.RecentFiles.Add(project2);
+            Properties.Settings.Default.RecentFiles.Add(project3);
 
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act - Open project2 which is already in the list
-            manager.OpenProject("C:\\project2.mfproj");
+            manager.OpenProject(new ProjectInfo() { FilePath = project2 });
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(3, projectFiles, "Should still have 3 projects");
-            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0], "Project list order should not change");
-            Assert.AreEqual("C:\\project2.mfproj", projectFiles[1]);
-            Assert.AreEqual("C:\\project3.mfproj", projectFiles[2]);
+            Assert.AreEqual(project1, projectFiles[0].FilePath, "Project list order should not change");
+            Assert.AreEqual(project2, projectFiles[1].FilePath);
+            Assert.AreEqual(project3, projectFiles[2].FilePath);
 
             Assert.HasCount(3, Properties.Settings.Default.RecentFiles, "RecentFiles should have 3 items");
-            Assert.AreEqual("C:\\project2.mfproj", Properties.Settings.Default.RecentFiles[0], "RecentFiles should reorder to top");
-            Assert.AreEqual("C:\\project1.mfproj", Properties.Settings.Default.RecentFiles[1]);
-            Assert.AreEqual("C:\\project3.mfproj", Properties.Settings.Default.RecentFiles[2]);
+            Assert.AreEqual(project2, Properties.Settings.Default.RecentFiles[0], "RecentFiles should reorder to top");
+            Assert.AreEqual(project1, Properties.Settings.Default.RecentFiles[1]);
+            Assert.AreEqual(project3, Properties.Settings.Default.RecentFiles[2]);
         }
 
         [TestMethod()]
-        public void OpenProject_WithNullOrEmpty_ShouldNotAddToList()
+        public async Task OpenProject_WithNullOrEmpty_ShouldNotAddToList()
         {
             // Arrange
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
             manager.OpenProject(null);
-            manager.OpenProject("");
-            manager.OpenProject("   ");
+            manager.OpenProject(new ProjectInfo() { FilePath = "" });
+            manager.OpenProject(new ProjectInfo() { FilePath = "   " });
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.IsEmpty(projectFiles, "Should not add null or empty files");
             Assert.IsEmpty(Properties.Settings.Default.RecentFiles, "RecentFiles should be empty");
         }
 
         [TestMethod()]
-        public void RemoveProject_WithExistingFile_ShouldRemoveFromBothLists()
+        public async Task RemoveProject_WithExistingFile_ShouldRemoveFromBothLists()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            var project2 = CreateTestFile("project2.mfproj");
+
+            Properties.Settings.Default.RecentFiles.Add(project1);
+            Properties.Settings.Default.RecentFiles.Add(project2);
 
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
-            manager.RemoveProject("C:\\project1.mfproj");
+            manager.RemoveProject(project1);
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(1, projectFiles, "Should have 1 project left");
-            Assert.AreEqual("C:\\project2.mfproj", projectFiles[0]);
+            Assert.AreEqual(project2, projectFiles[0].FilePath);
 
             Assert.HasCount(1, Properties.Settings.Default.RecentFiles);
-            Assert.AreEqual("C:\\project2.mfproj", Properties.Settings.Default.RecentFiles[0]);
+            Assert.AreEqual(project2, Properties.Settings.Default.RecentFiles[0]);
         }
 
         [TestMethod()]
-        public void RemoveProject_WithNonExistingFile_ShouldNotThrow()
+        public async Task RemoveProject_WithNonExistingFile_ShouldNotThrow()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add(project1);
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
             manager.RemoveProject("C:\\nonexistent.mfproj");
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(1, projectFiles, "Should still have 1 project");
         }
 
         [TestMethod()]
-        public void RemoveProjectByIndex_WithValidIndex_ShouldRemoveFromBothLists()
+        public async Task RemoveProjectByIndex_WithValidIndex_ShouldRemoveFromBothLists()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project3.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            var project2 = CreateTestFile("project2.mfproj");
+            var project3 = CreateTestFile("project3.mfproj");
+
+            Properties.Settings.Default.RecentFiles.Add(project1);
+            Properties.Settings.Default.RecentFiles.Add(project2);
+            Properties.Settings.Default.RecentFiles.Add(project3);
 
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
             manager.RemoveProjectByIndex(1); // Remove project2
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(2, projectFiles, "Should have 2 projects left");
-            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0]);
-            Assert.AreEqual("C:\\project3.mfproj", projectFiles[1]);
+            Assert.AreEqual(project1, projectFiles[0].FilePath);
+            Assert.AreEqual(project3, projectFiles[1].FilePath);
 
             Assert.HasCount(2, Properties.Settings.Default.RecentFiles);
-            Assert.DoesNotContain("C:\\project2.mfproj", Properties.Settings.Default.RecentFiles);
+            Assert.DoesNotContain(project2, Properties.Settings.Default.RecentFiles);
         }
 
         [TestMethod()]
-        public void RemoveProjectByIndex_WithInvalidIndex_ShouldNotThrow()
+        public async Task RemoveProjectByIndex_WithInvalidIndex_ShouldNotThrow()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add(project1);
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
             manager.RemoveProjectByIndex(-1);
             manager.RemoveProjectByIndex(10);
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(1, projectFiles, "Should still have 1 project");
         }
 
         [TestMethod()]
-        public void RemoveMissingFiles_WithMultipleFiles_ShouldRemoveAllFromBothLists()
+        public async Task RemoveMissingFiles_WithMultipleFiles_ShouldRemoveAllFromBothLists()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project3.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\project4.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            var project2 = CreateTestFile("project2.mfproj");
+            var project3 = CreateTestFile("project3.mfproj");
+            var project4 = CreateTestFile("project4.mfproj");
+
+            Properties.Settings.Default.RecentFiles.Add(project1);
+            Properties.Settings.Default.RecentFiles.Add(project2);
+            Properties.Settings.Default.RecentFiles.Add(project3);
+            Properties.Settings.Default.RecentFiles.Add(project4);
 
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             var missingFiles = new List<string>
             {
-                "C:\\project2.mfproj",
-                "C:\\project4.mfproj"
+                project2,
+                project4
             };
 
             // Act
             manager.RemoveMissingFiles(missingFiles);
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(2, projectFiles, "Should have 2 projects left");
-            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0]);
-            Assert.AreEqual("C:\\project3.mfproj", projectFiles[1]);
+            Assert.AreEqual(project1, projectFiles[0].FilePath);
+            Assert.AreEqual(project3, projectFiles[1].FilePath);
 
             Assert.HasCount(2, Properties.Settings.Default.RecentFiles);
-            Assert.AreEqual("C:\\project1.mfproj", Properties.Settings.Default.RecentFiles[0]);
-            Assert.AreEqual("C:\\project3.mfproj", Properties.Settings.Default.RecentFiles[1]);
+            Assert.AreEqual(project1, Properties.Settings.Default.RecentFiles[0]);
+            Assert.AreEqual(project3, Properties.Settings.Default.RecentFiles[1]);
         }
 
         [TestMethod()]
-        public void RemoveMissingFiles_WithNull_ShouldNotThrow()
+        public async Task RemoveMissingFiles_WithNull_ShouldNotThrow()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add(project1);
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
             manager.RemoveMissingFiles(null);
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(1, projectFiles, "Should still have 1 project");
         }
 
         [TestMethod()]
-        public void GetProjectFiles_ShouldReturnCopyOfList()
+        public async Task GetProjects_ShouldReturnCopyOfList()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add(project1);
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
-            var result1 = manager.GetProjectFiles();
-            result1.Add("C:\\modified.mfproj"); // Modify the returned list
-            var result2 = manager.GetProjectFiles();
+            var result1 = manager.GetProjects();
+            result1.Add(new ProjectInfo() { FilePath = "C:\\modified.mfproj" }); // Modify the returned list
+            var result2 = manager.GetProjects();
 
             // Assert
             Assert.HasCount(1, result2, "Original list should not be modified");
-            Assert.AreEqual("C:\\project1.mfproj", result2[0]);
+            Assert.AreEqual(project1, result2[0].FilePath);
         }
 
         [TestMethod()]
-        public void OpenProject_MultipleNewProjects_ShouldMaintainInsertionOrder()
+        public async Task OpenProject_MultipleNewProjects_ShouldMaintainInsertionOrder()
         {
             // Arrange
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            var testfiles = new List<string>() {
+                CreateTestFile("first.mfproj"),
+                CreateTestFile("second.mfproj"),
+                CreateTestFile("third.mfproj"),
+            };
+
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
-            manager.OpenProject("C:\\first.mfproj");
-            manager.OpenProject("C:\\second.mfproj");
-            manager.OpenProject("C:\\third.mfproj");
+            testfiles.ForEach(file =>
+            {
+                manager.OpenProject(new ProjectInfo() { FilePath = file });
+            });
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(3, projectFiles);
-            Assert.AreEqual("C:\\third.mfproj", projectFiles[0], "Most recent should be first");
-            Assert.AreEqual("C:\\second.mfproj", projectFiles[1]);
-            Assert.AreEqual("C:\\first.mfproj", projectFiles[2]);
+            Assert.AreEqual(testfiles[2], projectFiles[0].FilePath, "Third (most recent) should be first");
+            Assert.AreEqual(testfiles[1], projectFiles[1].FilePath);
+            Assert.AreEqual(testfiles[0], projectFiles[2].FilePath);
         }
 
         [TestMethod()]
-        public void OpenProject_SameFileTwice_ShouldOnlyAddOnceToProjectList()
+        public async Task OpenProject_SameFileTwice_ShouldOnlyAddOnceToProjectList()
         {
             // Arrange
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
+            var projectFile = CreateTestFile("project.mfproj");
 
             // Act
-            manager.OpenProject("C:\\project.mfproj");
-            manager.OpenProject("C:\\project.mfproj");
+            manager.OpenProject(new ProjectInfo() { FilePath = projectFile });
+            manager.OpenProject(new ProjectInfo() { FilePath = projectFile });
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(1, projectFiles, "Should only have one entry");
-            Assert.AreEqual("C:\\project.mfproj", projectFiles[0]);
+            Assert.AreEqual(projectFile, projectFiles[0].FilePath);
 
             // RecentFiles should also have only one entry (moved to top)
             Assert.HasCount(1, Properties.Settings.Default.RecentFiles);
         }
 
         [TestMethod()]
-        public void ComplexScenario_OpenThenReopen_ShouldMaintainProjectListStability()
+        public async Task ComplexScenario_OpenThenReopen_ShouldMaintainProjectListStability()
         {
             // Arrange - Start with 3 projects
-            Properties.Settings.Default.RecentFiles.Add("C:\\A.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\B.mfproj");
-            Properties.Settings.Default.RecentFiles.Add("C:\\C.mfproj");
+            var projectA = CreateTestFile("A.mfproj");
+            var projectB = CreateTestFile("B.mfproj");
+            var projectC = CreateTestFile("C.mfproj");
+
+            Properties.Settings.Default.RecentFiles.Add(projectA);
+            Properties.Settings.Default.RecentFiles.Add(projectB);
+            Properties.Settings.Default.RecentFiles.Add(projectC);
 
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act - User clicks on B (middle item) from UI
-            manager.OpenProject("C:\\B.mfproj");
+            manager.OpenProject(new ProjectInfo() { FilePath = projectB });
 
             // Assert - Project list order unchanged
-            var projectFiles = manager.GetProjectFiles();
-            Assert.AreEqual("C:\\A.mfproj", projectFiles[0], "A stays in position");
-            Assert.AreEqual("C:\\B.mfproj", projectFiles[1], "B stays in position");
-            Assert.AreEqual("C:\\C.mfproj", projectFiles[2], "C stays in position");
+            var projectFiles = manager.GetProjects();
+            Assert.AreEqual(projectA, projectFiles[0].FilePath, "A stays in position");
+            Assert.AreEqual(projectB, projectFiles[1].FilePath, "B stays in position");
+            Assert.AreEqual(projectC, projectFiles[2].FilePath, "C stays in position");
 
             // RecentFiles reordered
-            Assert.AreEqual("C:\\B.mfproj", Properties.Settings.Default.RecentFiles[0], "B moved to top in RecentFiles");
-            Assert.AreEqual("C:\\A.mfproj", Properties.Settings.Default.RecentFiles[1]);
-            Assert.AreEqual("C:\\C.mfproj", Properties.Settings.Default.RecentFiles[2]);
+            Assert.AreEqual(projectB, Properties.Settings.Default.RecentFiles[0], "B moved to top in RecentFiles");
+            Assert.AreEqual(projectA, Properties.Settings.Default.RecentFiles[1]);
+            Assert.AreEqual(projectC, Properties.Settings.Default.RecentFiles[2]);
         }
 
         [TestMethod()]
@@ -390,13 +459,13 @@ namespace MobiFlight.Base.Tests
             Properties.Settings.Default.RecentFiles.Add("C:\\missing2.mfproj");
 
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
             await manager.CleanMissingFilesAsync().ConfigureAwait(false);
 
             // Assert - All non-existent files should be removed
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.IsEmpty(projectFiles, "All files should be removed since none exist");
             Assert.IsEmpty(Properties.Settings.Default.RecentFiles, "RecentFiles should be empty");
         }
@@ -408,67 +477,76 @@ namespace MobiFlight.Base.Tests
             // Note: We can't easily create actual files in unit tests,
             // so this test verifies that empty list doesn't cause issues
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
             await manager.CleanMissingFilesAsync().ConfigureAwait(false);
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.IsEmpty(projectFiles, "List should remain empty");
         }
 
         [TestMethod()]
-        public void OpenProject_AfterInitialization_WithNewFile_ShouldAddToFront()
+        public async Task OpenProject_AfterInitialization_WithNewFile_ShouldAddToFront()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\existing.mfproj");
+            var existingFile = CreateTestFile("existing.mfproj");
+            Properties.Settings.Default.RecentFiles.Add(existingFile);
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
+
+            var newFile = CreateTestFile("new.mfproj");
 
             // Act
-            manager.OpenProject("C:\\new.mfproj");
+            manager.OpenProject(new ProjectInfo() { FilePath = newFile });
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(2, projectFiles);
-            Assert.AreEqual("C:\\new.mfproj", projectFiles[0], "New file should be at front");
-            Assert.AreEqual("C:\\existing.mfproj", projectFiles[1]);
+            Assert.AreEqual(newFile, projectFiles[0].FilePath, "New file should be at front");
+            Assert.AreEqual(existingFile, projectFiles[1].FilePath);
         }
 
         [TestMethod()]
-        public void RemoveMissingFiles_WithEmptyList_ShouldNotModifyAnything()
+        public async Task RemoveMissingFiles_WithEmptyList_ShouldNotModifyAnything()
         {
             // Arrange
-            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var project1 = CreateTestFile("project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add(project1);
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
 
             // Act
             manager.RemoveMissingFiles(new List<string>());
 
             // Assert
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             Assert.HasCount(1, projectFiles, "Should still have 1 project");
             Assert.HasCount(1, Properties.Settings.Default.RecentFiles);
         }
 
         [TestMethod()]
-        public void MultipleOperations_ShouldKeepBothListsInSync()
+        public async Task MultipleOperations_ShouldKeepBothListsInSync()
         {
             // Arrange
             var manager = new ProjectListManager();
-            manager.InitializeFromSettings();
+            await manager.InitializeFromSettingsAsync(mockBindingService.Object);
+
+            var projectA = CreateTestFile("A.mfproj");
+            var projectB = CreateTestFile("B.mfproj");
+            var projectC = CreateTestFile("C.mfproj");
+            var projectD = CreateTestFile("D.mfproj");
 
             // Act - Complex sequence of operations
-            manager.OpenProject("C:\\A.mfproj");
-            manager.OpenProject("C:\\B.mfproj");
-            manager.OpenProject("C:\\C.mfproj");
-            manager.RemoveProject("C:\\B.mfproj");
-            manager.OpenProject("C:\\D.mfproj");
+            manager.OpenProject(new ProjectInfo() { FilePath = projectA });
+            manager.OpenProject(new ProjectInfo() { FilePath = projectB });
+            manager.OpenProject(new ProjectInfo() { FilePath = projectC });
+            manager.RemoveProject(projectB);
+            manager.OpenProject(new ProjectInfo() { FilePath = projectD });
 
             // Assert - Both lists should be in sync
-            var projectFiles = manager.GetProjectFiles();
+            var projectFiles = manager.GetProjects();
             var recentFiles = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
 
             Assert.HasCount(3, projectFiles);
@@ -477,7 +555,7 @@ namespace MobiFlight.Base.Tests
             // Verify all items exist in both lists
             foreach (var file in projectFiles)
             {
-                Assert.Contains(file, recentFiles, $"{file} should exist in both lists");
+                Assert.Contains(file.FilePath, recentFiles, $"{file.FilePath} should exist in both lists");
             }
         }
     }

--- a/MobiFlightUnitTests/Base/ProjectListManagerTests.cs
+++ b/MobiFlightUnitTests/Base/ProjectListManagerTests.cs
@@ -1,0 +1,484 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace MobiFlight.Base.Tests
+{
+    [TestClass()]
+    public class ProjectListManagerTests
+    {
+        private StringCollection originalRecentFiles;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            // Save original RecentFiles
+            originalRecentFiles = Properties.Settings.Default.RecentFiles;
+
+            // Initialize with clean state
+            Properties.Settings.Default.RecentFiles = new StringCollection();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // Restore original RecentFiles
+            Properties.Settings.Default.RecentFiles = originalRecentFiles;
+            Properties.Settings.Default.Save();
+        }
+
+        [TestMethod()]
+        public void InitializeFromSettings_WithEmptyRecentFiles_ShouldCreateEmptyList()
+        {
+            // Arrange
+            var manager = new ProjectListManager();
+
+            // Act
+            manager.InitializeFromSettings();
+            var result = manager.GetProjectFiles();
+
+            // Assert
+            Assert.IsEmpty(result, "Project list should be empty");
+        }
+
+        [TestMethod()]
+        public void InitializeFromSettings_WithExistingFiles_ShouldCopyToProjectList()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
+            var manager = new ProjectListManager();
+
+            // Act
+            manager.InitializeFromSettings();
+            var result = manager.GetProjectFiles();
+
+            // Assert
+            Assert.HasCount(2, result, "Should have 2 projects");
+            Assert.AreEqual("C:\\project1.mfproj", result[0]);
+            Assert.AreEqual("C:\\project2.mfproj", result[1]);
+        }
+
+        [TestMethod()]
+        public void OpenProject_WithNewFile_ShouldAddToTopOfBothLists()
+        {
+            // Arrange
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.OpenProject("C:\\new.mfproj");
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(1, projectFiles, "Should have 1 project in stable list");
+            Assert.AreEqual("C:\\new.mfproj", projectFiles[0]);
+
+            Assert.HasCount(1, Properties.Settings.Default.RecentFiles, "Should have 1 in RecentFiles");
+            Assert.AreEqual("C:\\new.mfproj", Properties.Settings.Default.RecentFiles[0]);
+        }
+
+        [TestMethod()]
+        public void OpenProject_WithExistingFileInRecentFiles_ShouldReorderRecentFilesButNotProjectList()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project3.mfproj");
+
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act - Open project2 which is already in the list
+            manager.OpenProject("C:\\project2.mfproj");
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(3, projectFiles, "Should still have 3 projects");
+            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0], "Project list order should not change");
+            Assert.AreEqual("C:\\project2.mfproj", projectFiles[1]);
+            Assert.AreEqual("C:\\project3.mfproj", projectFiles[2]);
+
+            Assert.HasCount(3, Properties.Settings.Default.RecentFiles, "RecentFiles should have 3 items");
+            Assert.AreEqual("C:\\project2.mfproj", Properties.Settings.Default.RecentFiles[0], "RecentFiles should reorder to top");
+            Assert.AreEqual("C:\\project1.mfproj", Properties.Settings.Default.RecentFiles[1]);
+            Assert.AreEqual("C:\\project3.mfproj", Properties.Settings.Default.RecentFiles[2]);
+        }
+
+        [TestMethod()]
+        public void OpenProject_WithNullOrEmpty_ShouldNotAddToList()
+        {
+            // Arrange
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.OpenProject(null);
+            manager.OpenProject("");
+            manager.OpenProject("   ");
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.IsEmpty(projectFiles, "Should not add null or empty files");
+            Assert.IsEmpty(Properties.Settings.Default.RecentFiles, "RecentFiles should be empty");
+        }
+
+        [TestMethod()]
+        public void RemoveProject_WithExistingFile_ShouldRemoveFromBothLists()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
+
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.RemoveProject("C:\\project1.mfproj");
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(1, projectFiles, "Should have 1 project left");
+            Assert.AreEqual("C:\\project2.mfproj", projectFiles[0]);
+
+            Assert.HasCount(1, Properties.Settings.Default.RecentFiles);
+            Assert.AreEqual("C:\\project2.mfproj", Properties.Settings.Default.RecentFiles[0]);
+        }
+
+        [TestMethod()]
+        public void RemoveProject_WithNonExistingFile_ShouldNotThrow()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.RemoveProject("C:\\nonexistent.mfproj");
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(1, projectFiles, "Should still have 1 project");
+        }
+
+        [TestMethod()]
+        public void RemoveProjectByIndex_WithValidIndex_ShouldRemoveFromBothLists()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project3.mfproj");
+
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.RemoveProjectByIndex(1); // Remove project2
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(2, projectFiles, "Should have 2 projects left");
+            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0]);
+            Assert.AreEqual("C:\\project3.mfproj", projectFiles[1]);
+
+            Assert.HasCount(2, Properties.Settings.Default.RecentFiles);
+            Assert.DoesNotContain("C:\\project2.mfproj", Properties.Settings.Default.RecentFiles);
+        }
+
+        [TestMethod()]
+        public void RemoveProjectByIndex_WithInvalidIndex_ShouldNotThrow()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.RemoveProjectByIndex(-1);
+            manager.RemoveProjectByIndex(10);
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(1, projectFiles, "Should still have 1 project");
+        }
+
+        [TestMethod()]
+        public void RemoveMissingFiles_WithMultipleFiles_ShouldRemoveAllFromBothLists()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project2.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project3.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\project4.mfproj");
+
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            var missingFiles = new List<string>
+            {
+                "C:\\project2.mfproj",
+                "C:\\project4.mfproj"
+            };
+
+            // Act
+            manager.RemoveMissingFiles(missingFiles);
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(2, projectFiles, "Should have 2 projects left");
+            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0]);
+            Assert.AreEqual("C:\\project3.mfproj", projectFiles[1]);
+
+            Assert.HasCount(2, Properties.Settings.Default.RecentFiles);
+            Assert.AreEqual("C:\\project1.mfproj", Properties.Settings.Default.RecentFiles[0]);
+            Assert.AreEqual("C:\\project3.mfproj", Properties.Settings.Default.RecentFiles[1]);
+        }
+
+        [TestMethod()]
+        public void RemoveMissingFiles_WithNull_ShouldNotThrow()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.RemoveMissingFiles(null);
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(1, projectFiles, "Should still have 1 project");
+        }
+
+        [TestMethod()]
+        public void GetProjectFiles_ShouldReturnCopyOfList()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            var result1 = manager.GetProjectFiles();
+            result1.Add("C:\\modified.mfproj"); // Modify the returned list
+            var result2 = manager.GetProjectFiles();
+
+            // Assert
+            Assert.HasCount(1, result2, "Original list should not be modified");
+            Assert.AreEqual("C:\\project1.mfproj", result2[0]);
+        }
+
+        [TestMethod()]
+        public void OpenProject_MultipleNewProjects_ShouldMaintainInsertionOrder()
+        {
+            // Arrange
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.OpenProject("C:\\first.mfproj");
+            manager.OpenProject("C:\\second.mfproj");
+            manager.OpenProject("C:\\third.mfproj");
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(3, projectFiles);
+            Assert.AreEqual("C:\\third.mfproj", projectFiles[0], "Most recent should be first");
+            Assert.AreEqual("C:\\second.mfproj", projectFiles[1]);
+            Assert.AreEqual("C:\\first.mfproj", projectFiles[2]);
+        }
+
+        [TestMethod()]
+        public void OpenProject_SameFileTwice_ShouldOnlyAddOnceToProjectList()
+        {
+            // Arrange
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.OpenProject("C:\\project.mfproj");
+            manager.OpenProject("C:\\project.mfproj");
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(1, projectFiles, "Should only have one entry");
+            Assert.AreEqual("C:\\project.mfproj", projectFiles[0]);
+
+            // RecentFiles should also have only one entry (moved to top)
+            Assert.HasCount(1, Properties.Settings.Default.RecentFiles);
+        }
+
+        [TestMethod()]
+        public void ComplexScenario_OpenThenReopen_ShouldMaintainProjectListStability()
+        {
+            // Arrange - Start with 3 projects
+            Properties.Settings.Default.RecentFiles.Add("C:\\A.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\B.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\C.mfproj");
+
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act - User clicks on B (middle item) from UI
+            manager.OpenProject("C:\\B.mfproj");
+
+            // Assert - Project list order unchanged
+            var projectFiles = manager.GetProjectFiles();
+            Assert.AreEqual("C:\\A.mfproj", projectFiles[0], "A stays in position");
+            Assert.AreEqual("C:\\B.mfproj", projectFiles[1], "B stays in position");
+            Assert.AreEqual("C:\\C.mfproj", projectFiles[2], "C stays in position");
+
+            // RecentFiles reordered
+            Assert.AreEqual("C:\\B.mfproj", Properties.Settings.Default.RecentFiles[0], "B moved to top in RecentFiles");
+            Assert.AreEqual("C:\\A.mfproj", Properties.Settings.Default.RecentFiles[1]);
+            Assert.AreEqual("C:\\C.mfproj", Properties.Settings.Default.RecentFiles[2]);
+        }
+
+        [TestMethod()]
+        public void CheckForMissingFiles_WithNullList_ShouldReturnEmptyList()
+        {
+            // Act
+            var result = ProjectListManager.CheckForMissingFiles(null);
+
+            // Assert
+            Assert.IsEmpty(result, "Should return empty list for null input");
+        }
+
+        [TestMethod()]
+        public void CheckForMissingFiles_WithEmptyStrings_ShouldAddToMissingList()
+        {
+            // Arrange
+            var files = new List<string> { "", "  ", null };
+
+            // Act
+            var result = ProjectListManager.CheckForMissingFiles(files);
+
+            // Assert
+            Assert.HasCount(3, result, "Should identify empty/whitespace/null as missing");
+            Assert.Contains("", result, "Empty string should be missing");
+            Assert.Contains("  ", result, "Whitespace should be missing");
+            Assert.Contains(null as string, result, "Null should be missing");
+        }
+
+        [TestMethod()]
+        public void CheckForMissingFiles_WithNonExistentFiles_ShouldAddToMissingList()
+        {
+            // Arrange
+            var files = new List<string>
+            {
+                "C:\\doesnotexist.mfproj",
+                "C:\\alsomissing.mfproj"
+            };
+
+            // Act
+            var result = ProjectListManager.CheckForMissingFiles(files);
+
+            // Assert
+            Assert.HasCount(2, result, "Both non-existent files should be in missing list");
+            CollectionAssert.AreEqual(files, result, "Should return all non-existent files");
+        }
+
+        [TestMethod()]
+        public async Task CleanMissingFilesAsync_WithMissingFiles_ShouldRemoveThemFromBothLists()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\exists1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\missing1.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\exists2.mfproj");
+            Properties.Settings.Default.RecentFiles.Add("C:\\missing2.mfproj");
+
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            await manager.CleanMissingFilesAsync().ConfigureAwait(false);
+
+            // Assert - All non-existent files should be removed
+            var projectFiles = manager.GetProjectFiles();
+            Assert.IsEmpty(projectFiles, "All files should be removed since none exist");
+            Assert.IsEmpty(Properties.Settings.Default.RecentFiles, "RecentFiles should be empty");
+        }
+
+        [TestMethod()]
+        public async Task CleanMissingFilesAsync_WithNoMissingFiles_ShouldNotModifyLists()
+        {
+            // Arrange
+            // Note: We can't easily create actual files in unit tests,
+            // so this test verifies that empty list doesn't cause issues
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            await manager.CleanMissingFilesAsync().ConfigureAwait(false);
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.IsEmpty(projectFiles, "List should remain empty");
+        }
+
+        [TestMethod()]
+        public void OpenProject_AfterInitialization_WithNewFile_ShouldAddToFront()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\existing.mfproj");
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.OpenProject("C:\\new.mfproj");
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(2, projectFiles);
+            Assert.AreEqual("C:\\new.mfproj", projectFiles[0], "New file should be at front");
+            Assert.AreEqual("C:\\existing.mfproj", projectFiles[1]);
+        }
+
+        [TestMethod()]
+        public void RemoveMissingFiles_WithEmptyList_ShouldNotModifyAnything()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles.Add("C:\\project1.mfproj");
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act
+            manager.RemoveMissingFiles(new List<string>());
+
+            // Assert
+            var projectFiles = manager.GetProjectFiles();
+            Assert.HasCount(1, projectFiles, "Should still have 1 project");
+            Assert.HasCount(1, Properties.Settings.Default.RecentFiles);
+        }
+
+        [TestMethod()]
+        public void MultipleOperations_ShouldKeepBothListsInSync()
+        {
+            // Arrange
+            var manager = new ProjectListManager();
+            manager.InitializeFromSettings();
+
+            // Act - Complex sequence of operations
+            manager.OpenProject("C:\\A.mfproj");
+            manager.OpenProject("C:\\B.mfproj");
+            manager.OpenProject("C:\\C.mfproj");
+            manager.RemoveProject("C:\\B.mfproj");
+            manager.OpenProject("C:\\D.mfproj");
+
+            // Assert - Both lists should be in sync
+            var projectFiles = manager.GetProjectFiles();
+            var recentFiles = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
+
+            Assert.HasCount(3, projectFiles);
+            Assert.HasCount(3, recentFiles, "Both lists should have same count");
+
+            // Verify all items exist in both lists
+            foreach (var file in projectFiles)
+            {
+                Assert.Contains(file, recentFiles, $"{file} should exist in both lists");
+            }
+        }
+    }
+}

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -229,6 +229,7 @@
     <Compile Include="Base\Migration\ProjectMigrationTests.cs" />
     <Compile Include="Base\PreconditionListTests.cs" />
     <Compile Include="Base\PreconditionTests.cs" />
+    <Compile Include="Base\ProjectListManagerTests.cs" />
     <Compile Include="Base\ProjectTests.cs" />
     <Compile Include="Base\Serialization\Json\SourceConverterTests.cs" />
     <Compile Include="Base\SerialNumberTests.cs" />

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.Base;
 using MobiFlight.BrowserMessages.Incoming;
+using MobiFlight.Controllers;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -34,11 +35,12 @@ namespace MobiFlight.UI.Tests
                 methodInfo.Invoke(this, new object[] { });
             }
 
-            public void InitializeProjectListManager()
+            public async void InitializeProjectListManager()
             {
                 var propertyInfo = typeof(MainForm).GetProperty("ProjectListManager", BindingFlags.NonPublic | BindingFlags.Instance);
                 var projectListManager = new ProjectListManager();
-                projectListManager.InitializeFromSettings();
+
+                await projectListManager.InitializeFromSettingsAsync(new ControllerBindingService(ExecutionManager));
                 propertyInfo.SetValue(this, projectListManager);
             }
         }
@@ -204,11 +206,11 @@ namespace MobiFlight.UI.Tests
             // Assert - ProjectList also updated
             var propertyInfo = typeof(MainForm).GetProperty("ProjectListManager", BindingFlags.NonPublic | BindingFlags.Instance);
             var projectListManager = propertyInfo.GetValue(_mainForm) as ProjectListManager;
-            var projectFiles = projectListManager.GetProjectFiles();
+            var projectFiles = projectListManager.GetProjects();
 
             Assert.HasCount(2, projectFiles, "Should have 2 files remaining in ProjectList");
-            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0]);
-            Assert.AreEqual("C:\\project3.mfproj", projectFiles[1]);
+            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0].FilePath);
+            Assert.AreEqual("C:\\project3.mfproj", projectFiles[1].FilePath);
             Assert.DoesNotContain("C:\\project2.mfproj", projectFiles, "Removed file should not be in ProjectList");
         }
     }

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -5,15 +5,15 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Runtime.Serialization;
 
 namespace MobiFlight.UI.Tests
 {
     [TestClass()]
     public class MainFormTests
     {
+        private StringCollection originalRecentFiles;
+
         public class TestableMainForm : MainForm
         {
             // Expose protected/private members for testing if needed
@@ -33,6 +33,14 @@ namespace MobiFlight.UI.Tests
                 var methodInfo = typeof(MainForm).GetMethod("InitializeExecutionManager", BindingFlags.NonPublic | BindingFlags.Instance);
                 methodInfo.Invoke(this, new object[] { });
             }
+
+            public void InitializeProjectListManager()
+            {
+                var propertyInfo = typeof(MainForm).GetProperty("ProjectListManager", BindingFlags.NonPublic | BindingFlags.Instance);
+                var projectListManager = new ProjectListManager();
+                projectListManager.InitializeFromSettings();
+                propertyInfo.SetValue(this, projectListManager);
+            }
         }
 
         private TestableMainForm _mainForm;
@@ -42,6 +50,20 @@ namespace MobiFlight.UI.Tests
         {
             // Initialize the MainForm
             _mainForm = new TestableMainForm();
+
+            // Save original RecentFiles
+            originalRecentFiles = Properties.Settings.Default.RecentFiles;
+
+            // Initialize with clean state
+            Properties.Settings.Default.RecentFiles = new StringCollection();
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // Restore original RecentFiles
+            Properties.Settings.Default.RecentFiles = originalRecentFiles;
+            Properties.Settings.Default.Save();
         }
 
 
@@ -140,10 +162,11 @@ namespace MobiFlight.UI.Tests
         }
 
         [TestMethod()]
-        public void RecentFilesRemove_ViaCommandMainMenu()
+        public void RecentFilesRemove_ViaCommandMainMenu_ShouldRemoveFromBothLists()
         {
             // Arrange
             _mainForm.InitializeExecutionManager();
+            _mainForm.InitializeProjectListManager();
 
             var testFiles = new StringCollection
             {
@@ -155,11 +178,14 @@ namespace MobiFlight.UI.Tests
             Properties.Settings.Default.RecentFiles = testFiles;
             Properties.Settings.Default.Save();
 
+            // Re-initialize after adding files
+            _mainForm.InitializeProjectListManager();
+
             // Create the command message
             var command = new CommandMainMenu
             {
                 Action = CommandMainMenuAction.virtual_recent_remove,
-                Index = 1  // Remove the middle entry
+                Index = 1  // Remove the middle entry (project2)
             };
 
             // Get the handler
@@ -168,76 +194,22 @@ namespace MobiFlight.UI.Tests
             // Act
             handler.Handle(command);
 
-            // Assert
+            // Assert - RecentFiles updated
             var recentFiles = Properties.Settings.Default.RecentFiles;
-            Assert.HasCount(2, recentFiles, "Should have 2 files remaining");
+            Assert.HasCount(2, recentFiles, "Should have 2 files remaining in RecentFiles");
             Assert.AreEqual("C:\\project1.mfproj", recentFiles[0]);
             Assert.AreEqual("C:\\project3.mfproj", recentFiles[1]);
-            Assert.DoesNotContain("C:\\project2.mfproj", recentFiles, "Removed file should not be in the list");
-        }
+            Assert.DoesNotContain("C:\\project2.mfproj", recentFiles, "Removed file should not be in RecentFiles");
 
-        [TestMethod]
-        public void FindMissingFiles_ReturnsMissingAndIgnoresExisting()
-        {
-            var existing = Path.GetTempFileName();
-            var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".mfproj");
-            try
-            {
-                var inputs = new List<string> { existing, missing, "   " };
-                var result = MainForm.CheckForMissingFiles(inputs);
+            // Assert - ProjectList also updated
+            var propertyInfo = typeof(MainForm).GetProperty("ProjectListManager", BindingFlags.NonPublic | BindingFlags.Instance);
+            var projectListManager = propertyInfo.GetValue(_mainForm) as ProjectListManager;
+            var projectFiles = projectListManager.GetProjectFiles();
 
-                // missing path and whitespace entry are reported missing
-                Assert.Contains(missing, result, "Expected missing file to be reported.");
-                Assert.IsTrue(result.Any(x => string.IsNullOrWhiteSpace(x)), "Expected whitespace entry to be reported as missing.");
-                // existing file should not be reported missing
-                Assert.DoesNotContain(existing, result, "Existing file should not be reported missing.");
-            }
-            finally
-            {
-                // This sometimes fails in CI environments due to file locks.
-                // Just continue because Delete is not critical for the test.
-                try { File.Delete(existing); } catch { }
-            }
-        }
-
-        [TestMethod]
-        public void RemoveMissingFilesFromSettings_RemovesEntriesFromSettings()
-        {
-            var existing = Path.GetTempFileName();
-            var missing = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString() + ".mfproj");
-
-            try
-            {
-                // Prepare settings recent list
-                Properties.Settings.Default.RecentFiles.Clear();
-                Properties.Settings.Default.RecentFiles.Add(existing);
-                Properties.Settings.Default.RecentFiles.Add(missing);
-                Properties.Settings.Default.Save();
-
-                // Call instance method without running ctor to avoid UI initialization
-                var mainFormInstance = FormatterServices.GetUninitializedObject(typeof(MainForm));
-                var mi = typeof(MainForm).GetMethod("RemoveMissingFilesFromSettings", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
-
-                Assert.IsNotNull(mi, "RemoveMissingFilesFromSettings method not found via reflection.");
-
-                // Invoke with the missing list
-                mi.Invoke(mainFormInstance, new object[] { new List<string> { missing } });
-
-                var current = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
-
-                Assert.Contains(existing, current, "Existing file should remain in settings.");
-                Assert.DoesNotContain(missing, current, "Missing file should have been removed from settings.");
-            }
-            finally
-            {
-                // This sometimes fails in CI environments due to file locks.
-                // Just continue because Delete is not critical for the test.
-                try { File.Delete(existing); } catch { }
-
-                // Cleanup settings to avoid test pollution
-                Properties.Settings.Default.RecentFiles.Clear();
-                Properties.Settings.Default.Save();
-            }
+            Assert.HasCount(2, projectFiles, "Should have 2 files remaining in ProjectList");
+            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0]);
+            Assert.AreEqual("C:\\project3.mfproj", projectFiles[1]);
+            Assert.DoesNotContain("C:\\project2.mfproj", projectFiles, "Removed file should not be in ProjectList");
         }
     }
 }

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
 using System.Reflection;
+using System.Threading.Tasks;
 
 namespace MobiFlight.UI.Tests
 {
@@ -14,6 +15,7 @@ namespace MobiFlight.UI.Tests
     public class MainFormTests
     {
         private StringCollection originalRecentFiles;
+        private string _tempDirectory;
 
         public class TestableMainForm : MainForm
         {
@@ -35,7 +37,7 @@ namespace MobiFlight.UI.Tests
                 methodInfo.Invoke(this, new object[] { });
             }
 
-            public async void InitializeProjectListManager()
+            public async Task InitializeProjectListManagerAsync()
             {
                 var propertyInfo = typeof(MainForm).GetProperty("ProjectListManager", BindingFlags.NonPublic | BindingFlags.Instance);
                 var projectListManager = new ProjectListManager();
@@ -58,6 +60,10 @@ namespace MobiFlight.UI.Tests
 
             // Initialize with clean state
             Properties.Settings.Default.RecentFiles = new StringCollection();
+
+            // Create a temporary test directory
+            _tempDirectory = Path.Combine(Path.GetTempPath(), "MainFormTests", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_tempDirectory);
         }
 
         [TestCleanup]
@@ -66,6 +72,27 @@ namespace MobiFlight.UI.Tests
             // Restore original RecentFiles
             Properties.Settings.Default.RecentFiles = originalRecentFiles;
             Properties.Settings.Default.Save();
+
+            try
+            {
+                // Clean up test directory
+                if (Directory.Exists(_tempDirectory))
+                {
+                    Directory.Delete(_tempDirectory, true);
+                }
+            }
+            catch { }
+        }
+
+        /// <summary>
+        /// Helper method to create a temporary test file
+        /// </summary>
+        private string CreateTestFile(string fileName)
+        {
+            var filePath = Path.Combine(_tempDirectory, fileName);
+            var testProject = new Project() { FilePath = filePath };
+            testProject.SaveFile();
+            return filePath;
         }
 
 
@@ -164,24 +191,27 @@ namespace MobiFlight.UI.Tests
         }
 
         [TestMethod()]
-        public void RecentFilesRemove_ViaCommandMainMenu_ShouldRemoveFromBothLists()
+        public async Task RecentFilesRemove_ViaCommandMainMenu_ShouldRemoveFromBothLists()
         {
             // Arrange
             _mainForm.InitializeExecutionManager();
-            _mainForm.InitializeProjectListManager();
+            await _mainForm.InitializeProjectListManagerAsync();
 
-            var testFiles = new StringCollection
+            var recentFilesCollection = new StringCollection
             {
-                "C:\\project1.mfproj",
-                "C:\\project2.mfproj",
-                "C:\\project3.mfproj"
+                CreateTestFile("project1.mfproj"),
+                CreateTestFile("project2.mfproj"),
+                CreateTestFile("project3.mfproj")
             };
 
-            Properties.Settings.Default.RecentFiles = testFiles;
+            var testFiles = new String[recentFilesCollection.Count];
+            recentFilesCollection.CopyTo(testFiles, 0);
+
+            Properties.Settings.Default.RecentFiles = recentFilesCollection;
             Properties.Settings.Default.Save();
 
             // Re-initialize after adding files
-            _mainForm.InitializeProjectListManager();
+            await _mainForm.InitializeProjectListManagerAsync();
 
             // Create the command message
             var command = new CommandMainMenu
@@ -199,9 +229,9 @@ namespace MobiFlight.UI.Tests
             // Assert - RecentFiles updated
             var recentFiles = Properties.Settings.Default.RecentFiles;
             Assert.HasCount(2, recentFiles, "Should have 2 files remaining in RecentFiles");
-            Assert.AreEqual("C:\\project1.mfproj", recentFiles[0]);
-            Assert.AreEqual("C:\\project3.mfproj", recentFiles[1]);
-            Assert.DoesNotContain("C:\\project2.mfproj", recentFiles, "Removed file should not be in RecentFiles");
+            Assert.AreEqual(testFiles[0], recentFiles[0]);
+            Assert.AreEqual(testFiles[2], recentFiles[1]);
+            Assert.DoesNotContain(testFiles[1], recentFiles, "Removed file should not be in RecentFiles");
 
             // Assert - ProjectList also updated
             var propertyInfo = typeof(MainForm).GetProperty("ProjectListManager", BindingFlags.NonPublic | BindingFlags.Instance);
@@ -209,9 +239,9 @@ namespace MobiFlight.UI.Tests
             var projectFiles = projectListManager.GetProjects();
 
             Assert.HasCount(2, projectFiles, "Should have 2 files remaining in ProjectList");
-            Assert.AreEqual("C:\\project1.mfproj", projectFiles[0].FilePath);
-            Assert.AreEqual("C:\\project3.mfproj", projectFiles[1].FilePath);
-            Assert.DoesNotContain("C:\\project2.mfproj", projectFiles, "Removed file should not be in ProjectList");
+            Assert.AreEqual(testFiles[0], projectFiles[0].FilePath);
+            Assert.AreEqual(testFiles[2], projectFiles[1].FilePath);
+            Assert.DoesNotContain(testFiles[1], projectFiles, "Removed file should not be in ProjectList");
         }
     }
 }

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -515,10 +515,10 @@ namespace MobiFlight.UI
             Refresh();
 
             PublishSettings();
-            InitializeRecentProjectsList();
+            await InitializeRecentProjectsListAsync();
         }
 
-        private async void InitializeRecentProjectsList()
+        private async Task InitializeRecentProjectsListAsync()
         {
             // Subscribe to changes
             ProjectListManager.ProjectListChanged += (s, e) => PublishProjectList();

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -154,15 +154,6 @@ namespace MobiFlight.UI
         {
             UpgradeSettingsFromPreviousInstallation();
             Properties.Settings.Default.SettingChanging += new System.Configuration.SettingChangingEventHandler(Default_SettingChanging);
-            Properties.Settings.Default.PropertyChanged += (s, e) =>
-            {
-                PublishSettings();
-                if (e.PropertyName == "RecentFiles")
-                {
-                    PublishRecentProjectList();
-                }
-            };
-
             Properties.Settings.Default.SettingsSaving += (s, e) =>
             {
                 PublishSettings();
@@ -539,10 +530,10 @@ namespace MobiFlight.UI
                 Log.Instance.log($"Exception cleaning project files: {ex.Message}", LogSeverity.Error);
             }
 
-            PublishRecentProjectList();
+            PublishProjectList();
         }
 
-        private void PublishRecentProjectList()
+        private void PublishProjectList()
         {
             var recentFiles = ProjectListManager?.GetProjectFiles();
             var recentProjects = new List<ProjectInfo>();
@@ -962,7 +953,7 @@ namespace MobiFlight.UI
             UpdateAllConnectionIcons();
 
             UpdateStatusBarModuleInformation();
-            PublishRecentProjectList();
+            PublishProjectList();
 
             // Track config loaded event
             AppTelemetry.Instance.TrackStart();
@@ -2047,7 +2038,7 @@ namespace MobiFlight.UI
                 // the original file name has to be stored
                 // in the list of recent files.
                 ProjectListManager.OpenProject(execManager.Project.FilePath);
-                PublishRecentProjectList();
+                PublishProjectList();
 
                 // set the button back to "disabled"
                 // since due to initiliazing the dataSet
@@ -2135,9 +2126,11 @@ namespace MobiFlight.UI
             }
 
             ProjectListManager.OpenProject(execManager.Project.FilePath);
-            PublishRecentProjectList();
+            PublishProjectList();
+
             MessageExchange.Instance.Publish(execManager.Project);
             ResetProjectAndConfigChanges();
+            
             MessageExchange.Instance.Publish(new ProjectStatus()
             {
                 HasChanged = ProjectHasUnsavedChanges,
@@ -2932,7 +2925,7 @@ namespace MobiFlight.UI
         internal void RecentFilesRemove(int index)
         {
             ProjectListManager.RemoveProjectByIndex(index);
-            PublishRecentProjectList();
+            PublishProjectList();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -1203,10 +1203,12 @@ namespace MobiFlight.UI
 
         private void _autoloadLastConfig()
         {
-            var projectFiles = ProjectListManager.GetProjects().Where(p => File.Exists(p.FilePath)).ToList();
-            if (projectFiles.Count == 0) return;
-
-            LoadConfig(projectFiles.First().FilePath);
+            // use the recent files from application settings
+            // no async loading involved => no timing issues that can happen
+            var recentFile = Properties.Settings.Default.RecentFiles?.Cast<string>().ToList().First(f => File.Exists(f)) ?? null;
+            if (recentFile == null) return;
+            
+            LoadConfig(recentFile);
         }
 
 #if ARCAZE

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -926,7 +926,6 @@ namespace MobiFlight.UI
             UpdateAllConnectionIcons();
 
             UpdateStatusBarModuleInformation();
-            // PublishProjectList();
 
             // Track config loaded event
             AppTelemetry.Instance.TrackStart();
@@ -2011,7 +2010,6 @@ namespace MobiFlight.UI
                 // the original file name has to be stored
                 // in the list of recent files.
                 ProjectListManager.OpenProject(execManager.Project.ToProjectInfo());
-                // PublishProjectList();
 
                 // set the button back to "disabled"
                 // since due to initiliazing the dataSet
@@ -2099,7 +2097,6 @@ namespace MobiFlight.UI
             }
 
             ProjectListManager.OpenProject(execManager.Project.ToProjectInfo());
-            // PublishProjectList();
 
             MessageExchange.Instance.Publish(execManager.Project);
             ResetProjectAndConfigChanges();
@@ -2898,7 +2895,6 @@ namespace MobiFlight.UI
         internal void RecentFilesRemove(int index)
         {
             ProjectListManager.RemoveProjectByIndex(index);
-            // PublishProjectList();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -114,6 +114,8 @@ namespace MobiFlight.UI
 
         public ControllerBindingService ControllerBindingService { get; private set; }
 
+        private ProjectListManager ProjectListManager { get; set; } = new ProjectListManager();
+
         private void InitializeLogging()
         {
             LogAppenderLogPanel logAppenderTextBox = new LogAppenderLogPanel(logPanel1);
@@ -522,92 +524,27 @@ namespace MobiFlight.UI
             Refresh();
 
             PublishSettings();
+            InitializeRecentProjectsList();
+        }
+
+        private async void InitializeRecentProjectsList()
+        {
+            ProjectListManager.InitializeFromSettings();
             try
             {
-                await CleanRecentFilesAsync().ConfigureAwait(false);
+                await ProjectListManager.CleanMissingFilesAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
-                Log.Instance.log($"Exception in CleanRecentFilesAsync: {ex.Message}", LogSeverity.Error);
+                Log.Instance.log($"Exception cleaning project files: {ex.Message}", LogSeverity.Error);
             }
 
             PublishRecentProjectList();
         }
 
-        // Remove non-existing recent files asynchronously but return only after UI changes persisted.
-        // Caller can await to guarantee the settings are updated before using RecentFiles.
-        private async Task CleanRecentFilesAsync()
-        {
-            var recentSnapshot = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
-
-            var missingFiles = await Task.Run(() => CheckForMissingFiles(recentSnapshot)).ConfigureAwait(false);
-
-            if (missingFiles.Count == 0) return;
-
-            // Handle require to invoke settings update on UI thread
-            if (!IsHandleCreated) return;
-
-            var tcs = new TaskCompletionSource<bool>();
-            BeginInvoke((Action)(() =>
-            {
-                try
-                {
-                    RemoveMissingFilesFromSettings(missingFiles);
-                    tcs.SetResult(true);
-                }
-                catch (Exception ex)
-                {
-                    tcs.SetException(ex);
-                }
-            }));
-            await tcs.Task.ConfigureAwait(false);
-        }
-
-        internal static List<string> CheckForMissingFiles(IEnumerable<string> recentFiles)
-        {
-            var missingFiles = new List<string>();
-            if (recentFiles == null) return missingFiles;
-
-            foreach (var f in recentFiles)
-            {
-                try
-                {
-                    if (string.IsNullOrWhiteSpace(f) || !File.Exists(f))
-                        missingFiles.Add(f);
-                }
-                catch
-                {
-                    // Treat IO errors as missing; keep scanning
-                    missingFiles.Add(f);
-                }
-            }
-
-            return missingFiles;
-        }
-
-        internal void RemoveMissingFilesFromSettings(IEnumerable<string> missingFiles)
-        {
-            if (missingFiles == null) return;
-
-            var changed = false;
-            foreach (var f in missingFiles)
-            {
-                if (!Properties.Settings.Default.RecentFiles.Contains(f)) continue;
-
-                Properties.Settings.Default.RecentFiles.Remove(f);
-                Log.Instance.log($"Recent Project List - File doesn't exist: '{f}' removed.", LogSeverity.Info);
-                changed = true;
-            }
-
-            if (changed)
-            {
-                Properties.Settings.Default.Save();
-            }
-        }
-
         private void PublishRecentProjectList()
         {
-            var recentFiles = Properties.Settings.Default.RecentFiles.Cast<string>().ToList();
+            var recentFiles = ProjectListManager?.GetProjectFiles();
             var recentProjects = new List<ProjectInfo>();
             Task.Run(() =>
             {
@@ -619,7 +556,7 @@ namespace MobiFlight.UI
                         p.FilePath = project;
                         p.OpenFile(suppressMigrationLogging: true);
                         p.DetermineProjectInfos();
-                        ControllerBindingService.PerformAutoBinding(p);
+                        ControllerBindingService?.PerformAutoBinding(p);
 
                         recentProjects.Add(p.ToProjectInfo());
                     }
@@ -1303,18 +1240,10 @@ namespace MobiFlight.UI
 
         private void _autoloadLastConfig()
         {
-            // the new autoload feature
-            // step1 load config always... good feature ;)
-            // step2 run automatically -> see fsuipc connected event
-            if (Properties.Settings.Default.RecentFiles.Count > 0)
-            {
-                foreach (string file in Properties.Settings.Default.RecentFiles)
-                {
-                    if (!System.IO.File.Exists(file)) continue;
-                    LoadConfig(file);
-                    return;
-                }
-            } //if
+            var projectFiles = ProjectListManager.GetProjectFiles().Where(p => File.Exists(p)).ToList();
+            if (projectFiles.Count == 0) return;
+
+            LoadConfig(projectFiles.First());
         }
 
 #if ARCAZE
@@ -2001,21 +1930,6 @@ namespace MobiFlight.UI
         }
 
         /// <summary>
-        /// stores the provided filename in the list of recently used files
-        /// </summary>
-        /// <param name="fileName">the filename to be used</param>
-        private void _storeAsRecentFile(string fileName)
-        {
-            if (Properties.Settings.Default.RecentFiles.Contains(fileName))
-            {
-                Properties.Settings.Default.RecentFiles.Remove(fileName);
-            }
-            Properties.Settings.Default.RecentFiles.Insert(0, fileName);
-            Properties.Settings.Default.Save();
-            PublishRecentProjectList();
-        }
-
-        /// <summary>
         /// gets triggered when user clicks on recent used file entry
         /// loads the according config
         /// </summary>
@@ -2132,7 +2046,7 @@ namespace MobiFlight.UI
             {
                 // the original file name has to be stored
                 // in the list of recent files.
-                _storeAsRecentFile(execManager.Project.FilePath);
+                ProjectListManager.OpenProject(execManager.Project.FilePath);
 
                 // set the button back to "disabled"
                 // since due to initiliazing the dataSet
@@ -2219,8 +2133,8 @@ namespace MobiFlight.UI
                 return;
             }
 
+            ProjectListManager.OpenProject(execManager.Project.FilePath);
             MessageExchange.Instance.Publish(execManager.Project);
-            _storeAsRecentFile(execManager.Project.FilePath);
             ResetProjectAndConfigChanges();
             MessageExchange.Instance.Publish(new ProjectStatus()
             {
@@ -3015,14 +2929,7 @@ namespace MobiFlight.UI
 
         internal void RecentFilesRemove(int index)
         {
-            var recentFiles = Properties.Settings.Default.RecentFiles;
-
-            if (index < 0 || index >= recentFiles.Count)
-                return;
-
-            recentFiles.RemoveAt(index);
-            Properties.Settings.Default.RecentFiles = recentFiles;
-            Properties.Settings.Default.Save();
+            ProjectListManager.RemoveProjectByIndex(index);
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -2047,6 +2047,7 @@ namespace MobiFlight.UI
                 // the original file name has to be stored
                 // in the list of recent files.
                 ProjectListManager.OpenProject(execManager.Project.FilePath);
+                PublishRecentProjectList();
 
                 // set the button back to "disabled"
                 // since due to initiliazing the dataSet
@@ -2134,6 +2135,7 @@ namespace MobiFlight.UI
             }
 
             ProjectListManager.OpenProject(execManager.Project.FilePath);
+            PublishRecentProjectList();
             MessageExchange.Instance.Publish(execManager.Project);
             ResetProjectAndConfigChanges();
             MessageExchange.Instance.Publish(new ProjectStatus()
@@ -2930,6 +2932,7 @@ namespace MobiFlight.UI
         internal void RecentFilesRemove(int index)
         {
             ProjectListManager.RemoveProjectByIndex(index);
+            PublishRecentProjectList();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -520,44 +520,17 @@ namespace MobiFlight.UI
 
         private async void InitializeRecentProjectsList()
         {
-            ProjectListManager.InitializeFromSettings();
-            try
-            {
-                await ProjectListManager.CleanMissingFilesAsync().ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                Log.Instance.log($"Exception cleaning project files: {ex.Message}", LogSeverity.Error);
-            }
+            // Subscribe to changes
+            ProjectListManager.ProjectListChanged += (s, e) => PublishProjectList();
 
-            PublishProjectList();
+            // Initialize with ControllerBindingService
+            await ProjectListManager.InitializeFromSettingsAsync(ControllerBindingService).ConfigureAwait(false);
         }
 
         private void PublishProjectList()
         {
-            var recentFiles = ProjectListManager?.GetProjectFiles();
-            var recentProjects = new List<ProjectInfo>();
-            Task.Run(() =>
-            {
-                foreach (var project in recentFiles)
-                {
-                    try
-                    {
-                        var p = new Project();
-                        p.FilePath = project;
-                        p.OpenFile(suppressMigrationLogging: true);
-                        p.DetermineProjectInfos();
-                        ControllerBindingService?.PerformAutoBinding(p);
-
-                        recentProjects.Add(p.ToProjectInfo());
-                    }
-                    catch (Exception ex)
-                    {
-                        Log.Instance.log($"Could not load recent project file {project}: {ex.Message}", LogSeverity.Warn);
-                    }
-                }
-                MessageExchange.Instance.Publish(new RecentProjects() { Projects = recentProjects });
-            }).ConfigureAwait(false);
+            var projects = ProjectListManager?.GetProjects();
+            MessageExchange.Instance.Publish(new RecentProjects() { Projects = projects });
         }
 
         private void PublishSettings()
@@ -953,7 +926,7 @@ namespace MobiFlight.UI
             UpdateAllConnectionIcons();
 
             UpdateStatusBarModuleInformation();
-            PublishProjectList();
+            // PublishProjectList();
 
             // Track config loaded event
             AppTelemetry.Instance.TrackStart();
@@ -1231,10 +1204,10 @@ namespace MobiFlight.UI
 
         private void _autoloadLastConfig()
         {
-            var projectFiles = ProjectListManager.GetProjectFiles().Where(p => File.Exists(p)).ToList();
+            var projectFiles = ProjectListManager.GetProjects().Where(p => File.Exists(p.FilePath)).ToList();
             if (projectFiles.Count == 0) return;
 
-            LoadConfig(projectFiles.First());
+            LoadConfig(projectFiles.First().FilePath);
         }
 
 #if ARCAZE
@@ -2037,8 +2010,8 @@ namespace MobiFlight.UI
             {
                 // the original file name has to be stored
                 // in the list of recent files.
-                ProjectListManager.OpenProject(execManager.Project.FilePath);
-                PublishProjectList();
+                ProjectListManager.OpenProject(execManager.Project.ToProjectInfo());
+                // PublishProjectList();
 
                 // set the button back to "disabled"
                 // since due to initiliazing the dataSet
@@ -2125,8 +2098,8 @@ namespace MobiFlight.UI
                 return;
             }
 
-            ProjectListManager.OpenProject(execManager.Project.FilePath);
-            PublishProjectList();
+            ProjectListManager.OpenProject(execManager.Project.ToProjectInfo());
+            // PublishProjectList();
 
             MessageExchange.Instance.Publish(execManager.Project);
             ResetProjectAndConfigChanges();
@@ -2925,7 +2898,7 @@ namespace MobiFlight.UI
         internal void RecentFilesRemove(int index)
         {
             ProjectListManager.RemoveProjectByIndex(index);
-            PublishProjectList();
+            // PublishProjectList();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/frontend/src/components/project/ProjectList.tsx
+++ b/frontend/src/components/project/ProjectList.tsx
@@ -23,7 +23,9 @@ const ProjectList = ({
   activeProject,
   onSelect,
 }: ProjectListProps) => {
+  const SCROLL_INTO_VIEW_TIMEOUT = 2000 
   const refActiveElement = useRef<HTMLDivElement | null>(null)
+  const scrollTimeoutRef = useRef<number | null>(null)
 
   const { publish } = publishOnMessageExchange()
 
@@ -35,14 +37,22 @@ const ProjectList = ({
     setSearchParams({})
   }
 
+  const cancelScrollIntoView = () => {
+    if (scrollTimeoutRef.current !== null) {
+      window.clearTimeout(scrollTimeoutRef.current)
+      scrollTimeoutRef.current = null
+    }
+  }
+
   const scrollActiveProjectIntoView = () => {
     if (refActiveElement.current) {
-      window.setTimeout(() => {
+      scrollTimeoutRef.current = window.setTimeout(() => {
         refActiveElement.current?.scrollIntoView({
           behavior: "smooth",
           block: "nearest",
         })
-      }, 500)
+        scrollTimeoutRef.current = null
+      }, SCROLL_INTO_VIEW_TIMEOUT)
     }
   }
 
@@ -75,6 +85,7 @@ const ProjectList = ({
         <div className="relative flex flex-0 grow flex-col">
           <ScrollArea
             className="grow pr-2 transition-all duration-300"
+            onMouseEnter={cancelScrollIntoView}
             onMouseLeave={scrollActiveProjectIntoView}
           >
             <div

--- a/frontend/src/components/project/ProjectList.tsx
+++ b/frontend/src/components/project/ProjectList.tsx
@@ -46,6 +46,7 @@ const ProjectList = ({
 
   const scrollActiveProjectIntoView = () => {
     if (refActiveElement.current) {
+      cancelScrollIntoView()
       scrollTimeoutRef.current = window.setTimeout(() => {
         refActiveElement.current?.scrollIntoView({
           behavior: "smooth",


### PR DESCRIPTION
This PR improves the Project List in a set of ways:

- [x] Project list doesn't reorder when project is selected from list. It is independent from the "Recent files list"
- [x] The timeout to scroll the `active project` into view when leaving the project list is now 2000ms
- [x] The timeout will cancel if user enters with mouse before timeout has expired
- [x] Project list management is handled by its own dedicated class -> reduces code in MainForm.
- [x] unit tests

fixes #2668