### PR TITLE
Add running/stopped state badge to taskbar icon. Kill tray minimize

### DIFF
--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -514,6 +514,10 @@
     <Compile Include="SimConnectMSFS\SimConnectDefinitions.cs" />
     <Compile Include="SimConnectMSFS\WasmModuleClientData.cs" />
     <Compile Include="SimConnectMSFS\WasmModuleUpdater.cs" />
+    <Compile Include="UI\StateBadge\BadgedIcon.cs" />
+    <Compile Include="UI\StateBadge\StateBadgeRenderer.cs" />
+    <Compile Include="UI\StateBadge\TaskbarOverlay.cs" />
+    <Compile Include="UI\StateBadge\RunningStateIconBadge.cs" />
     <Compile Include="UI\Dialogs\AboutForm.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/src/MobiFlightConnector/ProjectMessages/ProjectMessages.de.resx
+++ b/src/MobiFlightConnector/ProjectMessages/ProjectMessages.de.resx
@@ -704,4 +704,7 @@ Website wird nach Betätigung von OK geöffnet.</value>
   <data name="uiMessagePythonHint" xml:space="preserve">
     <value>Python Umgebung nicht bereit</value>
   </data>
+  <data name="uiLabelTrayTooltipFormat" xml:space="preserve">
+    <value>MFConnector - {0}</value>
+  </data>
 </root>

--- a/src/MobiFlightConnector/ProjectMessages/ProjectMessages.resx
+++ b/src/MobiFlightConnector/ProjectMessages/ProjectMessages.resx
@@ -669,4 +669,7 @@ Page will be opened, when pressing OK.</value>
   <data name="uiMessagePythonHint" xml:space="preserve">
     <value>Python environment not ready</value>
   </data>
+  <data name="uiLabelTrayTooltipFormat" xml:space="preserve">
+    <value>MobiFlight - {0}</value>
+  </data>
 </root>

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -1807,11 +1807,202 @@ namespace MobiFlight.UI
 
                 // The Stop entry
                 contextMenuStripNotifyIcon.Items[1].Enabled = isRunning;
