### PR TITLE
 Fix ProSim input panel initialization, dataref list loading, and selection behavior

### DIFF
--- a/UI/Dialogs/InputConfigWizard.cs
+++ b/UI/Dialogs/InputConfigWizard.cs
@@ -568,6 +568,7 @@ namespace MobiFlight.UI.Dialogs
                             ProjectInfo = this.ProjectInfo,
                             CurrentConfig = Config
                         };
+                        InitializeInputPanel(panel);
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.button);
                         break;
 
@@ -578,6 +579,7 @@ namespace MobiFlight.UI.Dialogs
                             ProjectInfo = this.ProjectInfo,
                             CurrentConfig = Config,
                         };
+                        InitializeInputPanel(panel);
                         (panel as Panels.Input.EncoderPanel).syncFromConfig(config.encoder);
                         break;
 
@@ -589,6 +591,7 @@ namespace MobiFlight.UI.Dialogs
                             ProjectInfo = this.ProjectInfo,
                             CurrentConfig = Config
                         };
+                        InitializeInputPanel(panel);
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.inputShiftRegister);
                         PopulateInputPinDropdown(Convert.ToInt32(selectedInputShifter.NumModules), config.inputShiftRegister?.ExtPin);
                         inputPinDropDown.Visible = true;
@@ -602,6 +605,7 @@ namespace MobiFlight.UI.Dialogs
                             ProjectInfo = this.ProjectInfo,
                             CurrentConfig = Config
                         };
+                        InitializeInputPanel(panel);
                         (panel as Panels.Input.ButtonPanel).syncFromConfig(config.inputMultiplexer);
                         PopulateInputPinDropdown(Convert.ToInt32(selectedInputMultiplexer.NumBytes), config.inputMultiplexer?.DataPin);
                         inputPinDropDown.Visible = true;
@@ -614,15 +618,9 @@ namespace MobiFlight.UI.Dialogs
                             ProjectInfo = this.ProjectInfo,
                             CurrentConfig = Config
                         };
+                        InitializeInputPanel(panel);
                         (panel as Panels.Input.AnalogPanel).syncFromConfig(config.analog);
                         break;
-                }
-
-                // Initialize panels that implement IInputPanel interface
-                if (panel is IInputPanel inputPanel)
-                {
-                    inputPanel.Init(_execManager);
-                    inputPanel.SetVariableReferences(_execManager.GetAvailableVariables());
                 }
 
                 DeviceNotAvailableWarningLabel.Visible = (serial == "") && currentInputType != DeviceType.NotSet;
@@ -639,8 +637,17 @@ namespace MobiFlight.UI.Dialogs
                 Log.Instance.log(ex.Message, LogSeverity.Error);
                 MessageBox.Show(i18n._tr("uiMessageNotImplementedYet"),
                                 i18n._tr("Hint"),
-                                MessageBoxButtons.OK,
-                                MessageBoxIcon.Warning);
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Warning);
+            }
+        }
+
+        private void InitializeInputPanel(Control panel)
+        {
+            if (panel is IInputPanel inputPanel)
+            {
+                inputPanel.Init(_execManager);
+                inputPanel.SetVariableReferences(_execManager.GetAvailableVariables());
             }
         }
 

--- a/UI/Panels/Config/ProSimDataRefPanel.cs
+++ b/UI/Panels/Config/ProSimDataRefPanel.cs
@@ -56,7 +56,6 @@ namespace MobiFlight.UI.Panels.Config
                 _dataRefRetryTimer.Stop();
                 _dataRefRetryTimer.Dispose();
             };
-            Log.Instance.log($"ProSimDataRefPanel initialized. OutputMode={_isOutputMode}", LogSeverity.Debug);
         }
 
         private void DataGridView1_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
