### PR TITLE
Community infos - Remove redirect URL for links.

### DIFF
--- a/src/MobiFlightConnector/Base/Extensions.cs
+++ b/src/MobiFlightConnector/Base/Extensions.cs
@@ -41,7 +41,6 @@ namespace MobiFlight.Base
             return (byte) result;
         }
 
-
         public static byte HammingWeight(this byte value)
         {
             byte sum = 0;
@@ -89,6 +88,12 @@ namespace MobiFlight.Base
         {
             return Uri.TryCreate(url, UriKind.Absolute, out Uri uriResult)
                    && (uriResult.Scheme == Uri.UriSchemeHttp || uriResult.Scheme == Uri.UriSchemeHttps);
+        }
+
+        public static bool IsValidEmailLink(this string emailLink)
+        {
+            var pattern = @"^mailto:(.+@.+\..+)$";
+            return System.Text.RegularExpressions.Regex.IsMatch(emailLink, pattern);
         }
     }
 }

--- a/src/MobiFlightConnector/UI/Panels/Device/MFModulePanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/Device/MFModulePanel.cs
@@ -16,7 +16,12 @@ namespace MobiFlight.UI.Panels.Settings.Device
         /// </summary>
         public event EventHandler Changed;
         public event EventHandler<string> UploadDefaultConfigRequested;
-        const string redirectUrl = "https://mobiflight.com?redirect=";
+
+        // Redirect URL currently not in place
+        // so we directly open the target URL.
+        // In the future, we might want to have a redirect in place to track clicks on the buttons.
+        // or do some other form of tracking
+        const string redirectUrl = "";
 
         private MobiFlightModule module;
         bool initialized = false;
@@ -84,7 +89,6 @@ namespace MobiFlight.UI.Panels.Settings.Device
             {
                 pictureBoxLogo.Visible = false;
             }
-
 
             if (board.Info.Community?.Website != null)
                 buttonWebsite.Click += (s, e) => { Process.Start(CreateRedirectTarget(board.Info.Community.Website)); };

--- a/src/MobiFlightConnector/UI/Panels/Device/MFModulePanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/Device/MFModulePanel.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MobiFlight.Base;
+using System;
 using System.ComponentModel;
 using System.Data;
 using System.Diagnostics;
@@ -85,23 +86,24 @@ namespace MobiFlight.UI.Panels.Settings.Device
             {
                 pictureBoxLogo.Image = board.Info.BoardPicture;
                 pictureBoxLogo.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
-            } else
+            }
+            else
             {
                 pictureBoxLogo.Visible = false;
             }
 
             if (board.Info.Community?.Website != null)
-                buttonWebsite.Click += (s, e) => { Process.Start(CreateRedirectTarget(board.Info.Community.Website)); };
+                buttonWebsite.Click += (s, e) => { OpenCommunityLink(board.Info.Community.Website); };
             else
                 buttonWebsite.Enabled = false;
 
             if (board.Info.Community?.Docs != null)
-                buttonDocs.Click += (s, e) => { Process.Start(CreateRedirectTarget(board.Info.Community.Docs)); };
+                buttonDocs.Click += (s, e) => { OpenCommunityLink(board.Info.Community.Docs); };
             else
                 buttonDocs.Enabled = false;
 
             if (board.Info.Community?.Support != null)
-                buttonSupport.Click += (s, e) => { Process.Start(CreateRedirectTarget(board.Info.Community.Support)); };
+                buttonSupport.Click += (s, e) => { OpenCommunityLink(board.Info.Community.Support); };
             else
                 buttonSupport.Enabled = false;
 
@@ -116,11 +118,11 @@ namespace MobiFlight.UI.Panels.Settings.Device
                     if (specificDeviceConfigs.Count() == 1)
                     {
                         var profile = specificDeviceConfigs.First();
-                        if(profile.DefaultUpload)
+                        if (profile.DefaultUpload)
                         {
                             UploadDefaultConfigRequested?.Invoke(this, profile.File);
                         }
-                    }   
+                    }
                     // since we have more options, we present a context menu
                     else
                     {
@@ -135,10 +137,21 @@ namespace MobiFlight.UI.Panels.Settings.Device
                     }
                 };
                 UploadDeviceConfigPanel.Visible = true;
-            } else
+            }
+            else
             {
                 UploadDeviceConfigPanel.Visible = false;
             }
+        }
+
+        private void OpenCommunityLink(string target)
+        {
+            if (!target.IsValidUrl() && !target.IsValidEmailLink())
+            {
+                Log.Instance.log($"Community link target `{target}` is not valid", LogSeverity.Error);
+                return;
+            }
+            Process.Start(CreateRedirectTarget(target));
         }
 
         private string CreateRedirectTarget(string target)

--- a/tests/MobiFlightUnitTests/Base/ExtensionsTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ExtensionsTests.cs
@@ -86,5 +86,21 @@ namespace MobiFlight.Base.Tests
             var link4 = "http://localhost";
             Assert.IsTrue(link4.IsValidUrl(), "The URL should be valid.");
         }
+
+        [TestMethod()]
+        public void IsValidEmailLinkTest()
+        {
+            var link1 = @"mailto:test@example.com";
+            Assert.IsTrue(link1.IsValidEmailLink(), "The email link should be valid.");
+
+            var link2 = @"mailto:invalid-email";
+            Assert.IsFalse(link2.IsValidEmailLink(), "The email link should be invalid.");
+
+            var link3 = @"mailto:example.com";
+            Assert.IsFalse(link3.IsValidEmailLink(), "The email link should be invalid.");
+
+            var link4 = @"mailto:user@";
+            Assert.IsFalse(link4.IsValidEmailLink(), "The email link should be invalid.");
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the redirect logic for URLs that are defined in the boards.json

Background:

- Our website was flagged because we allowed arbitrary url redirects which could be misused for phishing.
- We removed the redirect logic from the webserver.
- Now that the website is moved over to azure, we don't have a redirect mechanism in place.


fixes #2866 