### PR TITLE
Skip tests that require secrets so that they don't fail on PRs

### DIFF
--- a/src/MobiFlightConnector/frontend/tests/CommunityToolbar.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/CommunityToolbar.spec.ts
@@ -41,6 +41,15 @@ test.describe("User without authentication", () => {
 })
 
 test.describe("Confirm community toolbar works for basic user", () => {
+  const basicEmail = process.env.TESTS_BASIC_EMAIL
+  const basicPassword = process.env.TESTS_BASIC_PASSWORD
+  const basicName = process.env.TESTS_BASIC_NAME
+
+  test.skip(
+    !basicEmail || !basicPassword || !basicName,
+    "Skipping community toolbar tests for basic user: required secrets are missing. This typically happens on a PR from a fork where secrets are not available.",
+  )
+
   test.use({ storageState: "./tests/.auth/basic.json" })
   test("Confirm community buttons in toolbar behave as expected", async ({
     configListPage,
@@ -57,6 +66,15 @@ test.describe("Confirm community toolbar works for basic user", () => {
 })
 
 test.describe("Confirm community toolbar works for member user", () => {
+  const memberEmail = process.env.TESTS_MEMBER_EMAIL
+  const memberPassword = process.env.TESTS_MEMBER_PASSWORD
+  const memberName = process.env.TESTS_MEMBER_NAME
+
+  test.skip(
+    !memberEmail || !memberPassword || !memberName,
+    "Skipping community toolbar tests for member user: required secrets are missing. This typically happens on a PR from a fork where secrets are not available.",
+  )
+
   test.use({ storageState: "./tests/.auth/member.json" })
   test("Confirm community buttons in toolbar behave as expected", async ({
     configListPage,


### PR DESCRIPTION
This guards tests that require secrets for user authentication. 
These tests will fail for PRs from forked repos.