+
+                UpdateNotifyIconBadge(isRunning);
             }
             catch (Exception ex)
             {
                 // do nothing
                 Log.Instance.log(ex.Message, LogSeverity.Info);
+            }
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern bool DestroyIcon(IntPtr handle);
+
+        // We stash the designer-loaded base icons on first use, then for each state
+        // change build fresh HICONs via Bitmap.GetHicon() and hand them to the
+        // NotifyIcon and the Form. GetHicon() returns an unmanaged handle that we
+        // own — we must DestroyIcon the previous one when swapping, or we leak a
+        // GDI handle per toggle. Tray and form icons are built from their own
+        // base icons so each retains its native resolution (the tray is typically
+        // 16x16, the form/taskbar icon is larger).
+        private Icon notifyIconBaseIcon;
+        private Icon notifyIconBadged;
+        private IntPtr notifyIconBadgedHandle = IntPtr.Zero;
+
+        private Icon formIconBase;
+        private Icon formIconBadged;
+        private IntPtr formIconBadgedHandle = IntPtr.Zero;
+
+        // Taskbar overlay badge (works for pinned launcher icons while the app
+        // is running; SetOverlayIcon layers a small icon on top of whatever the
+        // taskbar is already showing).
+        private Icon taskbarOverlayIcon;
+        private IntPtr taskbarOverlayIconHandle = IntPtr.Zero;
+        private ITaskbarList3 taskbarList;
+        private bool taskbarListInitFailed;
+
+        private void UpdateNotifyIconBadge(bool isRunning)
+        {
+            if (notifyIconBaseIcon == null) notifyIconBaseIcon = notifyIcon.Icon;
+            if (formIconBase == null) formIconBase = this.Icon;
+
+            if (notifyIconBaseIcon != null)
+            {
+                IntPtr newHandle;
+                var newIcon = BuildBadgedIcon(notifyIconBaseIcon, isRunning, out newHandle);
+                notifyIcon.Icon = newIcon;
+
+                notifyIconBadged?.Dispose();
+                if (notifyIconBadgedHandle != IntPtr.Zero) DestroyIcon(notifyIconBadgedHandle);
+                notifyIconBadged = newIcon;
+                notifyIconBadgedHandle = newHandle;
+            }
+
+            if (formIconBase != null)
+            {
+                IntPtr newHandle;
+                var newIcon = BuildBadgedIcon(formIconBase, isRunning, out newHandle);
+                this.Icon = newIcon;
+
+                formIconBadged?.Dispose();
+                if (formIconBadgedHandle != IntPtr.Zero) DestroyIcon(formIconBadgedHandle);
+                formIconBadged = newIcon;
+                formIconBadgedHandle = newHandle;
+            }
+
+            UpdateTaskbarOverlay(isRunning);
+
+            notifyIcon.Text = "MobiFlight - " + (isRunning ? "Running" : "Stopped");
+        }
+
+        private void UpdateTaskbarOverlay(bool isRunning)
+        {
+            if (taskbarListInitFailed) return;
+            if (!this.IsHandleCreated) return; // can't overlay a window that has no HWND yet
+
+            try
+            {
+                if (taskbarList == null)
+                {
+                    taskbarList = (ITaskbarList3)new TaskbarInstance();
+                    taskbarList.HrInit();
+                }
+
+                IntPtr newHandle;
+                var newIcon = BuildOverlayIcon(isRunning, out newHandle);
+                string description = isRunning ? "Running" : "Stopped";
+                taskbarList.SetOverlayIcon(this.Handle, newHandle, description);
+
+                taskbarOverlayIcon?.Dispose();
+                if (taskbarOverlayIconHandle != IntPtr.Zero) DestroyIcon(taskbarOverlayIconHandle);
+                taskbarOverlayIcon = newIcon;
+                taskbarOverlayIconHandle = newHandle;
+            }
+            catch (Exception ex)
+            {
+                // Pre-Win7 or no shell — give up silently.
+                taskbarListInitFailed = true;
+                Log.Instance.log("Taskbar overlay unavailable: " + ex.Message, LogSeverity.Info);
+            }
+        }
+
+        private static Icon BuildOverlayIcon(bool isRunning, out IntPtr hIcon)
+        {
+            // Overlay is drawn small (Windows displays it at ~16x16 in the corner
+            // of the taskbar icon). We render JUST the colored shape on a
+            // transparent background — no app icon underneath.
+            const int size = 16;
+            using (var bmp = new Bitmap(size, size))
+            using (var g = Graphics.FromImage(bmp))
+            {
+                g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+                var rect = new Rectangle(1, 1, size - 3, size - 3);
+                Color fill = isRunning ? Color.FromArgb(40, 200, 80) : Color.FromArgb(220, 50, 50);
+                using (var brush = new SolidBrush(fill))
+                using (var pen = new Pen(Color.FromArgb(220, 0, 0, 0), 1f))
+                {
+                    if (isRunning) { g.FillEllipse(brush, rect); g.DrawEllipse(pen, rect); }
+                    else { g.FillRectangle(brush, rect); g.DrawRectangle(pen, rect); }
+                }
+                hIcon = bmp.GetHicon();
+                return Icon.FromHandle(hIcon);
+            }
+        }
+
+        // COM interop for ITaskbarList3 — the shell interface that backs the Win7+
+        // taskbar API (progress bars, overlay icons, etc.). Discord/Slack use the
+        // same SetOverlayIcon call to put a small badge on the taskbar button.
+        // Methods MUST be declared in vtable order; we stop after SetOverlayIcon
+        // since we don't call any of the methods that come after it.
+        [ComImport]
+        [Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface ITaskbarList3
+        {
+            // ITaskbarList
+            void HrInit();
+            void AddTab(IntPtr hwnd);
+            void DeleteTab(IntPtr hwnd);
+            void ActivateTab(IntPtr hwnd);
+            void SetActiveAlt(IntPtr hwnd);
+            // ITaskbarList2
+            void MarkFullscreenWindow(IntPtr hwnd, [MarshalAs(UnmanagedType.Bool)] bool fFullscreen);
+            // ITaskbarList3 (only up through SetOverlayIcon — slots after are unused)
+            void SetProgressValue(IntPtr hwnd, ulong ullCompleted, ulong ullTotal);
+            void SetProgressState(IntPtr hwnd, int tbpFlags);
+            void RegisterTab(IntPtr hwndTab, IntPtr hwndMDI);
+            void UnregisterTab(IntPtr hwndTab);
+            void SetTabOrder(IntPtr hwndTab, IntPtr hwndInsertBefore);
+            void SetTabActive(IntPtr hwndTab, IntPtr hwndMDI, uint dwReserved);
+            void ThumbBarAddButtons(IntPtr hwnd, uint cButtons, IntPtr pButton);
+            void ThumbBarUpdateButtons(IntPtr hwnd, uint cButtons, IntPtr pButton);
+            void ThumbBarSetImageList(IntPtr hwnd, IntPtr himl);
+            void SetOverlayIcon(IntPtr hwnd, IntPtr hIcon, [MarshalAs(UnmanagedType.LPWStr)] string pszDescription);
+        }
+
+        [ComImport]
+        [Guid("56FDF344-FD6D-11d0-958A-006097C9A090")]
+        [ClassInterface(ClassInterfaceType.None)]
+        private class TaskbarInstance { }
+
+        private static Icon BuildBadgedIcon(Icon baseIcon, bool isRunning, out IntPtr hIcon)
+        {
+            // Render at the icon's native size (typically 32x32 in the tray on modern Windows).
+            int size = baseIcon.Width;
+            using (var bmp = new Bitmap(size, size))
+            using (var g = Graphics.FromImage(bmp))
+            {
+                g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+                g.DrawIcon(baseIcon, new Rectangle(0, 0, size, size));
+
+                // Badge: ~40% of icon size, anchored bottom-right.
+                // Running = green circle, Stopped = red square.
+                int badgeSize = Math.Max(8, (int)(size * 0.4f));
+                int x = size - badgeSize - 1;
+                int y = size - badgeSize - 1;
+                var badgeRect = new Rectangle(x, y, badgeSize, badgeSize);
+
+                Color fill = isRunning ? Color.FromArgb(40, 200, 80) : Color.FromArgb(220, 50, 50);
+                using (var brush = new SolidBrush(fill))
+                using (var pen = new Pen(Color.FromArgb(220, 0, 0, 0), Math.Max(1f, size / 32f)))
+                {
+                    if (isRunning)
+                    {
+                        g.FillEllipse(brush, badgeRect);
+                        g.DrawEllipse(pen, badgeRect);
+                    }
+                    else
+                    {
+                        g.FillRectangle(brush, badgeRect);
+                        g.DrawRectangle(pen, badgeRect);
+                    }
+                }
+
+                hIcon = bmp.GetHicon();
+                // Icon.FromHandle does not own the handle; caller (us) must DestroyIcon it later.
+                return Icon.FromHandle(hIcon);
             }
         }
 
@@ -1876,10 +2067,6 @@ namespace MobiFlight.UI
             if (minimized)
             {
                 notifyIcon.Visible = true;
-                notifyIcon.BalloonTipTitle = i18n._tr("uiMessageMFConnectorInterfaceActive");
-                notifyIcon.BalloonTipText = i18n._tr("uiMessageApplicationIsRunningInBackgroundMode");
-                notifyIcon.ShowBalloonTip(1000);
-                this.Hide();
             }
             else
             {

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -27,6 +27,7 @@ using System.Drawing;
 using MobiFlight.BrowserMessages.Incoming.Handler;
 using System.ComponentModel;
 using MobiFlight.Controllers;
+using MobiFlight.UI.StateBadge;
 
 namespace MobiFlight.UI
 {
@@ -903,6 +904,7 @@ namespace MobiFlight.UI
             SaveWindowPositionAndZoomLevel();
             Properties.Settings.Default.Save();
             logPanel1.Shutdown();
+            runningStateBadge?.Dispose();
         } //Form1_FormClosed
 
         private void SaveWindowPositionAndZoomLevel()
@@ -1631,6 +1633,7 @@ namespace MobiFlight.UI
                 execManager.Start();
                 if (Properties.Settings.Default.MinimizeOnAutoRun)
                 {
+                    this.WindowState = FormWindowState.Minimized;
                     minimizeMainForm(true);
                 }
             }
@@ -1808,7 +1811,9 @@ namespace MobiFlight.UI
                 // The Stop entry
                 contextMenuStripNotifyIcon.Items[1].Enabled = isRunning;
 
-                UpdateNotifyIconBadge(isRunning);
+                if (runningStateBadge == null)
+                    runningStateBadge = new RunningStateIconBadge(notifyIcon, this);
+                runningStateBadge.Update(isRunning);
             }
             catch (Exception ex)
             {
@@ -1817,194 +1822,7 @@ namespace MobiFlight.UI
             }
         }
 