@@ -69,13 +68,11 @@ namespace MobiFlight.UI.Panels.Config
         {
             _isOutputMode = isOutputPanel;
             transformOptionsGroup1.setMode(isOutputPanel);
-            Log.Instance.log($"ProSimDataRefPanel SetMode. OutputMode={_isOutputMode}", LogSeverity.Debug);
         }
 
         public void Init(IExecutionManager executionManager)
         {
             _executionManager = executionManager;
-            Log.Instance.log("ProSimDataRefPanel Init called.", LogSeverity.Debug);
         }
 
         internal void syncToConfig(OutputConfigItem config)
@@ -102,17 +99,14 @@ namespace MobiFlight.UI.Panels.Config
 
         public void LoadDataRefDescriptions()
         {
-            Log.Instance.log($"ProSimDataRefPanel LoadDataRefDescriptions. OutputMode={_isOutputMode}", LogSeverity.Debug);
             if (_executionManager == null)
             {
-                Log.Instance.log("ProSimDataRefPanel LoadDataRefDescriptions aborted: execution manager is null.", LogSeverity.Debug);
                 return; // Silently return if not initialized
             }
 
             var proSimCache = _executionManager.GetProSimCache();
             if (!proSimCache.IsConnected())
             {
-                Log.Instance.log("ProSimDataRefPanel LoadDataRefDescriptions aborted: ProSim cache not connected.", LogSeverity.Debug);
                 return; // Silently return if not connected
             }
 
@@ -121,16 +115,13 @@ namespace MobiFlight.UI.Panels.Config
                 _isLoading = true;
                 // Get the dataref descriptions from the already-connected ProSimCache
                 _dataRefDescriptions = proSimCache.GetDataRefDescriptions();
-                Log.Instance.log($"ProSimDataRefPanel fetched {_dataRefDescriptions.Count} datarefs from cache.", LogSeverity.Debug);
                 _canReadDataRefDescriptions = _dataRefDescriptions.Values
                     .Where(drd => _isOutputMode ? drd.CanRead : drd.CanWrite)
                     .ToList();
                 if (!_isOutputMode && _canReadDataRefDescriptions.Count == 0 && _dataRefDescriptions.Count > 0)
                 {
-                    Log.Instance.log("No writable ProSim datarefs reported; showing all datarefs.", LogSeverity.Warn);
                     _canReadDataRefDescriptions = _dataRefDescriptions.Values.ToList();
                 }
-                Log.Instance.log($"ProSimDataRefPanel filtered to {_canReadDataRefDescriptions.Count} datarefs.", LogSeverity.Debug);
 
                 if (_dataRefDescriptions.Count == 0)
                 {
@@ -151,7 +142,6 @@ namespace MobiFlight.UI.Panels.Config
                             _canReadDataRefDescriptions.Sort((drd1, drd2) => drd2.Name.CompareTo(drd1.Name));
                             dataGridView1.DataSource = null;
                             dataGridView1.DataSource = _canReadDataRefDescriptions;
-                            Log.Instance.log("ProSimDataRefPanel data grid updated on UI thread.", LogSeverity.Debug);
                         }));
                     }
                     else
@@ -159,7 +149,6 @@ namespace MobiFlight.UI.Panels.Config
                         _canReadDataRefDescriptions.Sort((drd1, drd2) => drd2.Name.CompareTo(drd1.Name));
                         dataGridView1.DataSource = null;
                         dataGridView1.DataSource = _canReadDataRefDescriptions;
-                        Log.Instance.log("ProSimDataRefPanel data grid updated on current thread.", LogSeverity.Debug);
                         SelectRowForCurrentPath();
                     }
                 }
@@ -208,7 +197,6 @@ namespace MobiFlight.UI.Panels.Config
         private void DataRefRetryTimer_Tick(object sender, EventArgs e)
         {
             _dataRefRetryTimer.Stop();
-            Log.Instance.log($"ProSimDataRefPanel retry tick {_dataRefRetryCount}/{MaxDataRefRetryCount}.", LogSeverity.Debug);
             LoadDataRefDescriptions();
         }
 
