### PR TITLE
Revert "Fix Winwing HID interface selection (#2992)"

### DIFF
--- a/src/MobiFlightWwFcu/WinwingMessageSender.cs
+++ b/src/MobiFlightWwFcu/WinwingMessageSender.cs
@@ -2,8 +2,6 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.IO;
-using System.Linq;
 
 namespace MobiFlightWwFcu
 {
@@ -30,50 +28,10 @@ namespace MobiFlightWwFcu
 
         public void Connect()
         {
-            Device = GetWritableHidDevice();
+            Device = DeviceList.Local.GetHidDeviceOrNull(vendorID: VendorId, productID: ProductId);
             if (Device == null) return;
-
             Stream = Device.Open();
             Stream.ReadTimeout = System.Threading.Timeout.Infinite;
-        }
-
-        private HidDevice GetWritableHidDevice()
-        {
-            // Winwing devices can expose multiple HID collections. Display and light commands need a writable
-            // 64-byte output report.
-            HidDevice writableDevice = DeviceList.Local.GetHidDevices(vendorID: VendorId, productID: ProductId)
-                .Select(hidDevice => new
-                {
-                    Device = hidDevice,
-                    MaxOutputReportLength = GetMaxOutputReportLength(hidDevice)
-                })
-                .Where(candidate => candidate.MaxOutputReportLength >= 64)
-                .OrderByDescending(candidate => candidate.MaxOutputReportLength)
-                .Select(candidate => candidate.Device)
-                .FirstOrDefault();
-
-            return writableDevice;
-        }
-
-        private int GetMaxOutputReportLength(HidDevice device)
-        {
-            try
-            {
-                return device.GetMaxOutputReportLength();
-            }
-            catch (IOException)
-            {
-                return 0;
-            }
-            catch (InvalidOperationException)
-            {
-                return 0;
-            }
-            catch (NotSupportedException)
-            {
-                // Treat devices with unreadable descriptors as non-writable candidates and keep looking.
-                return 0;
-            }
         }
 
         public void Shutdown()


### PR DESCRIPTION
This reverts commit 449e028e323e355f9bb374324ef56394ab57a8b7.

<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
We are removing the potential improvement of PR #2992 because it was not compatible with Airbus Sidestick

fixed #3002 