### PR TITLE
Add WinCtrl CDU support for X-Plane default FMC.

### DIFF
--- a/MobiFlightConnector.csproj
+++ b/MobiFlightConnector.csproj
@@ -278,6 +278,9 @@
     <Content Include="Scripts\Winwing\microsoft_aircraft_ec135.py">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="Scripts\Winwing\xplane_default_fmc.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Base\AutoUpdateChecker.cs" />

--- a/Scripts/ScriptMappings.json
+++ b/Scripts/ScriptMappings.json
@@ -131,6 +131,18 @@
       "ProductIds": [ "WinwingCDUs" ],
       "AircraftIdSnippet": "microsoft-aircraft-ec135",
       "ScriptName": "microsoft_aircraft_ec135.py"
+    },
+    {
+      "VendorId": "0x4098",
+      "ProductIds": [ "WinwingCDUs" ],
+      "AircraftIdSnippet": "md-82",
+      "ScriptName": "xplane_default_fmc.py"
+    },
+    {
+      "VendorId": "0x4098",
+      "ProductIds": [ "WinwingCDUs" ],
+      "AircraftIdSnippet": "q100",
+      "ScriptName": "xplane_default_fmc.py"
     }
   ]
 }

--- a/Scripts/Winwing/xplane_default_fmc.py
+++ b/Scripts/Winwing/xplane_default_fmc.py
@@ -111,6 +111,10 @@ def size_from_style(style):
     return 0 if style & (1 << 7) else 1
 
 
+def reverse_video_from_style(style):
+    return 1 if style & (1 << 6) else 0
+
+
 def generate_display_json(device: CduDevice, values: dict[str, str | bytes]):
     display_data = [[] for _ in range(CDU_CELLS)]
 
@@ -129,8 +133,9 @@ def generate_display_json(device: CduDevice, values: dict[str, str | bytes]):
 
             color = color_from_style(style[col])
             size = size_from_style(style[col])
+            reverse_video = reverse_video_from_style(style[col])
 
-            display_data[index] = [char, color, size]
+            display_data[index] = [char, color, size, reverse_video]
 
     return json.dumps({"Target": "Display", "Data": display_data})
 