-        [DllImport("user32.dll", CharSet = CharSet.Auto)]
-        private static extern bool DestroyIcon(IntPtr handle);
-
-        // We stash the designer-loaded base icons on first use, then for each state
-        // change build fresh HICONs via Bitmap.GetHicon() and hand them to the
-        // NotifyIcon and the Form. GetHicon() returns an unmanaged handle that we
-        // own — we must DestroyIcon the previous one when swapping, or we leak a
-        // GDI handle per toggle. Tray and form icons are built from their own
-        // base icons so each retains its native resolution (the tray is typically
-        // 16x16, the form/taskbar icon is larger).
-        private Icon notifyIconBaseIcon;
-        private Icon notifyIconBadged;
-        private IntPtr notifyIconBadgedHandle = IntPtr.Zero;
-
-        private Icon formIconBase;
-        private Icon formIconBadged;
-        private IntPtr formIconBadgedHandle = IntPtr.Zero;
-
-        // Taskbar overlay badge (works for pinned launcher icons while the app
-        // is running; SetOverlayIcon layers a small icon on top of whatever the
-        // taskbar is already showing).
-        private Icon taskbarOverlayIcon;
-        private IntPtr taskbarOverlayIconHandle = IntPtr.Zero;
-        private ITaskbarList3 taskbarList;
-        private bool taskbarListInitFailed;
-
-        private void UpdateNotifyIconBadge(bool isRunning)
-        {
-            if (notifyIconBaseIcon == null) notifyIconBaseIcon = notifyIcon.Icon;
-            if (formIconBase == null) formIconBase = this.Icon;
-
-            if (notifyIconBaseIcon != null)
-            {
-                IntPtr newHandle;
-                var newIcon = BuildBadgedIcon(notifyIconBaseIcon, isRunning, out newHandle);
-                notifyIcon.Icon = newIcon;
-
-                notifyIconBadged?.Dispose();
-                if (notifyIconBadgedHandle != IntPtr.Zero) DestroyIcon(notifyIconBadgedHandle);
-                notifyIconBadged = newIcon;
-                notifyIconBadgedHandle = newHandle;
-            }
-
-            if (formIconBase != null)
-            {
-                IntPtr newHandle;
-                var newIcon = BuildBadgedIcon(formIconBase, isRunning, out newHandle);
-                this.Icon = newIcon;
-
-                formIconBadged?.Dispose();
-                if (formIconBadgedHandle != IntPtr.Zero) DestroyIcon(formIconBadgedHandle);
-                formIconBadged = newIcon;
-                formIconBadgedHandle = newHandle;
-            }
-
-            UpdateTaskbarOverlay(isRunning);
-
-            notifyIcon.Text = "MobiFlight - " + (isRunning ? "Running" : "Stopped");
-        }
-
-        private void UpdateTaskbarOverlay(bool isRunning)
-        {
-            if (taskbarListInitFailed) return;
-            if (!this.IsHandleCreated) return; // can't overlay a window that has no HWND yet
-
-            try
-            {
-                if (taskbarList == null)
-                {
-                    taskbarList = (ITaskbarList3)new TaskbarInstance();
-                    taskbarList.HrInit();
-                }
-
-                IntPtr newHandle;
-                var newIcon = BuildOverlayIcon(isRunning, out newHandle);
-                string description = isRunning ? "Running" : "Stopped";
-                taskbarList.SetOverlayIcon(this.Handle, newHandle, description);
-
-                taskbarOverlayIcon?.Dispose();
-                if (taskbarOverlayIconHandle != IntPtr.Zero) DestroyIcon(taskbarOverlayIconHandle);
-                taskbarOverlayIcon = newIcon;
-                taskbarOverlayIconHandle = newHandle;
-            }
-            catch (Exception ex)
-            {
-                // Pre-Win7 or no shell — give up silently.
-                taskbarListInitFailed = true;
-                Log.Instance.log("Taskbar overlay unavailable: " + ex.Message, LogSeverity.Info);
-            }
-        }
-
-        private static Icon BuildOverlayIcon(bool isRunning, out IntPtr hIcon)
-        {
-            // Overlay is drawn small (Windows displays it at ~16x16 in the corner
-            // of the taskbar icon). We render JUST the colored shape on a
-            // transparent background — no app icon underneath.
-            const int size = 16;
-            using (var bmp = new Bitmap(size, size))
-            using (var g = Graphics.FromImage(bmp))
-            {
-                g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
-                var rect = new Rectangle(1, 1, size - 3, size - 3);
-                Color fill = isRunning ? Color.FromArgb(40, 200, 80) : Color.FromArgb(220, 50, 50);
-                using (var brush = new SolidBrush(fill))
-                using (var pen = new Pen(Color.FromArgb(220, 0, 0, 0), 1f))
-                {
-                    if (isRunning) { g.FillEllipse(brush, rect); g.DrawEllipse(pen, rect); }
-                    else { g.FillRectangle(brush, rect); g.DrawRectangle(pen, rect); }
-                }
-                hIcon = bmp.GetHicon();
-                return Icon.FromHandle(hIcon);
-            }
-        }
-
-        // COM interop for ITaskbarList3 — the shell interface that backs the Win7+
-        // taskbar API (progress bars, overlay icons, etc.). Discord/Slack use the
-        // same SetOverlayIcon call to put a small badge on the taskbar button.
-        // Methods MUST be declared in vtable order; we stop after SetOverlayIcon
-        // since we don't call any of the methods that come after it.
-        [ComImport]
-        [Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]
-        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-        private interface ITaskbarList3
-        {
-            // ITaskbarList
-            void HrInit();
-            void AddTab(IntPtr hwnd);
-            void DeleteTab(IntPtr hwnd);
-            void ActivateTab(IntPtr hwnd);
-            void SetActiveAlt(IntPtr hwnd);
-            // ITaskbarList2
-            void MarkFullscreenWindow(IntPtr hwnd, [MarshalAs(UnmanagedType.Bool)] bool fFullscreen);
-            // ITaskbarList3 (only up through SetOverlayIcon — slots after are unused)
-            void SetProgressValue(IntPtr hwnd, ulong ullCompleted, ulong ullTotal);
-            void SetProgressState(IntPtr hwnd, int tbpFlags);
-            void RegisterTab(IntPtr hwndTab, IntPtr hwndMDI);
-            void UnregisterTab(IntPtr hwndTab);
-            void SetTabOrder(IntPtr hwndTab, IntPtr hwndInsertBefore);
-            void SetTabActive(IntPtr hwndTab, IntPtr hwndMDI, uint dwReserved);
-            void ThumbBarAddButtons(IntPtr hwnd, uint cButtons, IntPtr pButton);
-            void ThumbBarUpdateButtons(IntPtr hwnd, uint cButtons, IntPtr pButton);
-            void ThumbBarSetImageList(IntPtr hwnd, IntPtr himl);
-            void SetOverlayIcon(IntPtr hwnd, IntPtr hIcon, [MarshalAs(UnmanagedType.LPWStr)] string pszDescription);
-        }
-
-        [ComImport]
-        [Guid("56FDF344-FD6D-11d0-958A-006097C9A090")]
-        [ClassInterface(ClassInterfaceType.None)]
-        private class TaskbarInstance { }
-
-        private static Icon BuildBadgedIcon(Icon baseIcon, bool isRunning, out IntPtr hIcon)
-        {
-            // Render at the icon's native size (typically 32x32 in the tray on modern Windows).
-            int size = baseIcon.Width;
-            using (var bmp = new Bitmap(size, size))
-            using (var g = Graphics.FromImage(bmp))
-            {
-                g.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
-                g.DrawIcon(baseIcon, new Rectangle(0, 0, size, size));
-
-                // Badge: ~40% of icon size, anchored bottom-right.
-                // Running = green circle, Stopped = red square.
-                int badgeSize = Math.Max(8, (int)(size * 0.4f));
-                int x = size - badgeSize - 1;
-                int y = size - badgeSize - 1;
-                var badgeRect = new Rectangle(x, y, badgeSize, badgeSize);
-
-                Color fill = isRunning ? Color.FromArgb(40, 200, 80) : Color.FromArgb(220, 50, 50);
-                using (var brush = new SolidBrush(fill))
-                using (var pen = new Pen(Color.FromArgb(220, 0, 0, 0), Math.Max(1f, size / 32f)))
-                {
-                    if (isRunning)
-                    {
-                        g.FillEllipse(brush, badgeRect);
-                        g.DrawEllipse(pen, badgeRect);
-                    }
-                    else
-                    {
-                        g.FillRectangle(brush, badgeRect);
-                        g.DrawRectangle(pen, badgeRect);
-                    }
-                }
-
-                hIcon = bmp.GetHicon();
-                // Icon.FromHandle does not own the handle; caller (us) must DestroyIcon it later.
-                return Icon.FromHandle(hIcon);
-            }
-        }
+        private RunningStateIconBadge runningStateBadge;
 
         /// <summary>
         /// present errors to user via message dialog or when minimized via balloon

