### PR TITLE
Fix WinCtrl CDU script loading for Toliss A330.

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Scripts/ScriptMapping.cs
+++ b/src/MobiFlightConnector/MobiFlight/Scripts/ScriptMapping.cs
@@ -5,6 +5,7 @@
         public string VendorId { get; set; }
         public string[] ProductIds { get; set; }
         public string AircraftIdSnippet { get; set; }
+        public string AircraftIdRegex { get; set; }
         public string ScriptName { get; set; }
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/Scripts/ScriptMapping.cs
+++ b/src/MobiFlightConnector/MobiFlight/Scripts/ScriptMapping.cs
@@ -4,8 +4,11 @@
     {
         public string VendorId { get; set; }
         public string[] ProductIds { get; set; }
+        // Deprecated, use AircraftMatchPattern instead.
         public string AircraftIdSnippet { get; set; }
-        public string AircraftIdRegex { get; set; }
+        // Regex to match against the aircraft ID. The script is run if the
+        // pattern matches somewhere within the aicraft ID.
+        public string AircraftMatchPattern { get; set; }
         public string ScriptName { get; set; }
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
+++ b/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
@@ -302,14 +302,14 @@ namespace MobiFlight.Scripts
 
         private static bool AircraftMatchesScriptMapping(string aircraftDescription, ScriptMapping scriptMapping)
         {
-            if (!string.IsNullOrEmpty(scriptMapping.AircraftIdSnippet))
-            {
-                return aircraftDescription.Contains(scriptMapping.AircraftIdSnippet);
-            }
-
             if (!string.IsNullOrEmpty(scriptMapping.AircraftMatchPattern))
             {
                 return Regex.IsMatch(aircraftDescription, scriptMapping.AircraftMatchPattern);
+            }
+
+            if (!string.IsNullOrEmpty(scriptMapping.AircraftIdSnippet))
+            {
+                return aircraftDescription.Contains(scriptMapping.AircraftIdSnippet);
             }
 
             return false;

--- a/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
+++ b/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
@@ -307,9 +307,9 @@ namespace MobiFlight.Scripts
                 return aircraftDescription.Contains(scriptMapping.AircraftIdSnippet);
             }
 
-            if (!string.IsNullOrEmpty(scriptMapping.AircraftIdRegex))
+            if (!string.IsNullOrEmpty(scriptMapping.AircraftMatchPattern))
             {
-                return Regex.IsMatch(aircraftDescription, scriptMapping.AircraftIdRegex);
+                return Regex.IsMatch(aircraftDescription, scriptMapping.AircraftMatchPattern);
             }
 
             return false;

--- a/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
+++ b/src/MobiFlightConnector/MobiFlight/Scripts/ScriptRunner.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -299,6 +300,21 @@ namespace MobiFlight.Scripts
             }
         }
 