--- a/Scripts/Winwing/xplane_default_fmc.py
+++ b/Scripts/Winwing/xplane_default_fmc.py
@@ -1,0 +1,268 @@
+"""
+Adds support for the default FMS in X-Plane
+
+Many X-Plane aircraft have similar formats for datarefs and the means of retrieving, translating and sending updates is mostly the same.
+
+In order to support multiple CDU devices seamlessly, a dynamic approach is taken whereby an enum class is defined that contains the supported devices.
+A device is considered "supported" if it exists in the aircraft. Some aircraft have 3 CDUs while others have 2.
+Each enum member is assigned a value that represents the X-Plane dataref identifier. Example: fmc1 of laminar/B738/fmc1/Line04_I.
+
+Upon script start, MobiFlight is probed (get_available_devices()) to detect the devices connected to the PC. Any device that returns a successful response is then tracked.
+
+Two tasks are started independently for each avialable CDU device.
+1. handle_dataref_updates -> Listens to X-Plane's WebSocket server for dataref updates for that specific CDU and pushes an event to a queue
+2. handle_device_update   -> Listens to the queue and dispatches updates to MobiFlight to update that CDU
+
+Tasks are started independently for each CDU device to ensure each device can update quickly, particularly when players might be performing shared cockpit flights.
+
+Upon a failed connection while dispatching updates to MobiFlight, the handle_device_update function use `async for` with the websockets client. The failed message is put back in the queue, the loop continues to the next iteration which then reconnects again.
+The failed message is picked back up and dispatched to MobiFlight. This ensures a user's device eventually receives the updated display contents and doesn't hang which would require the user to cycle the page again.
+"""
+
+import asyncio
+import base64
+import json
+import logging
+import urllib.request
+import websockets
+from enum import StrEnum
+
+CDU_COLUMNS = 24
+CDU_ROWS = 14
+CDU_CELLS = CDU_COLUMNS * CDU_ROWS
+
+WEBSOCKET_HOST = "localhost"
+WEBSOCKET_PORT = 8320
+
+BASE_REST_URL = "http://localhost:8086/api/v2/datarefs"
+BASE_WEBSOCKET_URI = f"ws://{WEBSOCKET_HOST}:8086/api/v2"
+
+WS_CAPTAIN = f"ws://{WEBSOCKET_HOST}:{WEBSOCKET_PORT}/winwing/cdu-captain"
+WS_CO_PILOT = f"ws://{WEBSOCKET_HOST}:{WEBSOCKET_PORT}/winwing/cdu-co-pilot"
+WS_OBSERVER = f"ws://{WEBSOCKET_HOST}:{WEBSOCKET_PORT}/winwing/cdu-observer"
+
+BALLOT_BOX = "☐"
+DEGREES = "°"
+
+COLOR_MAP = {
+  0: "e",  # Grey instead of black, which doesn't exist
+  1: "c",
+  2: "r",
+  3: "y",
+  4: "g",
+  5: "m",
+  6: "a",
+  7: "w",
+}
+
+
+FONT_REQUEST = json.dumps({"Target": "Font", "Data": "Boeing"})
+
+
+class CduDevice(StrEnum):
+    Captain = "fms_cdu1"
+    CoPilot = "fms_cdu2"
+    Observer = "fms_cdu3"
+
+    def get_endpoint(self) -> str:
+        match self:
+            case CduDevice.Captain:
+                return WS_CAPTAIN
+            case CduDevice.CoPilot:
+                return WS_CO_PILOT
+            case CduDevice.Observer:
+                return WS_OBSERVER
+            case _:
+                raise KeyError(f"Invalid device specified {self}")
+
+    def get_dataref_prefix(self) -> str:
+        return f"sim/cockpit2/radios/indicators/{self}"
+
+    def get_text_dataref(self, line) -> str:
+        return f"sim/cockpit2/radios/indicators/{self}_text_line{line}"
+
+    def get_style_dataref(self, line) -> str:
+        return f"sim/cockpit2/radios/indicators/{self}_style_line{line}"
+
+
+def fetch_dataref_mapping(device: CduDevice):
+    with urllib.request.urlopen(BASE_REST_URL, timeout=5) as response:
+        response_json = json.load(response)
+
+        return dict(
+            map(
+                lambda dataref: (int(dataref["id"]), str(dataref["name"])),
+                filter(
+                    lambda x: device.get_dataref_prefix() in str(x["name"]),
+                    response_json["data"],
+                ),
+            )
+        )
+
+
+def color_from_style(style):
+    return COLOR_MAP[style &  7]
+
+
+def size_from_style(style):
+    return 0 if style & (1 << 7) else 1
+
+
+def generate_display_json(device: CduDevice, values: dict[str, str]):
+    display_data = [[] for _ in range(CDU_CELLS)]
+
+    for row in range(CDU_ROWS):
+        text = values[device.get_text_dataref(row)]
+        style = values[device.get_style_dataref(row)]
+
+        for col in range(CDU_COLUMNS):
+            index = row * CDU_COLUMNS + col
+
+            # The dataref and WinWing both use Unicode, so no conversion
+            # of special characters is necessary.
+            char = text[col]
+            if char == " ":
+                continue
+
+            color = color_from_style(style[col]) 
+            size = size_from_style(style[col]) 
+
+            display_data[index] = [char, color, size]
+
+    return json.dumps({"Target": "Display", "Data": display_data})
+
+
+async def handle_device_update(queue: asyncio.Queue, device: CduDevice):
+    """
+    Translates and sends dataref updates to MobiFlight.
+    """
+    last_run_time = 0
+    rate_limit_time = 0.1
+
+    endpoint = device.get_endpoint()
+    logging.info("Connecting to CDU device %s", device)
+    async for websocket in websockets.connect(endpoint):
+        logging.info("Connected successfully to CDU device %s", device)
+        while True:
+            values = await queue.get()
+
+            try:
+                elapsed = asyncio.get_event_loop().time() - last_run_time
+
+                # Weaker CPUs may experience performance issues when a websocket connection is saturated with requests, such as when pages are frequently changed.
+                # This rate limits the number of active websocket requests to MobiFlight.
+                # The delay should not be noticeable unless a user heavily spams page changes, but it should be enough that too many messages won't be pushed at once.
+                if elapsed < rate_limit_time:
+                    await asyncio.sleep(rate_limit_time - elapsed)
+
+                display_json = generate_display_json(device, values)
+                await websocket.send(display_json)
+                last_run_time = asyncio.get_event_loop().time()
+
+            except websockets.exceptions.ConnectionClosed:
+                logging.error(
+                    "MobiFlight websocket connection was closed... Attempting to reconnect"
+                )
+                await queue.put(values)
+                break
+
+
+async def handle_dataref_updates(queue: asyncio.Queue, device: CduDevice):
+    last_known_values = {}
+
+    dataref_map = fetch_dataref_mapping(device)
+    logging.info("Connecting to X-Plane websocket server")
+    async for websocket in websockets.connect(BASE_WEBSOCKET_URI):
+        logging.info("Connected successfully to X-Plane websocket server")
+        try:
+            await websocket.send(
+                json.dumps(
+                    {
+                        "type": "dataref_subscribe_values",
+                        "req_id": 1,
+                        "params": {
+                            "datarefs": [
+                                {"id": id_value} for id_value in dataref_map.keys()
+                            ]
+                        },
+                    }
+                )
+            )
+            while True:
+                message = await websocket.recv()
+                data = json.loads(message)
+
+                if "data" not in data:
+                    continue
+
+                new_values = dict(last_known_values)
+
+                for dataref_id, value in data["data"].items():
+                    dataref_id = int(dataref_id)
+                    if dataref_id not in dataref_map:
+                        continue
+
+                    dataref_name = dataref_map[dataref_id]
+
+                    if "text_line" in dataref_name:
+                        new_values[dataref_name] = base64.b64decode(value).decode().replace("\x00", " ")
+                    elif "style_line" in dataref_name:
+                        new_values[dataref_name] = base64.b64decode(value)
+
+                if new_values == last_known_values:
+                    continue
+
+                last_known_values = new_values
+                await queue.put(new_values)
+        except websockets.exceptions.ConnectionClosed:
+            logging.error(
+                "X-Plane websocket connection was closed... Attempting to reconnect"
+            )
+            continue
+
+
+async def get_available_devices() -> list[CduDevice]:
+    device_candidates = [device for device in CduDevice]
+
+    available_devices = []
+
+    logging.info("Checking MobiFlight for available CDU devices")
+    for device in device_candidates:
+        device_endpoint = device.get_endpoint()
+        try:
+            async with websockets.connect(device_endpoint) as socket:
+                logging.info(
+                    "Discovered CDU device %s at endpoint %s", device, device_endpoint
+                )
+                available_devices.append(device)
+                await socket.send(FONT_REQUEST)
+                await asyncio.sleep(1) # wait a second for font to be set
+        except websockets.WebSocketException:
+            logging.warning(
+                "Attempted to probe CDU device %s at endpoint %s but device wasn't available",
+                device,
+                device_endpoint,
+            )
+            continue
+
+    return available_devices
+
+
+async def main():
+    available_devices = await get_available_devices()
+
+    tasks = []
+
+    for device in available_devices:
+        queue = asyncio.Queue()
+
+        tasks.append(asyncio.create_task(handle_dataref_updates(queue, device)))
+        tasks.append(asyncio.create_task(handle_device_update(queue, device)))
+
+    logging.info("Started background tasks for %s", available_devices)
+
+    await asyncio.gather(*tasks)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Scripts/Winwing/xplane_default_fmc.py
+++ b/Scripts/Winwing/xplane_default_fmc.py
@@ -5,17 +5,17 @@ Many X-Plane aircraft have similar formats for datarefs and the means of retriev
 
 In order to support multiple CDU devices seamlessly, a dynamic approach is taken whereby an enum class is defined that contains the supported devices.
 A device is considered "supported" if it exists in the aircraft. Some aircraft have 3 CDUs while others have 2.
