### PR TITLE
Update path for translation stats in workflow

### DIFF
--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path: translation-stats.md
+          path: src/MobiFlightConnector/frontend/translation-stats.md


### PR DESCRIPTION
I missed this in the last PR because the post translation action is not using run and therefore not using default.working-directory