### PR TITLE
Add playwright results and report artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -490,5 +490,7 @@ FodyWeavers.xsd
 # Python directory - include only RuntimeAndPackages*.zip files
 Python/*
 !Python/RuntimeAndPackages*.zip
+
+# Playwright test artifacts
 frontend/playwright-report/*
 frontend/test-results/*

--- a/.gitignore
+++ b/.gitignore
@@ -494,3 +494,6 @@ Python/*
 # Playwright test artifacts
 frontend/playwright-report/*
 frontend/test-results/*
+
+# devcontainer lock file
+devcontainer-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -490,3 +490,5 @@ FodyWeavers.xsd
 # Python directory - include only RuntimeAndPackages*.zip files
 Python/*
 !Python/RuntimeAndPackages*.zip
+frontend/playwright-report/*
+frontend/test-results/*


### PR DESCRIPTION
These feel like they don't belong to the repository, so adding them to .gitignore.

```
# Playwright test artifacts
frontend/playwright-report/*
frontend/test-results/*

```
In the case that I would be grossly mistaken, I am pre-emptively supplying myself with a handy paper-bag to wear. Like, maybe there is a "clean up the artifacts" command one tends to as part of the playwright test workflow, that takes care of this. So, just in case:

```
,-._,--.
|      |
| O  O |
!~~~~~~!

```
