### PR TITLE
DTR line must be enabled for Picos

### DIFF
--- a/src/MobiFlightConnector/Boards/raspberrypi_pico.board.json
+++ b/src/MobiFlightConnector/Boards/raspberrypi_pico.board.json
@@ -7,7 +7,7 @@
   "Connection": {
     "ConnectionDelay": 1250,
     "DelayAfterFirmwareUpdate": 1250,
-    "DtrEnable": false,
+    "DtrEnable": true,
     "EEPROMSize": 1496,
     "ExtraConnectionRetry": false,
     "ForceResetOnFirmwareUpdate": true,


### PR DESCRIPTION
With PR #2870 DTR was disabled on serial connect like for the AVR's.
Additonal tests have shown, that Picos are not responding when DTR line is disabled.

This PR rolls back disabling the DTR line.