### PR TITLE
Postpone initialization to after UI has sent Ready event

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/BrowserMessages/Incoming/CommandFrontendState.cs
+++ b/src/MobiFlightConnector/MobiFlight/BrowserMessages/Incoming/CommandFrontendState.cs
@@ -16,11 +16,11 @@ namespace MobiFlight.BrowserMessages.Incoming
             Error
         }
 
-        [JsonProperty("route")] // Matches the lowercase "item" in JSON
+        [JsonProperty("route")]
         public string Route { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
-        [JsonProperty("state")] // Matches the lowercase "item" in JSON
+        [JsonProperty("state")]
         public RouteState State { get; set; }
 
         [JsonProperty("message")]

--- a/src/MobiFlightConnector/MobiFlight/BrowserMessages/Incoming/CommandFrontendState.cs
+++ b/src/MobiFlightConnector/MobiFlight/BrowserMessages/Incoming/CommandFrontendState.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System.Runtime.Serialization;
+
+namespace MobiFlight.BrowserMessages.Incoming
+{
+    public class CommandFrontendState
+    {
+        public enum RouteState
+        {
+            [EnumMember(Value = "ready")]
+            Ready,
+            [EnumMember(Value = "loading")]
+            Loading,
+            [EnumMember(Value = "error")]
+            Error
+        }
+
+        [JsonProperty("route")] // Matches the lowercase "item" in JSON
+        public string Route { get; set; }
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonProperty("state")] // Matches the lowercase "item" in JSON
+        public RouteState State { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -330,6 +330,7 @@
     <Compile Include="HubHop\Msfs2020EventIdPresetList.cs" />
     <Compile Include="MobiFlight\Board.cs" />
     <Compile Include="MobiFlight\BoardDefinitions.cs" />
+    <Compile Include="MobiFlight\BrowserMessages\Incoming\CommandFrontendState.cs" />
     <Compile Include="MobiFlight\BrowserMessages\IMessageExchange.cs" />
     <Compile Include="MobiFlight\BrowserMessages\IMessagePublisher.cs" />
     <Compile Include="MobiFlight\BrowserMessages\Incoming\CommandActiveConfigFile.cs" />

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -194,14 +194,8 @@ namespace MobiFlight.UI
             // finally set up logging (based on settings)
             InitializeLogging();
 
-            // Initialize the board configurations
-            BoardDefinitions.LoadDefinitions();
-
             // Initialize python environment
             Scripts.PythonEnvironment.Initialize();
-
-            // Initialize the custom device configurations
-            CustomDevices.CustomDeviceDefinitions.LoadDefinitions();
 
             // configure tracking correctly
             InitializeTracking();
@@ -504,6 +498,12 @@ namespace MobiFlight.UI
 
         private async void OnFrontendReady(object sender, EventArgs e)
         {
+            // Initialize the board configurations
+            BoardDefinitions.LoadDefinitions();
+
+            // Initialize the custom device configurations
+            CustomDevices.CustomDeviceDefinitions.LoadDefinitions();
+
             if (Properties.Settings.Default.Started == 0)
             {
                 OnFirstStart();

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -58,7 +58,8 @@ namespace MobiFlight.UI
         private bool hasConnectedMidiBoards = false;
         private bool hasConnectedModules = false;
 
-        private bool IsMSFSRunning = false;
+        private bool IsMSFSRunning = false; 
+        private bool frontendReady = false;
 
         public ExecutionManager ExecutionManager
         {
@@ -208,6 +209,15 @@ namespace MobiFlight.UI
 
         private void InitializeFrontendSubscriptions()
         {
+            MessageExchange.Instance.Subscribe<CommandFrontendState>((message) =>
+            {
+                if (message.Route == "/start" && message.State == CommandFrontendState.RouteState.Ready && !frontendReady)
+                {
+                    frontendReady = true;
+                    OnFrontendReady(null, EventArgs.Empty);
+                }
+            });
+
             MessageExchange.Instance.Subscribe<CommandConfigContextMenu>((message) =>
             {
                 var msg = message;
@@ -484,13 +494,16 @@ namespace MobiFlight.UI
             }
         }
 
-        private async void MainForm_Shown(object sender, EventArgs e)
+        private void MainForm_Shown(object sender, EventArgs e)
         {
             // Check for updates before loading anything else
 #if (!DEBUG)
             AutoUpdateChecker.CheckForUpdate(true);
 #endif
+        }
 
+        private async void OnFrontendReady(object sender, EventArgs e)
+        {
             if (Properties.Settings.Default.Started == 0)
             {
                 OnFirstStart();
@@ -502,7 +515,6 @@ namespace MobiFlight.UI
             }
 
             Properties.Settings.Default.Started = Properties.Settings.Default.Started + 1;
-
 
             cmdLineParams = new CmdLineParams(Environment.GetCommandLineArgs());
             InitializeExecutionManager();
@@ -1033,7 +1045,6 @@ namespace MobiFlight.UI
                 }
             }
 
-
             if (Properties.Settings.Default.FwAutoUpdateCheck && (modulesForFlashing.Count > 0 || modulesForUpdate.Count > 0))
             {
                 if (!MobiFlightFirmwareUpdater.IsValidArduinoIdePath(Properties.Settings.Default.ArduinoIdePathDefault))
@@ -1356,7 +1367,6 @@ namespace MobiFlight.UI
 
             // The board already has MF firmware
             if (!module.FirmwareRequiresUpdate()) return;
-
 
             PerformFirmwareUpdateProcess(module);
         }
@@ -1778,8 +1788,6 @@ namespace MobiFlight.UI
         {
             ShowSettingsDialog("peripheralsTabPage", null, null, null);
         }
-
-
 
         /// <summary>
         /// updates the context menu entries for start and stop depending
@@ -2258,7 +2266,6 @@ namespace MobiFlight.UI
             proSimToolStripMenuItem.Visible = true;
             proSimToolStripMenuItem.Enabled = true;
 
-
             if (execManager.GetProSimCache().IsConnected())
             {
                 proSimToolStripMenuItem.Image = Properties.Resources.check;
@@ -2324,7 +2331,6 @@ namespace MobiFlight.UI
 
             execManager.Project.ConfigFiles.Add(newConfigFile);
             ProjectOrConfigFileHasChanged();
-
 
             ProjectLoaded?.Invoke(this, execManager.Project);
         }
@@ -2829,7 +2835,6 @@ namespace MobiFlight.UI
             }
             return result;
         }
-
 
         private void RestoreAutoLoadConfig()
         {

--- a/src/MobiFlightConnector/frontend/src/components/StartupProgress.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/StartupProgress.tsx
@@ -2,12 +2,15 @@ import SplashLogo from "@/components/SplashLogo"
 import { Progress } from "./ui/progress"
 import { StatusBarUpdate } from "@/types/messages"
 import { useEffect, useState } from "react"
-import { useAppMessage } from "@/lib/hooks/appMessage"
-import { useNavigate, useSearchParams } from "react-router"
+import { publishOnMessageExchange, useAppMessage } from "@/lib/hooks/appMessage"
+import { useLocation, useNavigate, useSearchParams } from "react-router"
 import { useTranslation } from "react-i18next"
 
 const StartupProgress = () => {
   const { t } = useTranslation()
+  const { publish } = publishOnMessageExchange()
+  const location = useLocation()
+
   // State for startup progress from app messages
   const [appStartupProgress, setAppStartupProgress] = useState<StatusBarUpdate>(
     {
@@ -47,6 +50,16 @@ const StartupProgress = () => {
       clearTimeout(timeoutId)
     }
   }, [startupProgress.Value, navigate])
+
+  useEffect(() => {
+    publish({
+      key: "CommandFrontendState",
+      payload: {
+        route: location.pathname,
+        state: "ready",
+      },
+    })
+  }, [publish, location.pathname])
 
   return (
     <div className="relative flex min-h-screen min-w-lg flex-col items-center justify-center gap-8 p-10 lg:min-w-xl">

--- a/src/MobiFlightConnector/frontend/src/types/commands.d.ts
+++ b/src/MobiFlightConnector/frontend/src/types/commands.d.ts
@@ -15,6 +15,7 @@ export type CommandMessageKey =
   | "CommandOpenLinkInBrowser"
   | "CommandControllerBindingsUpdate"
   | "CommandUserAuthentication"
+  | "CommandFrontendState"
 
 export type CommandMessage =
   | CommandConfigContextMenu
@@ -31,6 +32,7 @@ export type CommandMessage =
   | CommandOpenLinkInBrowser
   | CommandControllerBindingsUpdate
   | CommandUserAuthentication
+  | CommandFrontendState
 
 export interface CommandMessageBase {
   key: CommandMessageKey
@@ -199,5 +201,14 @@ export interface CommandUserAuthentication extends CommandMessageBase {
     flow: "login" | "logout"
     state: "started" | "success" | "cancelled" | "error",
     url?: string
+  }
+}
+
+export interface CommandFrontendState extends CommandMessageBase {
+  key: "CommandFrontendState"
+  payload: {
+    route: string
+    state: "ready" | "loading" | "error"
+    message?: string
   }
 }

--- a/src/MobiFlightConnector/frontend/tests/ConfigListView.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/ConfigListView.spec.ts
@@ -573,7 +573,7 @@ test.describe("Drag and drop tests", () => {
       await configListPage.mobiFlightPage.getTrackedCommands()
 
     // No commands should have been posted
-    expect(postedCommands).toBeUndefined()
+    expect(postedCommands).toHaveLength(0)
   })
 })
 
@@ -657,7 +657,7 @@ test.describe("Filter toolbar tests", () => {
     await searchTextBox.press("Backspace")
     const postedCommands =
       await configListPage.mobiFlightPage.getTrackedCommands()
-    await expect(postedCommands?.length).toBeUndefined()
+    await expect(postedCommands).toHaveLength(0)
   })
 
   test("Confirm `Config Type` filter toolbar is working", async ({

--- a/src/MobiFlightConnector/frontend/tests/StartupProgress.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/StartupProgress.spec.ts
@@ -33,3 +33,14 @@ test("Test that backend progress state is localized", async ({
     await expect(page.getByText(message.text)).toHaveCount(0)
   }
 })
+
+test("Test that frontend sends ready message", async ({ startupPage }) => {
+  await startupPage.mobiFlightPage.trackCommand("CommandFrontendState")
+  await startupPage.gotoStartupPage()
+
+  const postedCommands = await startupPage.mobiFlightPage.getTrackedCommands()
+  const lastCommand = postedCommands!.pop()
+  expect(lastCommand.key).toEqual("CommandFrontendState")
+  expect(lastCommand.payload.route).toEqual("/start")
+  expect(lastCommand.payload.state).toEqual("ready")
+})

--- a/src/MobiFlightConnector/frontend/tests/fixtures/MobiFlightPage.ts
+++ b/src/MobiFlightConnector/frontend/tests/fixtures/MobiFlightPage.ts
@@ -13,6 +13,8 @@ declare global {
   interface Window {
     commands?: CommandMessage[]
     auth?: Partial<AuthContextProps>
+    __trackedCommandKeys?: CommandMessageKey[]
+    __commandTrackerInstalled?: boolean
   }
 }
 
@@ -20,7 +22,7 @@ export class MobiFlightPage {
   readonly PostedMessages: AppMessage[] = []
   readonly PostedCommands: CommandMessage[] = []
 
-  constructor(public readonly page: Page) {
+  mockWebViewApi() {
     this.page.addInitScript(() => {
       if (!window.chrome?.webview?.postMessage) {
         console.log(
@@ -47,6 +49,34 @@ export class MobiFlightPage {
         }
       }
     })
+  }
+
+  setupCommandTracking() {
+    this.page.addInitScript(() => {
+      window.commands ??= []
+      window.__trackedCommandKeys ??= []
+
+      if (window.__commandTrackerInstalled) return
+      window.__commandTrackerInstalled = true
+
+      window.addEventListener("message", (event: Event) => {
+        const message = (event as MessageEvent).data as { key?: string }
+        if (!message?.key) return
+
+        if (
+          window.__trackedCommandKeys?.includes(
+            message.key as CommandMessageKey,
+          )
+        ) {
+          window.commands!.push(message as CommandMessage)
+        }
+      })
+    })
+  }
+
+  constructor(public readonly page: Page) {
+    this.mockWebViewApi()
+    this.setupCommandTracking()
   }
 
   async gotoPage() {
@@ -93,12 +123,20 @@ export class MobiFlightPage {
   }
 
   async trackCommand(key: CommandMessageKey) {
-    await this.subscribeToCommand(key, async (message) => {
-      if (window.commands === undefined) {
-        window.commands = []
+    await this.page.addInitScript((trackedKey) => {
+      window.__trackedCommandKeys ??= []
+      if (!window.__trackedCommandKeys.includes(trackedKey)) {
+        window.__trackedCommandKeys.push(trackedKey)
       }
-      window.commands.push(message)
-    })
+    }, key)
+
+    await this.page.evaluate((trackedKey) => {
+      window.__trackedCommandKeys ??= []
+      if (!window.__trackedCommandKeys.includes(trackedKey)) {
+        window.__trackedCommandKeys.push(trackedKey)
+      }
+      window.commands ??= []
+    }, key)
   }
 
   async getTrackedCommands() {


### PR DESCRIPTION
We now wait for the UI to signal that the progress bar is ready. Only then we will continue with the rest of the initialization.

Background:
* Users reported that sometimes the splash screen would not advance.
* Assumption: the initialization is faster than loading the frontend, and the frontend misses messages from the backend.
* This fix makes sure that the UI is ready to receive messages from the backend.

fixes #2864
