### PR TITLE
[X-Plane] Improved autoRun and aircraft change detection.

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -223,7 +223,6 @@ namespace MobiFlight
                 OnJoystickConnectedFinished?.Invoke(sender, e);
             };
 
-
             OnMidiBoardConnectedFinished += (s, e) => { PublishConnectedDevices(); };
             OnJoystickConnectedFinished += (s, e) => { PublishConnectedDevices(); };
 
@@ -380,7 +379,6 @@ namespace MobiFlight
                 MessageExchange.Instance.Publish(new ConfigValueFullUpdate(ActiveConfigIndex, ConfigItems));
                 OnConfigHasChanged?.Invoke(ConfigItems, null);
             });
-
 
             MessageExchange.Instance.Subscribe<CommandConfigContextMenu>((message) =>
             {
@@ -1131,6 +1129,13 @@ namespace MobiFlight
                 if (LastDetectedSim != FlightSimType.NONE)
                 {
                     OnSimUnavailable?.Invoke(LastDetectedSim, null);
+
+                    if (LastDetectedSim == FlightSimType.XPLANE)
+                    {
+                        xplaneCache.Disconnect();
+                        OnSimCacheConnectionLost?.Invoke(xplaneCache, EventArgs.Empty);
+                    }
+
                     LastDetectedSim = FlightSimType.NONE;
                 }
             }
@@ -1152,7 +1157,6 @@ namespace MobiFlight
         {
             var OutputConfigItems = ConfigItems.Where(i => (i.GetType() == typeof(OutputConfigItem)) && i.Active && i.Device != null).ToList();
             if (OutputConfigItems.Count == 0) return;
-
 
             var lastTestedConfig = ConfigItemInTestMode;
             var lastTestedConfigIndex = OutputConfigItems.FindIndex(i => i.GUID == lastTestedConfig?.GUID);
@@ -1210,7 +1214,6 @@ namespace MobiFlight
             }
         }
 
-
         public void ExecuteTestOff(OutputConfigItem cfg, bool ResetConfigItemInTest)
         {
             if (!IsStarted() && !TestModeIsStarted())
@@ -1259,7 +1262,6 @@ namespace MobiFlight
             executor.ExecuteTestOn(cfg, value);
             ConfigItemInTestMode = cfg;
         }
