### PR TITLE
App.tsx - Refactor Backend State Updates and Progress Bar

### DIFF
--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -533,7 +533,7 @@ namespace MobiFlight.UI
             SetTitle("");
 
             StartupProgressValue = 0;
-            MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Start Connecting" });
+            MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Startup.Starting" });
 
 #if ARCAZE
             _initializeArcazeModuleSettings();
@@ -937,15 +937,15 @@ namespace MobiFlight.UI
             }
 
             StartupProgressValue = 70;
-            MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Checking for Firmware Updates..." });
+            MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Startup.CheckingFirmwareUpdates" });
             CheckForFirmwareUpdates();
 
             StartupProgressValue = 90;
-            MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Loading last config..." });
+            MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Startup.LoadingLastConfig" });
             _autoloadConfig();
 
             StartupProgressValue = 100;
-            MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Finished." });
+            MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Startup.Finished" });
 
             CheckForWasmModuleUpdate();
             CheckForHubhopUpdate();
@@ -1319,7 +1319,7 @@ namespace MobiFlight.UI
                 StartupProgressValue = 50;
                 var progressIncrement = (75 - StartupProgressValue) / 2;
                 StartupProgressValue += progressIncrement;
-                MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Scanning for boards." });
+                MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Startup.ScanningControllers" });
                 return;
             }
 

--- a/UI/Panels/FrontendPanel.cs
+++ b/UI/Panels/FrontendPanel.cs
@@ -45,7 +45,7 @@ namespace MobiFlight.UI.Panels
             await FrontendWebView.EnsureCoreWebView2Async(null);
             await UserAuthenticationWebView.EnsureCoreWebView2Async(null);
 
-            InitializeWebView(FrontendWebView);
+            InitializeWebView(FrontendWebView, "/start");
             InitializeWebView(UserAuthenticationWebView);
 
             compositePublisher.AddPublisher("frontend", new PostMessagePublisher(FrontendWebView));
@@ -54,7 +54,7 @@ namespace MobiFlight.UI.Panels
             MessageExchange.Instance.SetPublisher(compositePublisher);
         }
 
-        private void InitializeWebView(ThreadSafeWebView2 webView)
+        private void InitializeWebView(ThreadSafeWebView2 webView, string route = "/")
         {
             if (IsRunningInProduction)
             {
@@ -79,7 +79,7 @@ namespace MobiFlight.UI.Panels
             webView.CoreWebView2.Settings.IsWebMessageEnabled = true;
             webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
             // Navigate to start the app
-            webView.CoreWebView2.Navigate($"{_frontendBaseUrl}/index.html");
+            webView.CoreWebView2.Navigate($"{_frontendBaseUrl}{route}");
 
             if (_desiredZoomFactor != 0.0)
             {

--- a/frontend/public/locales/de/translation.json
+++ b/frontend/public/locales/de/translation.json
@@ -295,6 +295,16 @@
       "Description": "{{errorMessage}}"
     }
   },
+  "Startup": {
+    "Starting": "Starte MobiFlight...",
+    "CheckingFirmwareUpdates": "Suche nach Firmware-Updates...",
+    "ScanningControllers": "Suche nach verbundenen Controllern...",
+    "LoadingLastConfig": "Lade letzte Konfiguration...",
+    "Finished": "Fertig.",
+    "Test": {
+      "Loading": "Lade..."
+    }
+  },
   "Feed": {
     "Title": "Community Feed",
     "Description": "Neuigkeiten und Updates aus der MobiFlight-Community.",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -289,6 +289,16 @@
       "Description": "{{errorMessage}}"
     }
   },
+  "Startup": {
+    "Starting": "Starting MobiFlight...",
+    "CheckingFirmwareUpdates": "Checking for Firmware Updates...",
+    "ScanningControllers": "Scanning for connected controllers...",
+    "LoadingLastConfig": "Loading last config...",
+    "Finished": "Finished.",
+    "Test": {
+      "Loading": "Loading..."
+    }
+  },
   "Feed": {
     "Title": "Community Feed",
     "Description": "News and updates from the MobiFlight community.",

--- a/frontend/public/locales/es/translation.json
+++ b/frontend/public/locales/es/translation.json
@@ -295,6 +295,16 @@
       "Description": "{{errorMessage}}"
     }
   },
