### PR TITLE
Remove async from Update method for DAP500

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/Dap500.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/Dap500.cs
@@ -1,7 +1,6 @@
 ﻿using HidSharp;
 using HidSharp.Reports.Input;
 using System;
-using System.Collections.Generic;
 using System.Threading;
 
 namespace MobiFlight.Joysticks.WingFlex
@@ -123,7 +122,7 @@ namespace MobiFlight.Joysticks.WingFlex
         /// Update is called by the base class
         /// It is currently needed to ensure that the hid device is correctly initialized.
         /// </summary>
-        public override async void Update()
+        public override void Update()
         {
             // Octavi is not a DirectInput device
             // so we have to connect it here.


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
Publish workflow was failing. Remove async from Update method for DAP500.
CS1998 is treated as warning during regular build but as an error on publish. The reason is unclear. This is not really on purpose.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Don't trigger CS1998 during build

### DoD Checklist
nothing relevant this time.
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3064

### Out-of-scope
Aligning workflow configs so that we can see this error during PR build and locally too.

### Notes
<!-- provide furhter information that might be of interest -->
