### PR TITLE
Improved support for Leo Bodnar boards

### DIFF
--- a/Joysticks/bodnar/authentikit.joystick.json
+++ b/Joysticks/bodnar/authentikit.joystick.json
@@ -63,46 +63,6 @@
       "Id": 12,
       "Type": "Button",
       "Label": "Button 12"
-    },
-    {
-      "Id": 48,
-      "Type": "Axis",
-      "Label": "Axis 1"
-    },
-    {
-      "Id": 49,
-      "Type": "Axis",
-      "Label": "Axis 2"
-    },
-    {
-      "Id": 50,
-      "Type": "Axis",
-      "Label": "Axis 3"
-    },
-    {
-      "Id": 51,
-      "Type": "Axis",
-      "Label": "Axis 4"
-    },
-    {
-      "Id": 52,
-      "Type": "Axis",
-      "Label": "Axis 5"
-    },
-    {
-      "Id": 53,
-      "Type": "Axis",
-      "Label": "Axis 6"
-    },
-    {
-      "Id": 54,
-      "Type": "Axis",
-      "Label": "Axis 7"
-    },
-    {
-      "Id": 55,
-      "Type": "Axis",
-      "Label": "Axis 8"
     }
   ]
 }

--- a/MobiFlight/Joysticks/Authentikit/Authentikit.cs
+++ b/MobiFlight/Joysticks/Authentikit/Authentikit.cs
@@ -205,5 +205,35 @@ namespace MobiFlight.Joysticks.AuthentiKit
         {
             return Math.Abs(oldValue - newValue) >= 2 << 3;
         }
+
+        protected override void EnumerateDevices()
+        {
+            foreach (DeviceObjectInstance device in this.DIJoystick.GetObjects().ToList().OrderBy((a) => a.Usage))
+            {
+                this.DIJoystick.GetObjectInfoById(device.ObjectId);
+
+                bool IsAxis = (device.ObjectId.Flags & DeviceObjectTypeFlags.AbsoluteAxis) > 0;
+                bool IsButton = (device.ObjectId.Flags & DeviceObjectTypeFlags.Button) > 0;
+                bool IsPOV = (device.ObjectId.Flags & DeviceObjectTypeFlags.PointOfViewController) > 0;
+
+
+                if (IsAxis && Axes.Count < DIJoystick.Capabilities.AxeCount)
+                {
+                    RegisterAxis(device);
+                }
+                else if (IsButton)
+                {
+                    RegisterButton(device);
+                }
+                else if (IsPOV)
+                {
+                    RegisterPOV(device);
+                }
+                else
+                {
+                    continue;
+                }
+            }
+        }
     }
 }

--- a/MobiFlight/Joysticks/Authentikit/Authentikit.cs
+++ b/MobiFlight/Joysticks/Authentikit/Authentikit.cs
@@ -203,7 +203,7 @@ namespace MobiFlight.Joysticks.AuthentiKit
         /// <returns>True if the change exceeds the threshold; otherwise, false.</returns>
         private static bool ExceedsThreshold(int oldValue, int newValue)
         {
-            return Math.Abs(oldValue - newValue) >= 2 << 4;
+            return Math.Abs(oldValue - newValue) >= 2 << 3;
         }
     }
 }

--- a/MobiFlight/Joysticks/ControllerFactory.cs
+++ b/MobiFlight/Joysticks/ControllerFactory.cs
@@ -40,7 +40,7 @@ namespace MobiFlight.Joysticks
             }
 
             // Check for AuthentiKit
-            if (instanceName.Trim() == "AuthentiKit" || instanceName.Trim() == "AuthentiKitX" || instanceName.Trim() == "BU0836A Interface")
+            if (instanceName.Trim().Contains("AuthentiKit") || instanceName.Trim().Contains("BU0836"))
             {
                 return true;
             }
@@ -103,7 +103,7 @@ namespace MobiFlight.Joysticks
             }
 
             // Handle AuthentiKit by instance name
-            if (instanceName.Trim() == "AuthentiKit" || instanceName.Trim() == "AuthentiKitX" || instanceName.Trim() == "BU0836A Interface")
+            if (instanceName.Trim().Contains("AuthentiKit") || instanceName.Trim().Contains("BU0836"))
             {
                 return new AuthentiKit.AuthentiKit(diJoystick, definition);
             }

--- a/MobiFlight/Joysticks/ControllerFactory.cs
+++ b/MobiFlight/Joysticks/ControllerFactory.cs
@@ -40,7 +40,7 @@ namespace MobiFlight.Joysticks
             }
 
             // Check for AuthentiKit
-            if (instanceName.Trim() == "AuthentiKit")
+            if (instanceName.Trim() == "AuthentiKit" || instanceName.Trim() == "AuthentiKitX" || instanceName.Trim() == "BU0836A Interface")
             {
                 return true;
             }
@@ -103,7 +103,7 @@ namespace MobiFlight.Joysticks
             }
 
             // Handle AuthentiKit by instance name
-            if (instanceName.Trim() == "AuthentiKit")
+            if (instanceName.Trim() == "AuthentiKit" || instanceName.Trim() == "AuthentiKitX" || instanceName.Trim() == "BU0836A Interface")
             {
                 return new AuthentiKit.AuthentiKit(diJoystick, definition);
             }

--- a/MobiFlightUnitTests/MobiFlight/Joysticks/ControllerFactoryTests.cs
+++ b/MobiFlightUnitTests/MobiFlight/Joysticks/ControllerFactoryTests.cs
@@ -32,6 +32,14 @@ namespace MobiFlight.Joysticks.Tests
             var deviceInstance = CreateDeviceInstance("AuthentiKit");
             var result = ControllerFactory.CanCreate(deviceInstance, OTHER_VENDOR_ID, 0x0000);
             Assert.IsTrue(result);
+
+            deviceInstance = CreateDeviceInstance("AuthentiKitX");
+            result = ControllerFactory.CanCreate(deviceInstance, OTHER_VENDOR_ID, 0x0000);
+            Assert.IsTrue(result);
+
+            deviceInstance = CreateDeviceInstance("BU0836");
+            result = ControllerFactory.CanCreate(deviceInstance, OTHER_VENDOR_ID, 0x0000);
+            Assert.IsTrue(result);
         }
 
         [TestMethod()]


### PR DESCRIPTION
This PR improves three different aspects:
- Supports instance name variants like "AuthentiKit*", "BU0836A*"
- Increase axis resolution for finer response
- Axis are now maintaining same order, regardless how many are in use, e.g. Axis X is always first, Y second, etc.

Remove specific labels for axis as they are currently not needed.