### PR TITLE
Show file path in window title bar

### DIFF
--- a/MobiFlightUnitTests/AssemblyInitialize.cs
+++ b/MobiFlightUnitTests/AssemblyInitialize.cs
@@ -1,0 +1,17 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.Base;
+
+namespace MobiFlight.Tests
+{
+    [TestClass]
+    public class AssemblyInitialize
+    {
+        [AssemblyInitialize]
+        public static void Initialize(TestContext context)
+        {
+            // Globally disable schema validation to not exceed 1,000 limit per hour
+            // https://www.newtonsoft.com/jsonschema
+            JsonBackedObject.SkipSchemaValidation = true;
+        }
+    }
+}

--- a/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -32,10 +32,6 @@ namespace MobiFlight.Tests
         [TestInitialize]
         public void Setup()
         {
-            // disable schema validation to not exceed 1,000 limit per hour
-            // https://www.newtonsoft.com/jsonschema
-            JsonBackedObject.SkipSchemaValidation = true;
-
             _mockXplaneCache = new Mock<XplaneCacheInterface>();
             _mockSimConnectCache = new Mock<SimConnectCacheInterface>();
             _mockFsuipcCache = new Mock<FSUIPCCacheInterface>();

--- a/MobiFlightUnitTests/MobiFlight/JsonDefinitionFilesTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/JsonDefinitionFilesTests.cs
@@ -6,6 +6,21 @@ namespace MobiFlight.Tests
     [TestClass()]
     public class JsonDefinitionFileTests
     {
+        [TestInitialize]
+        public void Setup() {
+            // enable schema validation to not exceed 1,000 limit per hour
+            // https://www.newtonsoft.com/jsonschema
+            JsonBackedObject.SkipSchemaValidation = false;
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            // enable schema validation
+            // https://www.newtonsoft.com/jsonschema
+            JsonBackedObject.SkipSchemaValidation = true;
+        }
+
         [TestMethod()]
         public void BoardDefinitionFileTest()
         {

--- a/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -210,6 +210,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="AssemblyInitialize.cs" />
     <Compile Include="Base\BooleanConverterConfigTests.cs" />
     <Compile Include="Base\CmdLineParamsTests.cs" />
     <Compile Include="Base\ComboBoxHelperTests.cs" />

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -131,7 +131,7 @@ namespace MobiFlight.UI.Tests
             Assert.IsTrue(_mainForm.ProjectHasUnsavedChanges, "ProjectHasUnsavedChanges should be true when starting with a fresh project.");
 
             var mainFormTitle = _mainForm.Text;
-            var expectedTitle = $"New MobiFlight Project* - MobiFlight Connector - {MainForm.DisplayVersion()}";
+            var expectedTitle = $"* - MobiFlight Connector - {MainForm.DisplayVersion()}";
             Assert.AreEqual(expectedTitle, mainFormTitle);
         }
 
@@ -243,5 +243,67 @@ namespace MobiFlight.UI.Tests
             Assert.AreEqual(testFiles[2], projectFiles[1].FilePath);
             Assert.DoesNotContain(testFiles[1], projectFiles, "Removed file should not be in ProjectList");
         }
+
+        #region Update window title tests
+        [TestMethod()]
+        public void SetProjectFilePathInTitle_WithSavedProject_ShowsCorrectFilePath()
+        {
+            // Arrange
+            _mainForm.InitializeExecutionManager();
+            var testProjectName = "MyTestProject";
+            var tempFilePath = Path.Combine(_tempDirectory, $"{testProjectName}.mfproj");
+
+            var project = new Project() { Name = testProjectName };
+            _mainForm.CreateNewProject(project);
+
+            // Act - Save the project to establish a file path
+            var saveMethod = typeof(MainForm).GetMethod("SaveConfig", BindingFlags.NonPublic | BindingFlags.Instance);
+            saveMethod.Invoke(_mainForm, new object[] { tempFilePath });
+
+            // Assert - Title should show file path without asterisk (saved state)
+            var expectedTitle = $"{tempFilePath} - MobiFlight Connector - {MainForm.DisplayVersion()}";
+            Assert.AreEqual(expectedTitle, _mainForm.Text, "Title should display project file path without unsaved indicator");
+            Assert.IsFalse(_mainForm.ProjectHasUnsavedChanges, "Project should not have unsaved changes");
+        }
+
+        [TestMethod()]
+        public void SetProjectFilePathInTitle_WithUnsavedChanges_ShowsAsterisk()
+        {
+            // Arrange
+            _mainForm.InitializeExecutionManager();
+            var testProjectName = "MyTestProject";
+            var tempFilePath = Path.Combine(_tempDirectory, $"{testProjectName}.mfproj");
+
+            var project = new Project() { Name = testProjectName };
+            _mainForm.CreateNewProject(project);
+
+            // Save first to establish file path
+            var saveMethod = typeof(MainForm).GetMethod("SaveConfig", BindingFlags.NonPublic | BindingFlags.Instance);
+            saveMethod.Invoke(_mainForm, new object[] { tempFilePath });
+
+            // Act - Make a change to trigger unsaved state
+            _mainForm.AddNewFileToProject();
+
+            // Assert - Title should show file path WITH asterisk (unsaved state)
+            var expectedTitle = $"{tempFilePath}* - MobiFlight Connector - {MainForm.DisplayVersion()}";
+            Assert.AreEqual(expectedTitle, _mainForm.Text, "Title should display project file path with unsaved indicator");
+            Assert.IsTrue(_mainForm.ProjectHasUnsavedChanges, "Project should have unsaved changes");
+        }
+
+        [TestMethod()]
+        public void SetProjectFilePathInTitle_WithNoProject_ShowsOnlyVersionInfo()
+        {
+            // Arrange
+            _mainForm.InitializeExecutionManager();
+
+            // Act - Call SetTitle with empty string (simulates no project loaded)
+            var setTitleMethod = typeof(MainForm).GetMethod("SetTitle", BindingFlags.NonPublic | BindingFlags.Instance);
+            setTitleMethod.Invoke(_mainForm, new object[] { "" });
+
+            // Assert - Title should show only version info
+            var expectedTitle = $"MobiFlight Connector - {MainForm.DisplayVersion()}";
+            Assert.AreEqual(expectedTitle, _mainForm.Text, "Title should display only version info when no project is loaded");
+        }
+        #endregion
     }
 }

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -52,10 +52,6 @@ namespace MobiFlight.UI.Tests
         [TestInitialize]
         public void SetUp()
         {
-            // disable schema validation to not exceed 1,000 limit per hour
-            // https://www.newtonsoft.com/jsonschema
-            JsonBackedObject.SkipSchemaValidation = true;
-
             // Initialize the MainForm
             _mainForm = new TestableMainForm();
 
@@ -73,10 +69,6 @@ namespace MobiFlight.UI.Tests
         [TestCleanup]
         public void Cleanup()
         {
-            // re-enable schema validation again after tests to avoid affecting other tests that may rely on it
-            // https://www.newtonsoft.com/jsonschema
-            JsonBackedObject.SkipSchemaValidation = false;
-
             // Restore original RecentFiles
             Properties.Settings.Default.RecentFiles = originalRecentFiles;
             Properties.Settings.Default.Save();

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -248,6 +248,7 @@ namespace MobiFlight.UI.Tests
             var tempFilePath = Path.Combine(_tempDirectory, $"{testProjectName}.mfproj");
 
             var project = new Project() { Name = testProjectName };
+
             _mainForm.CreateNewProject(project);
 
             // Act - Save the project to establish a file path
@@ -268,10 +269,15 @@ namespace MobiFlight.UI.Tests
             var testProjectName = "MyTestProject";
             var tempFilePath = Path.Combine(_tempDirectory, $"{testProjectName}.mfproj");
 
+            // Act - Create a new project (unsaved state)
             var project = new Project() { Name = testProjectName };
             _mainForm.CreateNewProject(project);
 
-            // Save first to establish file path
+            // Assert - Title should show file path WITH asterisk (unsaved state)
+            var expectedTitle = $"* - MobiFlight Connector - {MainForm.DisplayVersion()}";
+            Assert.AreEqual(expectedTitle, _mainForm.Text, "Title should display at least unsaved indicator (*)");
+
+            // Arrange - Save first to establish file path
             var saveMethod = typeof(MainForm).GetMethod("SaveConfig", BindingFlags.NonPublic | BindingFlags.Instance);
             saveMethod.Invoke(_mainForm, new object[] { tempFilePath });
 
@@ -279,7 +285,7 @@ namespace MobiFlight.UI.Tests
             _mainForm.AddNewFileToProject();
 
             // Assert - Title should show file path WITH asterisk (unsaved state)
-            var expectedTitle = $"{tempFilePath}* - MobiFlight Connector - {MainForm.DisplayVersion()}";
+            expectedTitle = $"{tempFilePath}* - MobiFlight Connector - {MainForm.DisplayVersion()}";
             Assert.AreEqual(expectedTitle, _mainForm.Text, "Title should display project file path with unsaved indicator");
             Assert.IsTrue(_mainForm.ProjectHasUnsavedChanges, "Project should have unsaved changes");
         }

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -52,6 +52,10 @@ namespace MobiFlight.UI.Tests
         [TestInitialize]
         public void SetUp()
         {
+            // disable schema validation to not exceed 1,000 limit per hour
+            // https://www.newtonsoft.com/jsonschema
+            JsonBackedObject.SkipSchemaValidation = true;
+
             // Initialize the MainForm
             _mainForm = new TestableMainForm();
 
@@ -69,6 +73,10 @@ namespace MobiFlight.UI.Tests
         [TestCleanup]
         public void Cleanup()
         {
+            // re-enable schema validation again after tests to avoid affecting other tests that may rely on it
+            // https://www.newtonsoft.com/jsonschema
+            JsonBackedObject.SkipSchemaValidation = false;
+
             // Restore original RecentFiles
             Properties.Settings.Default.RecentFiles = originalRecentFiles;
             Properties.Settings.Default.Save();

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -97,7 +97,7 @@ namespace MobiFlight.UI.Tests
 
 
         [TestMethod()]
-        public void CreateNewProjectTest()
+        public void CreateNewProject_ProjectHasUnsavedChanges_Updates_Correctly()
         {
             // Arrange
             _mainForm.InitializeExecutionManager();
@@ -129,15 +129,11 @@ namespace MobiFlight.UI.Tests
 
             // Assert
             Assert.IsTrue(_mainForm.ProjectHasUnsavedChanges, "ProjectHasUnsavedChanges should be true when starting with a fresh project.");
-
-            var mainFormTitle = _mainForm.Text;
-            var expectedTitle = $"* - MobiFlight Connector - {MainForm.DisplayVersion()}";
-            Assert.AreEqual(expectedTitle, mainFormTitle);
         }
 
 
         [TestMethod()]
-        public void AddNewFileToProjectTest()
+        public void AddNewFileToProjectTest_ProjectHasUnsavedChanges_Updates_Correctly()
         {
             // Arrange
             _mainForm.InitializeExecutionManager();
@@ -147,9 +143,7 @@ namespace MobiFlight.UI.Tests
             _mainForm.AddNewFileToProject();
 
             // Assert
-            var mainFormTitle = _mainForm.Text;
             Assert.IsTrue(_mainForm.ProjectHasUnsavedChanges, "ProjectHasUnsavedChanges should be true after adding a new file.");
-            Assert.Contains("*", mainFormTitle, "Project title should indicate that there are unsaved changes.");
         }
 
         [TestMethod()]

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -588,7 +588,7 @@ namespace MobiFlight.UI
         private void ProjectOrConfigFileHasChanged()
         {
             ProjectHasUnsavedChanges = true;
-            SetProjectNameInTitle();
+            SetProjectFilePathInTitle();
             UpdateAutoLoadMenu();
             UpdateAllConnectionIcons();
         }
@@ -2036,15 +2036,15 @@ namespace MobiFlight.UI
         private void ResetProjectAndConfigChanges()
         {
             ProjectHasUnsavedChanges = false;
-            SetProjectNameInTitle();
+            SetProjectFilePathInTitle();
         }
 
         private void SetTitle(string title)
         {
             string NewTitle = $"MobiFlight Connector - {DisplayVersion()}";
             var saveStatus = ProjectHasUnsavedChanges ? "*" : string.Empty;
-
-            if (title != null && title != "")
+            
+            if (ProjectHasUnsavedChanges || !string.IsNullOrEmpty(title))
             {
                 NewTitle = $"{title}{saveStatus} - {NewTitle}";
             }
@@ -2070,9 +2070,9 @@ namespace MobiFlight.UI
             return Version;
         }
 
-        private void SetProjectNameInTitle()
+        private void SetProjectFilePathInTitle()
         {
-            SetTitle(execManager.Project?.Name ?? string.Empty);
+            SetTitle(execManager.Project?.FilePath ?? string.Empty);
         }
 
         /// <summary>
@@ -2244,7 +2244,7 @@ namespace MobiFlight.UI
             // Indicate that the new project has unsaved changes
             // because it was never saved before.
             ProjectHasUnsavedChanges = true;
-            SetProjectNameInTitle();
+            SetProjectFilePathInTitle();
         }
 
         public void AddNewFileToProject()


### PR DESCRIPTION
## Pull request overview

Updates the WinForms main window title to display the currently loaded project’s file path (instead of the project name), addressing ambiguity when multiple projects share the same name (fixes #2713).

**Changes:**
- Replace title updates from project name to project file path in `MainForm`.
- Adjust title formatting logic to include unsaved-change indicator (`*`) with the displayed prefix.
- Update and add unit tests around window title behavior.

fixes #2713 