### PR TITLE
Fix translation and playwright workflow

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -34,5 +34,5 @@ jobs:
       if: ${{ !cancelled() }}
       with:
         name: playwright-report
-        path: frontend/playwright-report/
+        path: src/MobiFlightConnector/frontend/playwright-report/
         retention-days: 30

--- a/.github/workflows/translations.post-comment.yml
+++ b/.github/workflows/translations.post-comment.yml
@@ -10,8 +10,7 @@ jobs:
   comment:
     if: >
       github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.pull_requests[0] != null
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
 
     permissions:
@@ -20,17 +19,21 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Download translation stats
+      - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          name: translation-stats
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          path: translation-stats
+          pattern: "translation-stats|pr-number"
+          merge-multiple: false
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number/pr-number.txt)" >> $GITHUB_OUTPUT
 
       - name: Post translation stats
         uses: marocchino/sticky-pull-request-comment@v3
         with:
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ steps.pr.outputs.number }}
           path: translation-stats/translation-stats.md
           header: translation-stats

--- a/.github/workflows/translations.post-comment.yml
+++ b/.github/workflows/translations.post-comment.yml
@@ -19,7 +19,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Download artifacts
+      - name: Download translation stats and PR number
         uses: actions/download-artifact@v4
         with:
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -35,3 +35,14 @@ jobs:
           name: translation-stats
           path: src/MobiFlightConnector/frontend/translation-stats.md
           if-no-files-found: error
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: echo "$PR_NUMBER" > pr-number.txt
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr-number.txt
+          if-no-files-found: warn


### PR DESCRIPTION
Translation workflow will store PR number successfully even if PR is from for.
Playwright workflow will use correct path for uploading the report