### PR TITLE
Improve logging from Python scripts.

### DIFF
--- a/src/MobiFlightConnector/Base/Log.cs
+++ b/src/MobiFlightConnector/Base/Log.cs
@@ -11,12 +11,48 @@ using System.Diagnostics;
 
 namespace MobiFlight
 {
-    public enum LogSeverity    
+    public enum LogSeverity
     {
         Debug = 0,
         Info = 1,
         Warn = 2,
         Error = 3
+    }
+
+    public static class LogSeverityExtensions
+    {   public static String PythonLogLevel(this LogSeverity severity)
+        {
+            switch (severity)
+            {
+                case LogSeverity.Debug:
+                    return "DEBUG";
+                case LogSeverity.Info:
+                    return "INFO";
+                case LogSeverity.Warn:
+                    return "WARNING";
+                case LogSeverity.Error:
+                    return "ERROR";
+                default:
+                    return "WARNING";
+            }
+        }
+
+        public static LogSeverity SeverityFromPythonLogLevel(string logLevel)
+        {
+            switch (logLevel)
+            {
+                case "DEBUG":
+                    return LogSeverity.Debug;
+                case "INFO":
+                    return LogSeverity.Info;
+                case "WARNING":
+                    return LogSeverity.Warn;
+                case "ERROR":
+                    return LogSeverity.Error;
+                default:
+                    return LogSeverity.Info;
+            }
+        }
     }
 
     public sealed class Log

--- a/src/MobiFlightConnector/Base/Log.cs
+++ b/src/MobiFlightConnector/Base/Log.cs
@@ -20,7 +20,8 @@ namespace MobiFlight
     }
 
     public static class LogSeverityExtensions
-    {   public static String PythonLogLevel(this LogSeverity severity)
+    {
+        public static String PythonLogLevel(this LogSeverity severity)
         {
             switch (severity)
             {
@@ -37,20 +38,25 @@ namespace MobiFlight
             }
         }
 
-        public static LogSeverity SeverityFromPythonLogLevel(string logLevel)
+        public static bool SeverityFromPythonLogLevel(string logLevel, out LogSeverity severity)
         {
             switch (logLevel)
             {
                 case "DEBUG":
-                    return LogSeverity.Debug;
+                    severity = LogSeverity.Debug;
+                    return true;
                 case "INFO":
-                    return LogSeverity.Info;
+                    severity = LogSeverity.Info;
+                    return true;
                 case "WARNING":
-                    return LogSeverity.Warn;
+                    severity = LogSeverity.Warn;
+                    return true;
                 case "ERROR":
-                    return LogSeverity.Error;
+                    severity = LogSeverity.Error;
+                    return true;
                 default:
-                    return LogSeverity.Info;
+                    severity = LogSeverity.Info;
+                    return false;
             }
         }
     }

--- a/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
+++ b/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
@@ -177,6 +177,8 @@ namespace MobiFlight.Scripts
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                 };
+                LogSeverity severity = (LogSeverity)Enum.Parse(typeof(LogSeverity), Properties.Settings.Default.LogLevel, true);
+                psi.EnvironmentVariables.Add("LOGLEVEL", severity.PythonLogLevel());
 
                 Process process = new Process
                 {
@@ -259,11 +261,29 @@ namespace MobiFlight.Scripts
             }
         }
 
+        private string ScriptName(object sender)
+        {
+            string script = "(unknown script)";
+            Process process = (Process)sender;
+            ProcessTable.TryGetValue(process.Id, out script);
+            return script;
+        }
+
         private void Process_ErrorDataReceived(object sender, DataReceivedEventArgs e)
         {
             if (!string.IsNullOrEmpty(e.Data))
             {
-                Log.Instance.log($"ScriptRunner - Output: {e.Data}", LogSeverity.Info);
+                if (e.Data.IndexOf(':') is int i && i != -1)
+                {
+                    string logLevel = e.Data.Substring(0, i);
+                    string msg = e.Data.Substring(i + 1);
+                    LogSeverity severity = LogSeverityExtensions.SeverityFromPythonLogLevel(logLevel);
+                    Log.Instance.log($"{ScriptName(sender)} (stderr): {msg}", severity);
+                }
+                else
+                {
+                    Log.Instance.log($"{ScriptName(sender)} (stderr): {e.Data}", LogSeverity.Info);
+                }
             }
         }
 
