### PR TITLE
Stop hold/repeat timers on ExecutionManager.Stop() so they dont keep running forever

### DIFF
--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -50,6 +50,12 @@ namespace MobiFlight.Execution
             inputCache.Clear();
         }
 
+        public void StopAllHoldTimers()
+        {
+            foreach (var cfg in _configItems.OfType<InputConfigItem>())
+                cfg.button?.StopTimers();
+        }
+
         public Dictionary<string, IConfigItem> Execute(InputEventArgs e, bool isStarted)
         {
             var updatedValues = new Dictionary<string, IConfigItem>();

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -85,6 +85,7 @@ namespace MobiFlight.Execution
                 if (!cfg.Active)
                 {
                     Log.Instance.log($"{msgEventLabel} => Skipping inactive config \"{cfg.Name}\".", LogSeverity.Warn);
+                    cfg.button?.StopTimers();
                     continue;
                 }
 
@@ -93,10 +94,14 @@ namespace MobiFlight.Execution
                     if (!CheckPreconditions(cfg))
                     {
                         Log.Instance.log($"{msgEventLabel} => Preconditions not satisfied for \"{cfg.Name}\".", LogSeverity.Debug);
+                        cfg.button?.StopTimers();
                         continue;
                     }
 
                     Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({e.GetEventActionLabel()})", LogSeverity.Info);
+
+                    if (cfg.button != null)
+                        cfg.button.CanExecute = () => cfg.Active && CheckPreconditions(cfg);
 
                     cfg.RawValue = e.GetEventActionLabel();
                     cfg.Value = " ";

--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -633,6 +633,9 @@ namespace MobiFlight
             var configItemIndex = ConfigItems.FindIndex(i => i.GUID == item.GUID);
             if (configItemIndex == -1) return;
 
+            if (ConfigItems[configItemIndex] is InputConfigItem oldInputConfig)
+                oldInputConfig.button?.StopTimers();
+
             ConfigItems[configItemIndex] = item;
             MessageExchange.Instance.Publish(new ConfigValuePartialUpdate(item));
             OnInputConfigSettingsChanged(item, null);

--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -855,6 +855,8 @@ namespace MobiFlight
             joystickManager.Stop();
             midiBoardManager.Stop();
             inputActionExecutionCache.Clear();
+            foreach (var executor in _inputEventExecutors.Values)
+                executor.StopAllHoldTimers();
             ClearConfigItemStatus();
             ClearErrorMessages();
         }

--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -845,6 +845,8 @@ namespace MobiFlight
             mobiFlightCache.StopKeepAwake();
 
             isExecuting = false;
+            foreach (var executor in _inputEventExecutors.Values)
+                executor.StopAllHoldTimers();
 #if ARCAZE
             arcazeCache.Clear();
 #endif
@@ -855,8 +857,6 @@ namespace MobiFlight
             joystickManager.Stop();
             midiBoardManager.Stop();
             inputActionExecutionCache.Clear();
-            foreach (var executor in _inputEventExecutors.Values)
-                executor.StopAllHoldTimers();
             ClearConfigItemStatus();
             ClearErrorMessages();
         }

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -23,6 +23,7 @@ namespace MobiFlight.InputConfig
 
         private Timer HoldTimer = new Timer();
         private Timer RepeatTimer = new Timer();