-Each enum member is assigned a value that represents the X-Plane dataref identifier. Example: fmc1 of laminar/B738/fmc1/Line04_I.
+Each enum member is assigned a value that is used to construct the X-Plane dataref identifier. Example: "fms_cdu1" in "sim/cockpit2/radios/indicators/fms_cdu1_text_line0".
 
 Upon script start, MobiFlight is probed (get_available_devices()) to detect the devices connected to the PC. Any device that returns a successful response is then tracked.
 
-Two tasks are started independently for each avialable CDU device.
+Two tasks are started independently for each available CDU device.
 1. handle_dataref_updates -> Listens to X-Plane's WebSocket server for dataref updates for that specific CDU and pushes an event to a queue
 2. handle_device_update   -> Listens to the queue and dispatches updates to MobiFlight to update that CDU
 
 Tasks are started independently for each CDU device to ensure each device can update quickly, particularly when players might be performing shared cockpit flights.
 
-Upon a failed connection while dispatching updates to MobiFlight, the handle_device_update function use `async for` with the websockets client. The failed message is put back in the queue, the loop continues to the next iteration which then reconnects again.
+Upon a failed connection while dispatching updates to MobiFlight, the handle_device_update function uses `async for` with the websockets client. The failed message is put back in the queue, the loop continues to the next iteration which then reconnects again.
 The failed message is picked back up and dispatched to MobiFlight. This ensures a user's device eventually receives the updated display contents and doesn't hang which would require the user to cycle the page again.
 """
 
@@ -24,8 +24,9 @@ import base64
 import json
 import logging
 import urllib.request
-import websockets
 from enum import StrEnum
+
+import websockets
 
 CDU_COLUMNS = 24
 CDU_ROWS = 14
@@ -40,9 +41,6 @@ BASE_WEBSOCKET_URI = f"ws://{WEBSOCKET_HOST}:8086/api/v2"
 WS_CAPTAIN = f"ws://{WEBSOCKET_HOST}:{WEBSOCKET_PORT}/winwing/cdu-captain"
 WS_CO_PILOT = f"ws://{WEBSOCKET_HOST}:{WEBSOCKET_PORT}/winwing/cdu-co-pilot"
 WS_OBSERVER = f"ws://{WEBSOCKET_HOST}:{WEBSOCKET_PORT}/winwing/cdu-observer"
-
-BALLOT_BOX = "☐"
-DEGREES = "°"
 
 COLOR_MAP = {
   0: "e",  # Grey instead of black, which doesn't exist
@@ -108,7 +106,7 @@ def size_from_style(style):
     return 0 if style & (1 << 7) else 1
 
 
-def generate_display_json(device: CduDevice, values: dict[str, str]):
+def generate_display_json(device: CduDevice, values: dict[str, str | bytes]):
     display_data = [[] for _ in range(CDU_CELLS)]
 
     for row in range(CDU_ROWS):
@@ -124,8 +122,8 @@ def generate_display_json(device: CduDevice, values: dict[str, str]):
             if char == " ":
                 continue
 
-            color = color_from_style(style[col]) 
-            size = size_from_style(style[col]) 
+            color = color_from_style(style[col])
+            size = size_from_style(style[col])
 
             display_data[index] = [char, color, size]
 

--- a/Scripts/Winwing/xplane_default_fmc.py
+++ b/Scripts/Winwing/xplane_default_fmc.py
@@ -102,9 +102,9 @@ def color_from_style(style):
     # According to the documentation
     # (https://developer.x-plane.com/article/datarefs-for-the-cdu-screen/)
     # the four lowest bits encode color, but only color indexes 0 through 7
-    # are defined at this point. We therefore look at only the lowest three
-    # bits to avoid an out-of-bounds access on the `COLOR_MAP` list.
-    return COLOR_MAP[style & 7]
+    # are defined at this point. We default to white for any color indexes that
+    # currently aren't defined.
+    return COLOR_MAP.get(style & 0xf, "w")
 
 
 def size_from_style(style):

--- a/Scripts/Winwing/xplane_default_fmc.py
+++ b/Scripts/Winwing/xplane_default_fmc.py
@@ -99,7 +99,12 @@ def fetch_dataref_mapping(device: CduDevice):
 
 
 def color_from_style(style):
-    return COLOR_MAP[style &  7]
+    # According to the documentation
+    # (https://developer.x-plane.com/article/datarefs-for-the-cdu-screen/)
+    # the four lowest bits encode color, but only color indexes 0 through 7
+    # are defined at this point. We therefore look at only the lowest three
+    # bits to avoid an out-of-bounds access on the `COLOR_MAP` list.
+    return COLOR_MAP[style & 7]
 
 
 def size_from_style(style):
@@ -145,7 +150,7 @@ async def handle_device_update(queue: asyncio.Queue, device: CduDevice):
             values = await queue.get()
 
             try:
-                elapsed = asyncio.get_event_loop().time() - last_run_time
+                elapsed = asyncio.get_running_loop().time() - last_run_time
 
                 # Weaker CPUs may experience performance issues when a websocket connection is saturated with requests, such as when pages are frequently changed.
                 # This rate limits the number of active websocket requests to MobiFlight.
@@ -155,7 +160,7 @@ async def handle_device_update(queue: asyncio.Queue, device: CduDevice):
 
                 display_json = generate_display_json(device, values)
                 await websocket.send(display_json)
-                last_run_time = asyncio.get_event_loop().time()
+                last_run_time = asyncio.get_running_loop().time()
 
             except websockets.exceptions.ConnectionClosed:
                 logging.error(


### PR DESCRIPTION
The Python script for the X-Plane default FMC is configured in
ScriptMappings.json to run for the default MD-82 as well as the Manky /
Riviere Dash 8 100 / Q100 / Q200. (These all use the same aircraft ID,
which contains "q100", so that's what I'm using as the
`AircraftIdSnippet`.)

I haven't confdigured the script for the default 737-800 because the
`AircraftIdSnippet` "boeing 737-" is already in use for the Zibo mod. In
any case, I figure that just about everyone who wants to fly the 737 NG
will be flying the Zibo mod, not the default 737-800.
