### PR TITLE
Add WinCtrl CDU support for X-Plane default A330.

### DIFF
--- a/src/MobiFlightConnector/Scripts/ScriptMappings.json
+++ b/src/MobiFlightConnector/Scripts/ScriptMappings.json
@@ -153,6 +153,12 @@
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
+      "AircraftIdSnippet": "airbus a330",
+      "ScriptName": "xplane_default_fmc.py"
+    },
+    {
+      "VendorId": "0x4098",
+      "ProductIds": [ "WinwingCDUs" ],
       "AircraftIdSnippet": "ixeg b-737",
       "ScriptName": "ixeg_737.py"
     }


### PR DESCRIPTION
After submitting #2807, which adds support for the X-Plane default FMC,
I realized that the default A330 included in X-Plane uses the same
datarefs. So this PR simply adds a config to ScriptMappings.json to use
the existing script with the A330.
