### PR TITLE
Use latest v11 npm and set git safe.directory on build

### DIFF
--- a/frontend/.devcontainer/devcontainer.json
+++ b/frontend/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   },
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "git config --global --add safe.directory $(dirname $PWD) && npm install -g npm@11 && npm install && sudo npx playwright install-deps && npx playwright install",
+  "postCreateCommand": "git config --global --replace-all safe.directory \"$(dirname \"$PWD\")\" && npm install -g npm@11 && npm install && sudo npx playwright install-deps && npx playwright install",
   "postStartCommand": "npm install && npm run dev",
   "customizations": {
     "vscode": {

--- a/frontend/.devcontainer/devcontainer.json
+++ b/frontend/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   },
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm install -g npm@11 && npm install && sudo npx playwright install-deps && npx playwright install",
+  "postCreateCommand": "git config --global --add safe.directory $(dirname $PWD) && npm install -g npm@11 && npm install && sudo npx playwright install-deps && npx playwright install",
   "postStartCommand": "npm install && npm run dev",
   "customizations": {
     "vscode": {

--- a/frontend/.devcontainer/devcontainer.json
+++ b/frontend/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
   },
 
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "npm install && sudo npx playwright install-deps && npx playwright install",
+  "postCreateCommand": "npm install -g npm@11 && npm install && sudo npx playwright install-deps && npx playwright install",
   "postStartCommand": "npm install && npm run dev",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Updates the frontend devcontainer bootstrap so new containers install the latest npm v11 (addressing lockfile `peer=true` behavior) and configure Git’s `safe.directory` to avoid “dubious ownership” errors during builds.

**Changes:**
- Add a global Git `safe.directory` entry during `postCreateCommand`.
- Install latest npm v11 during devcontainer creation before running installs and Playwright setup.
 
fixes #2730