+        private volatile bool _holdTimersStopped = false;
 
         public ButtonInputConfig()
         {
@@ -210,6 +211,7 @@ namespace MobiFlight.InputConfig
 
         private void ExecuteRepeatOnHold()
         {
+            if (_holdTimersStopped) return;
             if (RepeatDelay > 0)
             {
                 RepeatTimer.Interval = RepeatDelay;
@@ -258,6 +260,7 @@ namespace MobiFlight.InputConfig
 
         public void StopTimers()
         {
+            _holdTimersStopped = true;
             CheckAndStopTimer();
         }
 
@@ -282,6 +285,7 @@ namespace MobiFlight.InputConfig
                                           InputEventArgs args,
                                           List<ConfigRefValue> configRefs)
         {
+            _holdTimersStopped = false;
             lock (LastOnPressLock)
             {
                 LastOnPressEvent = args;

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -2,6 +2,7 @@
 using System.Timers;
 using System.Collections.Generic;
 using System.Xml.Serialization;
+using Newtonsoft.Json;
 
 namespace MobiFlight.InputConfig
 {
@@ -24,6 +25,10 @@ namespace MobiFlight.InputConfig
         private Timer HoldTimer = new Timer();
         private Timer RepeatTimer = new Timer();
         private volatile bool _holdTimersStopped = false;
+
+        [XmlIgnore]
+        [JsonIgnore]
+        public Func<bool> CanExecute { get; set; }
 
         public ButtonInputConfig()
         {
@@ -188,6 +193,7 @@ namespace MobiFlight.InputConfig
 
         private void ExecuteOnHoldAction()
         {
+            if (CanExecute != null && !CanExecute()) { StopTimers(); return; }
             lock (LastOnPressLock)
             {
                 InputEventArgs args = (InputEventArgs)LastOnPressEvent.Clone();

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -198,7 +198,14 @@ namespace MobiFlight.InputConfig
 
         private void RepeatTimer_Elapsed(object sender, EventArgs e)
         {
-            ExecuteOnHoldAction();
+            try
+            {
+                ExecuteOnHoldAction();
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log($"Error executing onHold action: {ex.Message}", LogSeverity.Error);
+            }
         }
 
         private void ExecuteRepeatOnHold()
@@ -212,9 +219,19 @@ namespace MobiFlight.InputConfig
 
         private void HoldTimer_Elapsed(object sender, EventArgs e)
         {
-            ExecuteOnHoldAction();
-            HoldTimer.Stop();
-            ExecuteRepeatOnHold();
+            try
+            {
+                ExecuteOnHoldAction();
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log($"Error executing onHold action: {ex.Message}", LogSeverity.Error);
+            }
+            finally
+            {
+                HoldTimer.Stop();
+                ExecuteRepeatOnHold();
+            }
         }
 
         private void ExecuteOnHoldWithTimer()
@@ -237,6 +254,11 @@ namespace MobiFlight.InputConfig
                 HoldTimer.Stop();
             if (RepeatTimer.Enabled)
                 RepeatTimer.Stop();
+        }
+
+        public void StopTimers()
+        {
+            CheckAndStopTimer();
         }
 
         private void CheckAndAdaptForLongButtonRelease(InputEventArgs current, InputEventArgs previous)

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -24,8 +24,10 @@ namespace MobiFlight.InputConfig
 
         private Timer HoldTimer = new Timer();
         private Timer RepeatTimer = new Timer();
-        private volatile bool _holdTimersStopped = false;
 
+        // Func<bool> rather than bool so the check is deferred — the closure captures cfg
+        // and CheckPreconditions, evaluating current state on each timer fire rather than
+        // at press time.
         [XmlIgnore]
         [JsonIgnore]
         public Func<bool> CanExecute { get; set; }
@@ -217,7 +219,6 @@ namespace MobiFlight.InputConfig
 
         private void ExecuteRepeatOnHold()
         {
-            if (_holdTimersStopped) return;
             if (RepeatDelay > 0)
             {
                 RepeatTimer.Interval = RepeatDelay;
@@ -266,7 +267,6 @@ namespace MobiFlight.InputConfig
 
         public void StopTimers()
         {
-            _holdTimersStopped = true;
             CheckAndStopTimer();
         }
 
@@ -291,7 +291,6 @@ namespace MobiFlight.InputConfig
                                           InputEventArgs args,
                                           List<ConfigRefValue> configRefs)
         {
-            _holdTimersStopped = false;
             lock (LastOnPressLock)
             {
                 LastOnPressEvent = args;

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -600,20 +600,20 @@ namespace MobiFlight.Execution.Tests
                 Name = "DeactivatedConfig",
                 button = new ButtonInputConfig
                 {
-                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" }
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
+                    HoldDelay = 10000
                 }
             };
             _configItems.Add(configItem);
 
+            _executor.Execute(CreateButtonEventArgs(serial, deviceName, isOnPress: true), isStarted: true);
+
             var holdTimer = GetHoldTimer(configItem.button);
-            holdTimer.Interval = 10000;
-            holdTimer.Start();
-            Assert.IsTrue(holdTimer.Enabled, "Timer should be running before deactivation.");
+            Assert.IsTrue(holdTimer.Enabled, "Timer should be running after press.");
 
             configItem.Active = false;
 
-            var releaseEvent = CreateButtonEventArgs(serial, deviceName, isOnPress: false);
-            _executor.Execute(releaseEvent, isStarted: true);
+            _executor.Execute(CreateButtonEventArgs(serial, deviceName, isOnPress: false), isStarted: true);
 
             Assert.IsFalse(holdTimer.Enabled, "Timer should be stopped when the config is deactivated.");
         }
@@ -624,6 +624,8 @@ namespace MobiFlight.Execution.Tests
             var serial = "SN-precond001";
             var deviceName = "Button1";
 
+            _configItems[0].Value = "ExpectedValue";
+
             var configItem = new InputConfigItem
             {
                 Active = true,
@@ -632,22 +634,24 @@ namespace MobiFlight.Execution.Tests
                 Name = "PreconditionConfig",
                 button = new ButtonInputConfig
                 {
-                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p2" }
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p2" },
+                    HoldDelay = 10000
                 },
                 Preconditions = new PreconditionList
                 {
-                    new Precondition { Type = "variable", Active = true, Ref = "NonExistentRef", Value = "ExpectedValue" }
+                    new Precondition { Type = "config", Active = true, Ref = _configItems[0].GUID, Value = "ExpectedValue" }
                 }
             };
             _configItems.Add(configItem);
 
-            var holdTimer = GetHoldTimer(configItem.button);
-            holdTimer.Interval = 10000;
-            holdTimer.Start();
-            Assert.IsTrue(holdTimer.Enabled, "Timer should be running before precondition fails.");
+            _executor.Execute(CreateButtonEventArgs(serial, deviceName, isOnPress: true), isStarted: true);
 
-            var releaseEvent = CreateButtonEventArgs(serial, deviceName, isOnPress: false);
-            _executor.Execute(releaseEvent, isStarted: true);
+            var holdTimer = GetHoldTimer(configItem.button);
+            Assert.IsTrue(holdTimer.Enabled, "Timer should be running after press with precondition satisfied.");
+
+            _configItems[0].Value = "DifferentValue";
+
+            _executor.Execute(CreateButtonEventArgs(serial, deviceName, isOnPress: false), isStarted: true);
 
             Assert.IsFalse(holdTimer.Enabled, "Timer should be stopped when the precondition is not satisfied.");
         }

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -577,6 +577,83 @@ namespace MobiFlight.Execution.Tests
 
         #endregion
 
+        #region Hold Timer Cleanup on Skip
+
+        private static System.Timers.Timer GetHoldTimer(ButtonInputConfig button)
+        {
+            return (System.Timers.Timer)typeof(ButtonInputConfig)
+                .GetField("HoldTimer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .GetValue(button);
+        }
+
+        [TestMethod]
+        public void Execute_ConfigDeactivatedWhileButtonHeld_StopsHoldTimer()
+        {
+            var serial = "SN-deact001";
+            var deviceName = "Button1";
+
+            var configItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "DeactivatedConfig",
+                button = new ButtonInputConfig
+                {
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" }
+                }
+            };
+            _configItems.Add(configItem);
+
+            var holdTimer = GetHoldTimer(configItem.button);
+            holdTimer.Interval = 10000;
+            holdTimer.Start();
+            Assert.IsTrue(holdTimer.Enabled, "Timer should be running before deactivation.");
+
+            configItem.Active = false;
+
+            var releaseEvent = CreateButtonEventArgs(serial, deviceName, isOnPress: false);
+            _executor.Execute(releaseEvent, isStarted: true);
+
+            Assert.IsFalse(holdTimer.Enabled, "Timer should be stopped when the config is deactivated.");
+        }
+
+        [TestMethod]
+        public void Execute_PreconditionFailsWhileButtonHeld_StopsHoldTimer()
+        {
+            var serial = "SN-precond001";
+            var deviceName = "Button1";
+
+            var configItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "PreconditionConfig",
+                button = new ButtonInputConfig
+                {
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p2" }
+                },
+                Preconditions = new PreconditionList
+                {
+                    new Precondition { Type = "variable", Active = true, Ref = "NonExistentRef", Value = "ExpectedValue" }
+                }
+            };
+            _configItems.Add(configItem);
+
+            var holdTimer = GetHoldTimer(configItem.button);
+            holdTimer.Interval = 10000;
+            holdTimer.Start();
+            Assert.IsTrue(holdTimer.Enabled, "Timer should be running before precondition fails.");
+
+            var releaseEvent = CreateButtonEventArgs(serial, deviceName, isOnPress: false);
+            _executor.Execute(releaseEvent, isStarted: true);
+
+            Assert.IsFalse(holdTimer.Enabled, "Timer should be stopped when the precondition is not satisfied.");
+        }
+
+        #endregion
+
         #region Edge Cases - Stale Configs With Correct DeviceType
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -206,6 +206,25 @@ namespace MobiFlight.InputConfig.Tests
         }
 
         [TestMethod()]
+        public void StopTimers_WithRunningHoldTimer_StopsTimer()
+        {
+            ButtonInputConfig o = new ButtonInputConfig();
+            o.onHold = new XplaneInputAction() { Expression = "", InputType = "Command", Path = "sim/test" };
+
+            var holdTimer = typeof(ButtonInputConfig)
+                .GetField("HoldTimer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                .GetValue(o) as System.Timers.Timer;
+
+            holdTimer.Interval = 10000;
+            holdTimer.Start();
+            Assert.IsTrue(holdTimer.Enabled, "HoldTimer should be running before StopTimers()");
+
+            o.StopTimers();
+
+            Assert.IsFalse(holdTimer.Enabled, "HoldTimer should be stopped after StopTimers()");
+        }
+
+        [TestMethod()]
         public void JsonSerializationTest()
         {
             var serializerSettings = new JsonSerializerSettings

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -198,6 +198,14 @@ namespace MobiFlight.InputConfig.Tests
         }
 
         [TestMethod()]
+        public void StopTimers_WithNoOnHold_DoesNotThrow()
+        {
+            ButtonInputConfig o = new ButtonInputConfig();
+            o.onPress = new EventIdInputAction() { EventId = 12345 };
+            o.StopTimers();
+        }
+
+        [TestMethod()]
         public void JsonSerializationTest()
         {
             var serializerSettings = new JsonSerializerSettings


### PR DESCRIPTION
### Summary
When a button config has OnHold event defined with a timeout, and a OnHold event is received, a timer is created to execute the event at specified intervals until the button is released. When that happens, the button OnRelease event clears the timer. 

But if you stopped MobiFlight while the button was being held in pressed state (like a toggle switch) or if the input config has a precondition that became unsatisfied, the release event would be ignored, and the timer would keep running forever. 

Did this with Claude while learning more of the codebase.

- [x] Added StopAllHoldTimers() and hooked it to Stop();
- [x] Also added try/catch on RepeatTimer_Elapsed() and HoldTimer_Elapsed() using the pattern from inputEventExecutor.Execute() to log error instead of crashing if an event throws a fit for some reason.
- [x] tested that OnHold events are still working, with and without repeat

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
  - [x] ~~Frontend~~
- [x] ~~Frontend tests~~
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #2890 
