### PR TITLE
Fix editing in ControllerBindingsDialog's dropdown search field

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableBody.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableBody.tsx
@@ -30,6 +30,15 @@ const ConfigItemTableBody = forwardRef<
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement
+  
+      const isInputField = 
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable === true
+
+      if (isInputField) return // bail out when an editable widget has focus
+
       const supportedKeyPress = ["Delete", " ", "Enter", "Escape", "Backspace"]
 
       if (!supportedKeyPress.includes(e.key)) return

--- a/src/MobiFlightConnector/frontend/src/components/ui/command.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/ui/command.tsx
@@ -42,7 +42,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 select-text",
         className
       )}
       {...props}


### PR DESCRIPTION
I wasnt expecting to procrastinate by fiddling with html and css, but here we are.

- ~~remove `select-none` from top level ControllerBindingsDialog~~ not the case anymore
- add `select-text` to CommandInput component instead, so it is enabled on all input fields
- stop ConfigItemTable's EventListener from eating our keystrokes if we are in a text field (it's active when ControllerBindingDialog is open)

Fixes #2971 