@@ -216,15 +204,10 @@ namespace MobiFlight.UI.Panels.Config
         {
             if (_dataRefRetryTimer.Enabled || _dataRefRetryCount >= MaxDataRefRetryCount)
             {
-                if (_dataRefRetryCount >= MaxDataRefRetryCount)
-                {
-                    Log.Instance.log("ProSimDataRefPanel retry limit reached; stopping retries.", LogSeverity.Debug);
-                }
                 return;
             }
 
             _dataRefRetryCount++;
-            Log.Instance.log($"ProSimDataRefPanel scheduling retry {_dataRefRetryCount}/{MaxDataRefRetryCount}.", LogSeverity.Debug);
             _dataRefRetryTimer.Start();
         }
 
@@ -235,7 +218,6 @@ namespace MobiFlight.UI.Panels.Config
             {
                 _dataRefRetryTimer.Stop();
             }
-            Log.Instance.log("ProSimDataRefPanel retry reset.", LogSeverity.Debug);
         }
 
         private void SelectRowForCurrentPath()
@@ -257,7 +239,6 @@ namespace MobiFlight.UI.Panels.Config
                     {
                         dataGridView1.FirstDisplayedScrollingRowIndex = row.Index;
                     }
-                    Log.Instance.log($"ProSimDataRefPanel selected dataref '{path}'.", LogSeverity.Debug);
                     break;
                 }
             }

--- a/UI/Panels/Config/ProSimDataRefPanel.cs
+++ b/UI/Panels/Config/ProSimDataRefPanel.cs
@@ -13,6 +13,11 @@ namespace MobiFlight.UI.Panels.Config
     {
         public event EventHandler ModifyTabLink;
 
+        private const int DataRefRetryIntervalMs = 1000;
+        private const int MaxDataRefRetryCount = 10;
+        private readonly Timer _dataRefRetryTimer = new Timer();
+        private int _dataRefRetryCount = 0;
+
         private Dictionary<string, DataRefDescription> _dataRefDescriptions;
         private List<DataRefDescription> _canReadDataRefDescriptions;
         private List<DataRefDescription> _canReadDataRefDescriptionsFiltered;
@@ -43,22 +48,34 @@ namespace MobiFlight.UI.Panels.Config
             dataGridView1.DataBindingComplete += DataGridView1_DataBindingComplete;
 
             SetMode(_isOutputMode);
+
+            _dataRefRetryTimer.Interval = DataRefRetryIntervalMs;
+            _dataRefRetryTimer.Tick += DataRefRetryTimer_Tick;
+            Disposed += (sender, args) =>
+            {
+                _dataRefRetryTimer.Stop();
+                _dataRefRetryTimer.Dispose();
+            };
+            Log.Instance.log($"ProSimDataRefPanel initialized. OutputMode={_isOutputMode}", LogSeverity.Debug);
         }
 
         private void DataGridView1_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
         {
             _isLoading = false;
+            SelectRowForCurrentPath();
         }
 
         public void SetMode(bool isOutputPanel)
         {
             _isOutputMode = isOutputPanel;
             transformOptionsGroup1.setMode(isOutputPanel);
+            Log.Instance.log($"ProSimDataRefPanel SetMode. OutputMode={_isOutputMode}", LogSeverity.Debug);
         }
 
         public void Init(IExecutionManager executionManager)
         {
             _executionManager = executionManager;
+            Log.Instance.log("ProSimDataRefPanel Init called.", LogSeverity.Debug);
         }
 
         internal void syncToConfig(OutputConfigItem config)