--- a/src/MobiFlightConnector/UI/Panels/Settings/GeneralPanel.de.resx
+++ b/src/MobiFlightConnector/UI/Panels/Settings/GeneralPanel.de.resx
@@ -154,7 +154,7 @@
     <value>"Run" Optionen</value>
   </data>
   <data name="minimizeOnAutoRunCheckbox.Text" xml:space="preserve">
-    <value>Bei AutoRun in Task Leiste minimieren</value>
+    <value>Bei AutoRun minimieren</value>
   </data>
   <data name="autoRetriggerCheckBox.Text" xml:space="preserve">
     <value>Automatisch retrigger-action mit "run"-Mode ausführen.</value>

--- a/src/MobiFlightConnector/UI/Panels/Settings/GeneralPanel.resx
+++ b/src/MobiFlightConnector/UI/Panels/Settings/GeneralPanel.resx
@@ -884,7 +884,7 @@
     <value>1</value>
   </data>
   <data name="minimizeOnAutoRunCheckbox.Text" xml:space="preserve">
-    <value>Minimize to system tray on AutoRun</value>
+    <value>Minimize on AutoRun</value>
   </data>
   <data name="&gt;&gt;minimizeOnAutoRunCheckbox.Name" xml:space="preserve">
     <value>minimizeOnAutoRunCheckbox</value>

