### PR TITLE
Fix Test Mode Start/Stop for stepper motors

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Execution/ConfigItemExecutor.cs
+++ b/src/MobiFlightConnector/MobiFlight/Execution/ConfigItemExecutor.cs
@@ -297,14 +297,14 @@ namespace MobiFlight.Execution
                     // Do nothing for the InputAction
                     break;
 
-                case MobiFlightOutput.TYPE:
-                    ExecuteDisplay("0", offCfg);
-                    break;
-
                 case MobiFlightLedModule.TYPE:
                     var ledModule = offCfg.Device as LedModule;
                     ledModule.DisplayLedDecimalPoints = new List<string>();
                     ExecuteDisplay("        ", offCfg);
+                    break;
+
+                default:
+                    ExecuteDisplay("0", offCfg);
                     break;
             }
 

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightCache.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightCache.cs
@@ -39,13 +39,12 @@ namespace MobiFlight
         /// </summary>
         public event EventHandler LookupFinished;
 
-
 #pragma warning disable IDE0044 // Add readonly modifier.
         private volatile List<MobiFlightModuleInfo> AvailableComModules = new List<MobiFlightModuleInfo>();
 #pragma warning restore IDE0044 // Add readonly modifier
         Boolean isFirstTimeLookup = true;
 
-        private readonly Timer keepAwakeTimer = new Timer();
+        private readonly Timer KeepAwakeTimer = new Timer();
         const int KeepAwakeIntervalInMinutes = 5; // 5 Minutes
         
         /// <summary>
@@ -62,8 +61,8 @@ namespace MobiFlight
         public MobiFlightCache()
         {
             // ticks every KeepAwakeIntervalInMinutes
-            keepAwakeTimer.Interval = KeepAwakeIntervalInMinutes * 60 * 1000;
-            keepAwakeTimer.Tick += (s, e) => DeactivateConnectedModulePowerSave();
+            KeepAwakeTimer.Interval = KeepAwakeIntervalInMinutes * 60 * 1000;
+            KeepAwakeTimer.Tick += (s, e) => DeactivateConnectedModulePowerSave();
         }
 
         public void Start()
@@ -268,7 +267,6 @@ namespace MobiFlight
         public static List<MobiFlightModuleInfo> FindConnectedUsbDevices(double WaitInMilliseconds = 500)
         {
             var result = new List<MobiFlightModuleInfo>();
-
 
             var usbDeviceMonitor = new UsbDeviceMonitor();
             usbDeviceMonitor.Start();
@@ -477,7 +475,6 @@ namespace MobiFlight
                     module.SetPin("base", name, iValue);
                 }
 
-                
             }
             catch (ConfigErrorException e)
             {
@@ -603,7 +600,6 @@ namespace MobiFlight
 
                 int iValue = (int)dValue;
 
-
                 if (module.GetStepper(address).OutputRevolutionSteps != outputRevolutionSteps)
                 {
                     module.GetStepper(address).OutputRevolutionSteps = outputRevolutionSteps;
@@ -710,7 +706,6 @@ namespace MobiFlight
             }
         }
 
