### PR TITLE
Ensure that no Devices are stored in Controller property

### DIFF
--- a/src/MobiFlightConnector/Base/Controller.cs
+++ b/src/MobiFlightConnector/Base/Controller.cs
@@ -67,5 +67,15 @@ namespace MobiFlight.Base
         {
             return $"{Serial}:{Name}";
         }
+
+        /// <summary>
+        /// Determines whether the <see cref="Devices"/> property should be serialized.
+        /// </summary>
+        /// <returns><see langword="true"/> if <see cref="Devices"/> contains one or more elements;
+        /// otherwise, <see langword="false"/>.</returns>
+        public bool ShouldSerializeDevices()
+        {
+            return Devices != null && Devices.Count > 0;
+        }
     }
 }

--- a/src/MobiFlightConnector/frontend/src/components/controllers/ControllerBindingsDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/controllers/ControllerBindingsDialog.tsx
@@ -35,7 +35,8 @@ const ControllerBindingsDialog = ({
   onOpenChange,
 }: ControllerBindingsProps) => {
   const { t } = useTranslation()
-  const [lastPropBindings, setLastPropBindings] = useState<ControllerBinding[]>(bindings)
+  const [lastPropBindings, setLastPropBindings] =
+    useState<ControllerBinding[]>(bindings)
   const [finalBindings, setFinalBindings] =
     useState<ControllerBinding[]>(bindings)
   const { publish } = publishOnMessageExchange()
@@ -98,7 +99,11 @@ const ControllerBindingsDialog = ({
 
       return {
         ...b,
-        BoundController: controller,
+        BoundController: { 
+          ...controller,
+          // unset Devices before sending it back to backend. 
+          Devices: undefined 
+        },
         Status: controller ? "Match" : "Missing",
       } as ControllerBinding
     })

--- a/src/MobiFlightConnector/frontend/src/components/controllers/ControllerBindingsDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/controllers/ControllerBindingsDialog.tsx
@@ -99,11 +99,11 @@ const ControllerBindingsDialog = ({
 
       return {
         ...b,
-        BoundController: { 
+        BoundController: controller ? { 
           ...controller,
           // unset Devices before sending it back to backend. 
           Devices: undefined 
-        },
+        } : null,
         Status: controller ? "Match" : "Missing",
       } as ControllerBinding
     })

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
@@ -84,12 +84,14 @@ const ConfigTrigger = ({ configItem, setConfigItem }: ConfigTriggerProps) => {
   ) => {
     setConfigItem({
       ...configItem,
-      Controller: { 
-        ...controller,
-        // unset Devices 
-        // before sending it back to backend. 
-        Devices: undefined 
-      },
+      Controller: controller
+        ? {
+            ...controller,
+            // unset Devices 
+            // before sending it back to backend. 
+            Devices: undefined,
+          }
+        : undefined,
       Device: device
         ? {
             Name: device.Name,

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
@@ -84,7 +84,12 @@ const ConfigTrigger = ({ configItem, setConfigItem }: ConfigTriggerProps) => {
   ) => {
     setConfigItem({
       ...configItem,
-      Controller: controller,
+      Controller: { 
+        ...controller,
+        // unset Devices 
+        // before sending it back to backend. 
+        Devices: undefined 
+      },
       Device: device
         ? {
             Name: device.Name,
@@ -119,7 +124,9 @@ const ConfigTrigger = ({ configItem, setConfigItem }: ConfigTriggerProps) => {
     <Card data-testid="trigger-panel">
       <CardContent className="flex flex-col gap-4 pt-4">
         <div className="flex flex-col gap-2">
-          <div className="text-lg font-semibold">{t("Dialog.InputConfigWizard.ConfigTrigger.Title")}</div>
+          <div className="text-lg font-semibold">
+            {t("Dialog.InputConfigWizard.ConfigTrigger.Title")}
+          </div>
           <div className="text-muted-foreground text-sm">
             {t("Dialog.InputConfigWizard.ConfigTrigger.Description")}
           </div>
@@ -150,9 +157,15 @@ const ConfigTrigger = ({ configItem, setConfigItem }: ConfigTriggerProps) => {
               }
               items={completeControllers}
               selected={selectedController}
-              placeholder={t("Dialog.InputConfigWizard.ConfigTrigger.SelectController")}
-              searchPlaceholder={t("Dialog.InputConfigWizard.ConfigTrigger.SearchController")}
-              noOptionsPlaceholder={t("Dialog.InputConfigWizard.ConfigTrigger.NoControllerFound")}
+              placeholder={t(
+                "Dialog.InputConfigWizard.ConfigTrigger.SelectController",
+              )}
+              searchPlaceholder={t(
+                "Dialog.InputConfigWizard.ConfigTrigger.SearchController",
+              )}
+              noOptionsPlaceholder={t(
+                "Dialog.InputConfigWizard.ConfigTrigger.NoControllerFound",
+              )}
               setSelected={(controller) => {
                 setSelectedController(controller)
                 setSelectedDevice(undefined)
@@ -173,9 +186,15 @@ const ConfigTrigger = ({ configItem, setConfigItem }: ConfigTriggerProps) => {
               }
               items={devices}
               selected={selectedDevice}
-              placeholder={t("Dialog.InputConfigWizard.ConfigTrigger.SelectDevice")}
-              searchPlaceholder={t("Dialog.InputConfigWizard.ConfigTrigger.SearchDevice")}
-              noOptionsPlaceholder={t("Dialog.InputConfigWizard.ConfigTrigger.NoDeviceFound")}
+              placeholder={t(
+                "Dialog.InputConfigWizard.ConfigTrigger.SelectDevice",
+              )}
+              searchPlaceholder={t(
+                "Dialog.InputConfigWizard.ConfigTrigger.SearchDevice",
+              )}
+              noOptionsPlaceholder={t(
+                "Dialog.InputConfigWizard.ConfigTrigger.NoDeviceFound",
+              )}
               disabled={!selectedController}
               setSelected={(device) => {
                 setSelectedDevice(device)

--- a/src/MobiFlightConnector/frontend/tests/ControllerBindingDialog.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/ControllerBindingDialog.spec.ts
@@ -142,6 +142,7 @@ test("Confirm Controller Binding assignment works correctly", async ({
     "JS-c0875190-3b89-11ed-8007-444553540000",
   )
   expect(updatedBinding!.Status).toBe("Match")
+  expect(updatedBinding!.BoundController?.Devices).toBeUndefined()
 })
 
 test("Confirm Controller Binding Dialog filters correctly", async ({

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -26,7 +26,10 @@ const openActionEditor = async (
 ) => {
   await configListPage.gotoPage()
   if (projectOptions) {
-    await configListPage.mobiFlightPage.initWithTestDataAndSpecificProjectProps(projectOptions, "inputaction")
+    await configListPage.mobiFlightPage.initWithTestDataAndSpecificProjectProps(
+      projectOptions,
+      "inputaction",
+    )
   } else {
     await configListPage.mobiFlightPage.initWithTestData("inputaction")
   }
@@ -253,6 +256,56 @@ test.describe("Input Config Wizard - Trigger Panel", () => {
         .getByRole("combobox")
         .filter({ hasText: "Select device..." }),
     ).toBeDisabled()
+  })
+
+  test("Updating controller doesn't send Devices back to backend", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData("inputaction")
+    await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
+
+    await configListPage.clickEditButtonForRow(1)
+    const triggerPanel = page.getByTestId("trigger-panel")
+    await expect(triggerPanel).toBeVisible()
+
+    // Clear existing selection first
+    const clearSelectedInputButton = triggerPanel.getByRole("button", {
+      name: "Clear input",
+    })
+    await expect(clearSelectedInputButton).toBeVisible()
+    await clearSelectedInputButton.click()
+
+    const controllerDropDown = triggerPanel
+      .getByRole("combobox")
+      .filter({ hasText: "Select controller..." })
+
+    const optionsPopup = page.getByRole("listbox")
+    await controllerDropDown.click()
+    await expect(optionsPopup).toBeVisible()
+    const options = optionsPopup.getByRole("option")
+
+    // click throttle option
+    await expect(
+      options.filter({ hasText: "Bravo Throttle Quadrant" }),
+    ).toBeVisible()
+    await options.filter({ hasText: "Bravo Throttle Quadrant" }).click()
+    await expect(
+      options.filter({ hasText: "Bravo Throttle Quadrant" }),
+    ).not.toBeVisible()
+    const saveButton = page.getByRole("button", {
+      name: "Save",
+    })
+    await saveButton.click()
+
+    const commandsAfterClick =
+      await configListPage.mobiFlightPage.getTrackedCommands()
+    expect(commandsAfterClick?.length).toBe(1)
+    expect(commandsAfterClick![0].key).toBe("CommandUpdateConfigItem")
+    const updatedController = commandsAfterClick![0].payload.item.Controller
+
+    expect(updatedController?.Devices).toBeUndefined()
   })
 })
 
@@ -607,10 +660,16 @@ test.describe("Input Config Wizard - Action Type Panel", () => {
 
     const onReleaseTab = page.getByRole("tab", { name: "On Release" })
     await onReleaseTab.click()
-    await expect(actionEditor.getByRole("combobox").filter({ hasText: "Select..." })).toBeVisible()
+    await expect(
+      actionEditor.getByRole("combobox").filter({ hasText: "Select..." }),
+    ).toBeVisible()
 
     await pasteButton.click()
-    await expect(actionEditor.getByRole("combobox").filter({ hasText: "Microsoft Flight Simulator (all versions)" })).toBeVisible()
+    await expect(
+      actionEditor
+        .getByRole("combobox")
+        .filter({ hasText: "Microsoft Flight Simulator (all versions)" }),
+    ).toBeVisible()
   })
 })
 
@@ -686,47 +745,57 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
   }) => {
     const actionEditor = await openActionEditor(configListPage, page, 1)
     const countLabel = actionEditor.getByRole("status")
-    const resetFiltersButton = actionEditor.getByRole("button", { name: "Reset filters" })
+    const resetFiltersButton = actionEditor.getByRole("button", {
+      name: "Reset filters",
+    })
 
     await expect(countLabel).toHaveText("4 preset(s) found")
     await resetFiltersButton.click()
 
     const optionsList = page.getByRole("listbox")
-    
+
     // Select a vendor filter
-    await actionEditor.getByRole('combobox').filter({ hasText: 'Filter by vendor' }).click()
+    await actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: "Filter by vendor" })
+      .click()
     await expect(optionsList).toBeVisible()
     const vendorOption = optionsList.getByRole("option", { name: "Microsoft" })
     await expect(vendorOption).toBeVisible()
     await vendorOption.click()
     await expect(vendorOption).not.toBeVisible()
-    
+
     await expect(countLabel).toHaveText("3 preset(s) found")
-    
+
     // Select an aircraft filter
-    await actionEditor.getByRole("combobox").filter({ hasText: "Filter by aircraft" }).click()
-    await expect(optionsList).toBeVisible()    
+    await actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: "Filter by aircraft" })
+      .click()
+    await expect(optionsList).toBeVisible()
     const aircraftOption = optionsList.getByRole("option", { name: "Generic" })
     await expect(aircraftOption).toBeVisible()
     await aircraftOption.click()
     await expect(aircraftOption).not.toBeVisible() // Should be removed from options since it's already selected as a filter
-    
+
     await expect(countLabel).toHaveText("2 preset(s) found")
-    
+
     // Select a system filter
-    await actionEditor.getByRole("combobox").filter({ hasText: "Filter by system" }).click()
-    await expect(optionsList).toBeVisible()    
+    await actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: "Filter by system" })
+      .click()
+    await expect(optionsList).toBeVisible()
     const systemOption = optionsList.getByRole("option", { name: "Avionics" })
     await expect(systemOption).toBeVisible()
     await systemOption.click()
     await expect(systemOption).not.toBeVisible()
-    
+
     await expect(countLabel).toHaveText("1 preset(s) found")
-    
-    
+
     await expect(resetFiltersButton).toBeVisible()
     await resetFiltersButton.click()
-    
+
     await expect(countLabel).toHaveText("4 preset(s) found")
   })
 })
@@ -736,7 +805,13 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await openActionEditor(configListPage, page, 2, undefined, { Sim: "xplane" })
+    const actionEditor = await openActionEditor(
+      configListPage,
+      page,
+      2,
+      undefined,
+      { Sim: "xplane" },
+    )
     await expect(
       actionEditor
         .getByRole("combobox")
@@ -757,7 +832,9 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     ).toBeVisible()
     // Code field reflects the path
     await expect(
-      actionEditor.getByPlaceholder("Enter path for DataRef or Command, or select a preset above"),
+      actionEditor.getByPlaceholder(
+        "Enter path for DataRef or Command, or select a preset above",
+      ),
     ).toHaveValue("laminar/B738/knob/land_alt_press_dn")
   })
 
