### PR TITLE
Split translation workflow so PR comments work for PRs from forks

### DIFF
--- a/.github/workflows/translations.post-comment.yml
+++ b/.github/workflows/translations.post-comment.yml
@@ -1,0 +1,36 @@
+name: Comment translation statistics
+
+on:
+  workflow_run:
+    workflows: ["Check translations"]
+    types:
+      - completed
+
+jobs:
+  comment:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0] != null
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Download translation stats
+        uses: actions/download-artifact@v4
+        with:
+          name: translation-stats
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: translation-stats
+
+      - name: Post translation stats
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          path: translation-stats/translation-stats.md
+          header: translation-stats

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -29,9 +29,9 @@ jobs:
       - name: Generate Translation Statistics as Markdown
         run: echo "$(node src/scripts/check-translations.js)" > translation-stats.md
 
-      - name: Post Translation Statistics
-        uses: marocchino/sticky-pull-request-comment@v3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload translation statistics
+        uses: actions/upload-artifact@v4
         with:
+          name: translation-stats
           path: src/MobiFlightConnector/frontend/translation-stats.md
+          if-no-files-found: error


### PR DESCRIPTION
We found that for providing localization PRs, the translation workflow would fail because of insufficient privileges.

So the trick is to split up the original workflow into two steps:
- One does the work on code level and uploads the translation results as artifact. The workflow is executed with limited privileges, basically in the context of the fork.
- The second workflow is triggered once the first workflow finishes successfully. This one is executed in the context of the repo.