### PR TITLE
Fix: Disable font upload for PFP-7 to use device built-in font

### DIFF
--- a/src/MobiFlightWwFcu/WinwingCduDevice.cs
+++ b/src/MobiFlightWwFcu/WinwingCduDevice.cs
@@ -96,6 +96,14 @@ namespace MobiFlightWwFcu
             //new Tuple<string, byte[]>("1901", new byte[] {0x01, 0x00, 0x06, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}), // without fonts 
         };
 
+        private readonly List<Tuple<string, byte[]>> InitCommandHeaderPfpWithoutUploadedFonts = new List<Tuple<string, byte[]>>()
+        {
+            new Tuple<string, byte[]>("1e01", new byte[0]), // clear feature info - zero-length payload is valid for this opcode
+            new Tuple<string, byte[]>("1801", new byte[] {0x32, 0x00, 0x18, 0x00, 0x0e, 0x00, 0x18, 0x00}),
+            new Tuple<string, byte[]>("1901", new byte[] {0x01, 0x00, 0x05, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
+            new Tuple<string, byte[]>("1901", new byte[] {0x01, 0x00, 0x06, 0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}),
+        };
+
         private List<Tuple<string, byte[]>> InitCommandData = new List<Tuple<string, byte[]>>()
         {
             new Tuple<string, byte[]>("1901", new byte[] { 0x02, 0x00, 0x00, 0x00, 0x00, 0xff, 0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }),
@@ -165,6 +173,7 @@ namespace MobiFlightWwFcu
 
         private List<byte[]> InitCommands;
         private List<byte[]> ClearCommands;
+        private bool SkipFontUpload = false;
 
         private Dictionary<string, Action<string>> DisplayNameToActionMapping = new Dictionary<string, Action<string>>();
         private Dictionary<string, byte> LedIdentifiers;
@@ -212,9 +221,10 @@ namespace MobiFlightWwFcu
             }
             else if (CduType == WinwingCduType.PFP7)
             {
-                InitCommandSequence.AddRange(InitCommandHeaderPfp3n);
+                InitCommandSequence.AddRange(InitCommandHeaderPfpWithoutUploadedFonts);
                 InitCommandSequence.AddRange(InitCommandData);
                 DestinationAddress = WinwingConstants.DEST_PFP7;
+                SkipFontUpload = true;
                 LedIdentifiers = new Dictionary<string, byte>()
                 {
                     { $"DSPY",   0x03 },
@@ -290,11 +300,16 @@ namespace MobiFlightWwFcu
                 byte[] decrypted = CryptoHelper.Decrypt(Convert.FromBase64String(fontData), key, nonce);
                 plainFontJson = Encoding.UTF8.GetString(decrypted);
             }
-            var fontCommands = FontConverter.FontJsonToDisplayCommands(plainFontJson, DestinationAddress);
-            MessageSender.SendDisplayCommands(fontCommands.LargeFontHead);
-            MessageSender.SendDisplayCommands(fontCommands.LargeFont);
-            MessageSender.SendDisplayCommands(fontCommands.SmallFontHead);
-            MessageSender.SendDisplayCommands(fontCommands.SmallFont);
+            
+            if (!SkipFontUpload)
+            {
+                var fontCommands = FontConverter.FontJsonToDisplayCommands(plainFontJson, DestinationAddress);
+                MessageSender.SendDisplayCommands(fontCommands.LargeFontHead);
+                MessageSender.SendDisplayCommands(fontCommands.LargeFont);
+                MessageSender.SendDisplayCommands(fontCommands.SmallFontHead);
+                MessageSender.SendDisplayCommands(fontCommands.SmallFont);
+            }
+            
             MessageSender.SendDisplayCommands(InitCommands);
             EmptyDisplay();
         }
@@ -405,7 +420,7 @@ namespace MobiFlightWwFcu
             for (int i = 0; i < data.Count; i++)
             {
                 var item = data[i];
-                var (lowByte, highByte) = GetFormatBytes(item, out var currentChar); 
+                var (lowByte, highByte) = GetFormatBytes(item, out var currentChar);
                 
                 if (i == 0) // First char
                     lowByte += 0x01;
@@ -414,6 +429,13 @@ namespace MobiFlightWwFcu
 
                 byteList.Add(lowByte);
                 byteList.Add(highByte);
+                
+                // For PFP7 without font upload, only use single-byte ASCII
+                if (SkipFontUpload && currentChar > 127)
+                {
+                    // Replace multi-byte UTF-8 characters with ASCII equivalents
+                    currentChar = ' ';
+                }
                 byteList.AddRange(Encoding.UTF8.GetBytes(new char[] { currentChar }));
             }
 


### PR DESCRIPTION
## Problem
The Winwing PFP-7 display was rendering garbled and corrupted text (broken characters like "B F" and "IN") when using MobiFlight's bundled PFP font data. This made the display unusable for basic operations.

## Root Cause Analysis
Through comprehensive diagnostic testing, we determined:
- The HID interface and packet layout work correctly (proven by bypassing font upload)
- MobiFlight's font upload mechanism itself works (proven with alternative fonts)
- The PFP-7 is not rejecting uploaded fonts in general
- **The issue is specific to MobiFlight's bundled PFP font data, not the protocol**

The device's built-in/default font renders text cleanly and correctly, so for the PFP-7, we can safely skip the custom font upload and use the device's native font.

## Solution
Modified PFP-7 initialization to:
- Use "without uploaded fonts" header instead of the standard header with fonts
- Skip MobiFlight's default Boeing font upload for PFP-7 only
- Add glyph-byte guard to use ASCII fallbacks instead of multi-byte UTF-8 sequences
- Preserve existing font upload behavior for all other CDU and PFP display variants

## Technical Details
- Modified `src/MobiFlightWwFcu/WinwingCduDevice.cs`: Added `InitCommandHeaderPfpWithoutUploadedFonts` and conditional initialization logic
- The fix is variant-specific and does not affect MCDU, PFP5, PFP8, or other supported displays
- Verified working on actual Winwing PFP-7 hardware

## Testing
- Manual testing on Winwing PFP-7 confirms clean text rendering
- Display initialization and message encoding work correctly with device's built-in font
- No regressions expected for other display variants

## Compatibility
- No breaking changes
- Backward compatible with all existing display variants
- Fixes user-facing display rendering issue on PFP-7 devices

Closes #2991