@@ -271,7 +291,7 @@ namespace MobiFlight.Scripts
         {
             if (!string.IsNullOrEmpty(e.Data))
             {
-                Log.Instance.log($"ScriptRunner - StandardOutput: {e.Data}", LogSeverity.Info);
+                Log.Instance.log($"{ScriptName(sender)} (stdout): {e.Data}", LogSeverity.Info);
             }
         }
 

--- a/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
+++ b/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
@@ -177,8 +177,9 @@ namespace MobiFlight.Scripts
                     RedirectStandardOutput = true,
                     RedirectStandardError = true,
                 };
-                LogSeverity severity = (LogSeverity)Enum.Parse(typeof(LogSeverity), Properties.Settings.Default.LogLevel, true);
-                psi.EnvironmentVariables.Add("LOGLEVEL", severity.PythonLogLevel());
+                LogSeverity severity = LogSeverity.Info;
+                Enum.TryParse(Properties.Settings.Default.LogLevel, /*ignoreCase=*/ true, out severity);
+                psi.EnvironmentVariables["LOGLEVEL"] = severity.PythonLogLevel();
 
                 Process process = new Process
                 {
@@ -263,10 +264,12 @@ namespace MobiFlight.Scripts
 
         private string ScriptName(object sender)
         {
-            string script = "(unknown script)";
             Process process = (Process)sender;
-            ProcessTable.TryGetValue(process.Id, out script);
-            return script;
+            if (ProcessTable.TryGetValue(process.Id, out string script))
+            {
+                return script;
+            }
+            return "(unknown script)";
         }
 
         private void Process_ErrorDataReceived(object sender, DataReceivedEventArgs e)
@@ -276,14 +279,15 @@ namespace MobiFlight.Scripts
                 if (e.Data.IndexOf(':') is int i && i != -1)
                 {
                     string logLevel = e.Data.Substring(0, i);
-                    string msg = e.Data.Substring(i + 1);
-                    LogSeverity severity = LogSeverityExtensions.SeverityFromPythonLogLevel(logLevel);
-                    Log.Instance.log($"{ScriptName(sender)} (stderr): {msg}", severity);
+                    if (LogSeverityExtensions.SeverityFromPythonLogLevel(logLevel, out LogSeverity severity))
+                    {
+                        string msg = e.Data.Substring(i + 1);
+                        Log.Instance.log($"{ScriptName(sender)} (stderr): {msg}", severity);
+                        return;
+                    }
                 }
-                else
-                {
-                    Log.Instance.log($"{ScriptName(sender)} (stderr): {e.Data}", LogSeverity.Info);
-                }
+
+                Log.Instance.log($"{ScriptName(sender)} (stderr): {e.Data}", LogSeverity.Info);
             }
         }
 

--- a/src/MobiFlightConnector/Scripts/Winwing/aerosoft_crj_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/aerosoft_crj_winwing_cdu.py
@@ -4,6 +4,7 @@ import json
 import struct
 import logging
 import asyncio
+import os
 import websockets.asyncio.client as ws_client
 from typing import Optional, List, Dict, Union, Any
 from SimConnect import SimConnect, Enum
@@ -265,10 +266,10 @@ class CRJCDUClient:
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
-    )     
-    
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     sc_mobiflight: SimConnectMobiFlight = SimConnectMobiFlight()
     captain_client: CRJCDUClient = CRJCDUClient(sc_mobiflight, CAPTAIN_CDU_URL, CRJ_CDU_0_NAME, CRJ_CDU_0_CLIENT_DATA_ID, CRJ_CDU_0_DEFINITION)
     co_pilot_client: CRJCDUClient = CRJCDUClient(sc_mobiflight, CO_PILOT_CDU_URL, CRJ_CDU_1_NAME, CRJ_CDU_1_CLIENT_DATA_ID, CRJ_CDU_1_DEFINITION)

