### PR TITLE
Midi Controller don't throw Null Reference Error

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
@@ -380,7 +380,7 @@ namespace MobiFlight
 
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
-                        Controller = new Base.Controller() { Serial = SerialPrefix + DIJoystick.Information.InstanceGuid.ToString(), Name = Name },
+                        Controller = new Base.Controller() { Serial = Serial, Name = Name },
                         Device = new Base.DeviceReference() { Type = POV[index].Type, Name = POV[index].Name, Label = POV[index].Label },
                         InputType = DeviceType.Button,
                         Value = (int)MobiFlightButton.InputEvent.RELEASE
@@ -395,7 +395,7 @@ namespace MobiFlight
 
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
-                        Controller = new Base.Controller() { Serial = SerialPrefix + DIJoystick.Information.InstanceGuid.ToString(), Name = Name },
+                        Controller = new Base.Controller() { Serial = Serial, Name = Name },
                         Device = new Base.DeviceReference() { Type = POV[index].Type, Name = POV[index].Name, Label = POV[index].Label },
                         InputType = DeviceType.Button,
                         Value = (int)MobiFlightButton.InputEvent.PRESS

--- a/src/MobiFlightConnector/MobiFlight/MidiBoard/MidiBoard.cs
+++ b/src/MobiFlightConnector/MobiFlight/MidiBoard/MidiBoard.cs
@@ -167,6 +167,8 @@ namespace MobiFlight
             // Use channel+1 because all miditools show channel starting with 1, technically it starts with 0
             byte adaptedChannel = (byte)(channel + 1);
 
+            inputEventArgs.Controller = new Base.Controller() { Name = this.Name, Serial = this.Serial };
+
             // TODO: semantics of Device.Type is not entirely correct but data type doesn't allow us to set it to MidiBoardDeviceType
             // We have to refactor this before merging to main.
             inputEventArgs.Device = new DeviceReference()


### PR DESCRIPTION
### Summary
Midi Controller Input Events are now initialized correctly and all properties have values. The Null Reference Exception is not triggered anymore.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Initializing Controller property correctly

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
  - [x] ~~.NET backend~~
  - ~~[ ] Frontend~~
- [x] ~~Frontend tests~~
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3000

### Notes
Unfortunately the midi controller context is not covered by unit tests yet.