### PR TITLE
Dynamic news feed

### DIFF
--- a/src/MobiFlightConnector/frontend/.env.template
+++ b/src/MobiFlightConnector/frontend/.env.template
@@ -3,5 +3,4 @@ TESTS_USER_PASSWORD=#Password for test user
 TESTS_USER_NAME=#Your expected username
 
 # Optional remote feed override. If unset, bundled i18n feed remains the only source.
-VITE_FEED_REMOTE_BASE_URL=
 VITE_FEED_TIMEOUT_MS=3000

--- a/src/MobiFlightConnector/frontend/.env.template
+++ b/src/MobiFlightConnector/frontend/.env.template
@@ -1,3 +1,7 @@
 TESTS_USER_EMAIL=#Email for test user, needs to be registered in the backend
 TESTS_USER_PASSWORD=#Password for test user
 TESTS_USER_NAME=#Your expected username
+
+# Optional remote feed override. If unset, bundled i18n feed remains the only source.
+VITE_FEED_REMOTE_BASE_URL=
+VITE_FEED_TIMEOUT_MS=3000

--- a/src/MobiFlightConnector/frontend/.gitignore
+++ b/src/MobiFlightConnector/frontend/.gitignore
@@ -1,5 +1,7 @@
 # environment variables
 .env
+.env.*
+!.env.template
 
 # Logs
 logs

--- a/src/MobiFlightConnector/frontend/README.md
+++ b/src/MobiFlightConnector/frontend/README.md
@@ -24,12 +24,10 @@ and @types/lodash-es
 ## Community feed loading
 The community feed uses a hybrid strategy:
 
-- Immediate fallback: `feed:community` from bundled i18n files in `public/locales/*/feed.json`
+- Default items are: `feed:community` from bundled i18n files in `public/locales/*/feed.json`
 - Background refresh: optional remote JSON loaded per language
-- Replacement rule: remote feed replaces fallback only when remote `community` contains at least one valid item
-- Fallback rule: timeout, network errors, invalid payloads, or empty remote arrays keep bundled fallback visible
+- Merge rule: remote feed is prepended to fallback feed only when remote `community` contains at least one valid item
 
 Environment variables:
-
-- `VITE_FEED_REMOTE_BASE_URL`: remote base URL in the format `{base}/{language}/feed.json`
+- `VITE_FEED_REMOTE_BASE_URL`: remote base URL in the format, example for path `{base}/en/feed.json`
   If not set, it will use `https://mobiflight.com/feed`

--- a/src/MobiFlightConnector/frontend/README.md
+++ b/src/MobiFlightConnector/frontend/README.md
@@ -32,3 +32,4 @@ The community feed uses a hybrid strategy:
 Environment variables:
 
 - `VITE_FEED_REMOTE_BASE_URL`: remote base URL in the format `{base}/{language}/feed.json`
+  If not set, it will use `https://mobiflight.com/feed`

--- a/src/MobiFlightConnector/frontend/README.md
+++ b/src/MobiFlightConnector/frontend/README.md
@@ -20,3 +20,15 @@ https://www.npmjs.com/package/zustand
 ## lodash-es
 https://www.npmjs.com/package/lodash-es
 and @types/lodash-es
+
+## Community feed loading
+The community feed uses a hybrid strategy:
+
+- Immediate fallback: `feed:community` from bundled i18n files in `public/locales/*/feed.json`
+- Background refresh: optional remote JSON loaded per language
+- Replacement rule: remote feed replaces fallback only when remote `community` contains at least one valid item
+- Fallback rule: timeout, network errors, invalid payloads, or empty remote arrays keep bundled fallback visible
+
+Environment variables:
+
+- `VITE_FEED_REMOTE_BASE_URL`: remote base URL in the format `{base}/{language}/feed.json`

--- a/src/MobiFlightConnector/frontend/package-lock.json
+++ b/src/MobiFlightConnector/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@radix-ui/react-tabs": "^1.1.2",
         "@radix-ui/react-tooltip": "^1.1.8",
         "@tabler/icons-react": "^3.40.0",
+        "@tanstack/react-query": "^5.90.5",
         "@tanstack/react-table": "^8.20.6",
         "@tanstack/react-virtual": "^3.13.14",
         "class-variance-authority": "^0.7.1",
@@ -3083,6 +3084,32 @@
         "@tailwindcss/oxide": "4.2.1",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.5.tgz",
+      "integrity": "sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.5.tgz",
+      "integrity": "sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tanstack/react-table": {

--- a/src/MobiFlightConnector/frontend/package.json
+++ b/src/MobiFlightConnector/frontend/package.json
@@ -37,6 +37,7 @@
     "@radix-ui/react-tabs": "^1.1.2",
     "@radix-ui/react-tooltip": "^1.1.8",
     "@tabler/icons-react": "^3.40.0",
+    "@tanstack/react-query": "^5.90.5",
     "@tanstack/react-table": "^8.20.6",
     "@tanstack/react-virtual": "^3.13.14",
     "class-variance-authority": "^0.7.1",

--- a/src/MobiFlightConnector/frontend/playwright.config.ts
+++ b/src/MobiFlightConnector/frontend/playwright.config.ts
@@ -4,9 +4,12 @@ import { defineConfig, devices } from "@playwright/test"
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-// import dotenv from 'dotenv';
-// import path from 'path';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '.env') });
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -56,5 +59,11 @@ export default defineConfig({
     url: "http://localhost:5173/",
     reuseExistingServer: !process.env.CI,
     timeout: 20 * 1000,
+    env: {
+      ...process.env,
+      // Add any additional environment variables here
+      // so that typescript doesn't complain about object being undefined
+      DUMMY_ENV_VAR: "dummy_value_for_playwright", 
+    }
   },
 })

