### PR TITLE
Fix crash on startup due to empty recent project files list.

### DIFF
--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -305,5 +305,78 @@ namespace MobiFlight.UI.Tests
             Assert.AreEqual(expectedTitle, _mainForm.Text, "Title should display only version info when no project is loaded");
         }
         #endregion
+
+        #region GetFirstExistingRecentFileOrNull tests
+
+        [TestMethod()]
+        public void GetFirstExistingRecentFileOrNullOrNull_EmptyRecentFiles_ReturnsNull()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles = new StringCollection();
+            var method = typeof(MainForm).GetMethod("GetFirstExistingRecentFileOrNull", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var result = method.Invoke(_mainForm, null) as string;
+
+            // Assert
+            Assert.IsNull(result, "Should return null when RecentFiles is empty");
+        }
+
+        [TestMethod()]
+        public void GetFirstExistingRecentFileOrNull_NoExistingFiles_ReturnsNull()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles = 
+                new StringCollection
+                {
+                    Path.Combine(_tempDirectory, "nonexistent1.mfproj"),
+                    Path.Combine(_tempDirectory, "nonexistent2.mfproj")
+                };
+            var method = typeof(MainForm).GetMethod("GetFirstExistingRecentFileOrNull", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var result = method.Invoke(_mainForm, null) as string;
+
+            // Assert
+            Assert.IsNull(result, "Should return null when no files exist");
+        }
+
+        [TestMethod()]
+        public void GetFirstExistingRecentFileOrNull_WithExistingFile_ReturnsFirstExisting()
+        {
+            // Arrange
+            var nonExistentFile = Path.Combine(_tempDirectory, "nonexistent.mfproj");
+            var existingFile = CreateTestFile("existing.mfproj");
+
+            Properties.Settings.Default.RecentFiles =
+                new StringCollection
+                {
+                    nonExistentFile,
+                    existingFile
+                };
+            var method = typeof(MainForm).GetMethod("GetFirstExistingRecentFileOrNull", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var result = method.Invoke(_mainForm, null) as string;
+
+            // Assert
+            Assert.AreEqual(existingFile, result, "Should return the first existing file");
+        }
+
+        [TestMethod()]
+        public void GetFirstExistingRecentFileOrNull_NullRecentFiles_ReturnsNull()
+        {
+            // Arrange
+            Properties.Settings.Default.RecentFiles = null;
+            var method = typeof(MainForm).GetMethod("GetFirstExistingRecentFileOrNull", BindingFlags.NonPublic | BindingFlags.Instance);
+
+            // Act
+            var result = method.Invoke(_mainForm, null) as string;
+
+            // Assert
+            Assert.IsNull(result, "Should return null when RecentFiles is null");
+        }
+
+        #endregion
     }
 }

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -309,14 +309,13 @@ namespace MobiFlight.UI.Tests
         #region GetFirstExistingRecentFileOrNull tests
 
         [TestMethod()]
-        public void GetFirstExistingRecentFileOrNullOrNull_EmptyRecentFiles_ReturnsNull()
+        public void GetFirstExistingRecentFileOrNull_EmptyRecentFiles_ReturnsNull()
         {
             // Arrange
             Properties.Settings.Default.RecentFiles = new StringCollection();
-            var method = typeof(MainForm).GetMethod("GetFirstExistingRecentFileOrNull", BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Act
-            var result = method.Invoke(_mainForm, null) as string;
+            var result = _mainForm.GetFirstExistingRecentFileOrNull();
 
             // Assert
             Assert.IsNull(result, "Should return null when RecentFiles is empty");
@@ -332,10 +331,9 @@ namespace MobiFlight.UI.Tests
                     Path.Combine(_tempDirectory, "nonexistent1.mfproj"),
                     Path.Combine(_tempDirectory, "nonexistent2.mfproj")
                 };
-            var method = typeof(MainForm).GetMethod("GetFirstExistingRecentFileOrNull", BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Act
-            var result = method.Invoke(_mainForm, null) as string;
+            var result = _mainForm.GetFirstExistingRecentFileOrNull();
 
             // Assert
             Assert.IsNull(result, "Should return null when no files exist");
@@ -354,10 +352,9 @@ namespace MobiFlight.UI.Tests
                     nonExistentFile,
                     existingFile
                 };
-            var method = typeof(MainForm).GetMethod("GetFirstExistingRecentFileOrNull", BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Act
-            var result = method.Invoke(_mainForm, null) as string;
+            var result = _mainForm.GetFirstExistingRecentFileOrNull();
 
             // Assert
             Assert.AreEqual(existingFile, result, "Should return the first existing file");
@@ -368,10 +365,9 @@ namespace MobiFlight.UI.Tests
         {
             // Arrange
             Properties.Settings.Default.RecentFiles = null;
-            var method = typeof(MainForm).GetMethod("GetFirstExistingRecentFileOrNull", BindingFlags.NonPublic | BindingFlags.Instance);
 
             // Act
-            var result = method.Invoke(_mainForm, null) as string;
+            var result = _mainForm.GetFirstExistingRecentFileOrNull();
 
             // Assert
             Assert.IsNull(result, "Should return null when RecentFiles is null");


### PR DESCRIPTION
In #2711 we missed that `First()` will throw an exception if there are no items in the collection. Correct method is `FirstOrDefault`

This PR also adds unit tests to cover the autoLoadConfig logic. For this, a new method got introduced called `GetFirstExistingRecentFileOrNull` - it isolates the logic to identify the most recently used project.

fixes #2720 