### PR TITLE
Publish frontend message when Auto Run changes, added integration test.

### DIFF
--- a/MobiFlight/BrowserMessages/MessageExchange.cs
+++ b/MobiFlight/BrowserMessages/MessageExchange.cs
@@ -17,7 +17,7 @@ namespace MobiFlight.BrowserMessages
         /// <summary>
         /// Setting a contextProvider is only required for integration tests
         /// Provide a () => null provider so that the synchronization context is not used during unit tests,
-        /// Outside of unit tests, a working synchronization context will automaticall be available
+        /// Outside of unit tests, a working synchronization context will automatically be available
         /// </summary>
         private Func<System.Threading.SynchronizationContext> _syncContextProvider;
 

--- a/MobiFlight/BrowserMessages/MessageExchange.cs
+++ b/MobiFlight/BrowserMessages/MessageExchange.cs
@@ -14,6 +14,13 @@ namespace MobiFlight.BrowserMessages
         private static MessageExchange _instance;
         private IMessagePublisher _messagePublisher;
 
+        /// <summary>
+        /// Setting a contextProvider is only required for integration tests
+        /// Provide a () => null provider so that the synchronization context is not used during unit tests,
+        /// Outside of unit tests, a working synchronization context will automaticall be available
+        /// </summary>
+        private Func<System.Threading.SynchronizationContext> _syncContextProvider;
+
         public static MessageExchange Instance
         {
             get
@@ -91,8 +98,10 @@ namespace MobiFlight.BrowserMessages
             try
             {
                 var deserializedPayload = JsonConvert.DeserializeObject(eventToPublish.payload.ToString(), eventType);
-                var synchronizationContext = System.Threading.SynchronizationContext.Current;
-                
+                var synchronizationContext = _syncContextProvider != null
+                    ? _syncContextProvider.Invoke()
+                    : System.Threading.SynchronizationContext.Current;
+
                 foreach (var subscriber in subscribers)
                 {
                     Action invokeSubscriber = () =>
@@ -153,6 +162,10 @@ namespace MobiFlight.BrowserMessages
                     }
                 }
             }
+        }
+        public void SetSynchronizationContextProvider(Func<System.Threading.SynchronizationContext> provider)
+        {
+            _syncContextProvider = provider;
         }
     }
 }

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -4,6 +4,7 @@ using MobiFlight.BrowserMessages;
 using MobiFlight.BrowserMessages.Incoming;
 using MobiFlight.BrowserMessages.Outgoing;
 using MobiFlight.Controllers;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -495,20 +496,57 @@ namespace MobiFlight.UI.Tests
         }
         #endregion
 