--- a/src/MobiFlightConnector/Scripts/Winwing/fbw_a32nx_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/fbw_a32nx_winwing_cdu.py
@@ -5,6 +5,7 @@ from itertools import chain
 import json
 import logging
 from math import ceil, floor
+import os
 import re
 from typing import Literal, Never, Optional, List, Dict, Union
 import websockets.asyncio.client as ws_client
@@ -439,7 +440,8 @@ async def request_update_on_connect(connected: asyncio.Event, fbw_client: FbwMcd
 
 async def main():
     logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
 
     logging.info("----STARTED FBW A32NX MCDU to WinWing CDU Integration----")

--- a/src/MobiFlightConnector/Scripts/Winwing/fenix_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/fenix_winwing_cdu.py
@@ -1,6 +1,7 @@
 import asyncio, json
 import xml.etree.ElementTree as ET
 import logging
+import os
 import websockets.asyncio.client as ws_client
 import websockets.exceptions
 from gql import Client, gql
@@ -117,10 +118,12 @@ class Mobiflight_Client:
 
     
 
-async def main():   
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')  
-    log = logging.getLogger("gql.transport.websockets")
-    log.setLevel(logging.WARNING)   
+async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     logging.info("----STARTED fenix_winwing_cdu.py----")   
     client1 = Mobiflight_Client("ws://localhost:8320/winwing/cdu-captain", "CDU-CAPTAIN")
     client2 = Mobiflight_Client("ws://localhost:8320/winwing/cdu-co-pilot", "CDU-CO-PILOT")  

--- a/src/MobiFlightConnector/Scripts/Winwing/flightfactor_75_76.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/flightfactor_75_76.py
@@ -23,6 +23,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import urllib.request
 import websockets
 from enum import StrEnum
@@ -229,6 +230,11 @@ async def get_available_devices() -> list[CduDevice]:
 
 
 async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     available_devices = await get_available_devices()
 
     tasks = []

--- a/src/MobiFlightConnector/Scripts/Winwing/flightfactor_777v2.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/flightfactor_777v2.py
@@ -23,6 +23,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import urllib.request
 import websockets
 from enum import StrEnum
@@ -276,6 +277,11 @@ async def get_available_devices() -> list[CduDevice]:
 
 
 async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     available_devices = await get_available_devices()
 
     tasks = []

--- a/src/MobiFlightConnector/Scripts/Winwing/headwind_a33_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/headwind_a33_winwing_cdu.py
@@ -5,6 +5,7 @@ from itertools import chain
 import json
 import logging
 from math import ceil, floor
+import os
 import re
 from typing import Literal, Never, Optional, List, Dict, Union
 import websockets.asyncio.client as ws_client
@@ -432,7 +433,8 @@ async def request_update_on_connect(connected: asyncio.Event, fbw_client: FbwMcd
 
 async def main():
     logging.basicConfig(
-        level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
 
     logging.info("----STARTED FBW A32NX MCDU to WinWing CDU Integration----")

--- a/src/MobiFlightConnector/Scripts/Winwing/hotstart_cl650.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/hotstart_cl650.py
@@ -27,6 +27,7 @@ import base64
 import re
 import json
 import logging
+import os
 import urllib.request
 import websockets
 from enum import StrEnum, IntEnum
@@ -331,6 +332,11 @@ async def get_available_devices() -> list[CduDevice]:
 
 
 async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     available_devices = await get_available_devices()
 
 

--- a/src/MobiFlightConnector/Scripts/Winwing/ifly_737_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/ifly_737_winwing_cdu.py
@@ -7,6 +7,7 @@ import asyncio
 from typing import Dict, List, Optional, Union
 from websockets.asyncio.client import connect
 import mmap
+import os
 
 # WebSocket URLs
 CAPTAIN_CDU_URL: str = "ws://localhost:8320/winwing/cdu-captain"
@@ -394,7 +395,7 @@ async def main() -> None:
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
     asyncio.run(main())

--- a/src/MobiFlightConnector/Scripts/Winwing/ini_a340_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/ini_a340_winwing_cdu.py
@@ -1,4 +1,4 @@
-import asyncio, ctypes, json, logging, struct
+import asyncio, ctypes, json, logging, os, struct
 from ctypes import wintypes, Structure, c_ubyte, sizeof
 from typing import Any
 import websockets.asyncio.client as ws_client
@@ -152,7 +152,10 @@ class A340MCDUClient:
             
 # --- Main ---
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
     sc=SimConnectMobiFlight()
 
     mcdu_cpt=A340MCDUClient(sc, CAPTAIN_MCDU_URL, A340_MCDU_CPT_DEFINITION, A340_MCDU_CPT_NAME, A340_CPT_MCDU_CLIENT_DATA_ID)

--- a/src/MobiFlightConnector/Scripts/Winwing/ixeg_737.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/ixeg_737.py
@@ -23,6 +23,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import urllib.request
 from enum import StrEnum
 
@@ -309,6 +310,11 @@ async def get_available_devices() -> list[CduDevice]:
 
 
 async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     available_devices = await get_available_devices()
 
     tasks = []

--- a/src/MobiFlightConnector/Scripts/Winwing/laminar_747_400.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/laminar_747_400.py
@@ -23,6 +23,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import urllib.request
 from enum import StrEnum
 
@@ -243,6 +244,11 @@ async def get_available_devices() -> list[CduDevice]:
 
 
 async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     available_devices = await get_available_devices()
 
     tasks = []

--- a/src/MobiFlightConnector/Scripts/Winwing/maddogx_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/maddogx_winwing_cdu.py
@@ -3,6 +3,7 @@ import ctypes
 import json
 import logging
 import asyncio
+import os
 import struct
 import websockets.asyncio.client as ws_client
 from typing import Optional, List, Dict, Union, Any
@@ -281,8 +282,8 @@ class MDXCDUClient:
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
     
     sc_mobiflight: SimConnectMobiFlight = SimConnectMobiFlight()

--- a/src/MobiFlightConnector/Scripts/Winwing/pmdg_737_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/pmdg_737_winwing_cdu.py
@@ -381,8 +381,8 @@ class PMDGConfiguration:
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
 
     ini_configurator = PMDGConfiguration()

--- a/src/MobiFlightConnector/Scripts/Winwing/pmdg_777_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/pmdg_777_winwing_cdu.py
@@ -382,8 +382,8 @@ class PMDGConfiguration:
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
 
     ini_configurator = PMDGConfiguration()

--- a/src/MobiFlightConnector/Scripts/Winwing/prosim_737_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/prosim_737_winwing_cdu.py
@@ -6,6 +6,7 @@ import asyncio
 import websockets
 import xml.etree.ElementTree as ET
 import re
+import os
 from gql import Client, gql
 from gql.transport.websockets import WebsocketsTransport
 
@@ -510,8 +511,8 @@ class ProSimCDUClient:
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
 
     async def cleanup(prosim_client):

--- a/src/MobiFlightConnector/Scripts/Winwing/prosim_a320_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/prosim_a320_winwing_cdu.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional
 import json
 import logging
 import asyncio
+import os
 import websockets
 import xml.etree.ElementTree as ET
 from gql import Client, gql
@@ -263,8 +264,8 @@ class ProSimCDUClient:
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
     
     async def cleanup(prosim_client):

--- a/src/MobiFlightConnector/Scripts/Winwing/rotate_md80.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/rotate_md80.py
@@ -19,6 +19,7 @@ MD80 CDU Characteristics:
 import asyncio
 import json
 import logging
+import os
 import urllib.request
 import websockets
 from enum import StrEnum
@@ -26,7 +27,10 @@ from typing import List, Dict
 import base64
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+    format='%(levelname)s:%(message)s'
+)
 
 # CDU Display Configuration
 CDU_COLUMNS = 24  # Physical display width limit

--- a/src/MobiFlightConnector/Scripts/Winwing/tfdi_md11_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/tfdi_md11_winwing_cdu.py
@@ -3,6 +3,7 @@ import ctypes
 import json
 import logging
 import asyncio
+import os
 import struct
 import websockets.asyncio.client as ws_client
 from typing import Optional, List, Dict, Union, Any
@@ -279,8 +280,8 @@ class MD11CDUClient:
 
 if __name__ == "__main__":
     logging.basicConfig(
-        level=logging.INFO,
-        format='%(asctime)s - %(levelname)s - %(message)s'
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
     )
     
     sc_mobiflight: SimConnectMobiFlight = SimConnectMobiFlight()

--- a/src/MobiFlightConnector/Scripts/Winwing/toliss_a3xx.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/toliss_a3xx.py
@@ -23,6 +23,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import urllib.request
 import websockets
 from enum import StrEnum
@@ -339,6 +340,11 @@ async def get_available_devices() -> list[CduDevice]:
 
 
 async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     available_devices = await get_available_devices()
 
     tasks = []

--- a/src/MobiFlightConnector/Scripts/Winwing/xplane_default_fmc.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/xplane_default_fmc.py
@@ -23,6 +23,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import urllib.request
 from enum import StrEnum
 
@@ -257,6 +258,11 @@ async def get_available_devices() -> list[CduDevice]:
 
 
 async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     available_devices = await get_available_devices()
 
     tasks = []

--- a/src/MobiFlightConnector/Scripts/Winwing/zibo_737_800x.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/zibo_737_800x.py
@@ -23,6 +23,7 @@ import asyncio
 import base64
 import json
 import logging
+import os
 import urllib.request
 import websockets
 from enum import StrEnum
@@ -282,6 +283,11 @@ async def get_available_devices() -> list[CduDevice]:
 
 
 async def main():
+    logging.basicConfig(
+        level=os.environ.get("LOGLEVEL", "WARNING").upper(),
+        format='%(levelname)s:%(message)s'
+    )
+
     available_devices = await get_available_devices()
 
     tasks = []


### PR DESCRIPTION
*  Forward log severity level set in MobiFlight to Python in a
   `LOGLEVEL` environment variable. This allows controlling the
   verbosity of logging from Python scripts without needing to change the
   script itself.

*  Parse log level emitted by Python and display it appropriately in the
   MobiFlight log window. (This will fall back to generic "Info" level
   logging if the log message is not in the expected format with the log
   level at the beginning of the message.) Here is what this looks like in
   MobiFlight:
   <img width="834" height="111" alt="python_logging" src="https://github.com/user-attachments/assets/95b7bdf1-e331-4d64-97ec-5a25941e550c" />


*  In the log message shown in MobiFlight, replace the generic text "Script
   Runner" with the name of the script.

*  I have updated most scripts to query the `LOGLEVEL` environment
   variable and output the log format required so that MobiFlight can
   parse the log level. At the same time, I have removed the timestamp
   from the logging for some scripts since MobiFlight displays a
   timestamp itself, so this seemed redundant.

   Some scripts had an existing, more elaborate logging setup that can
   also log to a file. I have left these scripts unchanged because I did
   not want to remove the file logging. I suspect, however, that this
   was added at a time when MobiFlight did not yet have the ability to
   capture stderr. If desired, I can modify these scripts also to use
   the logging format that is now used by most other scripts.

   I have not been able to test all of the scripts that I have modified
   because I don't have all of the respective addons. However, since I
   am making the same change in each case, I believe that these changes
   are relatively low-risk.