-        
         public void Flush()
         {
             // not implemented, don't throw exception either
@@ -877,13 +872,15 @@ namespace MobiFlight
 
         public void StartKeepAwake()
         {
+            if (KeepAwakeTimer.Enabled) return;
+
             DeactivateConnectedModulePowerSave();
-            keepAwakeTimer.Start();
+            KeepAwakeTimer.Start();
         }
 
         public void StopKeepAwake()
         {
-            keepAwakeTimer.Stop();
+            KeepAwakeTimer.Stop();
             ActivateConnectedModulePowerSave();
         }
     }

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -274,6 +274,20 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsOutput()
+        {
+            // Arrange
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var name = "TestOutput";
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController(rawSerial), DeviceType = MobiFlightOutput.TYPE, Device = new OutputConfig.Output { Pin = name, PwmMode = false } };
+            // Act
+            executor.ExecuteTestOff(cfg);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetValue(serial, name, "0"), Times.Once);
+        }
+
+        [TestMethod]
         public void ExecuteTestOn_ShouldExecuteDisplay_WhenOutputAndValueNot0AndNotPwm()
         {
             // Arrange

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -11,6 +11,7 @@ using Moq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace MobiFlight.Tests
 {
@@ -315,6 +316,22 @@ namespace MobiFlight.Tests
             executor.ExecuteTestOff(cfg);
             // Assert
             mockMobiFlightCache.Verify(m => m.SetShiftRegisterOutput(serial, "Shifter01", pin, "0"), Times.Once);
+        }
+
+        [TestMethod]
+        public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsLedModule()
+        {
+            // Arrange
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var address = "1";
+            var stopValue = "        ";
+
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController(rawSerial), DeviceType = MobiFlightLedModule.TYPE, Device = new OutputConfig.LedModule { DisplayLedAddress = address } };
+            // Act
+            executor.ExecuteTestOff(cfg);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetDisplay(serial, address, It.IsAny<byte>(), It.IsAny<List<string>>(), It.IsAny<List<string>>(), stopValue, It.IsAny<bool>()), Times.Once);
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -262,6 +262,25 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsServo_WithDefaultValue()
+        {
+            var testValue = new ConnectorValue() { type = FSUIPCOffsetType.Integer, Float64 = 100 };
+            // Arrange
+            var cfg = new OutputConfigItem
+            {
+                Controller = SerialNumber.CreateController("Test / SN-123"),
+                DeviceType = MobiFlightServo.TYPE,
+                Device = new OutputConfig.Servo { Min = "0", Address = "1", Max = "180", MaxRotationPercent = "100", Name = "TestServo" },
+            };
+
+            // Act
+            executor.ExecuteTestOn(cfg);
+
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetServo(It.IsAny<string>(), It.IsAny<string>(), "180", 0, It.IsAny<int>(), It.IsAny<byte>()), Times.Once);
+        }
+
+        [TestMethod]
         public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsServo()
         {
             var testValue = new ConnectorValue() { type = FSUIPCOffsetType.Integer, Float64 = 100 };

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -224,7 +224,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
-        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsStepper()
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsStepper_WithTestValueFromConfig()
         {
             // Arrange
             var cfg = new OutputConfigItem { 
@@ -281,7 +281,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
-        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsServo()
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsServo_WithExplicitValue()
         {
             var testValue = new ConnectorValue() { type = FSUIPCOffsetType.Integer, Float64 = 100 };
             // Arrange
@@ -309,6 +309,52 @@ namespace MobiFlight.Tests
 
             // Assert
             mockMobiFlightCache.Verify(m => m.SetServo(It.IsAny<string>(), It.IsAny<string>(), "0", 0, It.IsAny<int>(), It.IsAny<byte>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsCustomDevice_WithDefaultValue()
+        {
+            // Arrange
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var name = "TestCustomDevice";
+            var msgType = 1;
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController(rawSerial), DeviceType = MobiFlightCustomDevice.TYPE, Device = new OutputConfig.CustomDevice { CustomName = name, MessageType = msgType } };
+            // Act
+            executor.ExecuteTestOn(cfg);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.Set(serial, It.IsAny<OutputConfig.CustomDevice>(), "1"), Times.Once);
+        }
+
+        [TestMethod]
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsCustomDevice_WithExplicitValue()
+        {
+            // Arrange
+            var testValue = new ConnectorValue() { type = FSUIPCOffsetType.Integer, Float64 = 100 };
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var name = "TestCustomDevice";
+            var msgType = 1;
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController(rawSerial), DeviceType = MobiFlightCustomDevice.TYPE, Device = new OutputConfig.CustomDevice { CustomName = name, MessageType = msgType } };
+            // Act
+            executor.ExecuteTestOn(cfg, testValue);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.Set(serial, It.IsAny<OutputConfig.CustomDevice>(), "100"), Times.Once);
+        }
+
+        [TestMethod]
+        public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsCustomDevice()
+        {
+            // Arrange
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var name = "TestCustomDevice";
+            var msgType = 1;
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController(rawSerial), DeviceType = MobiFlightCustomDevice.TYPE, Device = new OutputConfig.CustomDevice { CustomName = name, MessageType= msgType } };
+            // Act
+            executor.ExecuteTestOff(cfg);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.Set(serial, It.IsAny<OutputConfig.CustomDevice>(), "0"), Times.Once);
         }
 
         [TestMethod]