@@ -794,7 +871,9 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await page.getByRole("option", { name: "test_dataref" }).click()
     // Code field updates
     await expect(
-      actionEditor.getByPlaceholder("Enter path for DataRef or Command, or select a preset above"),
+      actionEditor.getByPlaceholder(
+        "Enter path for DataRef or Command, or select a preset above",
+      ),
     ).toHaveValue("laminar/B739/test/dataref")
     // Input type updates from Command to DataRef
     await expect(
@@ -804,53 +883,67 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await expect(actionEditor.getByText("Test DataRef Preset")).toBeVisible()
   })
 
-    test("Preset filter combo boxes work correctly", async ({
+  test("Preset filter combo boxes work correctly", async ({
     configListPage,
     page,
   }) => {
     const actionEditor = await openActionEditor(configListPage, page, 2)
     const countLabel = actionEditor.getByRole("status")
-    const resetFiltersButton = actionEditor.getByRole("button", { name: "Reset filters" })
+    const resetFiltersButton = actionEditor.getByRole("button", {
+      name: "Reset filters",
+    })
 
     await expect(countLabel).toHaveText("4 preset(s) found")
     await resetFiltersButton.click()
 
     const optionsList = page.getByRole("listbox")
-    
+
     // Select a vendor filter
-    await actionEditor.getByRole('combobox').filter({ hasText: 'Filter by vendor' }).click()
+    await actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: "Filter by vendor" })
+      .click()
     await expect(optionsList).toBeVisible()
-    const vendorOption = optionsList.getByRole("option", { name: "Laminar Research" })
+    const vendorOption = optionsList.getByRole("option", {
+      name: "Laminar Research",
+    })
     await expect(vendorOption).toBeVisible()
     await vendorOption.click()
     await expect(vendorOption).not.toBeVisible()
-    
+
     await expect(countLabel).toHaveText("3 preset(s) found")
-    
+
     // Select an aircraft filter
-    await actionEditor.getByRole("combobox").filter({ hasText: "Filter by aircraft" }).click()
-    await expect(optionsList).toBeVisible()    
-    const aircraftOption = optionsList.getByRole("option", { name: "Boeing 737-800" })
+    await actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: "Filter by aircraft" })
+      .click()
+    await expect(optionsList).toBeVisible()
+    const aircraftOption = optionsList.getByRole("option", {
+      name: "Boeing 737-800",
+    })
     await expect(aircraftOption).toBeVisible()
     await aircraftOption.click()
     await expect(aircraftOption).not.toBeVisible() // Should be removed from options since it's already selected as a filter
-    
+
     await expect(countLabel).toHaveText("2 preset(s) found")
-    
+
     // Select a system filter
-    await actionEditor.getByRole("combobox").filter({ hasText: "Filter by system" }).click()
-    await expect(optionsList).toBeVisible()    
+    await actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: "Filter by system" })
+      .click()
+    await expect(optionsList).toBeVisible()
     const systemOption = optionsList.getByRole("option", { name: "Autopilot" })
     await expect(systemOption).toBeVisible()
     await systemOption.click()
     await expect(systemOption).not.toBeVisible()
