### PR TITLE
Insert duplicated config item AFTER existing item

### DIFF
--- a/MobiFlight/ExecutionManager.cs
+++ b/MobiFlight/ExecutionManager.cs
@@ -389,7 +389,7 @@ namespace MobiFlight
                         var index = ConfigItems.FindIndex(i => i.GUID == message.Item.GUID);
                         if (index == -1) break;
                         var dup = ConfigItems[index].Duplicate();
-                        ConfigItems.Insert(index, dup);
+                        ConfigItems.Insert(index + 1, dup);
                         break;
 
                     case "test":

--- a/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -209,11 +209,11 @@ namespace MobiFlight.Tests
 
 
         [TestMethod]
-        public void CommandFileContextMenu_Duplicate_DuplicatesConfigCorrectly()
+        public void CommandConfigContextMenu_Duplicate_DuplicatesConfigItemCorrectly()
         {
             // Arrange
             var configItem1 = new OutputConfigItem { GUID = Guid.NewGuid().ToString(), Active = false };
-            var firstConfigItemGuid = configItem1.GUID.Clone() as string;
+            var firstConfigItemGuid = configItem1.GUID;
 
             var project = new Project();
             project.ConfigFiles.Add(new ConfigFile()

--- a/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -207,6 +207,40 @@ namespace MobiFlight.Tests
             Assert.AreEqual(1, _executionManager.ActiveConfigIndex);
         }
 
+
+        [TestMethod]
+        public void CommandFileContextMenu_Duplicate_DuplicatesConfigCorrectly()
+        {
+            // Arrange
+            var configItem1 = new OutputConfigItem { GUID = Guid.NewGuid().ToString(), Active = false };
+            var firstConfigItemGuid = configItem1.GUID.Clone() as string;
+
+            var project = new Project();
+            project.ConfigFiles.Add(new ConfigFile()
+            {
+                Label = "First Config",
+                ConfigItems = { configItem1 }
+            });
+
+            _executionManager.Project = project;
+            Assert.AreEqual(0, _executionManager.ActiveConfigIndex);
+            Assert.HasCount(1, project.ConfigFiles[0].ConfigItems);
+
+            var message = new CommandConfigContextMenu
+            {
+                Action = "duplicate",
+                Item = project.ConfigFiles[0].ConfigItems.First() as ConfigItem
+            };
+
+            // Act
+            MessageExchange.Instance.Publish(message);
+
+            // Assert
+            Assert.HasCount(2, project.ConfigFiles[0].ConfigItems);
+            Assert.AreEqual(firstConfigItemGuid, project.ConfigFiles[0].ConfigItems[0].GUID);
+            Assert.AreNotEqual(firstConfigItemGuid, project.ConfigFiles[0].ConfigItems[1].GUID, "Duplicated config items must have unique IDs");
+        }
+
         [TestMethod]
         public void CommandFileContextMenu_Remove_RemovesConfig()
         {


### PR DESCRIPTION
Adjusts config item duplication behavior so that a duplicated item is inserted *after* the original item, aligning the ExecutionManager behavior with expected UI/UX ordering.

**Changes:**
- Insert duplicated config items at `index + 1` instead of `index`.
- Add a unit test validating duplication preserves the original item position and generates a unique GUID.

fixes #2690 