### PR TITLE
Add new hardware support category to release.yml

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,11 +7,11 @@ changelog:
     - title: New Feature 🎉
       labels:
         - feature
-    - title: New Hardware support 🕹️
+    - title: New Hardware Support 🕹️
       labels:
         - controller
         - hardware
-    - title: Firmware & profile updates 🚀
+    - title: Firmware & Profile Updates 🚀
       labels:
         - firmware
         - profile


### PR DESCRIPTION
A new "New Hardware Support" category is added to make it stand out more from "New feature" section.