-    
+
     await expect(countLabel).toHaveText("1 preset(s) found")
-    
-    
+
     await expect(resetFiltersButton).toBeVisible()
     await resetFiltersButton.click()
-    
+
     await expect(countLabel).toHaveText("4 preset(s) found")
   })
 
@@ -1483,7 +1576,6 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
     await expect(
       actionEditor.getByRole("combobox").filter({ hasText: "Select..." }),
     ).toBeVisible()
-
 
     // onRightFast is empty
     await encoderPanel.getByRole("tab", { name: "On Right Fast" }).click()

--- a/tests/MobiFlightUnitTests/Base/ControllerTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ControllerTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 
 namespace MobiFlight.Base.Tests
 {
@@ -144,5 +145,20 @@ namespace MobiFlight.Base.Tests
             // Assert
             Assert.AreEqual(hash1, hash2);
         }
+
+        #region Serialization tests
+        [TestMethod()]
+        public void OnSerialization_EmptyDevices_IsNotSerialized()
+        {
+            // Arrange
+            var controller = new Controller() { Name = "TestBoard", Serial = "SN-123", Devices = new List<DeviceReference>() };
+            
+            string expected = @"{""Name"":""TestBoard"",""Serial"":""SN-123""}";
+
+            var result = Newtonsoft.Json.JsonConvert.SerializeObject(controller);
+
+            Assert.AreEqual(expected, result, "The serialized JSON does not match the expected output");
+        }
+        #endregion
     }
 }

