### PR TITLE
Double click opens project details

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectCard.tsx
@@ -164,6 +164,11 @@ const ProjectCard = ({
   const { showOverlay } = useProjectModal()
   const { showOverlay: showModalOverlay } = useModal()
 
+  const navigate = useNavigate()
+  const navigateToProject = () => {
+    navigate(`/config`)
+  }
+
   const handleEditSettings = () => {
     const options = { mode: "edit", project: summary } as ProjectModalOptions
     showOverlay(options)
@@ -204,6 +209,7 @@ const ProjectCard = ({
   return (
     <div
       data-testid="project-card"
+      onDoubleClick={navigateToProject}
       {...otherProps}
       className={cn(
         "border-primary/25 bg-card space-y-2 rounded-xl border p-4 shadow-md transition-all duration-200 ease-in-out hover:shadow-lg",

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectList.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectList.tsx
@@ -15,6 +15,7 @@ export type ProjectListProps = {
   summarys: ProjectInfo[]
   activeProject?: ProjectInfo
   onSelect: (project: ProjectInfo) => void
+  onDblClick: (project: ProjectInfo) => void
 }
 
 const ProjectList = ({
@@ -22,12 +23,14 @@ const ProjectList = ({
   summarys,
   activeProject,
   onSelect,
+  onDblClick
 }: ProjectListProps) => {
-  const SCROLL_INTO_VIEW_TIMEOUT = 2000 
+  const SCROLL_INTO_VIEW_TIMEOUT = 2000
   const refActiveElement = useRef<HTMLDivElement | null>(null)
   const scrollTimeoutRef = useRef<number | null>(null)
 
   const { publish } = publishOnMessageExchange()
+
 
   const [searchParams, setSearchParams] = useSearchParams()
   const activeFilter = searchParams.get("projects_filter") || "all"
@@ -108,6 +111,7 @@ const ProjectList = ({
                         if (isActive) return
                         onSelect(project)
                       }}
+                      onDoubleClick={() => onDblClick(project)}
                       onClickRemove={() => onListItemRemove(index)}
                     />
                   )

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectListItem.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectListItem.tsx
@@ -7,6 +7,7 @@ import ProjectFavStar from "./ProjectFavStar"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { IconTrash } from "@tabler/icons-react"
+import { useNavigate } from "react-router"
 
 export type ProjectListItemProps = HtmlHTMLAttributes<HTMLDivElement> & {
   summary: ProjectInfo
@@ -17,6 +18,10 @@ export type ProjectListItemProps = HtmlHTMLAttributes<HTMLDivElement> & {
 const ProjectListItem = forwardRef<HTMLDivElement, ProjectListItemProps>(
   ({ summary, className, active, onClickRemove, ...props }, ref) => {
     const { t } = useTranslation()
+    const navigate = useNavigate()
+    const navigateToProject = () => {
+      navigate(`/config`)
+    }
 
     const activateStateClassName = active
       ? "bg-primary/20"
@@ -39,6 +44,7 @@ const ProjectListItem = forwardRef<HTMLDivElement, ProjectListItemProps>(
         )}
         ref={ref}
         {...props}
+        onDoubleClick={navigateToProject}
       >
         <div className="flex w-full flex-row gap-4">
           <div className="relative shrink-0">
@@ -59,7 +65,7 @@ const ProjectListItem = forwardRef<HTMLDivElement, ProjectListItemProps>(
                 </div>
               </div>
             </div>
-            <div className="flex flex-row items-center justify-between gap-2 h-7">
+            <div className="flex h-7 flex-row items-center justify-between gap-2">
               <div
                 title={summary.FilePath}
                 className="text-muted-foreground truncate text-sm"

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectListItem.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectListItem.tsx
@@ -7,7 +7,6 @@ import ProjectFavStar from "./ProjectFavStar"
 import { useTranslation } from "react-i18next"
 import { Button } from "@/components/ui/button"
 import { IconTrash } from "@tabler/icons-react"
-import { useNavigate } from "react-router"
 
 export type ProjectListItemProps = HtmlHTMLAttributes<HTMLDivElement> & {
   summary: ProjectInfo
@@ -18,10 +17,6 @@ export type ProjectListItemProps = HtmlHTMLAttributes<HTMLDivElement> & {
 const ProjectListItem = forwardRef<HTMLDivElement, ProjectListItemProps>(
   ({ summary, className, active, onClickRemove, ...props }, ref) => {
     const { t } = useTranslation()
-    const navigate = useNavigate()
-    const navigateToProject = () => {
-      navigate(`/config`)
-    }
 
     const activateStateClassName = active
       ? "bg-primary/20"
@@ -44,7 +39,6 @@ const ProjectListItem = forwardRef<HTMLDivElement, ProjectListItemProps>(
         )}
         ref={ref}
         {...props}
-        onDoubleClick={navigateToProject}
       >
         <div className="flex w-full flex-row gap-4">
           <div className="relative shrink-0">

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectMainCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectMainCard.tsx
@@ -19,6 +19,7 @@ import { CommandMainMenu } from "@/types/commands"
 import { ProjectInfo } from "@/types/project"
 import { useCallback, useState } from "react"
 import { useTranslation } from "react-i18next"
+import { useNavigate } from "react-router"
 
 const ProjectMainCard = () => {
   // this component is wrapped in an error boundary
@@ -36,6 +37,7 @@ const ProjectMainCard = () => {
   const [pendingProject, setPendingProject] = useState<ProjectInfo | null>(null)
 
   const { waitForSaveStatus } = useAsynchronous()
+  const navigate = useNavigate()
 
   const loadProject = useCallback(
     (project: ProjectInfo) => {
@@ -102,6 +104,14 @@ const ProjectMainCard = () => {
     loadProject(project)
   }
 
+  const navigateToProject = (project: ProjectInfo) => {
+    const isActive = activeProject?.FilePath === project.FilePath
+    const hasChangedAndNotCurrentProject = hasChanged && !isActive
+
+    if (hasChangedAndNotCurrentProject) return
+    navigate(`/config`)
+  }
+
   const showRecentProjects = recentProjects.length > 0
 
   return (
@@ -164,6 +174,7 @@ const ProjectMainCard = () => {
                 summarys={recentProjects}
                 activeProject={activeProject as ProjectInfo}
                 onSelect={(project) => confirmLoadProject(project)}
+                onDblClick={(project) => navigateToProject(project)}
               />
             </div>
           </div>

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -628,6 +628,19 @@ test.describe("Project list view tests", () => {
     await expect(errorFallback).toBeVisible()
     await expect(errorFallback).toContainText("Ooops... something went wrong!")
   })
+
+  test("Double click on list item takes you to config page", async ({ dashboardPage, page }) => {
+    await dashboardPage.gotoPage()
+    await dashboardPage.mobiFlightPage.initWithTestData()
+
+    const recentProjectsList = page.getByTestId("recent-projects-list")
+    const projectItems = recentProjectsList.getByTestId("project-list-item")
+
+    await expect(recentProjectsList).toBeVisible()
+    await projectItems.first().dblclick()
+
+    await expect(page).toHaveURL(/.*\/config((\/|\?).*)?/)
+  })
 })
 
 test.describe("Asynchronous save tests", () => {

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -542,23 +542,36 @@ test.describe("Project list view tests", () => {
     const projectItems = recentProjectsList.getByTestId("project-list-item")
     await expect(projectItems).toHaveCount(27)
 
-    const firstProject = projectItems.nth(0)
-    await expect(firstProject).toBeVisible()
+    // First item is also active project
+    const firstAndActiveProject = projectItems.nth(0)
+    const secondProject = projectItems.nth(1)
+    await expect(firstAndActiveProject).toBeVisible()
 
     await dashboardPage.mobiFlightPage.trackCommand("CommandMainMenu")
-    await firstProject.click()
-
-    const postedCommands =
+    
+    // Clicking on actuive project should not post a command
+    await firstAndActiveProject.click()
+    let postedCommands =
       await dashboardPage.mobiFlightPage.getTrackedCommands()
+
+    expect(postedCommands).toBeUndefined()
+
+    // Clicking on second project should post a command
+    // so that backend can load the selected project
+    await secondProject.click()
+
+    postedCommands = await dashboardPage.mobiFlightPage.getTrackedCommands()
+    expect(postedCommands).toBeDefined()
+
     const lastCommand = postedCommands!.pop()
     expect(lastCommand.key).toEqual("CommandMainMenu")
     expect(lastCommand.payload.action).toEqual("file.recent")
     expect(lastCommand.payload.options.project).toEqual(
-      dashboardPage.mobiFlightPage.getRecentProjects()[0],
+      dashboardPage.mobiFlightPage.getRecentProjects()[1],
     )
 
     // Verify we navigate to config route
-    await firstProject.getByRole("button").nth(1).click()
+    await firstAndActiveProject.getByRole("button").nth(1).click()
     await expect(page).toHaveURL(/.*\/config((\/|\?).*)?/)
   })
 
@@ -659,6 +672,45 @@ test.describe("Project list view tests", () => {
     await projectItems.first().dblclick()
 
     await expect(page).toHaveURL(/.*\/config((\/|\?).*)?/)
+
+    // Also test with unsaved changes
+    await dashboardPage.gotoPage()
+    await dashboardPage.mobiFlightPage.initWithTestData()
+
+    await expect(recentProjectsList).toBeVisible()
+    
+    // Simulate unsaved changes
+    await dashboardPage.mobiFlightPage.updateProjectState({
+      HasChanged: true,
+      SaveStatus: "idle",
+    })
+
+    await projectItems.first().dblclick()
+
+    // We should still navigate to project details
+    await expect(page).toHaveURL(/.*\/config((\/|\?).*)?/)
+  })
+
+  test("Double click on different list item is ignored with pending changes", async ({
+    dashboardPage,
+    page,
+  }) => {
+    await dashboardPage.gotoPage()
+    await dashboardPage.mobiFlightPage.initWithTestData()
+
+    const recentProjectsList = page.getByTestId("recent-projects-list")
+    const projectItems = recentProjectsList.getByTestId("project-list-item")
+
+    await expect(recentProjectsList).toBeVisible()
+
+    // Simulate unsaved changes
+    await dashboardPage.mobiFlightPage.updateProjectState({
+      HasChanged: true,
+      SaveStatus: "idle",
+    })
+
+    await projectItems.nth(1).dblclick()
+    await expect(page).toHaveURL(/.*\/home((\/|\?).*)?/)
   })
 })
 

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -218,13 +218,29 @@ test.describe("Project view tests", () => {
     await expect(moreControllersIndicator.getByText("+1")).toBeVisible()
   })
 
-  test("Navigate to project view", async ({ dashboardPage, page }) => {
+  test("Navigate to project view via click on title", async ({
+    dashboardPage,
+    page,
+  }) => {
     await dashboardPage.gotoPage()
     await dashboardPage.mobiFlightPage.initWithTestData()
     const currentProjectCard = page.getByTestId("project-card")
 
     // Verify we navigate to config route
     await currentProjectCard.getByRole("button").nth(0).click()
+    await expect(page).toHaveURL(/.*\/config((\/|\?).*)?/)
+  })
+
+  test("Navigate to project view via double click on card", async ({
+    dashboardPage,
+    page,
+  }) => {
+    await dashboardPage.gotoPage()
+    await dashboardPage.mobiFlightPage.initWithTestData()
+
+    const currentProjectCard = page.getByTestId("project-card")
+    await currentProjectCard.first().dblclick()
+
     await expect(page).toHaveURL(/.*\/config((\/|\?).*)?/)
   })
 
@@ -475,7 +491,7 @@ test.describe("Project settings modal features", () => {
 
     // open settings modal
     await createProjectButton.click()
-    
+
     await expect(projectNameInput).toHaveAttribute("autocomplete", "off")
   })
 
@@ -629,7 +645,10 @@ test.describe("Project list view tests", () => {
     await expect(errorFallback).toContainText("Ooops... something went wrong!")
   })
 
-  test("Double click on list item takes you to config page", async ({ dashboardPage, page }) => {
+  test("Double click on list item takes you to config page", async ({
+    dashboardPage,
+    page,
+  }) => {
     await dashboardPage.gotoPage()
     await dashboardPage.mobiFlightPage.initWithTestData()
 

--- a/src/MobiFlightConnector/frontend/tests/data/recentProjects.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/recentProjects.testdata.json
@@ -2,8 +2,8 @@
   {
     "Aircraft": [],
     "Favorite": false,
-    "FilePath": ".\\Starship-MiniFCU-MiniEFIS-V2.mfproj",
-    "Name": "Starship-MiniFCU+miniEFIS-V1",
+    "Name": "Test Project",
+    "FilePath": "tests/data/project.testdata.json",
     "Sim": "msfs",
     "Features": {
       "FSUIPC": false,


### PR DESCRIPTION
On the dashboard, you can now double click on either the project card or one of the items from the project list to access the project detail view.

- [x] Double click on project card takes you to details
- [x] Double click on project list item takes you to details
- [x] Playwright tests are in place
- [x] i18n - not relevant

fixes #2781 