-
 
         private void ClearErrorMessages()
         {

--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -1132,8 +1132,11 @@ namespace MobiFlight
 
                     if (LastDetectedSim == FlightSimType.XPLANE)
                     {
-                        xplaneCache.Disconnect();
-                        OnSimCacheConnectionLost?.Invoke(xplaneCache, EventArgs.Empty);
+                        if (xplaneCache.IsConnected())
+                        {
+                            xplaneCache.Disconnect();
+                            OnSimCacheConnectionLost?.Invoke(xplaneCache, EventArgs.Empty);
+                        }
                     }
 
                     LastDetectedSim = FlightSimType.NONE;

--- a/src/MobiFlightConnector/xplane/XplaneCache.cs
+++ b/src/MobiFlightConnector/xplane/XplaneCache.cs
@@ -32,18 +32,21 @@ namespace MobiFlight.xplane
 
         public bool Connect()
         {
-            if (Connector == null) Connector = new XPlaneConnector.XPlaneConnector();
-
-            Connector.OnLog += (m) =>
+            if (Connector == null)
             {
-                // Log.Instance.log(m, LogSeverity.Debug);
-            };
+                Connector = new XPlaneConnector.XPlaneConnector();
 
-            OnUpdateFrequencyPerSecondChanged += (v, e) =>
-            {
-                Log.Instance.log($"update frequency changed: {v} per second.", LogSeverity.Debug);
-                UnsubscribeAll();
-            };
+                Connector.OnLog += (m) =>
+                {
+                    // Log.Instance.log(m, LogSeverity.Debug);
+                };
+
+                OnUpdateFrequencyPerSecondChanged += (v, e) =>
+                {
+                    Log.Instance.log($"update frequency changed: {v} per second.", LogSeverity.Debug);
+                    UnsubscribeAll();
+                };
+            }
 
             SubscribedDataRefs.Clear();
             _connected = true;
@@ -59,13 +62,19 @@ namespace MobiFlight.xplane
         {
             if (!_connected) return;
             // just start the connector
+            _detectedAircraft = string.Empty;
             Connector?.Start();
-            Connector.Subscribe(new DataRefElement() { DataRef = "sim/aircraft/view/acf_ui_name[0]", Frequency = 1, Value = 0 }, 1, (e, v) =>
+            var datarefAircraftName0 = new DataRefElement() { DataRef = "sim/aircraft/view/acf_ui_name[0]", Frequency = 1, Value = 0 };
+            var datarefAircraftName2 = new DataRefElement() { DataRef = "sim/aircraft/view/acf_ui_name[2]", Frequency = 1, Value = 0 };
+
+            Connector.Unsubscribe(datarefAircraftName0.DataRef);
+            Connector.Unsubscribe(datarefAircraftName2.DataRef);
+            Connector.Subscribe(datarefAircraftName0, 1, (e, v) =>
             {
                 Log.Instance.log($"sim/aircraft/view/acf_ui_name[0] = {v}", LogSeverity.Debug);
                 UpdateAircraftSubscription();
             });
-            Connector.Subscribe(new DataRefElement() { DataRef = "sim/aircraft/view/acf_ui_name[2]", Frequency = 1, Value = 0 }, 1, (e, v) =>
+            Connector.Subscribe(datarefAircraftName2, 1, (e, v) =>
             {
                 Log.Instance.log($"sim/aircraft/view/acf_ui_name[2] = {v}", LogSeverity.Debug);
                 UpdateAircraftSubscription();
@@ -93,7 +102,10 @@ namespace MobiFlight.xplane
         {
             if (_connected)
             {
+                _detectedAircraft = string.Empty;
+                AircraftChanged?.Invoke(this, _detectedAircraft);
                 _connected = false;
+                Connector.Stop();
                 Closed?.Invoke(this, new EventArgs());
             }
 
@@ -113,7 +125,6 @@ namespace MobiFlight.xplane
         public void Stop()
         {
             UnsubscribeAll();
-            CheckForAircraftName();
         }
 
         private void UnsubscribeAll()
@@ -137,10 +148,11 @@ namespace MobiFlight.xplane
             if (!SubscribedDataRefs.ContainsKey(dataRefPath))
             {
                 SubscribedDataRefs.Add(dataRefPath, new DataRefElement() { DataRef = dataRefPath, Frequency = UpdateFrequencyPerSecond, Value = 0 });
-                Connector.Subscribe(SubscribedDataRefs[dataRefPath], UpdateFrequencyPerSecond, (e, v) => {
-                        SubscribedDataRefs[e.DataRef].Value = v;
-                    });
-                }
+                Connector.Subscribe(SubscribedDataRefs[dataRefPath], UpdateFrequencyPerSecond, (e, v) =>
+                {
+                    SubscribedDataRefs[e.DataRef].Value = v;
+                });
+            }
             return SubscribedDataRefs[dataRefPath].Value;
         }
 

--- a/src/MobiFlightConnector/xplane/XplaneCache.cs
+++ b/src/MobiFlightConnector/xplane/XplaneCache.cs
@@ -37,7 +37,7 @@ namespace MobiFlight.xplane
                 // As soon as we get connected
                 // we want to check for the aircraft name,
                 // so we can trigger the AircraftChanged event correctly
-                UpdateAircraftSubscription();
+                CheckForAircraftName();
             };
         }
 
@@ -63,7 +63,11 @@ namespace MobiFlight.xplane
             return _connected;
         }
 
-        public void WaitForConnection()
+        /// <summary>
+        /// This method will raise a Connected event as soon as we detect that we are receiving values from the sim.
+        /// The method subscribes to a DatRef which is present for all aircraft and changes constantly.
+        /// </summary>
+        private void WaitForConnection()
         {
             var dataRefTime = new DataRefElement() { DataRef = "sim/time/total_running_time_sec", Frequency = 1, Value = 0 };
             
@@ -81,6 +85,14 @@ namespace MobiFlight.xplane
             });
         }
 
