### PR TITLE
Update System.** packages from 10.0.5 to 10.0.9

### DIFF
--- a/src/CommandMessenger.Transport.Serial/CommandMessenger.Transport.Serial.csproj
+++ b/src/CommandMessenger.Transport.Serial/CommandMessenger.Transport.Serial.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.IO.Ports" Version="10.0.5" />
+    <PackageReference Include="System.IO.Ports" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -185,22 +185,20 @@
       <HintPath>..\..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.CodeDom, Version=10.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
-      <HintPath>..\..\packages\System.CodeDom.10.0.5\lib\net462\System.CodeDom.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.CodeDom, Version=10.0.0.9, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.CodeDom.10.0.9\lib\net462\System.CodeDom.dll</HintPath>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.5, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>..\..\packages\System.Collections.Immutable.10.0.5\lib\net462\System.Collections.Immutable.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.9, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.10.0.9\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
     <Reference Include="System.Design" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.3, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.10.0.3\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.9, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.10.0.9\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
-    <Reference Include="System.IO.Ports, Version=10.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.IO.Ports.10.0.5\lib\net462\System.IO.Ports.dll</HintPath>
+    <Reference Include="System.IO.Ports, Version=10.0.0.9, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.IO.Ports.10.0.9\lib\net462\System.IO.Ports.dll</HintPath>
     </Reference>
     <Reference Include="System.Management" />
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">

--- a/src/MobiFlightConnector/app.config
+++ b/src/MobiFlightConnector/app.config
@@ -244,7 +244,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.3" newVersion="10.0.0.3" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -252,7 +252,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/MobiFlightConnector/packages.config
+++ b/src/MobiFlightConnector/packages.config
@@ -19,11 +19,11 @@
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net48" />
-  <package id="System.CodeDom" version="10.0.5" targetFramework="net48" />
-  <package id="System.Collections.Immutable" version="10.0.5" targetFramework="net48" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.5" targetFramework="net48" />
-  <package id="System.IO.Ports" version="10.0.5" targetFramework="net48" />
-  <package id="System.Management" version="10.0.5" targetFramework="net48" />
+  <package id="System.CodeDom" version="10.0.9" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="10.0.9" targetFramework="net48" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.9" targetFramework="net48" />
+  <package id="System.IO.Ports" version="10.0.9" targetFramework="net48" />
+  <package id="System.Management" version="10.0.9" targetFramework="net48" />
   <package id="System.Memory" version="4.6.3" targetFramework="net48" />
   <package id="System.Net.WebSockets.Client.Managed" version="1.0.22" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net48" />

--- a/tests/MobiFlightUnitTests/App.config
+++ b/tests/MobiFlightUnitTests/App.config
@@ -25,7 +25,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -33,7 +33,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
@@ -69,7 +69,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.5" newVersion="10.0.0.5" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.9" newVersion="10.0.0.9" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.TestPlatform.AdapterUtilities" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -162,13 +162,13 @@
       <HintPath>..\..\packages\System.Buffers.4.6.1\lib\net462\System.Buffers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=10.0.0.5, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Collections.Immutable.10.0.5\lib\net462\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=10.0.0.9, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Collections.Immutable.10.0.9\lib\net462\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.5, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.10.0.5\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=10.0.0.9, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Diagnostics.DiagnosticSource.10.0.9\lib\net462\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Memory, Version=4.0.5.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51">
       <HintPath>..\..\packages\System.Memory.4.6.3\lib\net462\System.Memory.dll</HintPath>
@@ -186,8 +186,8 @@
     <Reference Include="System.Reactive, Version=6.1.0.0, Culture=neutral, PublicKeyToken=94bc3704cddfc263, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Reactive.6.1.0\lib\net472\System.Reactive.dll</HintPath>
     </Reference>
-    <Reference Include="System.Reflection.Metadata, Version=10.0.0.5, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Reflection.Metadata.10.0.5\lib\net462\System.Reflection.Metadata.dll</HintPath>
+    <Reference Include="System.Reflection.Metadata, Version=10.0.0.9, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Reflection.Metadata.10.0.9\lib\net462\System.Reflection.Metadata.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=6.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/tests/MobiFlightUnitTests/packages.config
+++ b/tests/MobiFlightUnitTests/packages.config
@@ -25,13 +25,13 @@
   <package id="SharpDX" version="4.2.0" targetFramework="net48" />
   <package id="SharpDX.DirectInput" version="4.2.0" targetFramework="net48" />
   <package id="System.Buffers" version="4.6.1" targetFramework="net48" />
-  <package id="System.Collections.Immutable" version="10.0.5" targetFramework="net48" />
-  <package id="System.Diagnostics.DiagnosticSource" version="10.0.5" targetFramework="net48" />
+  <package id="System.Collections.Immutable" version="10.0.9" targetFramework="net48" />
+  <package id="System.Diagnostics.DiagnosticSource" version="10.0.9" targetFramework="net48" />
   <package id="System.Memory" version="4.6.3" targetFramework="net48" />
   <package id="System.Net.WebSockets.Client.Managed" version="1.0.22" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.6.1" targetFramework="net48" />
   <package id="System.Reactive" version="6.1.0" targetFramework="net48" />
-  <package id="System.Reflection.Metadata" version="10.0.5" targetFramework="net48" />
+  <package id="System.Reflection.Metadata" version="10.0.9" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="6.1.2" targetFramework="net48" />
   <package id="System.Threading.Tasks.Extensions" version="4.6.3" targetFramework="net48" />
   <package id="XPlaneConnector" version="1.3.0" targetFramework="net48" />

--- a/tests/MobiFlightWwFcuUnitTests/MobiFlightWwFcuUnitTests.csproj
+++ b/tests/MobiFlightWwFcuUnitTests/MobiFlightWwFcuUnitTests.csproj
@@ -13,9 +13,9 @@
     <PackageReference Include="Microsoft.Testing.Extensions.TrxReport.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.1.0" />
     <PackageReference Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.5" />
-    <PackageReference Include="System.Reflection.Metadata" Version="10.0.5" />
+    <PackageReference Include="System.Collections.Immutable" Version="10.0.9" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
+    <PackageReference Include="System.Reflection.Metadata" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Summary
Updates various dependencies to their latest version. Dependabot failed to do it automatically. So we did it manually.

### Acceptance criteria
- [x] Update packages through NuGet Manager
- [x] Project builds
- [x] All deps are showing the latest package version
     
## Related issues
- https://github.com/MobiFlight/MobiFlight-Connector/pull/3027
- https://github.com/MobiFlight/MobiFlight-Connector/pull/3026 
- https://github.com/MobiFlight/MobiFlight-Connector/pull/3025
- https://github.com/MobiFlight/MobiFlight-Connector/pull/3024