@@ -85,14 +102,17 @@ namespace MobiFlight.UI.Panels.Config
 
         public void LoadDataRefDescriptions()
         {
+            Log.Instance.log($"ProSimDataRefPanel LoadDataRefDescriptions. OutputMode={_isOutputMode}", LogSeverity.Debug);
             if (_executionManager == null)
             {
+                Log.Instance.log("ProSimDataRefPanel LoadDataRefDescriptions aborted: execution manager is null.", LogSeverity.Debug);
                 return; // Silently return if not initialized
             }
 
             var proSimCache = _executionManager.GetProSimCache();
             if (!proSimCache.IsConnected())
             {
+                Log.Instance.log("ProSimDataRefPanel LoadDataRefDescriptions aborted: ProSim cache not connected.", LogSeverity.Debug);
                 return; // Silently return if not connected
             }
 
@@ -101,9 +121,25 @@ namespace MobiFlight.UI.Panels.Config
                 _isLoading = true;
                 // Get the dataref descriptions from the already-connected ProSimCache
                 _dataRefDescriptions = proSimCache.GetDataRefDescriptions();
+                Log.Instance.log($"ProSimDataRefPanel fetched {_dataRefDescriptions.Count} datarefs from cache.", LogSeverity.Debug);
                 _canReadDataRefDescriptions = _dataRefDescriptions.Values
                     .Where(drd => _isOutputMode ? drd.CanRead : drd.CanWrite)
                     .ToList();
+                if (!_isOutputMode && _canReadDataRefDescriptions.Count == 0 && _dataRefDescriptions.Count > 0)
+                {
+                    Log.Instance.log("No writable ProSim datarefs reported; showing all datarefs.", LogSeverity.Warn);
+                    _canReadDataRefDescriptions = _dataRefDescriptions.Values.ToList();
+                }
+                Log.Instance.log($"ProSimDataRefPanel filtered to {_canReadDataRefDescriptions.Count} datarefs.", LogSeverity.Debug);
+
+                if (_dataRefDescriptions.Count == 0)
+                {
+                    ScheduleDataRefRetry();
+                }
+                else
+                {
+                    ResetDataRefRetry();
+                }
 
                 if (_dataRefDescriptions.Count > 0)
                 {
@@ -115,6 +151,7 @@ namespace MobiFlight.UI.Panels.Config
                             _canReadDataRefDescriptions.Sort((drd1, drd2) => drd2.Name.CompareTo(drd1.Name));
                             dataGridView1.DataSource = null;
                             dataGridView1.DataSource = _canReadDataRefDescriptions;
+                            Log.Instance.log("ProSimDataRefPanel data grid updated on UI thread.", LogSeverity.Debug);
                         }));
                     }
                     else
@@ -122,6 +159,8 @@ namespace MobiFlight.UI.Panels.Config
                         _canReadDataRefDescriptions.Sort((drd1, drd2) => drd2.Name.CompareTo(drd1.Name));
                         dataGridView1.DataSource = null;
                         dataGridView1.DataSource = _canReadDataRefDescriptions;
+                        Log.Instance.log("ProSimDataRefPanel data grid updated on current thread.", LogSeverity.Debug);
+                        SelectRowForCurrentPath();
                     }
                 }
             }
@@ -146,9 +185,11 @@ namespace MobiFlight.UI.Panels.Config
                     || words.All(drd.Description.ToLower().Contains)
                     || (words.Length > 1 && drd.Name.ToLower().Contains(words[0]) && words.Skip(1).All(drd.Description.ToLower().Contains))).ToList();
                 dataGridView1.DataSource = _canReadDataRefDescriptionsFiltered;
+                SelectRowForCurrentPath();
             } else
             {
                 dataGridView1.DataSource = _canReadDataRefDescriptions;
+                SelectRowForCurrentPath();
             }
         }
 