+        /// <summary>
+        /// Updates the subscription to the aircraft name data reference and notifies listeners when the aircraft
+        /// changes.
+        /// </summary>
+        /// <remarks>This method itself does not reliably detect the name change because of a flaw in the libary used.
+        /// We basically resubscribe to the datarefs which will provide us with the correct aircraft name reliably.
+        /// This method is called when CheckForAircraftName detects a change in the first or third character of the aircraft name.
+        /// </remarks>
         private void UpdateAircraftSubscription()
         {
             StringDataRefElement datarefAircraftName = new StringDataRefElement
@@ -97,6 +109,37 @@ namespace MobiFlight.xplane
                 if (_detectedAircraft == v1) return;
                 _detectedAircraft = v1;
                 AircraftChanged?.Invoke(this, _detectedAircraft);
+            });
+        }
+
+        /// <summary>
+        /// This method probes two characters of the aircraft name for change and is used in conjunction with the UpdateAircraftSubscription method.
+        /// </summary>
+        /// <remarks>It is a workkaround because the StringDataRefElement does not trigger
+        /// the change reliably. Subscribing only two characters does work reliably.
+        /// If the old aircraft and the new aircraft have the same characters at the position 0 and 2, \
+        /// then the change will not be detected. But in most cases this should work fine.
+        /// </remarks>
+        private void CheckForAircraftName()
+        {
+            if (!_connected) return;
+            // just start the connector
+            _detectedAircraft = string.Empty;
+            Connector?.Start();
+            var datarefAircraftName0 = new DataRefElement() { DataRef = "sim/aircraft/view/acf_ui_name[0]", Frequency = 1, Value = 0 };
+            var datarefAircraftName2 = new DataRefElement() { DataRef = "sim/aircraft/view/acf_ui_name[2]", Frequency = 1, Value = 0 };
+
+            Connector.Unsubscribe(datarefAircraftName0.DataRef);
+            Connector.Unsubscribe(datarefAircraftName2.DataRef);
+            Connector.Subscribe(datarefAircraftName0, 1, (e, v) =>
+            {
+                Log.Instance.log($"sim/aircraft/view/acf_ui_name[0] = {v}", LogSeverity.Debug);
+                UpdateAircraftSubscription();
+            });
+            Connector.Subscribe(datarefAircraftName2, 1, (e, v) =>
+            {
+                Log.Instance.log($"sim/aircraft/view/acf_ui_name[2] = {v}", LogSeverity.Debug);
+                UpdateAircraftSubscription();
             });
         }
 

--- a/src/MobiFlightConnector/xplane/XplaneCache.cs
+++ b/src/MobiFlightConnector/xplane/XplaneCache.cs
@@ -147,13 +147,18 @@ namespace MobiFlight.xplane
 
             if (!SubscribedDataRefs.ContainsKey(dataRefPath))
             {
-                SubscribedDataRefs.Add(dataRefPath, new DataRefElement() { DataRef = dataRefPath, Frequency = UpdateFrequencyPerSecond, Value = 0 });
-                Connector.Subscribe(SubscribedDataRefs[dataRefPath], UpdateFrequencyPerSecond, (e, v) =>
+                var dataRefElement = new DataRefElement() { DataRef = dataRefPath, Frequency = UpdateFrequencyPerSecond, Value = 0 };
+                SubscribedDataRefs.Add(dataRefPath, dataRefElement);
+                Connector.Subscribe(dataRefElement, UpdateFrequencyPerSecond, (e, v) =>
                 {
                     SubscribedDataRefs[e.DataRef].Value = v;
                 });
             }
-            return SubscribedDataRefs[dataRefPath].Value;
+
+            // make it extra safe when reading the value
+            if (!SubscribedDataRefs.TryGetValue(dataRefPath, out var data)) return 0;
+
+            return data.Value;
         }
 
         public void writeDataRef(string dataRefPath, float value)

