### PR TITLE
Use mono space font in all the different value fields for input actions.

### DIFF
--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -593,10 +593,13 @@
           "ClearInput": "Eingabe löschen"
         },
         "FsuipcOffset": {
+          "TypeLabel": "Typ",
           "SizeLabel": "Größe",
           "OffsetLabel": "Offset",
           "MaskLabel": "Maske",
-          "BcdModeLabel": "BCD-Modus"
+          "BcdModeLabel": "BCD-Modus",
+          "ValueLabel": "Wert",
+          "ValuePlaceholder": "Wert eingeben"
         },
         "LuaMacro": {
           "Title": "Lua-Makro-Eingabeaktion",

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -591,7 +591,9 @@
           "SizeLabel": "Size",
           "OffsetLabel": "Offset",
           "MaskLabel": "Mask",
-          "BcdModeLabel": "BCD Mode"
+          "BcdModeLabel": "BCD Mode",
+          "ValueLabel": "Value",
+          "ValuePlaceholder": "Enter value"
         },
         "LuaMacro": {
           "Title": "Lua Macro Input Action",

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -593,10 +593,13 @@
           "ClearInput": "Borrar entrada"
         },
         "FsuipcOffset": {
+          "TypeLabel": "Tipo",
           "SizeLabel": "Tamaño",
           "OffsetLabel": "Offset",
           "MaskLabel": "Máscara",
-          "BcdModeLabel": "Modo BCD"
+          "BcdModeLabel": "Modo BCD",
+          "ValueLabel": "Valor",
+          "ValuePlaceholder": "Ingresar valor"
         },
         "LuaMacro": {
           "Title": "Acción de entrada de macro Lua",

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -587,10 +587,13 @@
           "ClearInput": "Tyhjennä syöte"
         },
         "FsuipcOffset": {
+          "TypeLabel": "Tyyppi",
           "SizeLabel": "Koko",
           "OffsetLabel": "Offset",
           "MaskLabel": "Maski",
-          "BcdModeLabel": "BCD-tila"
+          "BcdModeLabel": "BCD-tila",
+          "ValueLabel": "Arvo",
+          "ValuePlaceholder": "Syötä arvo"
         },
         "LuaMacro": {
           "Title": "Lua-makro-syötetoiminto",

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -587,7 +587,7 @@
           "ClearInput": "Limpar entrada"
         },
         "FsuipcOffset": {
-          "Type": "Tipo",
+          "TypeLabel": "Tipo",
           "SizeLabel": "Tamanho",
           "OffsetLabel": "Deslocamento",
           "MaskLabel": "Máscara",

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -587,10 +587,13 @@
           "ClearInput": "Limpar entrada"
         },
         "FsuipcOffset": {
+          "Type": "Tipo",
           "SizeLabel": "Tamanho",
           "OffsetLabel": "Deslocamento",
           "MaskLabel": "Máscara",
-          "BcdModeLabel": "Modo BCD"
+          "BcdModeLabel": "Modo BCD",
+          "ValueLabel": "Valor",
+          "ValuePlaceholder": "Digite o valor"
         },
         "LuaMacro": {
           "Title": "Ação de Entrada Lua Macro",

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/EventIdInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/EventIdInputActionPanel.tsx
@@ -154,6 +154,7 @@ const EventIdInputActionPanel = ({
             )}
           </Label>
           <Input
+            className="font-mono text-sm whitespace-nowrap"
             id="customParam"
             value={config?.Param ?? ""}
             onChange={(e) =>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/FsuipcOffsetInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/FsuipcOffsetInputActionPanel.tsx
@@ -103,7 +103,7 @@ const FsuipcOffsetInputActionPanel = ({
               .padStart(4, "0")}
           </div>
         </div>
-        <div className="flex grow flex-col gap-1">
+        <div className="flex flex-col gap-1">
           <Label htmlFor="bcdMode">
             {t(
               "Dialog.InputConfigWizard.InputActions.FsuipcOffset.BcdModeLabel",
@@ -111,6 +111,14 @@ const FsuipcOffsetInputActionPanel = ({
           </Label>
           <div id="bcdMode">
             <Switch id="bcdMode" checked={currentConfig.FSUIPC.BcdMode} />
+          </div>
+        </div>
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="value">
+            {t("Dialog.InputConfigWizard.InputActions.FsuipcOffset.ValueLabel")}
+          </Label>
+          <div className="bg-accent rounded px-2 py-1 font-mono text-sm whitespace-pre-wrap truncate">
+            {currentConfig.Value}
           </div>
         </div>
       </div>
@@ -137,7 +145,10 @@ const FsuipcOffsetInputActionPanel = ({
                   ...currentConfig.FSUIPC,
                   OffsetType: option?.value ?? FSUIPC_TYPE_INTEGER,
                   // if switching to string, set size to 255
-                  Size: option?.value === FSUIPC_TYPE_STRING ? 255 : currentConfig.FSUIPC.Size, 
+                  Size:
+                    option?.value === FSUIPC_TYPE_STRING
+                      ? 255
+                      : currentConfig.FSUIPC.Size,
                 },
               } as FsuipcOffsetInputAction)
             }
@@ -194,60 +205,86 @@ const FsuipcOffsetInputActionPanel = ({
           />
         </div>
         {currentConfig.FSUIPC.OffsetType === FSUIPC_TYPE_INTEGER && (
-        <div className="flex flex-col gap-1">
-          <Label className="text-sm font-medium" htmlFor="mask">
-            {t("Dialog.InputConfigWizard.InputActions.FsuipcOffset.MaskLabel")}
-          </Label>
-          <Input
-            className="field-sizing-content"
-            autoComplete="off"
-            id="mask"
-            value={mask ?? formattedMask}
-            onKeyDown={filterHexInput}
-            onFocus={() => setMask(formattedMask)}
-            onChange={(e) =>
-              setMask(
-                e.target.value
+          <div className="flex flex-col gap-1">
+            <Label className="text-sm font-medium" htmlFor="mask">
+              {t(
+                "Dialog.InputConfigWizard.InputActions.FsuipcOffset.MaskLabel",
+              )}
+            </Label>
+            <Input
+              className="field-sizing-content"
+              autoComplete="off"
+              id="mask"
+              value={mask ?? formattedMask}
+              onKeyDown={filterHexInput}
+              onFocus={() => setMask(formattedMask)}
+              onChange={(e) =>
+                setMask(
+                  e.target.value
+                    .toUpperCase()
+                    .slice(-currentConfig.FSUIPC.Size * 2),
+                )
+              }
+              onBlur={() => {
+                const newMask = (mask ?? formattedMask)
                   .toUpperCase()
-                  .slice(-currentConfig.FSUIPC.Size * 2),
-              )
-            }
-            onBlur={() => {
-              const newMask = (mask ?? formattedMask)
-                .toUpperCase()
-                .padStart(currentConfig.FSUIPC.Size * 2, "0")
-                .slice(-(currentConfig.FSUIPC.Size * 2))
-              setMask(null)
-              onConfigChange({
-                ...currentConfig,
-                FSUIPC: {
-                  ...currentConfig.FSUIPC,
-                  Mask: parseInt(newMask, 16),
-                },
-              } as FsuipcOffsetInputAction)
-            }}
-          />
-        </div>
+                  .padStart(currentConfig.FSUIPC.Size * 2, "0")
+                  .slice(-(currentConfig.FSUIPC.Size * 2))
+                setMask(null)
+                onConfigChange({
+                  ...currentConfig,
+                  FSUIPC: {
+                    ...currentConfig.FSUIPC,
+                    Mask: parseInt(newMask, 16),
+                  },
+                } as FsuipcOffsetInputAction)
+              }}
+            />
+          </div>
         )}
         {currentConfig.FSUIPC.OffsetType === FSUIPC_TYPE_INTEGER && (
-        <div className="flex flex-row items-center gap-2 pt-5">
-          <Switch
-            id="bcdMode"
-            checked={currentConfig.FSUIPC.BcdMode}
-            onCheckedChange={(e) =>
-              onConfigChange({
-                ...currentConfig,
-                FSUIPC: { ...currentConfig.FSUIPC, BcdMode: e },
-              } as FsuipcOffsetInputAction)
-            }
-          />
-          <Label className="text-sm font-medium" htmlFor="bcdMode">
-            {t(
-              "Dialog.InputConfigWizard.InputActions.FsuipcOffset.BcdModeLabel",
-            )}
-          </Label>
-        </div>
+          <div className="flex flex-row items-center gap-2 pt-5">
+            <Switch
+              id="bcdMode"
+              checked={currentConfig.FSUIPC.BcdMode}
+              onCheckedChange={(e) =>
+                onConfigChange({
+                  ...currentConfig,
+                  FSUIPC: { ...currentConfig.FSUIPC, BcdMode: e },
+                } as FsuipcOffsetInputAction)
+              }
+            />
+            <Label className="text-sm font-medium" htmlFor="bcdMode">
+              {t(
+                "Dialog.InputConfigWizard.InputActions.FsuipcOffset.BcdModeLabel",
+              )}
+            </Label>
+          </div>
         )}
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="value">
+          {t("Dialog.InputConfigWizard.InputActions.FsuipcOffset.ValueLabel")}
+        </Label>
+        <Input
+          className="font-mono text-sm whitespace-nowrap"
+          id="value"
+          value={config?.Value ?? ""}
+          onChange={(e) =>
+            onConfigChange({
+              ...(config as FsuipcOffsetInputAction),
+              Value: e.target.value,
+            })
+          }
+          placeholder={t(
+            "Dialog.InputConfigWizard.InputActions.FsuipcOffset.ValuePlaceholder",
+          )}
+        />
+        <div className="text-muted-foreground text-sm">
+          {t(
+            "Dialog.InputConfigWizard.InputActions.Common.SupportedPlaceholders",
+          )}
+        </div>
       </div>
     </div>
   )

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/JeehellInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/JeehellInputActionPanel.tsx
@@ -15,7 +15,7 @@ export type JeehellInputActionPanelProps = {
 const JeehellInputActionPanel = ({
   variant,
   config,
-  onConfigChange
+  onConfigChange,
 }: JeehellInputActionPanelProps) => {
   const { t } = useTranslation()
   // In MsfsPresetPanel (or a dedicated hook)
@@ -31,7 +31,9 @@ const JeehellInputActionPanel = ({
     staleTime: Infinity, // presets don't change at runtime; HubHopState drives invalidation
   })
 
-  const selectedPreset = presets.find((item) => item.eventId === config?.EventId?.toString())
+  const selectedPreset = presets.find(
+    (item) => item.eventId === config?.EventId?.toString(),
+  )
 
   if (variant === "summary") {
     return (
@@ -60,9 +62,13 @@ const JeehellInputActionPanel = ({
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-col gap-2">
-        <Label htmlFor="mouseParam">{t("Dialog.InputConfigWizard.InputActions.Jeehell.FunctionLabel")}</Label>
+        <Label htmlFor="mouseParam">
+          {t("Dialog.InputConfigWizard.InputActions.Jeehell.FunctionLabel")}
+        </Label>
         <ComboBox
-          placeholder={t("Dialog.InputConfigWizard.InputActions.Jeehell.SelectFunctionPlaceholder")}
+          placeholder={t(
+            "Dialog.InputConfigWizard.InputActions.Jeehell.SelectFunctionPlaceholder",
+          )}
           items={presets}
           getLabel={(item) => item.name}
           getValue={(item) => item.eventId}
@@ -76,11 +82,16 @@ const JeehellInputActionPanel = ({
           }
           widthClass="w-100"
         />
-        <p className="text-sm text-muted-foreground">{selectedPreset?.description}</p>
+        <p className="text-muted-foreground text-sm">
+          {selectedPreset?.description}
+        </p>
       </div>
       <div className="flex w-100 flex-col gap-2">
-        <Label htmlFor="value">{t("Dialog.InputConfigWizard.InputActions.Jeehell.ValueLabel")}</Label>
+        <Label htmlFor="value">
+          {t("Dialog.InputConfigWizard.InputActions.Jeehell.ValueLabel")}
+        </Label>
         <Input
+          className="font-mono text-sm whitespace-nowrap"
           id="value"
           value={config?.Param ?? ""}
           onChange={(e) =>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -65,6 +65,7 @@ const MsfsInputActionPanel = ({
         </Label>
         <Textarea
           name="code"
+          className="font-mono text-sm whitespace-nowrap"
           placeholder={t("Dialog.InputConfigWizard.InputActions.Msfs.CodePlaceholder")}
           value={config?.Command ?? ""}
           onChange={(e) => {

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/ProSimInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/ProSimInputActionPanel.tsx
@@ -75,8 +75,12 @@ const ProSimInputActionPanel = ({
         <Label htmlFor="path">
           {t("Dialog.InputConfigWizard.InputActions.ProSim.PathLabel")}
         </Label>
-        <div id="path" className="rounded border p-2 text-sm" data-testid="pathValue">
-          {(config?.Path && config?.Path !== "")
+        <div
+          id="path"
+          className="rounded border p-2 text-sm"
+          data-testid="pathValue"
+        >
+          {config?.Path && config?.Path !== ""
             ? config?.Path
             : t(
                 "Dialog.InputConfigWizard.InputActions.ProSim.NoPresetSelected",
@@ -88,6 +92,7 @@ const ProSimInputActionPanel = ({
           {t("Dialog.InputConfigWizard.InputActions.ProSim.ParameterLabel")}
         </Label>
         <Input
+          className="font-mono text-sm whitespace-nowrap"
           id="param"
           placeholder={t(
             "Dialog.InputConfigWizard.InputActions.ProSim.ParameterPlaceholder",

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VJoyInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VJoyInputActionPanel.tsx
@@ -228,6 +228,7 @@ const VJoyInputActionPanel = ({
                 {t("Dialog.InputConfigWizard.InputActions.VJoy.AxisValueLabel")}
               </Label>
               <Input
+                className="font-mono text-sm whitespace-nowrap"
                 id="axisValue"
                 value={config?.sendValue ?? "1"}
                 onChange={(e) =>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VariablePanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VariablePanel.tsx
@@ -150,6 +150,7 @@ export const VariablePanel = ({
               )}
             </Label>
             <Input
+              className="font-mono text-sm whitespace-nowrap"
               value={variable.Expression}
               onKeyDown={(e) => {
                 e.stopPropagation()

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -89,6 +89,7 @@ const XplaneInputActionPanel = ({
         </Label>
         <Input
           id="path"
+          className="font-mono text-sm whitespace-nowrap"
           value={config?.Path ?? ""}
           onChange={(e) =>
             onConfigChange({
@@ -110,6 +111,7 @@ const XplaneInputActionPanel = ({
             {t("Dialog.InputConfigWizard.InputActions.Xplane.ValueLabel")}
           </Label>
           <Input
+            className="font-mono text-sm whitespace-nowrap"
             id="value"
             value={config?.Expression ?? ""}
             onChange={(e) =>

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2205,6 +2205,10 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     // from false to true
     await bcdModeSwitch.click()
 
+    const valueInput = actionEditor.getByRole("textbox", { name: "Value" })
+    await expect(valueInput).toBeVisible()
+    await valueInput.fill("1234")
+
     // End: provide specific user input
 
     const backButton = page.getByRole("button", { name: "Go back" })
@@ -2230,7 +2234,7 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
         Mask: 0xaabbccdd,
         BcdMode: true,
       },
-      Value: "",
+      Value: "1234",
       Modifiers: [],
     } as FsuipcOffsetInputAction)
   })
@@ -2278,6 +2282,10 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     const offsetInput = actionEditor.getByRole("textbox", { name: "Offset" })
     await expect(offsetInput).toBeVisible()
     await offsetInput.fill("66CC")
+
+    const valueInput = actionEditor.getByRole("textbox", { name: "Value" })
+    await expect(valueInput).toBeVisible()
+    await valueInput.fill("1.234")
     // End: provide specific user input
 
     const backButton = page.getByRole("button", { name: "Go back" })
@@ -2303,7 +2311,7 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
         Mask: 0xff,
         BcdMode: false,
       },
-      Value: "",
+      Value: "1.234",
       Modifiers: [],
     } as FsuipcOffsetInputAction)
   })
@@ -2340,6 +2348,10 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     const offsetInput = actionEditor.getByRole("textbox", { name: "Offset" })
     await expect(offsetInput).toBeVisible()
     await offsetInput.fill("66CC")
+
+    const valueInput = actionEditor.getByRole("textbox", { name: "Value" })
+    await expect(valueInput).toBeVisible()
+    await valueInput.fill("Test String")
     // End: provide specific user input
 
     const backButton = page.getByRole("button", { name: "Go back" })
@@ -2365,7 +2377,7 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
         Mask: 0xff,
         BcdMode: false,
       },
-      Value: "",
+      Value: "Test String",
       Modifiers: [],
     } as FsuipcOffsetInputAction)
   })


### PR DESCRIPTION
### Summary
Use mono space font in all the different value fields for input actions.

### Screenshots / recordings
<img width="1072" height="163" alt="image" src="https://github.com/user-attachments/assets/254843b2-df48-4761-be09-546376311cf3" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Mono space font is used in all value / code / parameter fields
  - [x] MSFS preset
  - [x] X-Plane preset
  - [x] Jeehell
  - [x] Prosim
  - [x] Variable
  - [x] vJoy
  - [x] FSUIPC Event ID
  - [x] FSUIPC Offset value


### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] Frontend tests
  - [x] new value field
- [x] i18n - All user-facing strings are translated
  - [x] core (en,de,es)
  - [x] additional langs
- [x] documentation
  - [ ] User docs (docs.mobiflight.com) - @neilenns 
     
## Related issues
fixes #3061
fixes #3062

### Out-of-scope
FSUIPC Offsets don't provide preset list.