+  "Startup": {
+    "Starting": "Iniciando MobiFlight...",
+    "CheckingFirmwareUpdates": "Buscando actualizaciones de firmware...",
+    "ScanningControllers": "Buscando controladores conectados...",
+    "LoadingLastConfig": "Cargando última configuración...",
+    "Finished": "Finalizado.",
+    "Test": {
+      "Loading": "Cargando..."
+    }
+  },
   "Feed": {
     "Title": "Community Feed",
     "Description": "Noticias y novedades de la comunidad de MobiFlight.",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,26 +2,9 @@ import { Outlet, useNavigate, useOutlet, useSearchParams } from "react-router"
 import StartupProgress from "./components/StartupProgress"
 import { useEffect, useState } from "react"
 import { useAppMessage } from "./lib/hooks/appMessage"
-import { Project, StatusBarUpdate } from "./types"
-import i18next from "i18next"
-import Settings from "./types/settings"
-import _ from "lodash"
-import { useProjectStore } from "./stores/projectStore"
+import { StatusBarUpdate } from "./types"
 import { MainMenu } from "./components/MainMenu"
-import { useRecentProjects, useSettingsStore } from "./stores/settingsStore"
-import { useControllerDefinitionsStore } from "./stores/definitionStore"
-import {
-  AuthenticationStatus,
-  BoardDefinitions,
-  ConnectedControllers,
-  ExecutionState,
-  HubHopState,
-  JoystickDefinitions,
-  MidiControllerDefinitions,
-  OverlayState,
-  ProjectStatus,
-  RecentProjects,
-} from "./types/messages"
+import { OverlayState } from "./types/messages"
 import {
   useKeyAccelerators,
   GlobalKeyAccelerators,
@@ -30,46 +13,21 @@ import LoaderOverlay from "./components/tables/config-item-table/LoaderOverlay"
 import { Toaster } from "./components/ui/sonner"
 import { useTheme } from "@/lib/hooks/useTheme"
 import { ToastNotificationHandler } from "./components/notifications/ToastNotificationHandler"
-import { useHubHopStateActions } from "./stores/stateStore"
 
-import testProject from "@/../tests/data/project.testdata.json" with { type: "json" }
-import testJsDefinition from "@/../tests/data/joystick.definition.json" with { type: "json" }
-import testMidiDefinition from "@/../tests/data/midicontroller.definition.json" with { type: "json" }
-import testRecentProjects from "@/../tests/data/recentProjects.testdata.json" with { type: "json" }
-import testControllers from "@/../tests/data/connectedControllers.testdata.json" with { type: "json" }
-
-import {
-  MidiControllerDefinition,
-  JoystickDefinition,
-} from "@/types/definitions"
 import DebugInfo from "@/components/DebugInfo"
-import { useExecutionStateStore } from "@/stores/executionStateStore"
-import { ProjectInfo } from "@/types/project"
-import { useControllerStore } from "@/stores/controllerStore"
 import { useTranslation } from "react-i18next"
-import { useAuth } from "react-oidc-context"
+import { useBackendStateAppMessages } from "@/lib/hooks/useBackendStateAppMessages"
 
 function App() {
+  // Initialize global app message handlers
+  useBackendStateAppMessages() 
   const [queryParameters] = useSearchParams()
   const navigate = useNavigate()
-  const { project, setProject, setProjectStatus } = useProjectStore()
-  const { setRecentProjects } = useRecentProjects()
-  const { setSettings } = useSettingsStore()
-  const { setControllers } = useControllerStore()
-  const {
-    setBoardDefinitions,
-    setJoystickDefinitions,
-    setMidiControllerDefinitions,
-  } = useControllerDefinitionsStore()
 
-  const { setIsRunning, setIsTesting } = useExecutionStateStore()
-
-  const setHubHopState = useHubHopStateActions()
   useKeyAccelerators(GlobalKeyAccelerators, true)
   const outlet = useOutlet()
   const [overlayVisible, setOverlayVisible] = useState(false)
   const { theme } = useTheme()
-  const auth = useAuth()
 
   // State for startup progress from app messages
   const [appStartupProgress, setAppStartupProgress] = useState<StatusBarUpdate>(
@@ -78,6 +36,16 @@ function App() {
       Text: "Starting...",
     },
   )
+
+  useAppMessage("StatusBarUpdate", (message) => {
+    setAppStartupProgress(message.payload as StatusBarUpdate)
+  })
+
+  useAppMessage("OverlayState", (message) => {
+    const overlayState = message.payload as OverlayState
+    console.log("OverlayState message received", overlayState)
+    setOverlayVisible(overlayState.Visible)
+  })
 
   const queryProgressValue = Number.parseInt(
     queryParameters.get("progress")?.toString() ?? "0",
@@ -92,97 +60,6 @@ function App() {
         }
       : appStartupProgress
 
-  useAppMessage("StatusBarUpdate", (message) => {
-    setAppStartupProgress(message.payload as StatusBarUpdate)
-  })
-
-  useAppMessage("Project", (message) => {
-    const project = message.payload as Project
-    console.log("Project message received", project)
-    setProject(project)
-  })
-
-  useAppMessage("RecentProjects", (message) => {
-    const recentProjects = message.payload as RecentProjects
-    setRecentProjects(recentProjects.Projects)
-    console.log("List of Recent Projects received", recentProjects.Projects)
-  })
-
-  useAppMessage("Settings", (message) => {
-    const settings = message.payload as Settings
-    console.log("Settings message received", settings)
-    setSettings(settings)
-
-    const language = settings.Language.split("-")[0]
-    if (!_.isEmpty(language)) i18next.changeLanguage(settings.Language)
-    else i18next.changeLanguage()
-  })
-
-  useAppMessage("BoardDefinitions", (message) => {
-    const boardDefinitions = message.payload as BoardDefinitions
-    console.log(
-      "BoardDefinitions message received",
-      boardDefinitions.Definitions,
-    )
-    setBoardDefinitions(boardDefinitions.Definitions)
-  })
-
-  useAppMessage("JoystickDefinitions", (message) => {
-    const joystickDefinitions = message.payload as JoystickDefinitions
-    console.log(
-      "JoystickDefinitions message received",
-      joystickDefinitions.Definitions,
-    )
-    setJoystickDefinitions(joystickDefinitions.Definitions)
-  })
-
-  useAppMessage("MidiControllerDefinitions", (message) => {
-    const definitions = message.payload as MidiControllerDefinitions
-    console.log(
-      "MidiControllerDefinitions message received",
-      definitions.Definitions,
-    )
-    setMidiControllerDefinitions(definitions.Definitions)
-  })
-
-  useAppMessage("ProjectStatus", (message) => {
-    const projectStatus = message.payload as ProjectStatus
-    console.log("ProjectStatus message received", projectStatus)
-    setProjectStatus(projectStatus)
-  })
-
-  useAppMessage("OverlayState", (message) => {
-    const overlayState = message.payload as OverlayState
-    console.log("OverlayState message received", overlayState)
-    setOverlayVisible(overlayState.Visible)
-  })
-
-  useAppMessage("HubHopState", (message) => {
-    const state = message.payload as HubHopState
-    setHubHopState(state)
-  })
-
-  useAppMessage("ConnectedControllers", (message) => {
-    const controllers = (message.payload as ConnectedControllers).Controllers
-    setControllers(controllers)
-  })
-
-  // Listen for auth state changes from C#
-  useAppMessage("AuthenticationStatus", async (message) => {
-    const authStatus = message.payload as AuthenticationStatus
-    console.log("AuthenticationStatus message received", authStatus)
-    try {
-      // Trigger silent signin to sync auth state from localStorage
-      if (authStatus.Authenticated) {
-        await auth.signinSilent()
-      } else {
-        auth.removeUser() // Clear user to ensure state is updated based on signinSilent result
-      }
-    } catch (err) {
-      console.log("Auth sync after window close:", err)
-    }
-  })
-
   useEffect(() => {
     if (startupProgress.Value == 100 && location.pathname == "/index.html") {
       console.log("Finished loading, navigating to home")
@@ -190,40 +67,6 @@ function App() {
     }
   }, [startupProgress.Value, navigate])
 
-  // this is only for easier UI testing
-  // while developing the UI
-  useEffect(() => {
-    if (
-      process.env.NODE_ENV === "development" &&
-      queryParameters.get("testdata") === "true" &&
-      !project // Only if no project loaded yet
-    ) {
-      setProject(testProject as Project)
-      setRecentProjects(testRecentProjects as ProjectInfo[])
-      setJoystickDefinitions([testJsDefinition as JoystickDefinition])
-
-      setMidiControllerDefinitions([
-        testMidiDefinition as MidiControllerDefinition,
-      ])
-
-      setControllers(testControllers as ConnectedControllers["Controllers"])
-    }
-  }, [
-    project,
-    queryParameters,
-    setJoystickDefinitions,
-    setMidiControllerDefinitions,
-    setProject,
-    setRecentProjects,
-    setControllers,
-  ])
-
-  useAppMessage("ExecutionState", (message) => {
-    console.log("ExecutionState message received", message.payload)
-    const { IsRunning, IsTesting } = message.payload as ExecutionState
-    setIsRunning(IsRunning)
-    setIsTesting(IsTesting)
-  })
   const { t } = useTranslation()
 
   return (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,12 +14,8 @@ import { ToastNotificationHandler } from "./components/notifications/ToastNotifi
 
 import DebugInfo from "@/components/DebugInfo"
 import { useTranslation } from "react-i18next"
-import { useBackendStateAppMessages } from "@/lib/hooks/useBackendStateAppMessages"
 
 function App() {
-  // Initialize global app message handlers
-  useBackendStateAppMessages() 
-
   useKeyAccelerators(GlobalKeyAccelerators, true)
   const outlet = useOutlet()
   const [overlayVisible, setOverlayVisible] = useState(false)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,6 @@
-import { Outlet, useNavigate, useOutlet, useSearchParams } from "react-router"
-import StartupProgress from "./components/StartupProgress"
-import { useEffect, useState } from "react"
+import { Outlet, useOutlet } from "react-router"
+import { useState } from "react"
 import { useAppMessage } from "./lib/hooks/appMessage"
-import { StatusBarUpdate } from "./types"
 import { MainMenu } from "./components/MainMenu"
 import { OverlayState } from "./types/messages"
 import {
@@ -21,51 +19,17 @@ import { useBackendStateAppMessages } from "@/lib/hooks/useBackendStateAppMessag
 function App() {
   // Initialize global app message handlers
   useBackendStateAppMessages() 
-  const [queryParameters] = useSearchParams()
-  const navigate = useNavigate()
 
   useKeyAccelerators(GlobalKeyAccelerators, true)
   const outlet = useOutlet()
   const [overlayVisible, setOverlayVisible] = useState(false)
   const { theme } = useTheme()
-
-  // State for startup progress from app messages
-  const [appStartupProgress, setAppStartupProgress] = useState<StatusBarUpdate>(
-    {
-      Value: 0,
-      Text: "Starting...",
-    },
-  )
-
-  useAppMessage("StatusBarUpdate", (message) => {
-    setAppStartupProgress(message.payload as StatusBarUpdate)
-  })
-
+  
   useAppMessage("OverlayState", (message) => {
     const overlayState = message.payload as OverlayState
     console.log("OverlayState message received", overlayState)
     setOverlayVisible(overlayState.Visible)
   })
-
-  const queryProgressValue = Number.parseInt(
-    queryParameters.get("progress")?.toString() ?? "0",
-  )
-
-  const startupProgress =
-    queryProgressValue > 0
-      ? {
-          Value: queryProgressValue,
-          Text:
-            queryProgressValue === 100 ? "Loading complete..." : "Loading...",
-        }
-      : appStartupProgress
-
-  useEffect(() => {
-    if (startupProgress.Value == 100 && location.pathname == "/index.html") {
-      console.log("Finished loading, navigating to home")
-      navigate("/home")
-    }
-  }, [startupProgress.Value, navigate])
 
   const { t } = useTranslation()
 
@@ -78,7 +42,7 @@ function App() {
           message={t("General.Overlay.OpeningWizard")}
         />
       )}
-      {outlet ? (
+      {outlet && (
         <div className="flex h-svh flex-row overflow-hidden p-0 select-none">
           {/* <Sidebar /> */}
           <div className="flex grow flex-col">
@@ -92,12 +56,7 @@ function App() {
             <DebugInfo />
           </div>
         </div>
-      ) : (
-        <StartupProgress
-          value={startupProgress.Value}
-          text={startupProgress.Text}
-        />
-      )}
+      ) }
       <ToastNotificationHandler />
       <Toaster
         expand

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -9,6 +9,7 @@ import ConfigListPage from "@/pages/ConfigList"
 import Dashboard from "@/pages/Dashboard"
 import Plain from "@/pages/Plain"
 import { Route, Routes, useLocation } from "react-router"
+import StartupProgress from "@/components/StartupProgress"
 
 export function AppRoutes() {
   const location = useLocation()
@@ -19,6 +20,9 @@ export function AppRoutes() {
       <Routes location={state?.backgroundLocation || location}>
         <Route path="/" element={<Plain />}>
           <Route index element={<SplashLogo />} />
+        </Route>
+        <Route path="/start" element={<Plain />}>
+          <Route index element={<StartupProgress />} />
         </Route>
         <Route path="/home" element={<App />}>
           <Route index element={<Dashboard />} />

--- a/frontend/src/components/BackendStateMessageHandler.tsx
+++ b/frontend/src/components/BackendStateMessageHandler.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from "react"
+import { useBackendStateAppMessages } from "@/lib/hooks/useBackendStateAppMessages"
+
+type BackendStateMessageHandlerProps = {
+  children: ReactNode
+}
+
+export function BackendStateMessageHandler({
+  children,
+}: BackendStateMessageHandlerProps) {
+  useBackendStateAppMessages()
+  return <>{children}</>
+}

--- a/frontend/src/components/StartupProgress.tsx
+++ b/frontend/src/components/StartupProgress.tsx
@@ -35,11 +35,16 @@ const StartupProgress = () => {
       : appStartupProgress
 
   useEffect(() => {
-    if (startupProgress.Value == 100) {
-      console.log("Finished loading, navigating to home")
-      setTimeout(() => {
-        navigate("/home")
-      }, 1000) // Add a small delay to allow users to see the completed progress bar
+    if (startupProgress.Value !== 100) return
+
+    console.log("Finished loading, navigating to home")
+    
+    const timeoutId = setTimeout(() => {
+      navigate("/home")
+    }, 1000) // Add a small delay to allow users to see the completed progress bar
+
+    return () => {
+      clearTimeout(timeoutId)
     }
   }, [startupProgress.Value, navigate])
 

--- a/frontend/src/components/StartupProgress.tsx
+++ b/frontend/src/components/StartupProgress.tsx
@@ -4,13 +4,15 @@ import { StatusBarUpdate } from "@/types/messages"
 import { useEffect, useState } from "react"
 import { useAppMessage } from "@/lib/hooks/appMessage"
 import { useNavigate, useSearchParams } from "react-router"
+import { useTranslation } from "react-i18next"
 
 const StartupProgress = () => {
+  const { t } = useTranslation()
   // State for startup progress from app messages
   const [appStartupProgress, setAppStartupProgress] = useState<StatusBarUpdate>(
     {
       Value: 0,
-      Text: "Starting...",
+      Text: "Startup.Starting",
     },
   )
   const [queryParameters] = useSearchParams()
@@ -26,7 +28,9 @@ const StartupProgress = () => {
       ? {
           Value: queryProgressValue,
           Text:
-            queryProgressValue === 100 ? "Loading complete..." : "Loading...",
+            queryProgressValue === 100
+              ? "Startup.Finished"
+              : "Startup.Test.Loading",
         }
       : appStartupProgress
 
@@ -40,7 +44,7 @@ const StartupProgress = () => {
   }, [startupProgress.Value, navigate])
 
   return (
-    <div className="relative min-w-lg lg:min-w-xl flex min-h-screen flex-col items-center justify-center gap-8 p-10">
+    <div className="relative flex min-h-screen min-w-lg flex-col items-center justify-center gap-8 p-10 lg:min-w-xl">
       <SplashLogo />
       <div className="w-full max-w-xl rounded-full p-0.5 dark:h-10 dark:bg-linear-to-br dark:from-indigo-500 dark:from-10% dark:via-sky-500 dark:via-30% dark:to-emerald-500 dark:to-90%">
         <Progress
@@ -48,7 +52,7 @@ const StartupProgress = () => {
           value={startupProgress.Value}
         ></Progress>
       </div>
-      <p className="text-white">{startupProgress.Text}</p>
+      <p className="text-white">{t(startupProgress.Text)}</p>
     </div>
   )
 }

--- a/frontend/src/components/StartupProgress.tsx
+++ b/frontend/src/components/StartupProgress.tsx
@@ -1,27 +1,55 @@
 import SplashLogo from "@/components/SplashLogo"
 import { Progress } from "./ui/progress"
+import { StatusBarUpdate } from "@/types/messages"
+import { useEffect, useState } from "react"
+import { useAppMessage } from "@/lib/hooks/appMessage"
+import { useNavigate, useSearchParams } from "react-router"
 
-interface StartupProgressProps {
-  value: number
-  text: string
-}
+const StartupProgress = () => {
+  // State for startup progress from app messages
+  const [appStartupProgress, setAppStartupProgress] = useState<StatusBarUpdate>(
+    {
+      Value: 0,
+      Text: "Starting...",
+    },
+  )
+  const [queryParameters] = useSearchParams()
+  const navigate = useNavigate()
+  useAppMessage("StatusBarUpdate", (message) => {
+    setAppStartupProgress(message.payload as StatusBarUpdate)
+  })
+  const queryProgressValue = Number.parseInt(
+    queryParameters.get("progress")?.toString() ?? "0",
+  )
+  const startupProgress =
+    queryProgressValue > 0
+      ? {
+          Value: queryProgressValue,
+          Text:
+            queryProgressValue === 100 ? "Loading complete..." : "Loading...",
+        }
+      : appStartupProgress
 
-const StartupProgress = (props: StartupProgressProps) => {
-  const { value, text } = props
+  useEffect(() => {
+    if (startupProgress.Value == 100) {
+      console.log("Finished loading, navigating to home")
+      setTimeout(() => {
+        navigate("/home")
+      }, 1000) // Add a small delay to allow users to see the completed progress bar
+    }
+  }, [startupProgress.Value, navigate])
+
   return (
-    <>
-      <div className="fixed inset-0 bg-linear-to-br from-indigo-500 from-10% via-sky-500 via-30% to-emerald-500 to-90% dark:from-indigo-500/10 dark:via-sky-500/0 dark:via-70% dark:to-emerald-500/5"></div>
-      <div className="relative flex min-h-screen flex-col items-center justify-center gap-8 p-10">
-        <SplashLogo />
-        <div className="w-full max-w-xl rounded-full p-0.5 dark:h-10 dark:bg-linear-to-br dark:from-indigo-500 dark:from-10% dark:via-sky-500 dark:via-30% dark:to-emerald-500 dark:to-90%">
-          <Progress
-            className="h-10 max-w-xl dark:h-9 dark:bg-black"
-            value={value}
-          ></Progress>
-        </div>
-        <p className="text-white">{text}</p>
+    <div className="relative min-w-lg lg:min-w-xl flex min-h-screen flex-col items-center justify-center gap-8 p-10">
+      <SplashLogo />
+      <div className="w-full max-w-xl rounded-full p-0.5 dark:h-10 dark:bg-linear-to-br dark:from-indigo-500 dark:from-10% dark:via-sky-500 dark:via-30% dark:to-emerald-500 dark:to-90%">
+        <Progress
+          className="h-10 max-w-xl dark:h-9 dark:bg-black"
+          value={startupProgress.Value}
+        ></Progress>
       </div>
-    </>
+      <p className="text-white">{startupProgress.Text}</p>
+    </div>
   )
 }
 

--- a/frontend/src/lib/hooks/useBackendStateAppMessages.ts
+++ b/frontend/src/lib/hooks/useBackendStateAppMessages.ts
@@ -27,13 +27,19 @@ import {
 } from "@/types/definitions"
 import { ProjectInfo } from "@/types/project"
 
-import testProject from "@/../tests/data/project.testdata.json" with { type: "json" }
-import testJsDefinition from "@/../tests/data/joystick.definition.json" with { type: "json" }
-import testMidiDefinition from "@/../tests/data/midicontroller.definition.json" with { type: "json" }
-import testRecentProjects from "@/../tests/data/recentProjects.testdata.json" with { type: "json" }
-import testControllers from "@/../tests/data/connectedControllers.testdata.json" with { type: "json" }
+let testProject : Project, testJsDefinition : JoystickDefinition, testMidiDefinition : MidiControllerDefinition, testRecentProjects : ProjectInfo[], testControllers : Controller[];
+
+if (process.env.NODE_ENV === "development") {
+  testProject = await import("@/../tests/data/project.testdata.json", { assert: { type: "json" } }) as Project;
+  testJsDefinition = await import("@/../tests/data/joystick.definition.json", { assert: { type: "json" } }) as JoystickDefinition;
+  testMidiDefinition = await import("@/../tests/data/midicontroller.definition.json", { assert: { type: "json" } }) as MidiControllerDefinition;
+  testRecentProjects = await import("@/../tests/data/recentProjects.testdata.json", { assert: { type: "json" } }) as ProjectInfo[];
+  testControllers = await import("@/../tests/data/connectedControllers.testdata.json", { assert: { type: "json" } }) as Controller[];
+}
+
 import { useSearchParams } from "react-router"
 import _ from "lodash"
+import { Controller } from "@/types/controller"
 
 export const useBackendStateAppMessages = () => {
   const [queryParameters] = useSearchParams()
@@ -156,7 +162,7 @@ export const useBackendStateAppMessages = () => {
         testMidiDefinition as MidiControllerDefinition,
       ])
 
-      setControllers(testControllers as ConnectedControllers["Controllers"])
+      setControllers(testControllers as Controller[])
     }
   }, [
     project,

--- a/frontend/src/lib/hooks/useBackendStateAppMessages.ts
+++ b/frontend/src/lib/hooks/useBackendStateAppMessages.ts
@@ -1,0 +1,170 @@
+import { useEffect } from "react"
+import i18next from "i18next"
+import { useAppMessage } from "@/lib/hooks/appMessage"
+import { useProjectStore } from "@/stores/projectStore"
+import { Project } from "@/types"
+import {
+  AuthenticationStatus,
+  BoardDefinitions,
+  ConnectedControllers,
+  ExecutionState,
+  HubHopState,
+  JoystickDefinitions,
+  MidiControllerDefinitions,
+  ProjectStatus,
+  RecentProjects,
+} from "@/types/messages"
+import Settings from "@/types/settings"
+import { useRecentProjects, useSettingsStore } from "@/stores/settingsStore"
+import { useControllerStore } from "@/stores/controllerStore"
+import { useControllerDefinitionsStore } from "@/stores/definitionStore"
+import { useHubHopStateActions } from "@/stores/stateStore"
+import { useExecutionStateStore } from "@/stores/executionStateStore"
+import { useAuth } from "react-oidc-context"
+import {
+  JoystickDefinition,
+  MidiControllerDefinition,
+} from "@/types/definitions"
+import { ProjectInfo } from "@/types/project"
+
+import testProject from "@/../tests/data/project.testdata.json" with { type: "json" }
+import testJsDefinition from "@/../tests/data/joystick.definition.json" with { type: "json" }
+import testMidiDefinition from "@/../tests/data/midicontroller.definition.json" with { type: "json" }
+import testRecentProjects from "@/../tests/data/recentProjects.testdata.json" with { type: "json" }
+import testControllers from "@/../tests/data/connectedControllers.testdata.json" with { type: "json" }
+import { useSearchParams } from "react-router"
+import _ from "lodash"
+
+export const useBackendStateAppMessages = () => {
+  const [queryParameters] = useSearchParams()
+  
+  const { project, setProject, setProjectStatus } = useProjectStore()
+  const { setRecentProjects } = useRecentProjects()
+  const { setSettings } = useSettingsStore()
+  const { setControllers } = useControllerStore()
+  const {
+    setBoardDefinitions,
+    setJoystickDefinitions,
+    setMidiControllerDefinitions,
+  } = useControllerDefinitionsStore()
+  const { setIsRunning, setIsTesting } = useExecutionStateStore()
+
+  const setHubHopState = useHubHopStateActions()
+  const auth = useAuth()
+
+  useAppMessage("Project", (message) => {
+    const project = message.payload as Project
+    console.log("Project message received", project)
+    setProject(project)
+  })
+
+  useAppMessage("RecentProjects", (message) => {
+    const recentProjects = message.payload as RecentProjects
+    setRecentProjects(recentProjects.Projects)
+    console.log("List of Recent Projects received", recentProjects.Projects)
+  })
+
+  useAppMessage("Settings", (message) => {
+    const settings = message.payload as Settings
+    console.log("Settings message received", settings)
+    setSettings(settings)
+
+    const language = settings.Language.split("-")[0]
+    if (!_.isEmpty(language)) i18next.changeLanguage(settings.Language)
+    else i18next.changeLanguage()
+  })
+
+  useAppMessage("BoardDefinitions", (message) => {
+    const boardDefinitions = message.payload as BoardDefinitions
+    console.log(
+      "BoardDefinitions message received",
+      boardDefinitions.Definitions,
+    )
+    setBoardDefinitions(boardDefinitions.Definitions)
+  })
+
+  useAppMessage("JoystickDefinitions", (message) => {
+    const joystickDefinitions = message.payload as JoystickDefinitions
+    console.log(
+      "JoystickDefinitions message received",
+      joystickDefinitions.Definitions,
+    )
+    setJoystickDefinitions(joystickDefinitions.Definitions)
+  })
+
+  useAppMessage("MidiControllerDefinitions", (message) => {
+    const definitions = message.payload as MidiControllerDefinitions
+    console.log(
+      "MidiControllerDefinitions message received",
+      definitions.Definitions,
+    )
+    setMidiControllerDefinitions(definitions.Definitions)
+  })
+
+  useAppMessage("ProjectStatus", (message) => {
+    const projectStatus = message.payload as ProjectStatus
+    console.log("ProjectStatus message received", projectStatus)
+    setProjectStatus(projectStatus)
+  })
+
+  useAppMessage("HubHopState", (message) => {
+    const state = message.payload as HubHopState
+    setHubHopState(state)
+  })
+
+  useAppMessage("ConnectedControllers", (message) => {
+    const controllers = (message.payload as ConnectedControllers).Controllers
+    setControllers(controllers)
+  })
+
+  // Listen for auth state changes from C#
+  useAppMessage("AuthenticationStatus", async (message) => {
+    const authStatus = message.payload as AuthenticationStatus
+    console.log("AuthenticationStatus message received", authStatus)
+    try {
+      // Trigger silent signin to sync auth state from localStorage
+      if (authStatus.Authenticated) {
+        await auth.signinSilent()
+      } else {
+        auth.removeUser() // Clear user to ensure state is updated based on signinSilent result
+      }
+    } catch (err) {
+      console.log("Auth sync after window close:", err)
+    }
+  })
+
+  useAppMessage("ExecutionState", (message) => {
+    console.log("ExecutionState message received", message.payload)
+    const { IsRunning, IsTesting } = message.payload as ExecutionState
+    setIsRunning(IsRunning)
+    setIsTesting(IsTesting)
+  })
+
+  // this is only for easier UI testing
+  // while developing the UI
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV === "development" &&
+      queryParameters.get("testdata") === "true" &&
+      !project // Only if no project loaded yet
+    ) {
+      setProject(testProject as Project)
+      setRecentProjects(testRecentProjects as ProjectInfo[])
+      setJoystickDefinitions([testJsDefinition as JoystickDefinition])
+
+      setMidiControllerDefinitions([
+        testMidiDefinition as MidiControllerDefinition,
+      ])
+
+      setControllers(testControllers as ConnectedControllers["Controllers"])
+    }
+  }, [
+    project,
+    queryParameters,
+    setJoystickDefinitions,
+    setMidiControllerDefinitions,
+    setProject,
+    setRecentProjects,
+    setControllers,
+  ])
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import { AppRoutes } from "@/Routes.tsx"
 import { BrowserRouter } from "react-router"
 import { AuthProvider } from "react-oidc-context"
 import { oidcConfig } from "@/lib/auth/config"
+import { BackendStateMessageHandler } from "@/components/BackendStateMessageHandler.tsx"
 
 if (process.env.NODE_ENV !== "development") {
   console.log = () => {}
@@ -23,7 +24,9 @@ createRoot(document.getElementById("root")!).render(
       <AuthProvider {...oidcConfig}>
         <TooltipProvider skipDelayDuration={0}>
           <BrowserRouter>
-            <AppRoutes />
+            <BackendStateMessageHandler>
+              <AppRoutes />
+            </BackendStateMessageHandler>
           </BrowserRouter>
         </TooltipProvider>
       </AuthProvider>

--- a/frontend/src/types/config.d.ts
+++ b/frontend/src/types/config.d.ts
@@ -23,7 +23,7 @@ export interface IConfigItem extends IConfigValueOnlyItem {
   // this is the type of the Device
   // Type: DeviceElementType;
   DeviceName?: string | null
-  DeviceType: DeviceElementType | string
+  DeviceType?: DeviceElementType | string | null
   // Tags: string[];
   Status: IDictionary<string, ConfigItemStatusType>
 }

--- a/frontend/src/types/messages.d.ts
+++ b/frontend/src/types/messages.d.ts
@@ -2,6 +2,7 @@ import { Settings } from "http2"
 import { IConfigValueOnlyItem } from "./config"
 import { JoystickDefinition, MidiControllerDefinition } from "./definitions"
 import { ProjectInfo } from "@/types/project"
+import { Controller } from "@/types/controller"
 
 export type AppMessageKey =
   | "StatusBarUpdate"

--- a/frontend/tests/StartupProgress.spec.ts
+++ b/frontend/tests/StartupProgress.spec.ts
@@ -1,16 +1,35 @@
-import { test, expect } from './fixtures';
+import { test, expect } from "./fixtures"
 
-test('Go beyond progress bar', async ({ startupPage, page }) => {
+test("Go beyond progress bar", async ({ startupPage, page }) => {
   await startupPage.gotoStartupPage()
-  await startupPage.setStatusBarUpdate(50,"Loading!")
+  await startupPage.setStatusBarUpdate(50, "Loading...")
   // expect to have exactly one progressBar
-  await expect(page.getByRole('progressbar')).toHaveCount(1)  
+  await expect(page.getByRole("progressbar")).toHaveCount(1)
   // expect the progressBar to be visible
-  await expect(page.getByRole('progressbar').isVisible()).toBeTruthy()
-  await startupPage.setStatusBarUpdate(100,"Finished!")
-  // expect the progressBar to be removed  
-  await expect(page.getByRole('progressbar')).toHaveCount(0)
-  // expect the heading to be visible
-  // this will have to change later to a more specific test
-  await page.getByRole('heading', { name: 'MobiFlight 2025' }).isVisible()
+  await expect(page.getByRole("progressbar").isVisible()).toBeTruthy()
+
+  await startupPage.setStatusBarUpdate(100, "Finished!")
+
+  // Once finished loading, we are redirected to the home page
+  expect(page).toHaveURL("http://localhost:5173/home")
+})
+
+test("Test that backend progress state is localized", async ({
+  startupPage,
+  page,
+}) => {
+  await startupPage.gotoStartupPage()
+
+  const backendMessages = [
+    { value: 10, text: "Startup.Starting" },
+    { value: 20, text: "Startup.CheckingFirmwareUpdates" },
+    { value: 30, text: "Startup.LoadingLastConfig" },
+    { value: 50, text: "Startup.ScanningControllers" },
+    { value: 99, text: "Startup.Finished" },
+  ]
+
+  for (const message of backendMessages) {
+    await startupPage.setStatusBarUpdate(message.value, message.text)
+    await expect(page.getByText(message.text)).toHaveCount(0)
+  }
 })

--- a/frontend/tests/StartupProgress.spec.ts
+++ b/frontend/tests/StartupProgress.spec.ts
@@ -6,12 +6,12 @@ test("Go beyond progress bar", async ({ startupPage, page }) => {
   // expect to have exactly one progressBar
   await expect(page.getByRole("progressbar")).toHaveCount(1)
   // expect the progressBar to be visible
-  await expect(page.getByRole("progressbar").isVisible()).toBeTruthy()
+  await expect(page.getByRole("progressbar")).toBeVisible()
 
   await startupPage.setStatusBarUpdate(100, "Finished!")
 
   // Once finished loading, we are redirected to the home page
-  expect(page).toHaveURL("http://localhost:5173/home")
+  await expect(page).toHaveURL("http://localhost:5173/home")
 })
 
 test("Test that backend progress state is localized", async ({

--- a/frontend/tests/fixtures/StartupPage.ts
+++ b/frontend/tests/fixtures/StartupPage.ts
@@ -6,7 +6,7 @@ export class StartupPage {
   constructor(public readonly mobiFlightPage: MobiFlightPage) {}
 
   async gotoStartupPage() {
-    await this.mobiFlightPage.page.goto("http://localhost:5173/index.html", { waitUntil: "networkidle" });
+    await this.mobiFlightPage.page.goto("http://localhost:5173/start", { waitUntil: "networkidle" });
   }
 
   async setStatusBarUpdate(value: number, text: string) {


### PR DESCRIPTION
This PR does some refactoring in App.tsx
* Move backend state updates via appMessages to a dedicated hook
* Move progress bar out of app.tsx into its own route (/start)
  * WebView2 now uses `/start`-route instead of index.html
* Added i18n for startup messages
* Added playwright tests  