--- a/src/MobiFlightConnector/UI/StateBadge/BadgedIcon.cs
+++ b/src/MobiFlightConnector/UI/StateBadge/BadgedIcon.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Drawing;
+using System.Runtime.InteropServices;
+
+namespace MobiFlight.UI.StateBadge
+{
+    // Owns a managed Icon together with the unmanaged HICON that backs it.
+    // Bitmap.GetHicon() returns a handle the caller must DestroyIcon — Icon.FromHandle
+    // does not take ownership — so this pair has to be disposed as a unit or
+    // every state toggle leaks one GDI icon handle.
+    internal sealed class BadgedIcon : IDisposable
+    {
+        [DllImport("user32.dll", CharSet = CharSet.Auto)]
+        private static extern bool DestroyIcon(IntPtr handle);
+
+        public Icon Icon { get; }
+        public IntPtr Handle { get; }
+
+        public BadgedIcon(Icon icon, IntPtr handle)
+        {
+            Icon = icon;
+            Handle = handle;
+        }
+
+        public void Dispose()
+        {
+            Icon?.Dispose();
+            if (Handle != IntPtr.Zero) DestroyIcon(Handle);
+        }
+    }
+}

--- a/src/MobiFlightConnector/UI/StateBadge/RunningStateIconBadge.cs
+++ b/src/MobiFlightConnector/UI/StateBadge/RunningStateIconBadge.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace MobiFlight.UI.StateBadge
+{
+    // Orchestrates the three places the running/stopped state is shown:
+    //   - the system tray icon
+    //   - the form's titlebar icon
+    //   - the Windows taskbar overlay (pinned/visible while the app is running)
+    //
+    // The designer-loaded base icons are stashed on first use so we can keep
+    // re-composing badges over the originals across many state toggles.
+    internal sealed class RunningStateIconBadge : IDisposable
+    {
+        private readonly NotifyIcon notifyIcon;
+        private readonly Form form;
+        private readonly TaskbarOverlay taskbarOverlay = new TaskbarOverlay();
+
+        private Icon notifyIconBase;
+        private Icon formIconBase;
+
+        private BadgedIcon currentNotifyIcon;
+        private BadgedIcon currentFormIcon;
+
+        public RunningStateIconBadge(NotifyIcon notifyIcon, Form form)
+        {
+            this.notifyIcon = notifyIcon;
+            this.form = form;
+        }
+
+        public void Update(bool isRunning)
+        {
+            if (notifyIconBase == null) notifyIconBase = notifyIcon.Icon;
+            if (formIconBase == null) formIconBase = form.Icon;
+
+            if (notifyIconBase != null)
+            {
+                var next = StateBadgeRenderer.BuildBadgedIcon(notifyIconBase, isRunning);
+                notifyIcon.Icon = next.Icon;
+                currentNotifyIcon?.Dispose();
+                currentNotifyIcon = next;
+            }
+
+            if (formIconBase != null)
+            {
+                var next = StateBadgeRenderer.BuildBadgedIcon(formIconBase, isRunning);
+                form.Icon = next.Icon;
+                currentFormIcon?.Dispose();
+                currentFormIcon = next;
+            }
+
+            string stateLabel = i18n._tr(isRunning ? "Running" : "Stopped");
+
+            if (form.IsHandleCreated)
+            {
+                taskbarOverlay.Set(form.Handle, isRunning, stateLabel);
+            }
+
+            notifyIcon.Text = string.Format(i18n._tr("uiLabelTrayTooltipFormat"), stateLabel);
+        }
+
+        public void Dispose()
+        {
+            currentNotifyIcon?.Dispose();
+            currentFormIcon?.Dispose();
+            taskbarOverlay.Dispose();
+        }
+    }
+}

