### PR TITLE
Use toast notification if project loading fails

### DIFF
--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -2082,7 +2082,7 @@ namespace MobiFlight.UI
                     Context = new Dictionary<string, string>()
                     {
                         { "FileName", fileName },
-                        { "Message", ex.Message  }
+                        { "ErrorMessage", ex.Message  }
                     }
                 });
 

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -2075,8 +2075,17 @@ namespace MobiFlight.UI
             }
             catch (Exception ex)
             {
-                Log.Instance.log($"Unable to load configuration file: {ex.Message}", LogSeverity.Error);
-                MessageBox.Show(i18n._tr("uiMessageProblemLoadingConfig"), i18n._tr("Hint"));
+                // show that something went wrong opening the file.
+                MessageExchange.Instance.Publish(new Notification()
+                {
+                    Event = "ProjectFileLoadError",
+                    Context = new Dictionary<string, string>()
+                    {
+                        { "FileName", fileName },
+                        { "Message", ex.Message  }
+                    }
+                });
+
                 return;
             }
 

--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -319,6 +319,10 @@
     "TestModeException": {
       "Title": "Testmodus-Fehler",
       "Description": "{{errorMessage}}"
+    },
+    "ProjectFileLoadError": {
+      "Title": "Projekt konnte nicht geladen werden",
+      "Description": "Beim Laden ist ein Fehler aufgetreten: {{fileName}} - {{errorMessage}}"
     }
   },
   "Startup": {

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -313,6 +313,10 @@
     "TestModeException": {
       "Title": "Test Mode Error",
       "Description": "{{errorMessage}}"
+    },
+    "ProjectFileLoadError": {
+      "Title": "Project could not be loaded",
+      "Description": "An error occurred on loading {{fileName}} - {{errorMessage}}"
     }
   },
   "Startup": {

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -319,6 +319,10 @@
     "TestModeException": {
       "Title": "Error en modo de prueba",
       "Description": "{{errorMessage}}"
+    },
+    "ProjectFileLoadError": {
+      "Title": "No se pudo cargar el proyecto",
+      "Description": "Ocurrió un error al cargar {{fileName}} - {{errorMessage}}"
     }
   },
   "Startup": {

--- a/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -80,6 +80,17 @@ export const ToastNotificationHandler = () => {
         break
       }
 
+      case "ProjectFileLoadError": {
+        const errorMessage = notification?.Context?.Message ?? "An error occurred while loading the project file."
+        const fileName = notification?.Context?.FileName ?? "Unknown file"
+        toast({
+          id: "project-file-load-error",
+          title: t("Notifications.ProjectFileLoadError.Title"),
+          description: t("Notifications.ProjectFileLoadError.Description", { fileName, errorMessage }),
+        })
+        break
+      }
+
       default:
         console.error("Unhandled notification event:", notification.Event)
         break

--- a/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -81,8 +81,8 @@ export const ToastNotificationHandler = () => {
       }
 
       case "ProjectFileLoadError": {
-        const errorMessage = notification?.Context?.Message ?? "An error occurred while loading the project file."
-        const fileName = notification?.Context?.FileName ?? "Unknown file"
+        const errorMessage = notification?.Context?.ErrorMessage ?? "An error occurred while loading the project file."
+        const fileName = notification?.Context?.FileName ?? "<<Unknown file>>"
         toast({
           id: "project-file-load-error",
           title: t("Notifications.ProjectFileLoadError.Title"),

--- a/src/MobiFlightConnector/frontend/src/types/messages.d.ts
+++ b/src/MobiFlightConnector/frontend/src/types/messages.d.ts
@@ -118,6 +118,7 @@ export interface Notification {
     | "SimConnectionLost"
     | "SimStopped"
     | "TestModeException"
+    | "ProjectFileLoadError"
   Guid?: string
   Context: Record<string, string> | null
 }

--- a/src/MobiFlightConnector/frontend/tests/General.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/General.spec.ts
@@ -67,7 +67,7 @@ test.describe("Generic Notifications tests", () => {
     await configListPage.gotoPage()
     await configListPage.mobiFlightPage.initWithTestData()
 
-    const toastAutoBindControllerSuccessful  = page.getByTestId(
+    const toastAutoBindControllerSuccessful = page.getByTestId(
       "toast-autobind-controllers-successful",
     )
     await expect(toastAutoBindControllerSuccessful).not.toBeVisible()
@@ -76,7 +76,7 @@ test.describe("Generic Notifications tests", () => {
       key: "Notification",
       payload: {
         Event: "ControllerAutoBindSuccessful",
-        Context: { Count: "1", Controllers: "Alpha Flight Controls"},
+        Context: { Count: "1", Controllers: "Alpha Flight Controls" },
       },
     })
 
@@ -90,7 +90,7 @@ test.describe("Generic Notifications tests", () => {
     await configListPage.gotoPage()
     await configListPage.mobiFlightPage.initWithTestData()
 
-    const toastManualBindingRequired  = page.getByTestId(
+    const toastManualBindingRequired = page.getByTestId(
       "toast-manual-binding-required",
     )
     await expect(toastManualBindingRequired).not.toBeVisible()
@@ -99,7 +99,7 @@ test.describe("Generic Notifications tests", () => {
       key: "Notification",
       payload: {
         Event: "ControllerManualBindRequired",
-        Context: { Count: "2", Controllers: "Alpha Flight Controls"},
+        Context: { Count: "2", Controllers: "Alpha Flight Controls" },
       },
     })
 
@@ -195,5 +195,36 @@ test.describe("Generic Notifications tests", () => {
     await expect(toastTestModeException).toBeVisible()
     await expect(toastTestModeException).toContainText("Test Mode Error")
     await expect(toastTestModeException).toContainText("Test error occurred")
+  })
+
+  test("Confirm Project File Load Error Notification shows correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData()
+
+    const toastProjectFileLoadError = page.getByTestId(
+      "toast-project-file-load-error",
+    )
+    await expect(toastProjectFileLoadError).not.toBeVisible()
+
+    await configListPage.mobiFlightPage.publishMessage({
+      key: "Notification",
+      payload: {
+        Event: "ProjectFileLoadError",
+        Context: {
+          FileName: "testFile.mf",
+          ErrorMessage: "Test error occurred",
+        },
+      },
+    })
+
+    await expect(toastProjectFileLoadError).toBeVisible()
+    await expect(toastProjectFileLoadError).toContainText(
+      "Project could not be loaded",
+    )
+    await expect(toastProjectFileLoadError).toContainText("testFile.mf")
+    await expect(toastProjectFileLoadError).toContainText("Test error occurred")
   })
 })


### PR DESCRIPTION
When an error happens on loading a project, a popup window was displayed.
This PR replaces the popup window with a toast notification. This is another task done replacing all the legacy popups with either notifications or overlay popups.

Old:
<img width="600" height="227" alt="image" src="https://github.com/user-attachments/assets/e0b4c519-07ec-4d99-b53e-bfc7219ff1d6" />

New: 
<img width="1026" height="233" alt="image" src="https://github.com/user-attachments/assets/e885f850-a16e-4e97-8fd6-be961c8a1224" />

relates to #2816 