--- a/tests/MobiFlightUnitTests/Base/ControllerTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ControllerTests.cs
@@ -153,11 +153,14 @@ namespace MobiFlight.Base.Tests
             // Arrange
             var controller = new Controller() { Name = "TestBoard", Serial = "SN-123", Devices = new List<DeviceReference>() };
             
-            string expected = @"{""Name"":""TestBoard"",""Serial"":""SN-123""}";
-
+            // Act
             var result = Newtonsoft.Json.JsonConvert.SerializeObject(controller);
 
-            Assert.AreEqual(expected, result, "The serialized JSON does not match the expected output");
+            // Assert
+            var json = Newtonsoft.Json.Linq.JObject.Parse(result);
+            Assert.AreEqual("TestBoard", (string)json["Name"]);
+            Assert.AreEqual("SN-123", (string)json["Serial"]);
+            Assert.IsFalse(json.ContainsKey("Devices"), "Devices should not be serialized when empty");
         }
         #endregion
     }


### PR DESCRIPTION
### Summary
This PR makes sure that we don't store Devices in the Controller property inside our project file.

### Acceptance criteria
- [x] Controller Binding Updates strip Devices from Controller 
- [x] Action Trigger update strips devices from controller.

### DoD Checklist
- [x] Unit tests available
  - [x] .NET backend
- [x] Frontend tests
- [x] ~~i18n - All user-facing strings are translated~~ 
- [x] ~~documentation~~ 

## Related issues
fixes #3014