### PR TITLE
Restore minimize-to-tray after badge feature

### DIFF
--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -1568,7 +1568,6 @@ namespace MobiFlight.UI
                 execManager.Start();
                 if (Properties.Settings.Default.MinimizeOnAutoRun)
                 {
-                    this.WindowState = FormWindowState.Minimized;
                     minimizeMainForm(true);
                 }
             }
@@ -1820,6 +1819,10 @@ namespace MobiFlight.UI
             if (minimized)
             {
                 notifyIcon.Visible = true;
+                notifyIcon.BalloonTipTitle = i18n._tr("uiMessageMFConnectorInterfaceActive");
+                notifyIcon.BalloonTipText = i18n._tr("uiMessageApplicationIsRunningInBackgroundMode");
+                notifyIcon.ShowBalloonTip(1000);
+                this.Hide();
             }
             else
             {
@@ -1828,6 +1831,9 @@ namespace MobiFlight.UI
                 if (this.WindowState != FormWindowState.Normal)
                     this.WindowState = FormWindowState.Normal;
                 ForceToFront();
+                // Hide() destroys the taskbar button, which takes the overlay with it.
+                // Re-apply the badge now that Show() has created a fresh button.
+                updateNotifyContextMenu(execManager?.IsStarted() ?? false);
             }
 
             execManager?.OnMinimize(minimized);


### PR DESCRIPTION
The badge PR (#2976) removed Hide() from minimizeMainForm to keep the taskbar overlay visible, but that killed the minimize-to-tray behavior beta users relied on. The overlay is moot while the form is hidden anyway -- the tray icon badge covers that case. Restore Hide() and the balloon tip, drop the now-redundant WindowState=Minimized in CheckAutoRun, and re-apply the badge on restore so the overlay re-attaches to the freshly-created taskbar button.

### Summary
The badge PR (#2976) removed Hide() from minimizeMainForm to keep the taskbar overlay visible, but that killed the minimize-to-tray behavior beta users relied on. The overlay is moot while the form is hidden anyway -- the tray icon badge covers that case. Restore Hide() and the balloon tip, drop the now-redundant WindowState=Minimized in CheckAutoRun, and re-apply the badge on restore so the overlay re-attaches to the freshly-created taskbar button.

### Screenshots / recordings
<img width="515" height="372" alt="image" src="https://github.com/user-attachments/assets/3f9d6ae3-c061-4d32-9bd6-a235887a8027" />

<img width="320" height="194" alt="image" src="https://github.com/user-attachments/assets/55935a7d-5f2c-4443-ad7e-1b0cdba1e25d" />
<p>Icon returned to tray with badge. Out of taskbar. Toast restored.

### Acceptance criteria
- Icon with running/stopped badge visible in taskbar if Connector on-screen.
- Icon with running/stopped badge visible in tray but not taskbar if Connector minimized.
- Toast with user reminder when Connector minimized.
- Clicking tray icon restores Connector
- Start/Stop works from Tray context menu. Badge correctly reflects state.
- Minimize on Autorun correctly returns to tray, not taskbar

### DoD Checklist
- [x] Frontend tests
- [x] i18n - All user-facing strings are translated
  - [x] core (en,de,es)
     
## Related issues
fixes #3039

### Out-of-scope
If application is pinned to taskbar and minimized, the pinned icon WILL NOT DISPLAY A BADGE. This is Windows limitation that would require hidden windows and other janky changes to implement fully. As this is minor use case, I did not implement. The tray icon can be made visible for users who need always-visible, real-time status.

### Notes
I underestimated how much people valued minimize-to-tray! I guess lesson here is "don't change how things work just because you think your way of working is better."
