### PR TITLE
Updated fslabs_winwing_cdu.py

### DIFF
--- a/src/MobiFlightConnector/Scripts/Winwing/fslabs_winwing_cdu.py
+++ b/src/MobiFlightConnector/Scripts/Winwing/fslabs_winwing_cdu.py
@@ -8,7 +8,7 @@ import http.client
 
 FSL_COLOR_MAP = {
     0: "w",  # black (ignore)
-    1: "c",  # cyan
+    1: "o",  # cyan
     2: "e",  # gray
     3: "y",  # yellow
     4: "g",  # light green
@@ -27,15 +27,14 @@ subs = {
     95: "\u2190",  
     110: "\u0394",  
     112: "*",
-    "#": "\u2610",  
-    "¤": "\u2191",  
-    "¥": "\u2193",  
-    "¢": "\u2192",  
-    "£": "\u2190",  
 }
 
 mobi_websocket_connections = {"captain": None, "co-pilot": None}
 data_queues = {"3CA1": asyncio.Queue(), "3CA2": asyncio.Queue()}
+
+# Most recent frame per MCDU, kept so it can be re-sent whenever a CDU
+# (re)connects -- otherwise a static display stays blank until it next changes.
+last_frames = {"3CA1": None, "3CA2": None}
 
 MAX_WS_RETRIES = 3   # <--- Added retry limit
 
@@ -43,6 +42,7 @@ MAX_WS_RETRIES = 3   # <--- Added retry limit
 async def fetch_fsl_mcdu(mcdu):
     """Fetch MCDU data using a persistent HTTP connection, avoiding redundant updates."""
     global data_queues
+    global last_frames
 
     last_fetched_data = None
     conn = http.client.HTTPConnection("localhost", 8080, timeout=1)
@@ -60,7 +60,13 @@ async def fetch_fsl_mcdu(mcdu):
 
                     if parsed_data != last_fetched_data:
                         last_fetched_data = parsed_data
+                        last_frames[mcdu] = parsed_data
                         await data_queues[mcdu].put(parsed_data)
+            else:
+                # Drain the body even on errors, otherwise the persistent
+                # HTTPConnection is left in a bad state and the next request
+                # raises ResponseNotReady.
+                response.read()
 
         except (http.client.HTTPException, TimeoutError) as ex:
             logging.warning(f"fetch_fsl_mcdu: Connection to FSLabs aircraft not possible. Timeout or HTTP error: {ex}")
@@ -77,16 +83,56 @@ async def fetch_fsl_mcdu(mcdu):
 async def run_fsl_http_client(mcdu, cdu):
     global mobi_websocket_connections
     global data_queues
+    global last_frames
 
-    while True:        
-        mobi_json = await data_queues[mcdu].get()
+    was_connected = False
 
-        if mobi_json and mobi_websocket_connections[cdu]:
-            await mobi_websocket_connections[cdu].send(mobi_json)
+    while True:
+        conn = mobi_websocket_connections[cdu]
+
+        # Not connected yet (or dropped): keep the latest frame queued and wait.
+        if conn is None:
+            was_connected = False
+            await asyncio.sleep(0.1)
+            continue
+
+        # Just (re)connected: the queue may only hold stale intermediate frames
+        # (or nothing), so drop the backlog and push the current frame straight
+        # away. This is what stops the screen loading blank on startup/reconnect.
+        if not was_connected:
+            was_connected = True
+            while not data_queues[mcdu].empty():
+                data_queues[mcdu].get_nowait()
+            if last_frames[mcdu] is not None:
+                try:
+                    await conn.send(last_frames[mcdu])
+                except Exception as ex:
+                    logging.warning(f"[{cdu}] resend on connect failed, will resync: {ex}")
+                    continue
+
+        # Wait for new frames, but time out so a disconnect is noticed promptly.
+        try:
+            mobi_json = await asyncio.wait_for(data_queues[mcdu].get(), timeout=0.5)
+        except asyncio.TimeoutError:
+            continue
+
+        conn = mobi_websocket_connections[cdu]
+        if mobi_json and conn:
+            try:
+                await conn.send(mobi_json)
+            except Exception as ex:
+                # Socket dropped between the check and the send; the ws task
+                # will reset the connection and we'll resync on reconnect.
+                logging.warning(f"[{cdu}] send failed, will resync on reconnect: {ex}")
 
 
 async def run_mobiflight_websocket_client(cdu_type):
-    """WebSocket client with retry limit."""
+    """WebSocket client.
+
+    The retry limit applies only until the first successful connection (so a
+    missing CDU stops trying); once connected, it reconnects indefinitely so a
+    transient drop doesn't permanently kill the CDU.
+    """
     global mobi_websocket_connections
 
     retries = 0
@@ -94,46 +140,47 @@ async def run_mobiflight_websocket_client(cdu_type):
 
     while True:
         try:
-            if mobi_websocket_connections[cdu_type] is None:
-
-                if not has_connected_once and retries >= MAX_WS_RETRIES:
-                    logging.info(
-                        f"[{cdu_type}] No CDU detected after {retries} attempts -> stopping task."
-                    )
-                    return
-
-                ws_url = f"ws://localhost:8320/winwing/cdu-{cdu_type}"
+            # Give up only if we've never connected -- likely no CDU attached.
+            if not has_connected_once and retries >= MAX_WS_RETRIES:
                 logging.info(
-                    f"[{cdu_type}] Connecting to MobiFlight WebSocket "
-                    f"(attempt {retries + 1}/{MAX_WS_RETRIES}) -> {ws_url}"
+                    f"[{cdu_type}] No CDU detected after {retries} attempts -> stopping task. "
+                    f"If you only have one CDU attached, you can ignore this message."
                 )
+                return
 
-                mobi_websocket_connections[cdu_type] = await ws_client.connect(ws_url)
-                logging.info(f"[{cdu_type}] Connected.")
+            ws_url = f"ws://localhost:8320/winwing/cdu-{cdu_type}"
+            logging.info(
+                f"[{cdu_type}] Connecting to MobiFlight WebSocket "
+                f"(attempt {retries + 1}) -> {ws_url}"
+            )
 
-                has_connected_once = True
-                retries = 0  # reset retry counter
+            connection = await ws_client.connect(ws_url)
+            logging.info(f"[{cdu_type}] Connected.")
 
-                fontName = "AirbusThales"
-                await mobi_websocket_connections[cdu_type].send(
-                    f'{{ "Target": "Font", "Data": "{fontName}" }}'
-                )
-                logging.info(f"[{cdu_type}] Setting font: {fontName}")
-                await asyncio.sleep(1) # wait a second for font to be set
+            # Set the font and let it settle BEFORE exposing the connection, so
+            # the first frame isn't sent with the wrong font.
+            fontName = "AirbusThales"
+            await connection.send(f'{{ "Target": "Font", "Data": "{fontName}" }}')
+            logging.info(f"[{cdu_type}] Setting font: {fontName}")
+            await asyncio.sleep(1)  # wait a second for font to be set
 
-            await asyncio.sleep(0.05)
-       
+            mobi_websocket_connections[cdu_type] = connection
+            has_connected_once = True
+            retries = 0  # reset retry counter
+
+            # Block until the connection drops. We don't expect inbound data;
+            # iterating the socket simply unblocks (or raises) when it closes.
+            try:
+                async for _ in connection:
+                    pass
+            finally:
+                mobi_websocket_connections[cdu_type] = None
+                logging.info(f"[{cdu_type}] Connection closed -> will reconnect.")
+
         except Exception as ex:
             logging.info(f"[{cdu_type}] WebSocket connection failed: {ex}")
             mobi_websocket_connections[cdu_type] = None
             retries += 1
-
-            if retries >= MAX_WS_RETRIES:
-                logging.info(
-                   f"[{cdu_type}] No CDU detected after {retries} attempts -> stopping task. If you only have one CDU attached, you can ignore this message."
-                )
-                return
-
             await asyncio.sleep(2)
 
 


### PR DESCRIPTION
### Summary
Fixes the FSLabs Winwing CDU bridge (fslabs_winwing_cdu.py) loading a blank screen until a button is pressed, changes Cyan colour to Blue, inline with in Sim MCDU plus several related reliability issues with connection handling.


### Problems

- Blank screen on load: the first display frame was fetched and de-duplicated before the MobiFlight WebSocket finished connecting, so it was silently dropped. Because the fetcher only re-sends on change, nothing was sent until the display next changed — i.e. until the user pressed a button.
- CDU could die permanently: the WebSocket task gave up after 3 retries and the wrapper then cancelled the fetch/process tasks for that CDU. This killed the CDU for the rest of the session if the script started before the sim was ready, or after any sustained disconnect.
- Disconnects went undetected: after connecting, the task busy-looped on a short sleep and never read the socket, so a dropped connection was never noticed and the reconnect path never armed.
- Persistent HTTP connection corruption: non-200 responses were left undrained, putting the persistent HTTPConnection into a ResponseNotReady state on the next request.
- Font-ordering race: the connection was exposed before the font command had settled, so the first frame could render in the wrong font.

### Changes

- Re-send current frame on (re)connect: track the latest frame per MCDU (last_frames) and push it immediately whenever the socket connects, draining any stale backlog first. Fixes both the cold-start blank screen and repaint-after-reconnect.
- Reconnect indefinitely after first connect: the retry cap now only applies before the first successful connection (the genuine "no CDU attached" case); transient drops no longer permanently kill the CDU.
- Detect dropped connections: block on the socket iterator (like the Fenix bridge) instead of busy-looping, and reset the connection to None in a finally so the reconnect/resync logic actually fires. Removes the busy-loop.
- Drain non-200 HTTP responses to keep the persistent connection usable.
- Set the font and let it settle before publishing the connection, eliminating the first-frame font race.
- Crash-proof sends: wrap frame sends in try/except so a socket dropping mid-send logs and resyncs on reconnect instead of crashing the process task.
- Remove dead subs entries: the five string keys could never match, since lookups are always by integer ASCII value.