--- a/src/MobiFlightConnector/UI/StateBadge/StateBadgeRenderer.cs
+++ b/src/MobiFlightConnector/UI/StateBadge/StateBadgeRenderer.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+namespace MobiFlight.UI.StateBadge
+{
+    // Pure drawing helpers for the running/stopped badge. No window/icon state lives
+    // here — callers own the resulting BadgedIcon and decide when to swap it in.
+    internal static class StateBadgeRenderer
+    {
+        private static readonly Color RunningFill = Color.FromArgb(40, 200, 80);
+        private static readonly Color StoppedFill = Color.FromArgb(220, 50, 50);
+        private static readonly Color OutlineColor = Color.FromArgb(220, 0, 0, 0);
+
+        // Composite a small state badge onto the top-right of baseIcon at its
+        // native resolution, matching where Windows draws the taskbar overlay.
+        // Running = green circle, stopped = red square.
+        public static BadgedIcon BuildBadgedIcon(Icon baseIcon, bool isRunning)
+        {
+            int size = baseIcon.Width;
+            using (var bmp = new Bitmap(size, size))
+            using (var g = Graphics.FromImage(bmp))
+            {
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                g.DrawIcon(baseIcon, new Rectangle(0, 0, size, size));
+
+                int badgeSize = Math.Max(8, (int)(size * 0.4f));
+                int x = size - badgeSize - 1;
+                int y = 1;
+                var badgeRect = new Rectangle(x, y, badgeSize, badgeSize);
+
+                DrawBadgeShape(g, badgeRect, isRunning, Math.Max(1f, size / 32f));
+
+                IntPtr hIcon = bmp.GetHicon();
+                return new BadgedIcon(Icon.FromHandle(hIcon), hIcon);
+            }
+        }
+
+        // Standalone overlay icon (no underlying app glyph) — Windows draws this
+        // small in the corner of the taskbar button via ITaskbarList3.SetOverlayIcon.
+        public static BadgedIcon BuildOverlayIcon(bool isRunning)
+        {
+            const int size = 16;
+            using (var bmp = new Bitmap(size, size))
+            using (var g = Graphics.FromImage(bmp))
+            {
+                g.SmoothingMode = SmoothingMode.AntiAlias;
+                var rect = new Rectangle(1, 1, size - 3, size - 3);
+                DrawBadgeShape(g, rect, isRunning, 1f);
+
+                IntPtr hIcon = bmp.GetHicon();
+                return new BadgedIcon(Icon.FromHandle(hIcon), hIcon);
+            }
+        }
+
+        private static void DrawBadgeShape(Graphics g, Rectangle rect, bool isRunning, float penWidth)
+        {
+            Color fill = isRunning ? RunningFill : StoppedFill;
+            using (var brush = new SolidBrush(fill))
+            using (var pen = new Pen(OutlineColor, penWidth))
+            {
+                if (isRunning)
+                {
+                    g.FillEllipse(brush, rect);
+                    g.DrawEllipse(pen, rect);
+                }
+                else
+                {
+                    g.FillRectangle(brush, rect);
+                    g.DrawRectangle(pen, rect);
+                }
+            }
+        }
+    }
+}

