### PR TITLE
Fix WinCtrl CDU script loading for Leonardo Maddog 20th Anniversary.

### DIFF
--- a/src/MobiFlightConnector/Scripts/ScriptMappings.json
+++ b/src/MobiFlightConnector/Scripts/ScriptMappings.json
@@ -141,7 +141,7 @@
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftIdSnippet": "md-82",
+      "AircraftIdSnippet": "mcdonnell douglas md-82",
       "ScriptName": "xplane_default_fmc.py"
     },
     {


### PR DESCRIPTION
As [reported on Discord](https://discord.com/channels/608690978081210392/1497140948948226218), the WinCtrl CDU support for the Leonardo Fly The Maddog 20th Anniversary edition no longer works correctly after https://github.com/MobiFlight/MobiFlight-Connector/commit/47c11365a52d85e6df87bc1d74f6a530957b5b59 added support for the X-Plane default FMC, which is mapped for the default X-Plane MD-82, among other aircraft.

This commit used the aircraft ID snippet "md-82". This snippet is not contained in the aircraft ID of the Leonardo Maddog X with which I tested, but it _is_ conatined in the Aircraft ID of the Maddog 20th Anniversary. The effect of this is that both maddogx_winwing_cdu.py and xplane_default_fmc.py get loaded, and this prevents the CDU from working correctly with the Leonardo Maddog.

To avoid this, this PR changes the aircraft ID snippet for the X-Plane default MD-82 to the more specific "mcdonnell douglas md-82", which will prevent this conflict.