+        #region Browser Message Handling Tests
+        [TestMethod]
+        public void ToggleAutoRun_PublishesSettingsUpdate()
+        {
+            // Arrange
+            var initialAutoRun = Properties.Settings.Default.AutoRun;
+
+            // Act (Simulate Frontend action after clicking on autorun toggle button)
+            var jsonMessage = JsonConvert.SerializeObject(new BrowserMessages.Message<CommandProjectToolbar>(new CommandProjectToolbar()
+            {
+                Action = CommandProjectToolbarAction.toggleAutoRun
+            }));
+
+            _mainForm.Publisher.SimulateIncomingMessage(jsonMessage);
+
+            // Assert
+            var settingsMessage = _mainForm.Publisher.PublishedMessages.FirstOrDefault(m => m.GetType() == typeof(Settings)) as Settings;
+            Assert.IsNotNull(settingsMessage, "Settings message should be published");
+            Assert.AreEqual(!initialAutoRun, settingsMessage.AutoRun,
+                "AutoRun should be toggled in published settings");
+
+            // Verify persisted
+            Assert.AreEqual(!initialAutoRun, Properties.Settings.Default.AutoRun);
+        }
+        #endregion
+
         public class TestMessagePublisher : IMessagePublisher
         {
             public List<object> PublishedMessages { get; } = new List<object>();
+            private Action<object> _onMessageReceived;
 
             public void Publish<TEvent>(TEvent eventToPublish)
             {
                 PublishedMessages.Add(eventToPublish);
             }
 
-            public void OnMessageReceived(Action<string> callback) { }
+            public void OnMessageReceived(Action<string> callback)
+            {
+                _onMessageReceived = (message) => callback((string)message);
+            }
 
             public void Reset()
             {
                 PublishedMessages.Clear();
+            }
+
+            public void SimulateIncomingMessage(string jsonMessage)
+            {
+                MessageExchange.Instance.SetSynchronizationContextProvider(() => null);
+                _onMessageReceived?.Invoke(jsonMessage);
+                MessageExchange.Instance.SetSynchronizationContextProvider(null);
             }
         }
     }

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -18,6 +18,7 @@ namespace MobiFlight.UI.Tests
     [TestClass()]
     public class MainFormTests
     {
+        private bool originalAutoRun;
         private StringCollection originalRecentFiles;
         private string _tempDirectory;
 
@@ -90,6 +91,9 @@ namespace MobiFlight.UI.Tests
             // Save original RecentFiles
             originalRecentFiles = Properties.Settings.Default.RecentFiles;
 
+            // Save original AutoRun setting
+            originalAutoRun = Properties.Settings.Default.AutoRun;
+
             // Initialize with clean state
             Properties.Settings.Default.RecentFiles = new StringCollection();
 
@@ -105,6 +109,7 @@ namespace MobiFlight.UI.Tests
         {
             // Restore original RecentFiles
             Properties.Settings.Default.RecentFiles = originalRecentFiles;
+            Properties.Settings.Default.AutoRun = originalAutoRun;
             Properties.Settings.Default.Save();
 
             _mainForm.RestorePublisher();

--- a/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -516,9 +516,6 @@ namespace MobiFlight.UI.Tests
             Assert.IsNotNull(settingsMessage, "Settings message should be published");
             Assert.AreEqual(!initialAutoRun, settingsMessage.AutoRun,
                 "AutoRun should be toggled in published settings");
-
-            // Verify persisted
-            Assert.AreEqual(!initialAutoRun, Properties.Settings.Default.AutoRun);
         }
         #endregion
 

--- a/UI/MainForm.cs
+++ b/UI/MainForm.cs
@@ -521,12 +521,6 @@ namespace MobiFlight.UI
             xPlaneDirectToolStripMenuItem.Image = Properties.Resources.warning;
             toolStripConnectedDevicesIcon.Image = Properties.Resources.warning;
 
-            // we only load the autorun value stored in settings
-            // and do not use possibly passed in autoRun from cmdline
-            // because latter shall only have an temporary influence
-            // on the program
-            setAutoRunValue(Properties.Settings.Default.AutoRun);
-
             updateNotifyContextMenu(false);
 
             // Reset the Title of the Main Window so that it displays the Version too.
@@ -2461,6 +2455,9 @@ namespace MobiFlight.UI
         private void setAutoRunValue(bool value)
         {
             Properties.Settings.Default.AutoRun = value;
+
+            // Triggers update to frontend
+            Properties.Settings.Default.Save();
         }
 
         public void settingsToolStripMenuItem_Click(object sender, EventArgs e)


### PR DESCRIPTION
## Pull request overview

This PR fixes a bug where the AutoRun icon in the frontend toolbar didn't visually update when clicked. The issue was caused by the removal of a `PropertyChanged` event handler in PR #2711, which previously triggered settings updates to the frontend. The fix implements a cleaner approach by calling `Properties.Settings.Default.Save()` when the AutoRun value changes, which automatically triggers the `SettingsSaving` event handler that publishes settings to the frontend.

**Changes:**
- Removed redundant `setAutoRunValue()` call from `MainForm_Shown()` that was setting AutoRun to its own value
- Added `Properties.Settings.Default.Save()` call in `setAutoRunValue()` to trigger frontend settings update
- Added integration test to verify AutoRun toggle publishes Settings message to frontend
- Enhanced test infrastructure with `SetSynchronizationContextProvider()` to support synchronous message handling in tests

fixes #2753 