+        private static bool AircraftMatchesScriptMapping(string aircraftDescription, ScriptMapping scriptMapping)
+        {
+            if (!string.IsNullOrEmpty(scriptMapping.AircraftIdSnippet))
+            {
+                return aircraftDescription.Contains(scriptMapping.AircraftIdSnippet);
+            }
+
+            if (!string.IsNullOrEmpty(scriptMapping.AircraftIdRegex))
+            {
+                return Regex.IsMatch(aircraftDescription, scriptMapping.AircraftIdRegex);
+            }
+
+            return false;
+        }
+
         private void CheckAndExecuteScripts(string aircraftDescription)
         {
             var executionList = new List<string>();
@@ -321,7 +337,7 @@ namespace MobiFlight.Scripts
                         // Hardware found, now compare aircraft 
                         foreach (var config in MappingDictionary[hardwareId])
                         {
-                            if (aircraftDescription.Contains(config.AircraftIdSnippet))
+                            if (AircraftMatchesScriptMapping(aircraftDescription, config))
                             {
                                 if (!GameControllersWithScripts.Contains(gameController))
                                 {

--- a/src/MobiFlightConnector/Scripts/ScriptMappings.json
+++ b/src/MobiFlightConnector/Scripts/ScriptMappings.json
@@ -3,169 +3,169 @@
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "fslabs a3",
+      "AircraftMatchPattern": "fslabs a3",
       "ScriptName": "fslabs_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "inibuilds-a340",
+      "AircraftMatchPattern": "inibuilds-a340",
       "ScriptName": "ini_a340_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "fnx_3",
+      "AircraftMatchPattern": "fnx_3",
       "ScriptName": "fenix_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "pmdg 737",
+      "AircraftMatchPattern": "pmdg 737",
       "ScriptName": "pmdg_737_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "pmdg 777",
+      "AircraftMatchPattern": "pmdg 777",
       "ScriptName": "pmdg_777_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "ifly 737",
+      "AircraftMatchPattern": "ifly 737",
       "ScriptName": "ifly_737_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "design_md-11",
+      "AircraftMatchPattern": "design_md-11",
       "ScriptName": "tfdi_md11_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "prosim-a322",
+      "AircraftMatchPattern": "prosim-a322",
       "ScriptName": "prosim_a320_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "prosim-b73",
+      "AircraftMatchPattern": "prosim-b73",
       "ScriptName": "prosim_737_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "flybywire_a32",
+      "AircraftMatchPattern": "flybywire_a32",
       "ScriptName": "fbw_a32nx_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "maddog",
+      "AircraftMatchPattern": "maddog",
       "ScriptName": "maddogx_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "headwind_a33",
+      "AircraftMatchPattern": "headwind_a33",
       "ScriptName": "headwind_a33_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "aerosoft_crj",
+      "AircraftMatchPattern": "aerosoft_crj",
       "ScriptName": "aerosoft_crj_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "boeing 757",
+      "AircraftMatchPattern": "boeing 757",
       "ScriptName": "flightfactor_75_76.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "boeing 767",
+      "AircraftMatchPattern": "boeing 767",
       "ScriptName": "flightfactor_75_76.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "boeing 777",
+      "AircraftMatchPattern": "boeing 777",
       "ScriptName": "flightfactor_777v2.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "toliss",
+      "AircraftMatchPattern": "toliss",
       "ScriptName": "toliss_a3xx.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "boeing 737-",
+      "AircraftMatchPattern": "boeing 737-",
       "ScriptName": "zibo_737_800x.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "challenger 650",
+      "AircraftMatchPattern": "challenger 650",
       "ScriptName": "hotstart_cl650.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "rotate md-11",
+      "AircraftMatchPattern": "rotate md-11",
       "ScriptName": "rotate_md11.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "rotate md-80",
+      "AircraftMatchPattern": "rotate md-80",
       "ScriptName": "rotate_md80.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "microsoft-aircraft-ec135",
+      "AircraftMatchPattern": "microsoft-aircraft-ec135",
       "ScriptName": "microsoft_aircraft_ec135.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "A300",
+      "AircraftMatchPattern": "A300",
       "ScriptName": "ini_a300_winwing_cdu.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "mcdonnell douglas md-82",
+      "AircraftMatchPattern": "mcdonnell douglas md-82",
       "ScriptName": "xplane_default_fmc.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "q100",
+      "AircraftMatchPattern": "q100",
       "ScriptName": "xplane_default_fmc.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdRegex": "^airbus a330",
+      "AircraftMatchPattern": "^airbus a330",
       "ScriptName": "xplane_default_fmc.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "ixeg b-737",
+      "AircraftMatchPattern": "ixeg b-737",
       "ScriptName": "ixeg_737.py"
     },
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "boeing 747-400",
+      "AircraftMatchPattern": "boeing 747-400",
       "ScriptName": "laminar_747_400.py"
     }
   ]

--- a/src/MobiFlightConnector/Scripts/ScriptMappings.json
+++ b/src/MobiFlightConnector/Scripts/ScriptMappings.json
@@ -153,7 +153,7 @@
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "airbus a330",
+      "AircraftIdRegex": "^airbus a330",
       "ScriptName": "xplane_default_fmc.py"
     },
     {


### PR DESCRIPTION
I've realized that #2874, which added WinCtrl CDU support for the
X-Plane default A330, inadvertently broke loading of the WinCtrl CDU
script for the Toliss A330.

The reason for this is that the `AircraftIdSnippet` that I specified for
the default A330, "airbus a330", is also a substring of the Aircraft ID
for the Toliss A330. As a result, _both_ scripts (toliss_a3xx.py and
xplane_default_fmc.py) are run at the same time, both try to control the
CDU, and as a result, neither controls it correctly.

This problem cannot be resolved with the existing `AircraftIdSnippet`
mechanism as the Aircraft ID for the default A330, "airbus a330", is a
substring of the Aircraft ID for the Toliss A330. As a result, it is not
possible to specify an `AircraftIdSnippet` for the default A330 that
does not also match the Toliss A330.

What I have therefore done is to introduce an alternative JSON field,
`AircraftIdRegex`, that matches the Aircraft ID using a regex. For the
default A330, I specify `^airbus a330`. Because the Aircraft ID for the
Toliss A330 starts with "Toliss", this regex does not match the Toliss
A330.

The remaining entries in ScriptMapping.cs continue to use
`AircraftIdSnippet` as there was no need to change them. As we add
support for more aircraft, I can however foresee that there will be more
"conflicts" in the future that can't be resolved with the
`AircraftIdSnippet` mechanism, and we will be able to use the regex
mechanism for these too.