@@ -160,6 +201,64 @@ namespace MobiFlight.UI.Panels.Config
                 if (drd != null)
                 {
                     DatarefPathTextBox.Text = drd.Name;
+                }
+            }
+        }
+
+        private void DataRefRetryTimer_Tick(object sender, EventArgs e)
+        {
+            _dataRefRetryTimer.Stop();
+            Log.Instance.log($"ProSimDataRefPanel retry tick {_dataRefRetryCount}/{MaxDataRefRetryCount}.", LogSeverity.Debug);
+            LoadDataRefDescriptions();
+        }
+
+        private void ScheduleDataRefRetry()
+        {
+            if (_dataRefRetryTimer.Enabled || _dataRefRetryCount >= MaxDataRefRetryCount)
+            {
+                if (_dataRefRetryCount >= MaxDataRefRetryCount)
+                {
+                    Log.Instance.log("ProSimDataRefPanel retry limit reached; stopping retries.", LogSeverity.Debug);
+                }
+                return;
+            }
+
+            _dataRefRetryCount++;
+            Log.Instance.log($"ProSimDataRefPanel scheduling retry {_dataRefRetryCount}/{MaxDataRefRetryCount}.", LogSeverity.Debug);
+            _dataRefRetryTimer.Start();
+        }
+
+        private void ResetDataRefRetry()
+        {
+            _dataRefRetryCount = 0;
+            if (_dataRefRetryTimer.Enabled)
+            {
+                _dataRefRetryTimer.Stop();
+            }
+            Log.Instance.log("ProSimDataRefPanel retry reset.", LogSeverity.Debug);
+        }
+
+        private void SelectRowForCurrentPath()
+        {
+            var path = DatarefPathTextBox.Text?.Trim();
+            if (string.IsNullOrEmpty(path) || dataGridView1.Rows.Count == 0)
+            {
+                return;
+            }
+
+            foreach (DataGridViewRow row in dataGridView1.Rows)
+            {
+                if (row.DataBoundItem is DataRefDescription dataRef &&
+                    string.Equals(dataRef.Name, path, StringComparison.OrdinalIgnoreCase))
+                {
+                    dataGridView1.ClearSelection();
+                    row.Selected = true;
+                    if (row.Index >= 0 && row.Index < dataGridView1.RowCount)
+                    {
+                        dataGridView1.FirstDisplayedScrollingRowIndex = row.Index;
+                    }
+                    Log.Instance.log($"ProSimDataRefPanel selected dataref '{path}'.", LogSeverity.Debug);
+                    break;
                 }
             }
         }

--- a/UI/Panels/Input/ButtonPanel.Designer.cs
+++ b/UI/Panels/Input/ButtonPanel.Designer.cs
@@ -87,6 +87,7 @@
             this.tabControl1.TabIndex = 21;
             // 
             // onPressTabPage
+            this.onPressTabPage.AutoScroll = true;
             // 
             this.onPressTabPage.Controls.Add(this.onPressActionConfigPanel);
             this.onPressTabPage.Controls.Add(this.onPressActionTypePanel);
@@ -110,6 +111,7 @@
             this.onPressActionTypePanel.TabIndex = 20;
             // 
             // onReleaseTabPage
+            this.onReleaseTabPage.AutoScroll = true;
             // 
             this.onReleaseTabPage.Controls.Add(this.onReleaseActionConfigPanel);
             this.onReleaseTabPage.Controls.Add(this.onReleaseActionTypePanel);
@@ -145,6 +147,7 @@
             this.onReleaseActionTypePanel.TabIndex = 20;
             // 
             // onHoldTabPage
+            this.onHoldTabPage.AutoScroll = true;
             // 
             this.onHoldTabPage.Controls.Add(this.onHoldActionConfigPanel);
             this.onHoldTabPage.Controls.Add(this.onHoldActionTypePanel);
@@ -243,6 +246,7 @@
             this.holdDelayTextBox.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.textBox_KeyPress);
             // 
             // onLongReleaseTabPage
+            this.onLongReleaseTabPage.AutoScroll = true;
             // 
             this.onLongReleaseTabPage.Controls.Add(this.onLongRelActionConfigPanel);
             this.onLongReleaseTabPage.Controls.Add(this.onLongReleaseActionTypePanel);


### PR DESCRIPTION
Fixes https://github.com/MobiFlight/MobiFlight-Connector/issues/2766 https://github.com/MobiFlight/MobiFlight-Connector/issues/2767 https://github.com/MobiFlight/MobiFlight-Connector/issues/2768

This PR fixes multiple ProSim input UX/runtime issues in the Input Config Wizard:

  - ProSim action content being clipped in tabs.
  - Dataref list appearing empty in some open/edit flows.
  - Existing configured dataref not selected when reopening input configs.
  - Retry/fallback behavior when writable filtering returns no rows.