### PR TITLE
Prevent keyboards events from propagating beyond dialog

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
@@ -74,8 +74,8 @@ const ProjectForm = ({
   }
 
   const handleFormKeyDown = (e: React.KeyboardEvent) => {
+    e.stopPropagation()
     if (e.key === "Enter") {
-      e.stopPropagation()
       handleSubmit(e as unknown as React.FormEvent)
     }
   }

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
@@ -74,8 +74,8 @@ const ProjectForm = ({
   }
 
   const handleFormKeyDown = (e: React.KeyboardEvent) => {
-    e.stopPropagation()
     if (e.key === "Enter") {
+      e.stopPropagation()
       handleSubmit(e as unknown as React.FormEvent)
     }
   }

--- a/src/MobiFlightConnector/frontend/src/components/ui/dialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/ui/dialog.tsx
@@ -41,6 +41,27 @@ const DialogContent = React.forwardRef<
         "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
         className
       )}
+      onKeyDown={(e) => {
+        if(props.onKeyDown) {
+          props.onKeyDown?.(e)
+          return
+        }
+        /* this prevents that keyboard shortcuts trigger outside the dialog */
+        e.stopPropagation()
+      }}
+      
+      onKeyUp={(e) => {
+        if(props.onKeyUp) {
+          props.onKeyUp?.(e)
+          return
+        }
+        /* 
+         * this prevents that keyboard shortcuts trigger outside the dialog.
+         * see  
+         */
+        e.stopPropagation()
+      }}
+
       {...props}
     >
       {children}

--- a/src/MobiFlightConnector/frontend/tests/ControllerBindingDialog.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/ControllerBindingDialog.spec.ts
@@ -296,3 +296,43 @@ test.describe("Controller Bindings Update Message Tests", () => {
     await expect(thirdItem).toContainText("Original Controller 1")
   })
 })
+
+// see: https://github.com/MobiFlight/MobiFlight-Connector/issues/2971
+test("Confirm Controller Binding Dialog input field content can be deleted using backspace", async ({
+  configListPage,
+  page,
+}) => {
+  const mobiFlightPage = configListPage.mobiFlightPage
+
+  await configListPage.gotoPage()
+  await mobiFlightPage.initWithTestData()
+
+  const rows = await page.getByRole("row")
+  // initially 7 items
+  await expect(rows).toHaveCount(17)
+
+  const firstRow = rows.first()
+  await firstRow.click()
+
+  await mobiFlightPage.openControllerBindingsDialog()
+  const dialog = page.getByRole("dialog", { name: "Controller Bindings" })
+  const comboboxConnected = dialog.getByRole("combobox").first()
+
+  await comboboxConnected.click()
+  const searchInput = page.getByPlaceholder("Search controller...")
+  await searchInput.fill("Test")
+  await expect(searchInput).toHaveValue("Test")
+  await searchInput.focus()
+  await page.keyboard.press("Backspace")
+  await expect(searchInput).toHaveValue("Tes")
+  
+  // Close the options overlay
+  await page.keyboard.press("Escape") 
+  await expect(searchInput).not.toBeVisible()
+
+  // we have to close the dialog first 
+  // to be able to check the number of rows.
+  await dialog.getByRole("button", { name: "Apply changes" }).click()
+  // still 7 items, backspace did not delete any
+  await expect(page.getByRole("row")).toHaveCount(17)
+})


### PR DESCRIPTION
Dialog now has default KeyDown and KeyUp handler that prevents Keyboard Event propagation.

- [x]  ~~unit tests~~
- [x]  UI tests
- [x]  ~~i18n~~

fixes #2971 