### PR TITLE
Disable DTR on connecting boards

### DIFF
--- a/src/MobiFlightConnector/Boards/arduino_mega.board.json
+++ b/src/MobiFlightConnector/Boards/arduino_mega.board.json
@@ -11,7 +11,7 @@
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": false,
     "DelayAfterFirmwareUpdate": 0,
-    "DtrEnable": true,
+    "DtrEnable": false,
     "MessageSize": 90,
     "EEPROMSize": 1496
   },

--- a/src/MobiFlightConnector/Boards/arduino_micro.board.json
+++ b/src/MobiFlightConnector/Boards/arduino_micro.board.json
@@ -14,7 +14,7 @@
     "EEPROMSize": 440,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": true,
-    "MessageSize": 64
+    "MessageSize": 90
   },
   "HardwareIds": [
     "^VID_1B4F&PID_9206",

--- a/src/MobiFlightConnector/Boards/arduino_nano.board.json
+++ b/src/MobiFlightConnector/Boards/arduino_nano.board.json
@@ -14,7 +14,7 @@
     "EEPROMSize": 286,
     "ExtraConnectionRetry": true,
     "ForceResetOnFirmwareUpdate": false,
-    "MessageSize": 64,
+    "MessageSize": 90,
     "TimeoutForFirmwareUpdate": 60000
   },
   "HardwareIds": [

--- a/src/MobiFlightConnector/Boards/arduino_nano.board.json
+++ b/src/MobiFlightConnector/Boards/arduino_nano.board.json
@@ -10,7 +10,7 @@
   "Connection": {
     "ConnectionDelay": 1750,
     "DelayAfterFirmwareUpdate": 0,
-    "DtrEnable": true,
+    "DtrEnable": false,
     "EEPROMSize": 286,
     "ExtraConnectionRetry": true,
     "ForceResetOnFirmwareUpdate": false,

--- a/src/MobiFlightConnector/Boards/arduino_uno.board.json
+++ b/src/MobiFlightConnector/Boards/arduino_uno.board.json
@@ -14,7 +14,7 @@
     "EEPROMSize": 286,
     "ExtraConnectionRetry": true,
     "ForceResetOnFirmwareUpdate": false,
-    "MessageSize": 64
+    "MessageSize": 90
   },
   "HardwareIds": [
     "^VID_10C4&PID_EA60",

--- a/src/MobiFlightConnector/Boards/arduino_uno.board.json
+++ b/src/MobiFlightConnector/Boards/arduino_uno.board.json
@@ -10,7 +10,7 @@
   "Connection": {
     "ConnectionDelay": 1750,
     "DelayAfterFirmwareUpdate": 0,
-    "DtrEnable": true,
+    "DtrEnable": false,
     "EEPROMSize": 286,
     "ExtraConnectionRetry": true,
     "ForceResetOnFirmwareUpdate": false,

--- a/src/MobiFlightConnector/Boards/raspberrypi_pico.board.json
+++ b/src/MobiFlightConnector/Boards/raspberrypi_pico.board.json
@@ -11,7 +11,7 @@
     "EEPROMSize": 1496,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": true,
-    "MessageSize": 64
+    "MessageSize": 90
   },
   "HardwareIds": ["^VID_2E8A&PID_000A"],
   "Info": {

--- a/src/MobiFlightConnector/Boards/raspberrypi_pico.board.json
+++ b/src/MobiFlightConnector/Boards/raspberrypi_pico.board.json
@@ -7,7 +7,7 @@
   "Connection": {
     "ConnectionDelay": 1250,
     "DelayAfterFirmwareUpdate": 1250,
-    "DtrEnable": true,
+    "DtrEnable": false,
     "EEPROMSize": 1496,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": true,


### PR DESCRIPTION
When connecting to AVR boards with DTR enabled, these boards get resettet on connect. After resetting the boards respond at least with `17,OK;` (not processed from the connector). Other board types which are used for community devices might also respond with additional messages which could lead to an unrecognized board or set them into bootlaoder mode (could happen for some ESP32 boards).
Furthermore the message size is set to `90` for all boards (for the Mega it's already in place). On the FW repo this is already implemented within the board.json files.

This PR disables setting DTR line on connect for all boards except for ProMicro which requires setting the DTR line.

See also PR 376 on the FW repo.

Fixes #2849