### PR TITLE
Log messages show in panel right after enabling logging

### DIFF
--- a/src/MobiFlightConnector/Base/LogAppender/MessageExchangeAppender.cs
+++ b/src/MobiFlightConnector/Base/LogAppender/MessageExchangeAppender.cs
@@ -7,12 +7,13 @@ namespace MobiFlight.Base.LogAppender
 {
     public class MessageExchangeAppender : ILogAppender
     {
-        public ConcurrentQueue<LogEntry> LogQueue = new ConcurrentQueue<LogEntry>();
+        private readonly ConcurrentQueue<LogEntry> LogQueue = new ConcurrentQueue<LogEntry>();
         private Timer ProcessTimer;
+        private readonly object _timerLock = new object();
 
         public MessageExchangeAppender()
         {
-            
+
         }
 
         public void log(string message, LogSeverity severity)
@@ -25,19 +26,21 @@ namespace MobiFlight.Base.LogAppender
             };
 
             LogQueue.Enqueue(m);
-            
+
             if (ProcessTimer == null)
             {
-                ProcessTimer = new Timer(ProcessTimer_Tick, this, 0, 100);
-                return;
+                var newTimer = new Timer(ProcessTimer_Tick, this, 0, 100);
+                // handle potential race condition during timer initialization
+                if (Interlocked.CompareExchange(ref ProcessTimer, newTimer, null) != null)
+                {
+                    newTimer.Dispose();
+                }
             }
         }
 
-        public static void ProcessTimer_Tick(object state)
+        private static void ProcessTimer_Tick(object state)
         {
-            var appender = (MessageExchangeAppender)state;
-
-            if (appender == null) { return; }
+            if (!(state is MessageExchangeAppender appender)) return;
 
             while (appender.LogQueue.TryDequeue(out var logEntry))
             {

--- a/src/MobiFlightConnector/Base/LogAppender/MessageExchangeAppender.cs
+++ b/src/MobiFlightConnector/Base/LogAppender/MessageExchangeAppender.cs
@@ -1,28 +1,22 @@
 ﻿using MobiFlight.BrowserMessages.Outgoing;
 using System;
 using System.Collections.Concurrent;
-using System.Windows.Forms;
+using System.Threading;
 
 namespace MobiFlight.Base.LogAppender
 {
     public class MessageExchangeAppender : ILogAppender
     {
-        private ConcurrentQueue<LogEntry> LogQueue = new ConcurrentQueue<LogEntry>();
-        private readonly Timer ProcessTimer = new System.Windows.Forms.Timer();
+        public ConcurrentQueue<LogEntry> LogQueue = new ConcurrentQueue<LogEntry>();
+        private Timer ProcessTimer;
 
         public MessageExchangeAppender()
         {
-            ProcessTimer.Interval = 50;
-            ProcessTimer.Tick += ProcessTimer_Tick;
+            
         }
 
         public void log(string message, LogSeverity severity)
         {
-            if (!ProcessTimer.Enabled)
-            {
-                ProcessTimer.Start();
-            }
-
             var m = new LogEntry
             {
                 Timestamp = DateTime.Now,
@@ -31,11 +25,21 @@ namespace MobiFlight.Base.LogAppender
             };
 
             LogQueue.Enqueue(m);
+            
+            if (ProcessTimer == null)
+            {
+                ProcessTimer = new Timer(ProcessTimer_Tick, this, 0, 100);
+                return;
+            }
         }
 
-        private void ProcessTimer_Tick(object sender, EventArgs e)
+        public static void ProcessTimer_Tick(object state)
         {
-            while (LogQueue.TryDequeue(out var logEntry))
+            var appender = (MessageExchangeAppender)state;
+
+            if (appender == null) { return; }
+
+            while (appender.LogQueue.TryDequeue(out var logEntry))
             {
                 BrowserMessages.MessageExchange.Instance.Publish(logEntry);
             }


### PR DESCRIPTION
### Summary
The log messages are now arriving in the log panel if a user enables logging and opens the log panel. It doesn't require a restart anymore after changing from Log Enabled = false, to Log Enabled = true.

### Screenshots / recordings
n/a

### Acceptance criteria
- [x] Enabling log doesn't require a restart for messages to show up in Log Panel

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] ~~Frontend tests~~
- [x] ~~documentation~~

## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3018

### Notes
It must have been some timer issue when using Timer from Windows.Forms
We switched over to System.Threading.Timer and it works just fine.