@@ -342,7 +388,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
-        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsLcdDisplayDeprecatedType()
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsLcdDisplayDeprecatedType_WithExplicitValue()
         {
             // Arrange
             var rawSerial = "Test / SN-123";

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -240,6 +240,27 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsStepper()
+        {
+            // Arrange
+            var stopValue = 0;
+            var stepperAddress = "1";
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var cfg = new OutputConfigItem { 
+                Controller = SerialNumber.CreateController(rawSerial), 
+                DeviceType = MobiFlightStepper.TYPE, 
+                Device = new OutputConfig.Stepper { Address = stepperAddress, Name="Stepper", TestValue = 100 } 
+            };
+
+            // Act
+            executor.ExecuteTestOff(cfg);
+
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetStepper(serial, stepperAddress, stopValue.ToString(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<short>(), It.IsAny<short>()), Times.Once);
+        }
+
+        [TestMethod]
         public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsServo()
         {
             // Arrange

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -262,6 +262,24 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsServo()
+        {
+            var testValue = new ConnectorValue() { type = FSUIPCOffsetType.Integer, Float64 = 100 };
+            // Arrange
+            var cfg = new OutputConfigItem { 
+                Controller = SerialNumber.CreateController("Test / SN-123"), 
+                DeviceType = MobiFlightServo.TYPE, 
+                Device = new OutputConfig.Servo { Min = "0", Address = "1", Max = "180", MaxRotationPercent = "100", Name = "TestServo" },
+            };
+
+            // Act
+            executor.ExecuteTestOn(cfg, testValue);
+
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetServo(It.IsAny<string>(), It.IsAny<string>(), "100", 0, It.IsAny<int>(), It.IsAny<byte>()), Times.Once);
+        }
+
+        [TestMethod]
         public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsServo()
         {
             // Arrange

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -11,7 +11,6 @@ using Moq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace MobiFlight.Tests
 {
@@ -264,7 +263,6 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsServo_WithDefaultValue()
         {
-            var testValue = new ConnectorValue() { type = FSUIPCOffsetType.Integer, Float64 = 100 };
             // Arrange
             var cfg = new OutputConfigItem
             {

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -326,6 +326,38 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsLcdDisplayDeprecatedType_WithDefaultvalue()
+        {
+            // Arrange
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var name = "TestOutput";
+            var address = "0x27";
+            var expectedTestLine = "1234567890";
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController("Test / SN-123"), DeviceType = OutputConfig.LcdDisplay.DeprecatedType, Device = new OutputConfig.LcdDisplay { Name = name, Address = address } };
+            // Act
+            executor.ExecuteTestOn(cfg);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetLcdDisplay(serial, It.IsAny<OutputConfig.LcdDisplay>(), expectedTestLine, It.IsAny<List<ConfigRefValue>>()), Times.Once);
+        }
+
+        [TestMethod]
+        public void ExecuteTestOn_ShouldExecuteDisplay_WhenDeviceTypeIsLcdDisplayDeprecatedType()
+        {
+            // Arrange
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var name = "TestOutput";
+            var address = "0x27";
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController("Test / SN-123"), DeviceType = OutputConfig.LcdDisplay.DeprecatedType, Device = new OutputConfig.LcdDisplay { Name = name, Address = address } };
+            var testValue = new ConnectorValue() { type = FSUIPCOffsetType.String, String = "Test" };
+            // Act
+            executor.ExecuteTestOn(cfg, testValue);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetLcdDisplay(serial, It.IsAny<OutputConfig.LcdDisplay>(), testValue.String, It.IsAny<List<ConfigRefValue>>()), Times.Once);
+        }
+
+        [TestMethod]
         public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsLcdDisplayDeprecatedType() 
         {
             // Arrange

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -304,6 +304,20 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsOutputShiftRegister()
+        {
+            // Arrange
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var pin = "0|2";
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController(rawSerial), DeviceType = MobiFlightShiftRegister.TYPE, Device = new OutputConfig.ShiftRegister { Address = "Shifter01", PWM = false, Pin = pin } };
+            // Act
+            executor.ExecuteTestOff(cfg);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetShiftRegisterOutput(serial, "Shifter01", pin, "0"), Times.Once);
+        }
+
+        [TestMethod]
         public void ExecuteTestOn_ShouldExecuteDisplay_WhenOutputAndValueNot0AndNotPwm()
         {
             // Arrange

--- a/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Execution/ConfigItemExecutorTests.cs
@@ -288,6 +288,22 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void ExecuteTestOff_ShouldExecuteDisplay_WhenDeviceTypeIsLcdDisplayDeprecatedType() 
+        {
+            // Arrange
+            var rawSerial = "Test / SN-123";
+            var serial = SerialNumber.ExtractSerial(rawSerial);
+            var name = "TestOutput";
+            var address = "0x27";
+            var expectedEmptyLine = new string(' ', 20 * 4);
+            var cfg = new OutputConfigItem { Controller = SerialNumber.CreateController("Test / SN-123"), DeviceType = OutputConfig.LcdDisplay.DeprecatedType, Device = new OutputConfig.LcdDisplay { Name = name, Address= address } };
+            // Act
+            executor.ExecuteTestOff(cfg);
+            // Assert
+            mockMobiFlightCache.Verify(m => m.SetLcdDisplay(serial, It.IsAny<OutputConfig.LcdDisplay>(), expectedEmptyLine, It.IsAny<List<ConfigRefValue>>()), Times.Once);
+        }
+
+        [TestMethod]
         public void ExecuteTestOn_ShouldExecuteDisplay_WhenOutputAndValueNot0AndNotPwm()
         {
             // Arrange


### PR DESCRIPTION
This PR fixes the Test Stop issue for Stepper motors. It was simply not migrated correctly during refactoring.

This PR contains:
- explicit stepper motor stop behavior
- reduces repeated calling of keep awake which flooded the logs
- adds additional unit tests to cover the current behaviors for all output device types.

fixes #2778 