### PR TITLE
Register file associations for .mfproj and .mmc files during installation (requires uninstall and reinstall)

### DIFF
--- a/Build/setup.nsi
+++ b/Build/setup.nsi
@@ -140,7 +140,7 @@ Section "uninstall"
     
     # Remove file associations
     DeleteRegKey HKCU "Software\Classes\.mfproj"
-    DeleteRegKey HKCU "Software\Classes\.mmc"
+    DeleteRegKey HKCU "Software\Classes\.mcc"
     DeleteRegKey HKCU "Software\Classes\MobiFlight.Project"
     
     # Notify Windows of file association changes

--- a/Build/setup.nsi
+++ b/Build/setup.nsi
@@ -73,6 +73,9 @@ Section "install"
 
     ExecWait '"$INSTDIR\MobiFlight-Installer.exe" /installOnly'
  
+    # Register file associations for .mfproj and .mmc files
+    Call RegisterFileAssociations
+ 
     # create a shortcut named "new shortcut" in the start menu programs directory
     # point the new shortcut at the program uninstaller
     CreateShortcut "$SMPROGRAMS\${APPNAME}.lnk" "$INSTDIR\MFConnector.exe"
@@ -85,6 +88,27 @@ Section "install"
 	WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "NoRepair" 1
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "EstimatedSize" 45000
 SectionEnd
+
+# Register file associations for .mfproj and .mmc files
+Function RegisterFileAssociations
+    SetRegView 64
+    
+    # Register .mfproj file type
+    WriteRegStr HKCU "Software\Classes\.mfproj" "" "MobiFlight.Project"
+    WriteRegStr HKCU "Software\Classes\.mfproj" "Content Type" "application/x-mfproj"
+    
+    # Register .mmc file type (legacy format)
+    WriteRegStr HKCU "Software\Classes\.mmc" "" "MobiFlight.Project"
+    WriteRegStr HKCU "Software\Classes\.mmc" "Content Type" "application/x-mmc"
+    
+    # Configure MobiFlight.Project class
+    WriteRegStr HKCU "Software\Classes\MobiFlight.Project" "" "MobiFlight Project"
+    WriteRegStr HKCU "Software\Classes\MobiFlight.Project\DefaultIcon" "" "$INSTDIR\mobiflight.ico"
+    WriteRegStr HKCU "Software\Classes\MobiFlight.Project\shell\open\command" "" "$\"$INSTDIR\MFConnector.exe$\" $\"%1$\""
+    
+    # Notify Windows of file association changes
+    System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
+FunctionEnd
 
 Function un.onInit
     System::Call 'kernel32::OpenMutex(i 0x100000, i 0, t "{57699317-1D72-4B54-82BC-CF6B38254550}")p.R0'
@@ -113,5 +137,13 @@ Section "uninstall"
     RMDir /r $LOCALAPPDATA\MobiFlight
 
     DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}"
+    
+    # Remove file associations
+    DeleteRegKey HKCU "Software\Classes\.mfproj"
+    DeleteRegKey HKCU "Software\Classes\.mmc"
+    DeleteRegKey HKCU "Software\Classes\MobiFlight.Project"
+    
+    # Notify Windows of file association changes
+    System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'
 # uninstaller section end
 SectionEnd

--- a/Build/setup.nsi
+++ b/Build/setup.nsi
@@ -104,7 +104,7 @@ Function RegisterFileAssociations
     # Configure MobiFlight.Project class
     WriteRegStr HKCU "Software\Classes\MobiFlight.Project" "" "MobiFlight Project"
     WriteRegStr HKCU "Software\Classes\MobiFlight.Project\DefaultIcon" "" "$INSTDIR\mobiflight.ico"
-    WriteRegStr HKCU "Software\Classes\MobiFlight.Project\shell\open\command" "" "$\"$INSTDIR\MFConnector.exe$\" $\"%1$\""
+    WriteRegStr HKCU "Software\Classes\MobiFlight.Project\shell\open\command" "" "$\"$INSTDIR\MFConnector.exe$\" /cfg $\"%1$\""
     
     # Notify Windows of file association changes
     System::Call 'Shell32::SHChangeNotify(i 0x8000000, i 0, i 0, i 0)'

--- a/Build/setup.nsi
+++ b/Build/setup.nsi
@@ -89,7 +89,7 @@ Section "install"
     WriteRegDWORD HKCU "SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\${APPNAME}" "EstimatedSize" 45000
 SectionEnd
 
-# Register file associations for .mfproj and .mmc files
+# Register file associations for .mfproj and .mcc files
 Function RegisterFileAssociations
     SetRegView 64
     

--- a/Build/setup.nsi
+++ b/Build/setup.nsi
@@ -73,7 +73,7 @@ Section "install"
 
     ExecWait '"$INSTDIR\MobiFlight-Installer.exe" /installOnly'
  
-    # Register file associations for .mfproj and .mmc files
+    # Register file associations for .mfproj and .mcc files
     Call RegisterFileAssociations
  
     # create a shortcut named "new shortcut" in the start menu programs directory

--- a/Build/setup.nsi
+++ b/Build/setup.nsi
@@ -97,9 +97,9 @@ Function RegisterFileAssociations
     WriteRegStr HKCU "Software\Classes\.mfproj" "" "MobiFlight.Project"
     WriteRegStr HKCU "Software\Classes\.mfproj" "Content Type" "application/x-mfproj"
     
-    # Register .mmc file type (legacy format)
-    WriteRegStr HKCU "Software\Classes\.mmc" "" "MobiFlight.Project"
-    WriteRegStr HKCU "Software\Classes\.mmc" "Content Type" "application/x-mmc"
+    # Register .mcc file type (legacy format)
+    WriteRegStr HKCU "Software\Classes\.mcc" "" "MobiFlight.Project"
+    WriteRegStr HKCU "Software\Classes\.mcc" "Content Type" "application/x-mcc"
     
     # Configure MobiFlight.Project class
     WriteRegStr HKCU "Software\Classes\MobiFlight.Project" "" "MobiFlight Project"


### PR DESCRIPTION
This was generated by Copilot, I don't actually know if it works.

## Description

This PR fixes issue #2969 by registering file associations for `.mfproj` and `.mmc` files during installation. Users can now double-click these files in File Explorer to open them directly in MobiFlight.

## Problem Being Solved

When users double-click a `.mfproj` or `.mmc` file in Windows File Explorer, Windows doesn't recognize MobiFlight as the associated application. This forces users to manually select an application to open the file with, and MobiFlight doesn't appear in the suggestions.

## Implementation Details

The installer (`Build/setup.nsi`) has been updated to register the file associations during installation:

### Installation Phase
- Creates file type associations for `.mfproj` and `.mmc` extensions
- Associates both extensions with the `MobiFlight.Project` ProgId
- Registers the icon and open command in the Windows registry
- Uses the already-implemented command-line parameter feature to pass the file path to MobiFlight

### Uninstallation Phase
- Removes all registered file associations
- Cleans up related registry keys

## Registry Changes

The implementation writes to `HKCU` (current user) registry hive, which:
- Works with standard user permissions (no admin required)
- Is scoped to the current user (aligns with the installer's user-level execution)
- Allows each user to have their own file associations

## Fixes

Closes #2969