--- a/src/MobiFlightConnector/frontend/playwright.config.ts
+++ b/src/MobiFlightConnector/frontend/playwright.config.ts
@@ -4,12 +4,12 @@ import { defineConfig, devices } from "@playwright/test"
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
  */
-import dotenv from 'dotenv';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import dotenv from "dotenv"
+import path from "path"
+import { fileURLToPath } from "url"
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-dotenv.config({ path: path.resolve(__dirname, '.env') });
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+dotenv.config({ path: path.resolve(__dirname, ".env") })
 
 /**
  * See https://playwright.dev/docs/test-configuration.
@@ -49,7 +49,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         storageState: "./tests/.auth/user.json",
       },
-     // dependencies: ["setup"],
+      // dependencies: ["setup"],
     },
   ],
 
@@ -58,12 +58,6 @@ export default defineConfig({
     command: "npm run dev",
     url: "http://localhost:5173/",
     reuseExistingServer: !process.env.CI,
-    timeout: 20 * 1000,
-    env: {
-      ...process.env,
-      // Add any additional environment variables here
-      // so that typescript doesn't complain about object being undefined
-      DUMMY_ENV_VAR: "dummy_value_for_playwright", 
-    }
+    timeout: 20 * 1000
   },
 })

--- a/src/MobiFlightConnector/frontend/public/locales/de/feed.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/feed.json
@@ -1,44 +1,6 @@
 {
   "community": [
     {
-      "title": "Treffe MobiFlight bei FSWeekend 2026!",
-      "date": "2025-12-04",
-      "content": [
-        "Das MobiFlight Team ist beim FSWeekend 2026 mit dabei! Treffe uns am Stand, sieh dir Live-Demos an und erhalte exklusive Einblicke in kommende Funktionen."
-      ],
-      "action": {
-        "title": "Mehr erfahren",
-        "url": "https://flightsimweekend.com/"
-      },
-      "media": {
-        "type": "image",
-        "src": "/feed/fsweekend-2025.jpg",
-        "alt": "Treffe das MobiFlight Team beim FSWeekend 2026"
-      },
-      "tags": ["events"]
-    },
-    {
-      "date": "2026-02-15",
-      "title": "FSWeekend 2026 Workshops",
-      "content": [
-        "**Besuche uns auf FSWeekend 2026** für praxisnahe Workshops mit dem MobiFlight-Team!",
-        "**Du baust es, du behältst es!** - Baue und konfiguriere dein eigenes Multifunktionsgerät. Keine Vorkenntnisse erforderlich. **Wir sehen uns dort!**",
-        "Jede Voranmeldung erhält einen **10 EUR Rabatt!**"
-      ],
-      "featured": false,
-      "tags": ["events"],
-      "media": {
-        "type": "image",
-        "src": "/feed/mobiflight-workshops.jpg",
-        "alt": "FSWeekend 2026 Workshops",
-        "className": "bg-foreground dark:bg-background"
-      },
-      "action": {
-        "title": "Jetzt gleich anmelden!",
-        "url": "https://shop.mobiflight.com/product/mobiflight-workshop-fsweekend26"
-      }
-    },
-    {
       "date": "2025-11-30",
       "title": "Freigabe für neue Flight Levels!",
       "content": [

--- a/src/MobiFlightConnector/frontend/public/locales/en/feed.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/feed.json
@@ -1,44 +1,6 @@
 {
   "community": [
     {
-      "date": "2025-12-04",
-      "title": "Meet MobiFlight at FSWeekend 2026!",
-      "content": [
-        "The MobiFlight team will be at FSWeekend 2026! Come meet us at our booth, see live demos, and get exclusive insights into upcoming features."
-      ],
-      "action": {
-        "title": "Learn More",
-        "url": "https://flightsimweekend.com/"
-      },
-      "media": {
-        "type": "image",
-        "src": "/feed/fsweekend-2025.jpg",
-        "alt": "Meet the MobiFlight team at FSWeekend 2026"
-      },
-      "tags": ["events"]
-    },
-    {
-      "date": "2026-02-15",
-      "title": "FSWeekend 2026 Workshops",
-      "content": [
-        "**Join us at FSWeekend 2026** for hands-on workshops with the MobiFlight team!",
-        "**You build it, you keep it!** - Build and configure your own multi-function device. No experience required. **See you there!**",
-        "Early registration receives a **10 EUR discount!**"
-      ],
-      "featured": false,
-      "tags": ["events"],
-      "media": {
-        "type": "image",
-        "src": "/feed/mobiflight-workshops.jpg",
-        "alt": "FSWeekend 2026 Workshops",
-        "className": "bg-foreground dark:bg-background"
-      },
-      "action": {
-        "title": "Sign up!",
-        "url": "https://shop.mobiflight.com/product/mobiflight-workshop-fsweekend26"
-      }
-    },
-    {
       "date": "2025-11-30",
       "title": "Cleared for new flight levels!",
       "content": [

--- a/src/MobiFlightConnector/frontend/public/locales/es/feed.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/feed.json
@@ -1,44 +1,6 @@
 {
   "community": [
     {
-      "title": "¡Encuentra al equipo de MobiFlight en FSWeekend 2026!",
-      "date": "2025-12-04",
-      "content": [
-        "¡El equipo de MobiFlight estará presente en FSWeekend 2026! Encuéntrate con nosotros, puedes ver demostraciones en vivo y obtener información exclusiva sobre las próximas funciones."
-      ],
-      "action": {
-        "title": "Más información",
-        "url": "https://flightsimweekend.com/"
-      },
-      "media": {
-        "type": "image",
-        "src": "/feed/fsweekend-2025.jpg",
-        "alt": "¡Encuentra al equipo de MobiFlight en FSWeekend 2026!"
-      },
-      "tags": ["events"]
-    },
-    {
-      "date": "2026-02-15",
-      "title": "Talleres FSWeekend 2026",
-      "content": [
-        "**¡Ven a FSWeekend 2026** y participa en nuestros talleres prácticos junto al equipo de MobiFlight!",
-        "**¡Te lo llevas a casa!** - Monta y configura tu propio dispositivo multifunción desde cero. No hace falta experiencia previa. **¡Te esperamos!**",
-        "¡Regístrate temprano y obtén un **descuento de 10 EUR!**"
-      ],
-      "featured": false,
-      "tags": ["events"],
-      "media": {
-        "type": "image",
-        "src": "/feed/mobiflight-workshops.jpg",
-        "alt": "¡Talleres FSWeekend 2026!",
-        "className": "bg-foreground dark:bg-background"
-      },
-      "action": {
-        "title": "¡Regístrate!",
-        "url": "https://shop.mobiflight.com/product/mobiflight-workshop-fsweekend26"
-      }
-    },
-    {
       "date": "2025-11-30",
       "title": "¡Autorizado para nuevos niveles de vuelo!",
       "content": [

--- a/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
@@ -31,15 +31,20 @@ const CommunityMainCard = () => {
     returnObjects: true,
   }) as CommunityPost[]
 
-  const remoteFeedBaseUrl = import.meta.env.VITE_FEED_REMOTE_BASE_URL?.trim()
+  
+  // For local development, we are able to point the feed to a custom url 
+  // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
+  // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
+  const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
+  const remoteFeedBaseUrl = (import.meta.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
+
   const language = i18n.resolvedLanguage || i18n.language || "en"
 
   const remoteFeedQuery = useQuery({
     queryKey: ["community-feed", language, remoteFeedBaseUrl],
-    enabled: Boolean(remoteFeedBaseUrl),
     queryFn: () =>
       fetchRemoteCommunityFeed({
-        baseUrl: remoteFeedBaseUrl!,
+        baseUrl: remoteFeedBaseUrl,
         language
       }),
   })

--- a/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
@@ -10,8 +10,10 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import { fetchRemoteCommunityFeed } from "@/lib/feed"
 import { useErrorFallbackTest } from "@/lib/hooks/useErrorFallbackTest"
 import { CommunityPost } from "@/types/feed"
+import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 import { useSearchParams } from "react-router"
 
@@ -23,13 +25,31 @@ const CommunityMainCard = () => {
 
   const [searchParams] = useSearchParams()
   const activeFilter = searchParams.get("feed_filter") || "all"
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   const communityFeed = t("feed:community", {
     returnObjects: true,
   }) as CommunityPost[]
 
-  const filteredFeed = communityFeed.filter(
+  const remoteFeedBaseUrl = import.meta.env.VITE_FEED_REMOTE_BASE_URL?.trim()
+  const language = i18n.resolvedLanguage || i18n.language || "en"
+
+  const remoteFeedQuery = useQuery({
+    queryKey: ["community-feed", language, remoteFeedBaseUrl],
+    enabled: Boolean(remoteFeedBaseUrl),
+    queryFn: () =>
+      fetchRemoteCommunityFeed({
+        baseUrl: remoteFeedBaseUrl!,
+        language
+      }),
+  })
+
+  const displayedFeed =
+    remoteFeedQuery.data && remoteFeedQuery.data.length > 0
+      ? remoteFeedQuery.data
+      : communityFeed
+
+  const filteredFeed = displayedFeed.filter(
     (post) => post.tags.includes(activeFilter) || activeFilter === "all",
   )
 

--- a/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
@@ -49,10 +49,7 @@ const CommunityMainCard = () => {
       }),
   })
 
-  const displayedFeed =
-    remoteFeedQuery.data && remoteFeedQuery.data.length > 0
-      ? remoteFeedQuery.data
-      : communityFeed
+  const displayedFeed = [ ...remoteFeedQuery.data ?? [], ...communityFeed ]
 
   const filteredFeed = displayedFeed.filter(
     (post) => post.tags.includes(activeFilter) || activeFilter === "all",

--- a/src/MobiFlightConnector/frontend/src/lib/feed.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/feed.ts
@@ -1,0 +1,75 @@
+import { CommunityPost } from "@/types/feed"
+
+interface FetchRemoteFeedOptions {
+  baseUrl: string
+  language: string
+  timeoutMs?: number
+}
+
+interface RemoteFeedPayload {
+  community: CommunityPost[]
+}
+
+const isStringArray = (value: unknown): value is string[] => {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}
+
+const isCommunityPost = (value: unknown): value is CommunityPost => {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+  const post = value as Record<string, unknown>
+  return (
+    typeof post.title === "string" &&
+    typeof post.date === "string" &&
+    isStringArray(post.content) &&
+    isStringArray(post.tags)
+  )
+}
+
+const isRemoteFeedPayload = (value: unknown): value is RemoteFeedPayload => {
+  if (!value || typeof value !== "object") {
+    return false
+  }
+  const payload = value as Record<string, unknown>
+  if (!Array.isArray(payload.community)) {
+    return false
+  }
+  return payload.community.every((post) => isCommunityPost(post))
+}
+
+const resolveLanguage = (language: string): string => {
+  const [languageCode] = language.split("-")
+  return languageCode || "en"
+}
+
+const buildRemoteFeedUrl = (baseUrl: string, language: string): string => {
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "")
+  return `${normalizedBaseUrl}/${resolveLanguage(language)}/feed.json`
+}
+
+export const fetchRemoteCommunityFeed = async ({
+  baseUrl,
+  language,
+  timeoutMs = 3000,
+}: FetchRemoteFeedOptions): Promise<CommunityPost[]> => {
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  const url = buildRemoteFeedUrl(baseUrl, language)
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      cache: "no-store",
+    })
+    if (!response.ok) {
+      throw new Error(`Feed request failed with status ${response.status}`)
+    }
+    const payload = (await response.json()) as unknown
+    if (!isRemoteFeedPayload(payload)) {
+      throw new Error("Feed payload is invalid")
+    }
+    return payload.community
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}

--- a/src/MobiFlightConnector/frontend/src/lib/feed.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/feed.ts
@@ -48,6 +48,30 @@ const buildRemoteFeedUrl = (baseUrl: string, language: string): string => {
   return `${normalizedBaseUrl}/${resolveLanguage(language)}/feed.json`
 }
 
+const makeUrlAbsolute = (
+  media: CommunityPost["media"],
+  baseUrl: string,
+): CommunityPost["media"] => {
+  if (!media) {
+    return media
+  }
+  const isAbsoluteUrl =
+    media.src.startsWith("http://") ||
+    media.src.startsWith("https://") ||
+    media.src.startsWith("//")
+
+  if (isAbsoluteUrl) {
+    return media
+  }
+
+  const normalizedBaseUrl = baseUrl.replace(/\/+$/, "")
+  const normalizedSrc = media.src.replace(/^\/+/, "")
+  return {
+    ...media,
+    src: `${normalizedBaseUrl}/${normalizedSrc}`,
+  }
+}
+
 export const fetchRemoteCommunityFeed = async ({
   baseUrl,
   language,
@@ -68,7 +92,13 @@ export const fetchRemoteCommunityFeed = async ({
     if (!isRemoteFeedPayload(payload)) {
       throw new Error("Feed payload is invalid")
     }
-    return payload.community
+    return payload.community.map((post) => {
+      const media = makeUrlAbsolute(post.media, baseUrl)
+      return {
+        ...post,
+        media,
+      }
+    })
   } finally {
     clearTimeout(timeoutId)
   }

--- a/src/MobiFlightConnector/frontend/src/lib/feed.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/feed.ts
@@ -52,9 +52,10 @@ const makeUrlAbsolute = (
   media: CommunityPost["media"],
   baseUrl: string,
 ): CommunityPost["media"] => {
-  if (!media) {
+  if (!media || !media.src) {
     return media
   }
+
   const isAbsoluteUrl =
     media.src.startsWith("http://") ||
     media.src.startsWith("https://") ||

--- a/src/MobiFlightConnector/frontend/src/main.tsx
+++ b/src/MobiFlightConnector/frontend/src/main.tsx
@@ -9,6 +9,16 @@ import { BrowserRouter } from "react-router"
 import { AuthProvider } from "react-oidc-context"
 import { oidcConfig } from "@/lib/auth/config"
 import { BackendStateMessageHandler } from "@/components/BackendStateMessageHandler.tsx"
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+})
 
 if (process.env.NODE_ENV !== "development") {
   console.log = () => {}
@@ -20,16 +30,18 @@ if (process.env.NODE_ENV !== "development") {
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ThemeProvider defaultTheme="light" storageKey="ui-mode">
-      <AuthProvider {...oidcConfig}>
-        <TooltipProvider skipDelayDuration={0}>
-          <BrowserRouter>
-            <BackendStateMessageHandler>
-              <AppRoutes />
-            </BackendStateMessageHandler>
-          </BrowserRouter>
-        </TooltipProvider>
-      </AuthProvider>
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider defaultTheme="light" storageKey="ui-mode">
+        <AuthProvider {...oidcConfig}>
+          <TooltipProvider skipDelayDuration={0}>
+            <BrowserRouter>
+              <BackendStateMessageHandler>
+                <AppRoutes />
+              </BackendStateMessageHandler>
+            </BrowserRouter>
+          </TooltipProvider>
+        </AuthProvider>
+      </ThemeProvider>
+    </QueryClientProvider>
   </StrictMode>,
 )

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -872,7 +872,13 @@ test.describe("Community Feed tests", () => {
     dashboardPage,
     page,
   }) => {
-    const remoteFeedBaseUrl = process.env.VITE_FEED_REMOTE_BASE_URL?.trim()
+    // For testing, we are able to point the feed to a custom url 
+    // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
+    // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
+    // We have to make sure to use the same base url in the test when we mock the feed response, 
+    // otherwise the frontend will not use our mocked response and the test will fail
+    const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
+    const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
 
     await page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
       await route.fulfill({
@@ -891,7 +897,14 @@ test.describe("Community Feed tests", () => {
     dashboardPage,
     page,
   }) => {
-    const remoteFeedBaseUrl = process.env.VITE_FEED_REMOTE_BASE_URL?.trim()
+    // For testing, we are able to point the feed to a custom url 
+    // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
+    // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
+    // We have to make sure to use the same base url in the test when we mock the feed response, 
+    // otherwise the frontend will not use our mocked response and the test will fail
+    const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
+    const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
+    
     const relativeFeedImageUrl = "/feed/test-image.jpg"
     const absoluteFeedImageUrl = `${remoteFeedBaseUrl}${relativeFeedImageUrl}`
 

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -548,11 +548,10 @@ test.describe("Project list view tests", () => {
     await expect(firstAndActiveProject).toBeVisible()
 
     await dashboardPage.mobiFlightPage.trackCommand("CommandMainMenu")
-    
+
     // Clicking on actuive project should not post a command
     await firstAndActiveProject.click()
-    let postedCommands =
-      await dashboardPage.mobiFlightPage.getTrackedCommands()
+    let postedCommands = await dashboardPage.mobiFlightPage.getTrackedCommands()
 
     expect(postedCommands).toHaveLength(0)
 
@@ -678,7 +677,7 @@ test.describe("Project list view tests", () => {
     await dashboardPage.mobiFlightPage.initWithTestData()
 
     await expect(recentProjectsList).toBeVisible()
-    
+
     // Simulate unsaved changes
     await dashboardPage.mobiFlightPage.updateProjectState({
       HasChanged: true,
@@ -867,6 +866,110 @@ test.describe("Community Feed tests", () => {
 
     await eventsFilterButton.click()
     await expect(feedItems).toHaveCount(2)
+  })
+
+  test("Confirm fallback feed items are rendered correctly if dynamic feed is unavailable", async ({
+    dashboardPage,
+    page,
+  }) => {
+    const remoteFeedBaseUrl = process.env.VITE_FEED_REMOTE_BASE_URL?.trim()
+
+    await page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      })
+    })
+    await dashboardPage.gotoPage()
+
+    const feedItems = page.getByTestId("community-feed-item")
+    await expect(feedItems).toHaveCount(5)
+  })
+
+  test("Confirm dynamic feed items are rendered correctly", async ({
+    dashboardPage,
+    page,
+  }) => {
+    const remoteFeedBaseUrl = process.env.VITE_FEED_REMOTE_BASE_URL?.trim()
+    const relativeFeedImageUrl = "/feed/test-image.jpg"
+    const absoluteFeedImageUrl = `${remoteFeedBaseUrl}${relativeFeedImageUrl}`
+
+    const absoluteFeedImageUrl2 = "https://example.com/test-image.jpg"
+    const absoluteFeedImageUrl3 = "http://example.com/test-image.jpg"
+    const absoluteFeedImageUrl4 = "//example.com/test-image.jpg"
+
+    await page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          community: [
+            {
+              title: "Dynamic Post 1",
+              date: "2026-04-28",
+              content: ["Hello"],
+              tags: ["community"],
+              media: { type: "image", src: relativeFeedImageUrl, alt: "x" },
+            },
+            {
+              title: "Dynamic Post 2",
+              date: "2026-04-28",
+              content: ["Hello"],
+              tags: ["community"],
+              media: { type: "image", src: absoluteFeedImageUrl2, alt: "x" },
+            },
+            {
+              title: "Dynamic Post 3",
+              date: "2026-04-28",
+              content: ["Hello"],
+              tags: ["community"],
+              media: { type: "image", src: absoluteFeedImageUrl3, alt: "x" },
+            },
+            {
+              title: "Dynamic Post 4",
+              date: "2026-04-28",
+              content: ["Hello"],
+              tags: ["community"],
+              media: { type: "image", src: absoluteFeedImageUrl4, alt: "x" },
+            },
+          ],
+        }),
+      })
+    })
+    await dashboardPage.gotoPage()
+
+    const feedItems = page.getByTestId("community-feed-item")
+    await expect(feedItems).toHaveCount(4)
+    await expect(feedItems.first()).toContainText("Dynamic Post 1")
+
+    const img = page.locator('[data-testid="community-feed-item"] img').first()
+    await expect(img).toBeVisible()
+    await expect(img).toHaveAttribute(
+      "src",
+      absoluteFeedImageUrl,
+    )
+
+    const img2 = page.locator('[data-testid="community-feed-item"] img').nth(1)
+    await expect(img2).toBeVisible()
+    await expect(img2).toHaveAttribute(
+      "src",
+      absoluteFeedImageUrl2,
+    )
+
+    const img3 = page.locator('[data-testid="community-feed-item"] img').nth(2)
+    await expect(img3).toBeVisible()
+    await expect(img3).toHaveAttribute(
+      "src",
+      absoluteFeedImageUrl3,
+    )
+
+    const img4 = page.locator('[data-testid="community-feed-item"] img').nth(3)
+    await expect(img4).toBeVisible()
+    await expect(img4).toHaveAttribute(
+      "src",
+      absoluteFeedImageUrl4,
+    )
   })
 
   test("Confirm button links are working correctly", async ({

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -838,14 +838,7 @@ test.describe("Community Feed tests", () => {
     const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
     const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
 
-    await page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
-      await route.fulfill({
-        status: 404,
-        contentType: "application/json",
-        body: JSON.stringify({}),
-      })
-    })
-
+    await dashboardPage.disableDynamicFeed(remoteFeedBaseUrl)
     await dashboardPage.gotoPage()
 
     await expect(page.getByText("Community Feed")).toBeVisible()
@@ -900,13 +893,7 @@ test.describe("Community Feed tests", () => {
     const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
     const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
 
-    await page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
-      await route.fulfill({
-        status: 404,
-        contentType: "application/json",
-        body: JSON.stringify({}),
-      })
-    })
+    await dashboardPage.disableDynamicFeed(remoteFeedBaseUrl)
     await dashboardPage.gotoPage()
 
     const feedItems = page.getByTestId("community-feed-item")
@@ -1013,7 +1000,17 @@ test.describe("Community Feed tests", () => {
     dashboardPage,
     page,
   }) => {
+    // For testing, we are able to point the feed to a custom url 
+    // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
+    // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
+    // We have to make sure to use the same base url in the test when we mock the feed response, 
+    // otherwise the frontend will not use our mocked response and the test will fail
+    const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
+    const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
+
+    await dashboardPage.disableDynamicFeed(remoteFeedBaseUrl)
     await dashboardPage.gotoPage()
+
     const feedItems = page.getByTestId("community-feed-item")
     await expect(feedItems).toHaveCount(3)
     const offerItem = feedItems.nth(2)

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -829,7 +829,23 @@ test.describe("Asynchronous save tests", () => {
 })
 
 test.describe("Community Feed tests", () => {
-  test("Confirm default feed items", async ({ dashboardPage, page }) => {
+  test("Confirm feed filter is working correctly", async ({ dashboardPage, page }) => {
+    // For testing, we are able to point the feed to a custom url 
+    // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
+    // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
+    // We have to make sure to use the same base url in the test when we mock the feed response, 
+    // otherwise the frontend will not use our mocked response and the test will fail
+    const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
+    const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
+
+    await page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      })
+    })
+
     await dashboardPage.gotoPage()
 
     await expect(page.getByText("Community Feed")).toBeVisible()
@@ -838,25 +854,26 @@ test.describe("Community Feed tests", () => {
     await expect(feedFilter).toBeVisible()
 
     const allFilterButton = page.getByRole("button", { name: "All" })
-    await expect(allFilterButton).toBeVisible()
-    await expect(allFilterButton).toHaveCount(1)
-
     const communityFilterButton = page.getByRole("button", {
       name: "Community",
     })
+    const offersFilterButton = page.getByRole("button", { name: "Offers" })
+    const eventsFilterButton = page.getByRole("button", { name: "Events" })
+    const feedItems = page.getByTestId("community-feed-item")
+    
+    await expect(allFilterButton).toBeVisible()
+    await expect(allFilterButton).toHaveCount(1)
+
     await expect(communityFilterButton).toBeVisible()
     await expect(communityFilterButton).toHaveCount(1)
 
-    const offersFilterButton = page.getByRole("button", { name: "Offers" })
     await expect(offersFilterButton).toBeVisible()
     await expect(offersFilterButton).toHaveCount(1)
 
-    const eventsFilterButton = page.getByRole("button", { name: "Events" })
     await expect(eventsFilterButton).toBeVisible()
     await expect(eventsFilterButton).toHaveCount(1)
 
-    const feedItems = page.getByTestId("community-feed-item")
-    await expect(feedItems).toHaveCount(5)
+    await expect(feedItems).toHaveCount(3)
 
     await communityFilterButton.click()
     await expect(feedItems).toHaveCount(2)
@@ -865,7 +882,10 @@ test.describe("Community Feed tests", () => {
     await expect(feedItems).toHaveCount(1)
 
     await eventsFilterButton.click()
-    await expect(feedItems).toHaveCount(2)
+    await expect(feedItems).toHaveCount(0)
+
+    await allFilterButton.click()
+    await expect(feedItems).toHaveCount(3)
   })
 
   test("Confirm fallback feed items are rendered correctly if dynamic feed is unavailable", async ({
@@ -890,7 +910,7 @@ test.describe("Community Feed tests", () => {
     await dashboardPage.gotoPage()
 
     const feedItems = page.getByTestId("community-feed-item")
-    await expect(feedItems).toHaveCount(5)
+    await expect(feedItems).toHaveCount(3)
   })
 
   test("Confirm dynamic feed items are rendered correctly", async ({
@@ -953,9 +973,13 @@ test.describe("Community Feed tests", () => {
     await dashboardPage.gotoPage()
 
     const feedItems = page.getByTestId("community-feed-item")
-    await expect(feedItems).toHaveCount(4)
+    // 4 from dynamic feed + 3 fallback items
+    await expect(feedItems).toHaveCount(7) 
     await expect(feedItems.first()).toContainText("Dynamic Post 1")
 
+    // dynamic feed is prepended to fallback feed
+    // and relative image urls are resolved against the feed base url
+    // and absolute image urls are untouched
     const img = page.locator('[data-testid="community-feed-item"] img').first()
     await expect(img).toBeVisible()
     await expect(img).toHaveAttribute(
@@ -991,8 +1015,8 @@ test.describe("Community Feed tests", () => {
   }) => {
     await dashboardPage.gotoPage()
     const feedItems = page.getByTestId("community-feed-item")
-    await expect(feedItems).toHaveCount(5)
-    const offerItem = feedItems.nth(4)
+    await expect(feedItems).toHaveCount(3)
+    const offerItem = feedItems.nth(2)
     const offerButton = offerItem.getByRole("button", {
       name: "Subscribe",
       exact: true,

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -829,14 +829,19 @@ test.describe("Asynchronous save tests", () => {
 })
 
 test.describe("Community Feed tests", () => {
-  test("Confirm feed filter is working correctly", async ({ dashboardPage, page }) => {
-    // For testing, we are able to point the feed to a custom url 
+  test("Confirm feed filter is working correctly", async ({
+    dashboardPage,
+    page,
+  }) => {
+    // For testing, we are able to point the feed to a custom url
     // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
     // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
-    // We have to make sure to use the same base url in the test when we mock the feed response, 
+    // We have to make sure to use the same base url in the test when we mock the feed response,
     // otherwise the frontend will not use our mocked response and the test will fail
     const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
-    const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
+    const remoteFeedBaseUrl = (
+      process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl
+    ).trim()
 
     await dashboardPage.disableDynamicFeed(remoteFeedBaseUrl)
     await dashboardPage.gotoPage()
@@ -853,7 +858,7 @@ test.describe("Community Feed tests", () => {
     const offersFilterButton = page.getByRole("button", { name: "Offers" })
     const eventsFilterButton = page.getByRole("button", { name: "Events" })
     const feedItems = page.getByTestId("community-feed-item")
-    
+
     await expect(allFilterButton).toBeVisible()
     await expect(allFilterButton).toHaveCount(1)
 
@@ -885,13 +890,15 @@ test.describe("Community Feed tests", () => {
     dashboardPage,
     page,
   }) => {
-    // For testing, we are able to point the feed to a custom url 
+    // For testing, we are able to point the feed to a custom url
     // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
     // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
-    // We have to make sure to use the same base url in the test when we mock the feed response, 
+    // We have to make sure to use the same base url in the test when we mock the feed response,
     // otherwise the frontend will not use our mocked response and the test will fail
     const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
-    const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
+    const remoteFeedBaseUrl = (
+      process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl
+    ).trim()
 
     await dashboardPage.disableDynamicFeed(remoteFeedBaseUrl)
     await dashboardPage.gotoPage()
@@ -904,14 +911,16 @@ test.describe("Community Feed tests", () => {
     dashboardPage,
     page,
   }) => {
-    // For testing, we are able to point the feed to a custom url 
+    // For testing, we are able to point the feed to a custom url
     // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
     // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
-    // We have to make sure to use the same base url in the test when we mock the feed response, 
+    // We have to make sure to use the same base url in the test when we mock the feed response,
     // otherwise the frontend will not use our mocked response and the test will fail
     const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
-    const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
-    
+    const remoteFeedBaseUrl = (
+      process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl
+    ).trim()
+
     const relativeFeedImageUrl = "/feed/test-image.jpg"
     const absoluteFeedImageUrl = `${remoteFeedBaseUrl}${relativeFeedImageUrl}`
 
@@ -919,49 +928,42 @@ test.describe("Community Feed tests", () => {
     const absoluteFeedImageUrl3 = "http://example.com/test-image.jpg"
     const absoluteFeedImageUrl4 = "//example.com/test-image.jpg"
 
-    await page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          community: [
-            {
-              title: "Dynamic Post 1",
-              date: "2026-04-28",
-              content: ["Hello"],
-              tags: ["community"],
-              media: { type: "image", src: relativeFeedImageUrl, alt: "x" },
-            },
-            {
-              title: "Dynamic Post 2",
-              date: "2026-04-28",
-              content: ["Hello"],
-              tags: ["community"],
-              media: { type: "image", src: absoluteFeedImageUrl2, alt: "x" },
-            },
-            {
-              title: "Dynamic Post 3",
-              date: "2026-04-28",
-              content: ["Hello"],
-              tags: ["community"],
-              media: { type: "image", src: absoluteFeedImageUrl3, alt: "x" },
-            },
-            {
-              title: "Dynamic Post 4",
-              date: "2026-04-28",
-              content: ["Hello"],
-              tags: ["community"],
-              media: { type: "image", src: absoluteFeedImageUrl4, alt: "x" },
-            },
-          ],
-        }),
-      })
-    })
+    const communityPosts = [
+      {
+        title: "Dynamic Post 1",
+        date: "2026-04-28",
+        content: ["Hello"],
+        tags: ["community"],
+        media: { type: "image", src: relativeFeedImageUrl, alt: "x" },
+      },
+      {
+        title: "Dynamic Post 2",
+        date: "2026-04-28",
+        content: ["Hello"],
+        tags: ["community"],
+        media: { type: "image", src: absoluteFeedImageUrl2, alt: "x" },
+      },
+      {
+        title: "Dynamic Post 3",
+        date: "2026-04-28",
+        content: ["Hello"],
+        tags: ["community"],
+        media: { type: "image", src: absoluteFeedImageUrl3, alt: "x" },
+      },
+      {
+        title: "Dynamic Post 4",
+        date: "2026-04-28",
+        content: ["Hello"],
+        tags: ["community"],
+        media: { type: "image", src: absoluteFeedImageUrl4, alt: "x" },
+      },
+    ]
+    await dashboardPage.mockDynamicFeed(remoteFeedBaseUrl, communityPosts)
     await dashboardPage.gotoPage()
 
     const feedItems = page.getByTestId("community-feed-item")
     // 4 from dynamic feed + 3 fallback items
-    await expect(feedItems).toHaveCount(7) 
+    await expect(feedItems).toHaveCount(7)
     await expect(feedItems.first()).toContainText("Dynamic Post 1")
 
     // dynamic feed is prepended to fallback feed
@@ -969,44 +971,34 @@ test.describe("Community Feed tests", () => {
     // and absolute image urls are untouched
     const img = page.locator('[data-testid="community-feed-item"] img').first()
     await expect(img).toBeVisible()
-    await expect(img).toHaveAttribute(
-      "src",
-      absoluteFeedImageUrl,
-    )
+    await expect(img).toHaveAttribute("src", absoluteFeedImageUrl)
 
     const img2 = page.locator('[data-testid="community-feed-item"] img').nth(1)
     await expect(img2).toBeVisible()
-    await expect(img2).toHaveAttribute(
-      "src",
-      absoluteFeedImageUrl2,
-    )
+    await expect(img2).toHaveAttribute("src", absoluteFeedImageUrl2)
 
     const img3 = page.locator('[data-testid="community-feed-item"] img').nth(2)
     await expect(img3).toBeVisible()
-    await expect(img3).toHaveAttribute(
-      "src",
-      absoluteFeedImageUrl3,
-    )
+    await expect(img3).toHaveAttribute("src", absoluteFeedImageUrl3)
 
     const img4 = page.locator('[data-testid="community-feed-item"] img').nth(3)
     await expect(img4).toBeVisible()
-    await expect(img4).toHaveAttribute(
-      "src",
-      absoluteFeedImageUrl4,
-    )
+    await expect(img4).toHaveAttribute("src", absoluteFeedImageUrl4)
   })
 
   test("Confirm button links are working correctly", async ({
     dashboardPage,
     page,
   }) => {
-    // For testing, we are able to point the feed to a custom url 
+    // For testing, we are able to point the feed to a custom url
     // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
     // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
-    // We have to make sure to use the same base url in the test when we mock the feed response, 
+    // We have to make sure to use the same base url in the test when we mock the feed response,
     // otherwise the frontend will not use our mocked response and the test will fail
     const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
-    const remoteFeedBaseUrl = (process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
+    const remoteFeedBaseUrl = (
+      process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl
+    ).trim()
 
     await dashboardPage.disableDynamicFeed(remoteFeedBaseUrl)
     await dashboardPage.gotoPage()

--- a/src/MobiFlightConnector/frontend/tests/fixtures/DashboardPage.ts
+++ b/src/MobiFlightConnector/frontend/tests/fixtures/DashboardPage.ts
@@ -17,4 +17,14 @@ export class DashboardPage {
       },
     )
   }
+
+  async disableDynamicFeed(remoteFeedBaseUrl: string) {
+    await this.mobiFlightPage.page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: "application/json",
+        body: JSON.stringify({}),
+      })
+    })
+  }
 }

--- a/src/MobiFlightConnector/frontend/tests/fixtures/DashboardPage.ts
+++ b/src/MobiFlightConnector/frontend/tests/fixtures/DashboardPage.ts
@@ -1,3 +1,4 @@
+import { CommunityPost } from "@/types/feed"
 import { MobiFlightPage } from "./MobiFlightPage"
 
 export class DashboardPage {
@@ -24,6 +25,16 @@ export class DashboardPage {
         status: 404,
         contentType: "application/json",
         body: JSON.stringify({}),
+      })
+    })
+  }
+
+  async mockDynamicFeed(remoteFeedBaseUrl: string, data: CommunityPost[]) {
+    await this.mobiFlightPage.page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ community: data }),
       })
     })
   }


### PR DESCRIPTION
The community news feed now fetches the latest news from a web URL and adds them to the feed inside the app. This allows to share current news independent from release cycles.

fixes #2926