--- a/src/MobiFlightConnector/xplane/XplaneCache.cs
+++ b/src/MobiFlightConnector/xplane/XplaneCache.cs
@@ -30,6 +30,17 @@ namespace MobiFlight.xplane
 
         Dictionary<String, DataRefElement> SubscribedDataRefs = new Dictionary<String, DataRefElement>();
 
+        public XplaneCache()
+        {
+            Connected += (s, e) =>
+            {
+                // As soon as we get connected
+                // we want to check for the aircraft name,
+                // so we can trigger the AircraftChanged event correctly
+                UpdateAircraftSubscription();
+            };
+        }
+
         public bool Connect()
         {
             if (Connector == null)
@@ -48,46 +59,37 @@ namespace MobiFlight.xplane
                 };
             }
 
-            SubscribedDataRefs.Clear();
-            _connected = true;
-
-            Connected?.Invoke(this, new EventArgs());
-
-            CheckForAircraftName();
-
+            WaitForConnection();
             return _connected;
         }
 
-        public void CheckForAircraftName()
+        public void WaitForConnection()
         {
-            if (!_connected) return;
-            // just start the connector
-            _detectedAircraft = string.Empty;
-            Connector?.Start();
-            var datarefAircraftName0 = new DataRefElement() { DataRef = "sim/aircraft/view/acf_ui_name[0]", Frequency = 1, Value = 0 };
-            var datarefAircraftName2 = new DataRefElement() { DataRef = "sim/aircraft/view/acf_ui_name[2]", Frequency = 1, Value = 0 };
+            var dataRefTime = new DataRefElement() { DataRef = "sim/time/total_running_time_sec", Frequency = 1, Value = 0 };
+            
+            Connector.Start();
+            Connector.Unsubscribe(dataRefTime.DataRef);
+            Connector.Subscribe(dataRefTime, 1, (e, v) =>
+            {
+#if DEBUG
+                Log.Instance.log($"sim/time/total_running_time_sec = {v}", LogSeverity.Debug);
+#endif
+                if (_connected) return;
 
-            Connector.Unsubscribe(datarefAircraftName0.DataRef);
-            Connector.Unsubscribe(datarefAircraftName2.DataRef);
-            Connector.Subscribe(datarefAircraftName0, 1, (e, v) =>
-            {
-                Log.Instance.log($"sim/aircraft/view/acf_ui_name[0] = {v}", LogSeverity.Debug);
-                UpdateAircraftSubscription();
-            });
-            Connector.Subscribe(datarefAircraftName2, 1, (e, v) =>
-            {
-                Log.Instance.log($"sim/aircraft/view/acf_ui_name[2] = {v}", LogSeverity.Debug);
-                UpdateAircraftSubscription();
+                _connected = true;
+                Connected?.Invoke(this, new EventArgs());
             });
         }
 
         private void UpdateAircraftSubscription()
         {
-            var datarefAircraftName = new StringDataRefElement();
-            datarefAircraftName.DataRef = "sim/aircraft/view/acf_ui_name";
-            datarefAircraftName.Frequency = 1;
-            datarefAircraftName.Value = string.Empty;
-            datarefAircraftName.StringLenght = 64;
+            StringDataRefElement datarefAircraftName = new StringDataRefElement
+            {
+                DataRef = "sim/aircraft/view/acf_ui_name",
+                Frequency = 1,
+                Value = string.Empty,
+                StringLenght = 64
+            };
 
             Connector.Unsubscribe(datarefAircraftName.DataRef);
             Connector.Subscribe(datarefAircraftName, 1, (e1, v1) =>
@@ -138,7 +140,7 @@ namespace MobiFlight.xplane
 
         public void Clear()
         {
-            SubscribedDataRefs.Clear();
+            UnsubscribeAll();
         }
 
         public float readDataRef(string dataRefPath)

--- a/src/MobiFlightConnector/xplane/XplaneCache.cs
+++ b/src/MobiFlightConnector/xplane/XplaneCache.cs
@@ -15,7 +15,8 @@ namespace MobiFlight.xplane
         private bool _connected = false;
         private int _updateFrequencyPerSecond = 10;
         private string _detectedAircraft = string.Empty;
-        public int UpdateFrequencyPerSecond { 
+        public int UpdateFrequencyPerSecond
+        {
             get { return _updateFrequencyPerSecond; }
             set
             {
@@ -32,7 +33,7 @@ namespace MobiFlight.xplane
         public bool Connect()
         {
             if (Connector == null) Connector = new XPlaneConnector.XPlaneConnector();
-            
+
             Connector.OnLog += (m) =>
             {
                 // Log.Instance.log(m, LogSeverity.Debug);
@@ -41,8 +42,7 @@ namespace MobiFlight.xplane
             OnUpdateFrequencyPerSecondChanged += (v, e) =>
             {
                 Log.Instance.log($"update frequency changed: {v} per second.", LogSeverity.Debug);
-                Connector?.Stop();
-                Connector?.Start();
+                UnsubscribeAll();
             };
 
             SubscribedDataRefs.Clear();
@@ -96,7 +96,7 @@ namespace MobiFlight.xplane
                 _connected = false;
                 Closed?.Invoke(this, new EventArgs());
             }
-            
+
             return _connected;
         }
 
@@ -107,14 +107,22 @@ namespace MobiFlight.xplane
 
         public void Start()
         {
-            SubscribedDataRefs.Clear();
-            Connector?.Start();
+            UnsubscribeAll();
         }
 
         public void Stop()
         {
-            Connector?.Stop();
+            UnsubscribeAll();
             CheckForAircraftName();
+        }
+
+        private void UnsubscribeAll()
+        {
+            foreach (var dataRef in SubscribedDataRefs)
+            {
+                Connector.Unsubscribe(dataRef.Value.DataRef);
+            }
+            SubscribedDataRefs.Clear();
         }
 
         public void Clear()
@@ -130,9 +138,9 @@ namespace MobiFlight.xplane
             {
                 SubscribedDataRefs.Add(dataRefPath, new DataRefElement() { DataRef = dataRefPath, Frequency = UpdateFrequencyPerSecond, Value = 0 });
                 Connector.Subscribe(SubscribedDataRefs[dataRefPath], UpdateFrequencyPerSecond, (e, v) => {
-                    SubscribedDataRefs[e.DataRef].Value = v;
-                });
-            }
+                        SubscribedDataRefs[e.DataRef].Value = v;
+                    });
+                }
             return SubscribedDataRefs[dataRefPath].Value;
         }
 


### PR DESCRIPTION
This PR change Start/Stop behavior of the XplaneConnector, instead of calling Stop/Start which was causing issues because the UDP is disposed and created newly, we just clear the subscribed DataRefs on Stop and register them on Start.

This has fixed the AutoRun issue and now DataRefs are available right away.

- [x] Project starts as soon as loaded into flight. 
  - [x] MobiFlight is started first, then X-Plane
  - [x] X-Plane is started first, no flight loaded, then MobiFlight is started, then Flight is loaded
  - [x] X-Plane is started, incl. flight loaded, then MobiFlight is started
- [x] MobiFlight will work if X-Plane crashes and is restarted
  - [x] "Connection lost" notification is displayed.
  - [x] Auto-Start will work after X-Plane restart

fixes #1931 
fixes #2209