--- a/src/MobiFlightConnector/UI/StateBadge/TaskbarOverlay.cs
+++ b/src/MobiFlightConnector/UI/StateBadge/TaskbarOverlay.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace MobiFlight.UI.StateBadge
+{
+    // Wraps the Win7+ ITaskbarList3.SetOverlayIcon shell call (the same API
+    // Discord/Slack use to badge their pinned taskbar buttons). Owns the COM
+    // object lifetime and the currently-applied overlay icon's GDI handle.
+    internal sealed class TaskbarOverlay : IDisposable
+    {
+        private ITaskbarList3 taskbarList;
+        private bool initFailed;
+        private BadgedIcon currentOverlay;
+
+        public void Set(IntPtr hwnd, bool isRunning, string description)
+        {
+            if (initFailed) return;
+            if (hwnd == IntPtr.Zero) return; // can't overlay a window that has no HWND yet
+
+            try
+            {
+                if (taskbarList == null)
+                {
+                    taskbarList = (ITaskbarList3)new TaskbarInstance();
+                    taskbarList.HrInit();
+                }
+
+                var newOverlay = StateBadgeRenderer.BuildOverlayIcon(isRunning);
+                taskbarList.SetOverlayIcon(hwnd, newOverlay.Handle, description);
+
+                currentOverlay?.Dispose();
+                currentOverlay = newOverlay;
+            }
+            catch (Exception ex)
+            {
+                // Pre-Win7 or no shell — give up silently.
+                initFailed = true;
+                Log.Instance.log("Taskbar overlay unavailable: " + ex.Message, LogSeverity.Info);
+            }
+        }
+
+        public void Dispose()
+        {
+            currentOverlay?.Dispose();
+            currentOverlay = null;
+            if (taskbarList != null)
+            {
+                Marshal.FinalReleaseComObject(taskbarList);
+                taskbarList = null;
+            }
+        }
+
+        // COM interop for ITaskbarList3 — the shell interface that backs the Win7+
+        // taskbar API (progress bars, overlay icons, etc.). Methods MUST be declared
+        // in vtable order; we stop after SetOverlayIcon since we don't call any of
+        // the methods that come after it.
+        [ComImport]
+        [Guid("ea1afb91-9e28-4b86-90e9-9e9f8a5eefaf")]
+        [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+        private interface ITaskbarList3
+        {
+            // ITaskbarList
+            void HrInit();
+            void AddTab(IntPtr hwnd);
+            void DeleteTab(IntPtr hwnd);
+            void ActivateTab(IntPtr hwnd);
+            void SetActiveAlt(IntPtr hwnd);
+            // ITaskbarList2
+            void MarkFullscreenWindow(IntPtr hwnd, [MarshalAs(UnmanagedType.Bool)] bool fFullscreen);
+            // ITaskbarList3 (only up through SetOverlayIcon — slots after are unused)
+            void SetProgressValue(IntPtr hwnd, ulong ullCompleted, ulong ullTotal);
+            void SetProgressState(IntPtr hwnd, int tbpFlags);
+            void RegisterTab(IntPtr hwndTab, IntPtr hwndMDI);
+            void UnregisterTab(IntPtr hwndTab);
+            void SetTabOrder(IntPtr hwndTab, IntPtr hwndInsertBefore);
+            void SetTabActive(IntPtr hwndTab, IntPtr hwndMDI, uint dwReserved);
+            void ThumbBarAddButtons(IntPtr hwnd, uint cButtons, IntPtr pButton);
+            void ThumbBarUpdateButtons(IntPtr hwnd, uint cButtons, IntPtr pButton);
+            void ThumbBarSetImageList(IntPtr hwnd, IntPtr himl);
+            void SetOverlayIcon(IntPtr hwnd, IntPtr hIcon, [MarshalAs(UnmanagedType.LPWStr)] string pszDescription);
+        }
+
+        [ComImport]
+        [Guid("56FDF344-FD6D-11d0-958A-006097C9A090")]
+        [ClassInterface(ClassInterfaceType.None)]
+        private class TaskbarInstance { }
+    }
+}


### PR DESCRIPTION
Stopped: 
<img width="81" height="78" alt="image" src="https://github.com/user-attachments/assets/804dc39c-ccc2-4430-a402-abcd7113508f" />
Running: 
<img width="62" height="63" alt="image" src="https://github.com/user-attachments/assets/b32cd0cc-44ac-4026-aef5-93cbb1d86fc1" />
Title bar running: 
<img width="210" height="144" alt="image" src="https://github.com/user-attachments/assets/58bd8ccd-d89a-47b1-9f3f-f93554e720dd" />
Title bar stopped:
<img width="200" height="114" alt="image" src="https://github.com/user-attachments/assets/b1f89b5d-b7d3-4c00-9664-c3e8f30a8be8" />
Minimized and in Tray  (NOTE : Taskbar Icon is now NOT hidden when minimized. It appears in both places)
<img width="295" height="162" alt="image" src="https://github.com/user-attachments/assets/de70e94c-be88-40cd-b4ab-277c0c5453aa" />
Minimized to tray showing i8n of state in hover text:
<img width="306" height="144" alt="image" src="https://github.com/user-attachments/assets/416b5ce3-6ec0-4507-ace7-e0221f1a37a5" />


Pinned to taskbar and MF not open at all (no stopped/running badge): 
<img width="152" height="89" alt="image" src="https://github.com/user-attachments/assets/1054a0ce-cc5d-4ed8-8753-9d512a608542" />

Just for comparison, as I debated if badge was right size, side by side with Discord:
<img width="156" height="82" alt="image" src="https://github.com/user-attachments/assets/2cf54c28-b429-4b3c-b870-5e7ef453e2ab" />


Fixes request #2975 (by me!)

Show whether the app is in its internal Running vs Stopped state at a glance, in three places:

- system tray icon: composited base icon + green-circle (running) or red-square (stopped) badge in the bottom-right corner
- main form / window titlebar icon: same composited badge, sized to the form icon's native resolution
- Windows taskbar overlay via ITaskbarList3::SetOverlayIcon, so the badge is visible on pinned taskbar entries while the app is running (the same approach Discord/Slack use)

To make the taskbar badge useful when the app is running in the background, this also disables the "hide form on minimize" behavior: minimizing now leaves the taskbar button in place (showing the badge) instead of hiding the form entirely. The "running in background mode" balloon tip is removed accordingly — it no longer makes sense since the form is no longer hidden.

The ITaskbarList3 ComImport block is verbose but is almost entirely mechanical vtable-order method declarations; only HrInit and SetOverlayIcon are actually called.

The running badge is a green circle in the upper right of the MF icon. The stopped badge is a red square in the same place. If MF is not running in windows, no badge appears.