### PR TITLE
Prevent exception with Precondition Value being null

### DIFF
--- a/src/MobiFlightConnector/Base/Precondition.cs
+++ b/src/MobiFlightConnector/Base/Precondition.cs
@@ -75,7 +75,6 @@ namespace MobiFlight
             else
                 Label = null;
 
-
             if (Type == "config" || Type == "variable")
             {
                 Ref = reader["ref"];
@@ -184,8 +183,6 @@ namespace MobiFlight
             return this.Label;
         }
 
-
-
         public bool Evaluate(MobiFlightVariable value)
         {
             var cacheKey = $"{value.TYPE}:{value.Number}:{value.Text}:{Value}:{Operand}";
@@ -228,7 +225,7 @@ namespace MobiFlight
             var comparison = new Comparison
             {
                 Active = true,
-                Value = Value.Replace("$", currentValue.ToString()),
+                Value = Value?.Replace("$", currentValue.ToString()),
                 Operand = Operand,
                 IfValue = "1",
                 ElseValue = "0"

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Comparison.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Comparison.cs
@@ -203,7 +203,7 @@ namespace MobiFlight.Modifier
                     break;
             }
 
-            result = result?.Replace("$", value.ToString());
+            result = result?.Replace("$", value.ToString() ?? string.Empty);
 
             return result;
         }

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Comparison.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Comparison.cs
@@ -60,7 +60,6 @@ namespace MobiFlight.Modifier
             ElseValue = reader["elseValue"];
         }
 
-
         override public void WriteXml(XmlWriter writer)
         {
             writer.WriteStartElement("comparison");
@@ -204,7 +203,7 @@ namespace MobiFlight.Modifier
                     break;
             }
 
-            result = result.Replace("$", value.ToString());
+            result = result?.Replace("$", value.ToString());
 
             return result;
         }

--- a/tests/MobiFlightUnitTests/Base/PreconditionTests.cs
+++ b/tests/MobiFlightUnitTests/Base/PreconditionTests.cs
@@ -217,20 +217,13 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
-        public void Evaluate_ShouldNotThrowException_WhenValueIsNull()
+        public void Evaluate_ShouldReturnFalse_WhenValueIsNull()
         {
             var p = _generateTestObject();
             p.Value = null;
 
-            try
-            {
-                var result = p.Evaluate(null, new ConnectorValue());
-                Assert.IsFalse(result, "Evaluate should return false when Value is null.");
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail($"Evaluate threw an exception when Value is null: {ex}");
-            }
+            var result = p.Evaluate(null, new ConnectorValue());
+            Assert.IsFalse(result, "Evaluate should return false when Value is null.");
         }
     }
 }

--- a/tests/MobiFlightUnitTests/Base/PreconditionTests.cs
+++ b/tests/MobiFlightUnitTests/Base/PreconditionTests.cs
@@ -215,5 +215,22 @@ namespace MobiFlight.Tests
             Assert.AreNotEqual("", json, "Non-empty Precondition must not be serialized to empty when the converter is enabled.");
             Assert.IsFalse(string.IsNullOrEmpty(json), "Serialized JSON should not be empty.");
         }
+
+        [TestMethod]
+        public void Evaluate_ShouldNotThrowException_WhenValueIsNull()
+        {
+            var p = _generateTestObject();
+            p.Value = null;
+
+            try
+            {
+                var result = p.Evaluate(null, new ConnectorValue());
+                Assert.IsFalse(result, "Evaluate should return false when Value is null.");
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail($"Evaluate threw an exception when Value is null: {ex}");
+            }
+        }
     }
 }


### PR DESCRIPTION
### Summary
Prevent exception with Precondition when Value was not really configured.
This is possible because the new Precondition UI doesn't validate user input yet.

### Acceptance criteria
- [x] Precondition evaluation doesn't throw exception when Value is null

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [x] ~~Frontend tests~~
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~
     
## Related issues
fixes #3020

### Notes
There are currently no unit tests that test Precondition.Evaluate