### PR TITLE
Add support for WingFlex RMP Cube

### DIFF
--- a/src/MobiFlightConnector/Joysticks/wingflex/wingflex_rmpcube.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/wingflex/wingflex_rmpcube.joystick.json
@@ -1,0 +1,351 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "RMP Cube",
+  "VendorId": "0xA616",
+  "ProductId": "0x5750",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Transfer Key"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "VHF1 Key"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "VHF2 Key"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "VHF3 Key"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "LOAD Key"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "HF1 Key"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "HF2 Key"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "ATC Key"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "NAV Key"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "VOR Key"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "ILS Key"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "GLS Key"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "MLS Key"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "ADF Key"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "IDENT Key"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "Power On"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "Power Off"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "ATC MSG Key"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "AUTO LAND Key"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "Transponder - STBY"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "Transponder - ON"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "Transponder - AUTO"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "TCAS - STBY"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "TCAS - TA"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "TCAS - TA/RA"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "Small Knob - Turn Left"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "Small Knob - Turn Right"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "Big Knob - Turn Right"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "Big Knob - Turn Right"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "Transfer Light",
+      "Id": "transfer.led",
+      "Byte": 6,
+      "Bit": 0
+    },
+    {
+      "Label": "VHF1",
+      "Id": "VHF1.led",
+      "Byte": 6,
+      "Bit": 1
+    },
+    {
+      "Label": "VHF2",
+      "Id": "VHF2.led",
+      "Byte": 6,
+      "Bit": 2
+    },
+    {
+      "Label": "VHF3",
+      "Id": "VHF3.led",
+      "Byte": 6,
+      "Bit": 3
+    },
+    {
+      "Label": "LOAD",
+      "Id": "LOAD.led",
+      "Byte": 6,
+      "Bit": 4
+    },
+    {
+      "Label": "HF1",
+      "Id": "HF1.led",
+      "Byte": 6,
+      "Bit": 5
+    },
+    {
+      "Label": "SEL",
+      "Id": "SEL.led",
+      "Byte": 6,
+      "Bit": 6
+    },
+    {
+      "Label": "HF2",
+      "Id": "HF2.led",
+      "Byte": 6,
+      "Bit": 7
+    },
+    {
+      "Label": "ATC",
+      "Id": "ATC.led",
+      "Byte": 7,
+      "Bit": 0
+    },
+    {
+      "Label": "NAV",
+      "Id": "NAV.led",
+      "Byte": 7,
+      "Bit": 1
+    },
+    {
+      "Label": "VOR",
+      "Id": "VOR.led",
+      "Byte": 7,
+      "Bit": 2
+    },
+    {
+      "Label": "ILS",
+      "Id": "ILS.led",
+      "Byte": 7,
+      "Bit": 3
+    },
+    {
+      "Label": "GLS",
+      "Id": "GLS.led",
+      "Byte": 7,
+      "Bit": 4
+    },
+    {
+      "Label": "MLS",
+      "Id": "MLS.led",
+      "Byte": 7,
+      "Bit": 5
+    },
+    {
+      "Label": "ADF",
+      "Id": "ADF.led",
+      "Byte": 7,
+      "Bit": 6
+    },
+    {
+      "Label": "ATC MSG (upper)",
+      "Id": "ATC.upper.led",
+      "Byte": 7,
+      "Bit": 7
+    },
+    {
+      "Label": "AUTO LAND",
+      "Id": "autoland.led",
+      "Byte": 8,
+      "Bit": 0
+    },
+    {
+      "Label": "Left LCD Switch",
+      "Id": "llcd.switch",
+      "Byte": 8,
+      "Bit": 1
+    },
+    {
+      "Label": "Right LCD Switch",
+      "Id": "rlcd.switch",
+      "Byte": 8,
+      "Bit": 2
+    },
+    {
+      "Label": "Left Display - \"C\" Mode",
+      "Id": "lcmode.switch",
+      "Byte": 8,
+      "Bit": 3
+    },
+    {
+      "Label": "Right Display - \"C\" Mode",
+      "Id": "rcmode.switch",
+      "Byte": 8,
+      "Bit": 4
+    },
+    {
+      "Label": "Left Display - \"DATA\" Mode",
+      "Id": "ldatamode.switch",
+      "Byte": 8,
+      "Bit": 5
+    },
+    {
+      "Label": "Right Display - \"DATA\" Mode",
+      "Id": "rdatamode.switch",
+      "Byte": 8,
+      "Bit": 6
+    },
+    {
+      "Label": "ATC MSG (lower)",
+      "Id": "ATC.lower.led",
+      "Byte": 8,
+      "Bit": 7
+    },
+    {
+      "Label": "Display Brightness",
+      "Id": "brightness.panel",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "Background Brightness",
+      "Id": "brightness.display",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "Left Dot Position",
+      "Id": "left.dot.pos",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "Right Dot Position",
+      "Id": "right.dot.pos",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "Left Digits",
+      "Id": "left.digits",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "Right Digits",
+      "Id": "right.digits",
+      "Byte": 16,
+      "Bit": 0
+    },
+    {
+      "Label": "Active Lcd",
+      "Id": "active.lcd",
+      "Type": "LcdDisplay",
+      "Byte": 19,
+      "Cols": 6,
+      "Lines": 1
+    },
+    {
+      "Label": "Standby Lcd",
+      "Id": "standby.l.lcd",
+      "Type": "LcdDisplay",
+      "Byte": 23,
+      "Cols": 6,
+      "Lines": 1
+    }
+  ]
+}

--- a/src/MobiFlightConnector/Joysticks/wingflex/wingflex_rmpcube.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/wingflex/wingflex_rmpcube.joystick.json
@@ -308,30 +308,6 @@
       "Bit": 0
     },
     {
-      "Label": "Left Dot Position",
-      "Id": "left.dot.pos",
-      "Byte": 13,
-      "Bit": 0
-    },
-    {
-      "Label": "Right Dot Position",
-      "Id": "right.dot.pos",
-      "Byte": 14,
-      "Bit": 0
-    },
-    {
-      "Label": "Left Digits",
-      "Id": "left.digits",
-      "Byte": 15,
-      "Bit": 0
-    },
-    {
-      "Label": "Right Digits",
-      "Id": "right.digits",
-      "Byte": 16,
-      "Bit": 0
-    },
-    {
       "Label": "Active Lcd",
       "Id": "active.lcd",
       "Type": "LcdDisplay",
@@ -341,7 +317,7 @@
     },
     {
       "Label": "Standby Lcd",
-      "Id": "standby.l.lcd",
+      "Id": "standby.lcd",
       "Type": "LcdDisplay",
       "Byte": 23,
       "Cols": 6,

--- a/src/MobiFlightConnector/Joysticks/wingflex/wingflex_rmpcube.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/wingflex/wingflex_rmpcube.joystick.json
@@ -107,12 +107,12 @@
     {
       "Id": 21,
       "Type": "Button",
-      "Label": "Transponder - ON"
+      "Label": "Transponder - AUTO"
     },
     {
       "Id": 22,
       "Type": "Button",
-      "Label": "Transponder - AUTO"
+      "Label": "Transponder - ON"
     },
     {
       "Id": 23,

--- a/src/MobiFlightConnector/Joysticks/wingflex/wingflex_rmpcube.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/wingflex/wingflex_rmpcube.joystick.json
@@ -142,7 +142,7 @@
     {
       "Id": 28,
       "Type": "Button",
-      "Label": "Big Knob - Turn Right"
+      "Label": "Big Knob - Turn Left"
     },
     {
       "Id": 29,

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/HidControllerFactory.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/HidControllerFactory.cs
@@ -13,6 +13,7 @@ namespace MobiFlight.Joysticks
 
             switch (InstanceName.Trim())
             {
+                case "RMP Cube":
                 case "EFIS Cube":
                 case "FCU Cube":
                     return true;
@@ -25,6 +26,9 @@ namespace MobiFlight.Joysticks
             Joystick result = null;
             switch (definition.InstanceName)
             {
+                case "RMP Cube":
+                    result = new WingFlex.RmpCube(definition);
+                    break;
                 case "EFIS Cube":
                     result = new WingFlex.EfisCube(definition);
                     break;

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
@@ -297,8 +297,12 @@ namespace MobiFlight
                         joystick.Connect(new IntPtr());
                         joystick.OnButtonPressed += Js_OnButtonPressed;
                         joystick.OnDisconnected += Js_OnDisconnected;
-                        Joysticks.TryAdd(joystick.Serial, joystick);
-                        Log.Instance.log($"Connected HID device: {definition.InstanceName}", LogSeverity.Info);
+                        if (!Joysticks.TryAdd(joystick.Serial, joystick))
+                        {
+                            Log.Instance.log($"Error adding HID device: {definition.InstanceName} / {joystick.Serial}. Likely Joystick Serial conflict.", LogSeverity.Error);
+                            return;
+                        }
+                        Log.Instance.log($"Connected HID device: {definition.InstanceName} / {joystick.Serial}", LogSeverity.Info);
                     }
                     catch (Exception ex)
                     {

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/BaseCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/BaseCube.cs
@@ -45,7 +45,7 @@ namespace MobiFlight.Joysticks.WingFlex
         /// </summary>
         public override string Name
         {
-            get { return Definition?.InstanceName ?? "WingFlex Cube"; }
+            get { return Definition?.InstanceName ?? "WFCube"; }
         }
 
         /// <summary>
@@ -54,7 +54,13 @@ namespace MobiFlight.Joysticks.WingFlex
         /// </summary>
         public override string Serial
         {
-            get { return $"{Joystick.SerialPrefix}{Device?.ConnectedDeviceDefinition?.SerialNumber}" ?? "WFCUBE-1234-ABCD-12345678"; }
+            get
+            {
+                return
+                    (Device?.ConnectedDeviceDefinition?.SerialNumber != null) ?
+                    $"{Joystick.SerialPrefix}{Device?.ConnectedDeviceDefinition?.SerialNumber}"
+                    : $"{Name.ToUpper().Replace(" ", "-")}-1234-ABCD-12345678";
+            }
         }
 
         /// <summary>

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/BaseCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/BaseCube.cs
@@ -95,7 +95,8 @@ namespace MobiFlight.Joysticks.WingFlex
                 Name = $"{Name}-HID-Reader"
             };
             readThread.Start();
-
+            Log.Instance.log($"Connected to {Name} with VID:{VendorId.ToString("X4")} and PID:{ProductId.ToString("X4")}", LogSeverity.Debug);
+            Log.Instance.log($"Starting read thread for HID reports. {Name}-HID-Reader", LogSeverity.Debug);
             return true;
         }
 
@@ -112,8 +113,10 @@ namespace MobiFlight.Joysticks.WingFlex
                     var data = HidReport.TransferResult.Data;
                     ProcessInputReportBuffer(HidReport.ReportId, data);
                 }
-                catch
+                catch (Exception ex) 
                 {
+                    Log.Instance.log($"Exception during read from {Name} ({ex.GetType().Name}): {ex.Message}", LogSeverity.Error);
+                    Log.Instance.log($"Stopping read thread and shutting down device {Name}.", LogSeverity.Error);
                     // Exception when disconnecting fcu while mobiflight is running.
                     Shutdown();
                     break;

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/EfisCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/EfisCube.cs
@@ -12,15 +12,6 @@
         }
 
         /// <summary>
-        /// Provides Serial including prefix.
-        /// Serial information is provided through Device.Net
-        /// </summary>
-        public override string Serial
-        {
-            get { return $"{Joystick.SerialPrefix}{Device?.ConnectedDeviceDefinition?.SerialNumber}" ?? "EFIS-CUBE-1234-ABCD-12345678"; }
-        }
-
-        /// <summary>
         /// The constructor.
         /// </summary>
         /// <param name="definition">joystick definition file.</param>

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/FcuCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/FcuCube.cs
@@ -12,15 +12,6 @@
         }
 
         /// <summary>
-        /// Provides Serial including prefix.
-        /// Serial information is provided through Device.Net
-        /// </summary>
-        public override string Serial
-        {
-            get { return $"{Joystick.SerialPrefix}{Device?.ConnectedDeviceDefinition?.SerialNumber}" ?? "FCU-CUBE-1234-ABCD-12345678"; }
-        }
-
-        /// <summary>
         /// The constructor.
         /// </summary>
         /// <param name="definition">joystick definition file.</param>

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/FcuCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/FcuCube.cs
@@ -1,13 +1,4 @@
-﻿using Device.Net;
-using Hid.Net;
-using Hid.Net.Windows;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
-
-namespace MobiFlight.Joysticks.WingFlex
+﻿namespace MobiFlight.Joysticks.WingFlex
 {
     internal class FcuCube : BaseCube
     {

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCube.cs
@@ -1,0 +1,32 @@
+﻿namespace MobiFlight.Joysticks.WingFlex
+{
+    internal class RmpCube : BaseCube
+    {
+        /// <summary>
+        /// Provide same instance name as defined in the definition file.
+        /// Also works if Defintion file is not set yet.
+        /// </summary>
+        public override string Name
+        {
+            get { return Definition?.InstanceName ?? "RMP Cube"; }
+        }
+
+        /// <summary>
+        /// Provides Serial including prefix.
+        /// Serial information is provided through Device.Net
+        /// </summary>
+        public override string Serial
+        {
+            get { return $"{Joystick.SerialPrefix}{Device?.ConnectedDeviceDefinition?.SerialNumber}" ?? "RMP-CUBE-1234-ABCD-12345678"; }
+        }
+
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        /// <param name="definition">joystick definition file.</param>
+        public RmpCube(JoystickDefinition definition) 
+            : base(new RmpCubeReport(), definition)
+        {
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCube.cs
@@ -12,19 +12,10 @@
         }
 
         /// <summary>
-        /// Provides Serial including prefix.
-        /// Serial information is provided through Device.Net
-        /// </summary>
-        public override string Serial
-        {
-            get { return $"{Joystick.SerialPrefix}{Device?.ConnectedDeviceDefinition?.SerialNumber}" ?? "RMP-CUBE-1234-ABCD-12345678"; }
-        }
-
-        /// <summary>
         /// The constructor.
         /// </summary>
         /// <param name="definition">joystick definition file.</param>
-        public RmpCube(JoystickDefinition definition) 
+        public RmpCube(JoystickDefinition definition)
             : base(new RmpCubeReport(), definition)
         {
         }

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -231,44 +231,46 @@ namespace MobiFlight.Joysticks.WingFlex
 
         public JoystickState ToJoystickState()
         {
-            //  Name                Note                                Mask    Byte[]  Bit[]   Example
-            //  Head                Constant: 0xF2                              0       -       0xF2
-            //  Head                Constant: 0xE1                              1       -       0xE1
-            //  Head                Constant: 0x06                              2       -       0x06
-            //  Data Type Total     Has 2 Data Type                             3       -       0x02
-            //  Data Type           Bit Type                                    4       -       0x01
-            //  Data Length         Following data occupies 4 Bytes             5       -       0x04
-            //  Transfer Key        Press: 1, Release: 0                0x01    6       0       0
-            //  VHF1 Key            Press: 1, Release: 0                0x02    6       1       0
-            //  VHF2 Key            Press: 1, Release: 0                0x04    6       2       0
-            //  VHF3 Key            Press: 1, Release: 0                0x08    6       3       0
-            //  LOAD Key            Press: 1, Release: 0                0x10    6       4       0
-            //  HF1 Key             Press: 1, Release: 0                0x20    6       5       0
-            //  HF2 Key             Press: 1, Release: 0                0x40    6       6       0
-            //  ATC Key             Press: 1, Release: 0                0x80    6       7       0
-            //  NAV Key             Push: 1, Release: 0                 0x01    7       0       0
-            //  VOR Key             Pull: 1, Release: 0                 0x02    7       1       0
-            //  ILS Key             Push: 1, Release: 0                 0x04    7       2       0
-            //  GLS Key             Pull: 1, Release: 0                 0x08    7       3       0
-            //  MLS Key             Press: 1, Release: 0                0x10    7       4       0
-            //  ADF Key             Press: 1, Release: 0                0x20    7       5       0
-            //  Encoder Key -IDENT  Press: 1, Release: 0                0x40    7       6       0
-            //  Power On            Press: 1, Release: 0                0x80    7       7       1
-            //  Power Off           Press: 1, Release: 0                0x01    8       0       0
-            //  ATC MSG Key         Press: 1, Release: 0                0x02    8       1       0
-            //  AUTO LAND Key       Press: 1, Release: 0                0x04    8       2       0
-            //  Mode Selector -STBY Pointing: 1, Non - pointing: 0      0x08    8       3       1
-            //  Mode Selector -ON   Pointing: 1, Non - pointing: 0      0x10    8       4       0
-            //  Mode Selector -AUTO Pointing: 1, Non - pointing: 0      0x20    8       5       0
-            //  TCAS Mode -STBY     Pointing: 1, Non - pointing: 0      0x40    8       6       1
-            //  TCAS Mode -TA       Pointing: 1, Non - pointing: 0      0x80    8       7       0
-            //  TCAS Mode -TA / RA  Pointing: 1, Non - pointing: 0      0x01    9       0       0
+            //  Name                                Note                                Mask    Byte[]  Bit[]   Example
+            //  Head                                Constant: 0xF2                              0       -       0xF2
+            //  Head                                Constant: 0xE1                              1       -       0xE1
+            //  Head                                Constant: 0x06                              2       -       0x06
+            //  Data Type Total                     Has 2 Data Type                             3       -       0x02
+            //  Data Type                           Bit Type                                    4       -       0x01
+            //  Data Length                         Following data occupies 4 Bytes             5       -       0x04
+            //  Transfer Key                        Press: 1, Release: 0                0x01    6       0       0
+            //  VHF1 Key                            Press: 1, Release: 0                0x02    6       1       0
+            //  VHF2 Key                            Press: 1, Release: 0                0x04    6       2       0
+            //  VHF3 Key                            Press: 1, Release: 0                0x08    6       3       0
+            //  LOAD Key                            Press: 1, Release: 0                0x10    6       4       0
+            //  HF1 Key                             Press: 1, Release: 0                0x20    6       5       0
+            //  HF2 Key                             Press: 1, Release: 0                0x40    6       6       0
+            //  ATC Key                             Press: 1, Release: 0                0x80    6       7       0
+            //  NAV Key                             Push: 1, Release: 0                 0x01    7       0       0
+            //  VOR Key                             Pull: 1, Release: 0                 0x02    7       1       0
+            //  ILS Key                             Push: 1, Release: 0                 0x04    7       2       0
+            //  GLS Key                             Pull: 1, Release: 0                 0x08    7       3       0
+            //  MLS Key                             Press: 1, Release: 0                0x10    7       4       0
+            //  ADF Key                             Press: 1, Release: 0                0x20    7       5       0
+            //  Encoder Key -IDENT                  Press: 1, Release: 0                0x40    7       6       0
+            //  Power On                            Press: 1, Release: 0                0x80    7       7       1
+            //  Power Off                           Press: 1, Release: 0                0x01    8       0       0
+            //  ATC MSG Key                         Press: 1, Release: 0                0x02    8       1       0
+            //  AUTO LAND Key                       Press: 1, Release: 0                0x04    8       2       0
+            //  Mode Selector -STBY                 Pointing: 1, Non - pointing: 0      0x08    8       3       1
+            //  Mode Selector -ON                   Pointing: 1, Non - pointing: 0      0x10    8       4       0
+            //  Mode Selector -AUTO                 Pointing: 1, Non - pointing: 0      0x20    8       5       0
+            //  TCAS Mode -STBY                     Pointing: 1, Non - pointing: 0      0x40    8       6       1
+            //  TCAS Mode -TA                       Pointing: 1, Non - pointing: 0      0x80    8       7       0
+            //  TCAS Mode -TA / RA                  Pointing: 1, Non - pointing: 0      0x01    9       0       0
+            //  Frequency Selector Knobs - Upper    0x00~0xFF in Two's Complement               12      -       0
+            //  Frequency Selector Knobs - Lower    0x00~0xFF in Two's Complement               13      -       0
 
             JoystickState state = new JoystickState();
 
             // Buttons
             // copy the button states from the buffer to the Buttons bit by bit starting from byte 6 to byte 9
-            for (int i = 0; i < 26; i++)
+            for (int i = 0; i < 25; i++)
             {
                 int byteIndex = 6 + (i / 8);
                 int bitIndex = i % 8;
@@ -278,10 +280,10 @@ namespace MobiFlight.Joysticks.WingFlex
 
             // Encoders
             // As long as we don't have proper Encoders, we will map them to buttons
-            state.Buttons[26] = ((sbyte)LastInputBufferState[12]) < 0; // Small Knob Rotate Left
-            state.Buttons[27] = ((sbyte)LastInputBufferState[12]) > 0; // Small Knob Rotate Right
-            state.Buttons[28] = ((sbyte)LastInputBufferState[13]) < 0; // Big Knob Rotate Left
-            state.Buttons[29] = ((sbyte)LastInputBufferState[13]) > 0; // Big Knob Rotate Right
+            state.Buttons[25] = ((sbyte)LastInputBufferState[12]) < 0; // Small Knob Rotate Left
+            state.Buttons[26] = ((sbyte)LastInputBufferState[12]) > 0; // Small Knob Rotate Right
+            state.Buttons[27] = ((sbyte)LastInputBufferState[13]) < 0; // Big Knob Rotate Left
+            state.Buttons[28] = ((sbyte)LastInputBufferState[13]) > 0; // Big Knob Rotate Right
 
             return state;
         }

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -1,9 +1,6 @@
-﻿using CommandMessenger;
-using SharpDX.DirectInput;
+﻿using SharpDX.DirectInput;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Runtime.InteropServices.ComTypes;
 
 namespace MobiFlight.Joysticks.WingFlex
 {
@@ -74,7 +71,7 @@ namespace MobiFlight.Joysticks.WingFlex
 
         public ICubeReport Parse(byte[] inputBuffer)
         {
-            var result = new EfisCubeReport();
+            var result = new RmpCubeReport();
             result.CopyFromInputBuffer(inputBuffer);
 
             return result;
@@ -138,7 +135,7 @@ namespace MobiFlight.Joysticks.WingFlex
             // This ensures that if no device state explicitly sets power off,
             // the power will remain on by default.
             //
-            
+
             // This is required to make test mode work correctly, as test mode
             // requires power to be on to light up the single LED and the display.
             // 
@@ -154,8 +151,10 @@ namespace MobiFlight.Joysticks.WingFlex
 
                     var textWithoutDot = lcdDisplay.Text.Replace(".", "");
                     var paddedText = textWithoutDot.PadLeft(lcdDisplay.Cols, '0');
-                    UpdateLcdDisplay(item.Byte, paddedText.Substring(0, (int)Math.Floor(lcdDisplay.Cols / 2.0)));
-                    UpdateLcdDisplay(item.Byte + 1, paddedText.Substring((int)Math.Floor(lcdDisplay.Cols / 2.0)));
+                    var group1 = paddedText.Substring(0, (int)Math.Floor(lcdDisplay.Cols / 2.0));
+                    var group2 = paddedText.Substring((int)Math.Floor(lcdDisplay.Cols / 2.0));
+                    UpdateLcdDisplay(item.Byte, group1);
+                    UpdateLcdDisplay(item.Byte + 2, group2);
 
                     // Update visible digits based on original text length without dots
 

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -41,6 +41,12 @@ namespace MobiFlight.Joysticks.WingFlex
         private byte[] LastInputBufferState = new byte[64];
         private byte[] LastOutputBufferState = new byte[64];
 
+        private readonly static Dictionary<byte, byte> DotByteMapping = new Dictionary<byte, byte>
+            {
+                { 19, 13 }, // Left LCD
+                { 21, 14 }  // Right LCD
+            };
+
         public RmpCubeReport()
         {
             InitLastInputBufferState();
@@ -146,19 +152,7 @@ namespace MobiFlight.Joysticks.WingFlex
             {
                 if (item.Type == DeviceType.LcdDisplay)
                 {
-                    var lcdDisplay = item as JoystickOutputDisplay;
-                    if (lcdDisplay == null) return;
-
-                    var textWithoutDot = lcdDisplay.Text.Replace(".", "");
-                    var paddedText = textWithoutDot.PadLeft(lcdDisplay.Cols, '0');
-                    var group1 = paddedText.Substring(0, (int)Math.Floor(lcdDisplay.Cols / 2.0));
-                    var group2 = paddedText.Substring((int)Math.Floor(lcdDisplay.Cols / 2.0));
-                    UpdateLcdDisplay(item.Byte, group1);
-                    UpdateLcdDisplay(item.Byte + 2, group2);
-
-                    // Update visible digits based on original text length without dots
-
-                    // update dot position based on first dot position in the original text
+                    UpdateLcdDisplayOutputState(item);
                     return;
                 }
 
@@ -182,6 +176,41 @@ namespace MobiFlight.Joysticks.WingFlex
             });
 
             return LastOutputBufferState.Clone() as byte[];
+        }
+
+        private void UpdateLcdDisplayOutputState(JoystickOutputDevice item)
+        {
+
+            var lcdDisplay = item as JoystickOutputDisplay;
+            if (lcdDisplay == null) return;
+
+            var hasDot = lcdDisplay.Text.Contains(".");
+            var textWithoutDot = lcdDisplay.Text.Replace(".", "");
+            var paddedText = textWithoutDot.PadLeft(lcdDisplay.Cols, '0');
+            var group1 = paddedText.Substring(0, (int)Math.Floor(lcdDisplay.Cols / 2.0));
+            var group2 = paddedText.Substring((int)Math.Floor(lcdDisplay.Cols / 2.0));
+            UpdateLcdDisplay(item.Byte, group1);
+            UpdateLcdDisplay(item.Byte + 2, group2);
+
+            // Update visible digits based on original text length without dots
+
+            // update dot position based on first dot position in the original text
+            if (DotByteMapping.ContainsKey(lcdDisplay.Byte))
+            {
+                var dotByte = DotByteMapping[lcdDisplay.Byte];
+                // Always clear the dot
+                LastOutputBufferState[dotByte] = 0; 
+                if (hasDot)
+                {
+                    int dotPosition = lcdDisplay.Text.IndexOf(".");
+                    // the dot position corresponds to the position of the dot in the original text
+                    // example: 123.456 -> dot-position is 3 which is the 3rd digit from the left
+                    // this seems to be fine for the resulting dot position too.
+                    LastOutputBufferState[dotByte] = (byte)(dotPosition);
+                }
+            }
+            // continue with next item, as we have already processed the LCD display state
+            return;
         }
 
         protected void UpdateLcdDisplay(int byteIndex, string text)

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -258,8 +258,8 @@ namespace MobiFlight.Joysticks.WingFlex
             //  ATC MSG Key                         Press: 1, Release: 0                0x02    8       1       0
             //  AUTO LAND Key                       Press: 1, Release: 0                0x04    8       2       0
             //  Mode Selector -STBY                 Pointing: 1, Non - pointing: 0      0x08    8       3       1
-            //  Mode Selector -ON                   Pointing: 1, Non - pointing: 0      0x10    8       4       0
-            //  Mode Selector -AUTO                 Pointing: 1, Non - pointing: 0      0x20    8       5       0
+            //  Mode Selector -AUTO                 Pointing: 1, Non - pointing: 0      0x10    8       4       0
+            //  Mode Selector -ON                   Pointing: 1, Non - pointing: 0      0x20    8       5       0
             //  TCAS Mode -STBY                     Pointing: 1, Non - pointing: 0      0x40    8       6       1
             //  TCAS Mode -TA                       Pointing: 1, Non - pointing: 0      0x80    8       7       0
             //  TCAS Mode -TA / RA                  Pointing: 1, Non - pointing: 0      0x01    9       0       0

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -1,0 +1,262 @@
+﻿using CommandMessenger;
+using SharpDX.DirectInput;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.InteropServices.ComTypes;
+
+namespace MobiFlight.Joysticks.WingFlex
+{
+    internal class RmpCubeReport : ICubeReport
+    {
+        // -                Head                         Constant: 0xF2                          -       0       -       0xF2
+        // -                Head                         Constant: 0xE1                          -       1       -       0xE1
+        // -                Head                         Constant: 0x06                          -       2       -       0x06
+        private readonly static byte[] InputHeader = new byte[] { 0xF2, 0xE1, 0x06 };
+        // -                Data Type Total              Has 2 Data Type                         -       3       -       0x02
+        // -                Data Type                    Bit Type                                -       4       -       0x01
+        // -                Data Length                  Following data occupies 4 Bytes         -       5       -       0x04
+        private readonly static byte[] InputBitSection = new byte[] { 0x02, 0x01, 0x04 };
+        // -                Data Type                    Single Byte Type                        -       10      -       0x02
+        // -                Data Length                  Following data occupies 2 Bytes         -       11      -       0x02
+        private readonly static byte[] InputByteSection = new byte[] { 0x02, 0x02 };
+
+        // -                Head                         Constant: 0xF2                          -       0       -       0xF2
+        // -                Head                         Constant: 0xE1                          -       1       -       0xE1
+        // -                Head                         Constant: 0x06                          -       2       -       0x06
+        private readonly static byte[] OutputHeader = new byte[] { 0xF2, 0xE1, 0x06 };
+        // -                Data Type Total              Has 3 Data Type                         -       3       -       0x02
+        // -                Data Type                    Bit Type                                -       4       -       0x01
+        // -                Data Length                  Following data occupies 3 Bytes         -       5       -       0x03
+        private readonly static byte[] OutputBitSection = new byte[] { 0x02, 0x01, 0x03 };
+        // -                Data Type                    Single Byte Type                        -       9       -       0x02
+        // -                Data Length                  Following data occupies 2 Bytes         -       10      -       0x02
+        // Output           LCDBrightness                0x00(Minimum)~0xFF(Maximum)             -       11      -       0
+        // Output           Background Light Brightness  0x00(Minimum)~0xFF(Maximum)             -       12      -       0
+        // Output           Left Dot Position            0-5                                     -       13      -       0
+        // Output           Right Dot Position           0-5                                     -       14      -       3
+        // Output           Left Display Digit Switch    digits enabled                          -       15      -       3
+        // Output           Right Display Digit Switch   digits enabled                          -       16      -       3
+        //                  Data Type                    Double Byte Type                        -       17      -       0x00
+        //                  Data Length                  Following data occupies 8 Bytes         -       18      -       0x08
+        private readonly static byte[] OutputByteSection = new byte[] { 0x02, 0x02, 0, 0, 0, 0, 0, 0, 0x00, 0x08 };
+
+        private byte[] LastInputBufferState = new byte[64];
+        private byte[] LastOutputBufferState = new byte[64];
+
+        public RmpCubeReport()
+        {
+            InitLastInputBufferState();
+            InitLastOutputBufferState();
+        }
+        private void InitLastInputBufferState()
+        {
+            Buffer.BlockCopy(InputHeader, 0, LastInputBufferState, 0, InputHeader.Length);
+            Buffer.BlockCopy(InputBitSection, 0, LastInputBufferState, 3, InputBitSection.Length);
+            Buffer.BlockCopy(InputByteSection, 0, LastInputBufferState, 10, InputByteSection.Length);
+        }
+
+        private void InitLastOutputBufferState()
+        {
+            Buffer.BlockCopy(OutputHeader, 0, LastOutputBufferState, 0, OutputHeader.Length);
+            Buffer.BlockCopy(OutputBitSection, 0, LastOutputBufferState, 3, OutputBitSection.Length);
+            Buffer.BlockCopy(OutputByteSection, 0, LastOutputBufferState, 9, OutputByteSection.Length);
+        }
+
+        public void CopyFromInputBuffer(byte[] inputBuffer)
+        {
+            if (inputBuffer == null || inputBuffer.Length < LastInputBufferState.Length)
+            {
+                throw new ArgumentException($"Invalid input buffer length. Expected {LastInputBufferState.Length}, got {inputBuffer?.Length ?? 0}");
+            }
+            LastInputBufferState = (byte[])inputBuffer?.Clone();
+        }
+
+        public ICubeReport Parse(byte[] inputBuffer)
+        {
+            var result = new EfisCubeReport();
+            result.CopyFromInputBuffer(inputBuffer);
+
+            return result;
+        }
+
+        public byte[] FromOutputDeviceState(List<JoystickOutputDevice> state)
+        {
+            //  OUTPUT DATA STRUCTURE - RMP Cube Output Report
+            //  Name	                    Note                                    Mask    Byte[]	Bit[]	Example
+            //  Head                        Constant: 0xF2                                  0       -       0xF2
+            //  Head                        Constant: 0xE1                                  1       -       0xE1
+            //  Head                        Constant: 0x06                                  2       -       0x06
+            //  Data Type Total             Has 3 Data Type                                 3       -       0x03
+            //  Data Type                   Bit Type                                        4       -       0x01
+            //  Data Length                 Following data occupies 3 Bytes                 5       -       0x03
+            //  Transfer Led                On: 1, Off: 0                           0x01    6       0       1
+            //  VHF1 Signal                 On: 1, Off: 0                           0x02    6       1       1
+            //  VHF2 Signal                 On: 1, Off: 0                           0x04    6       2       1
+            //  VHF3 Signal                 On: 1, Off: 0                           0x08    6       3       1
+            //  LOAD Signal                 On: 1, Off: 0                           0x10    6       4       1
+            //  HF1 Signal                  On: 1, Off: 0                           0x20    6       5       1
+            //  SEL Signal                  On: 1, Off: 0                           0x40    6       6       1
+            //  HF2 Signal                  On: 1, Off: 0                           0x80    6       7       1
+            //  ATC Signal                  On: 1, Off: 0                           0x01    7       0       1
+            //  NAV Signal                  On: 1, Off: 0                           0x02    7       1       1
+            //  VOR Signal                  On: 1, Off: 0                           0x04    7       2       1
+            //  ILS Signal                  On: 1, Off: 0                           0x08    7       3       1
+            //  GLS Signal                  On: 1, Off: 0                           0x10    7       4       1
+            //  MLS Signal                  On: 1, Off: 0                           0x20    7       5       1
+            //  ADF Signal                  On: 1, Off: 0                           0x40    7       6       1
+            //  ATC MSG Upper Led           On: 1, Off: 0                           0x80    7       7       0
+            //  AUTO LAND Led               On: 1, Off: 0                           0x01    8       0       1
+            //  Left LCD Switch             On: 1, Off: 0                           0x02    8       1       1
+            //  Right LCD Switch            On: 1, Off: 0                           0x04    8       2       1
+            //  Left Display -"C" Mode      On: 1, Off: 0, priority second.         -       8       3       0
+            //  Right Display -"C" Mode     On: 1, Off: 0, priority second.         -       8       4       0
+            //  Left Display -"Data" Mode   On:1, Off: 0, priority first.           -       8       5       0
+            //  Right Display -"Data" Mode  On:1, Off: 0 priority first.            -       8       6       0
+            //  ATC MSG Lower Led           On: 1, Off: 0                           -       8       7       0
+            //  Data Type                   Single Byte Type                        -       9       -       0x02
+            //  Data Length                 Following data occupies 2 Bytes         -       10      -       0x02
+            //  LCD Brightness              0x00(Minimum) - 0xFF(Maximum)           -       12      -       0
+            //  Background Light Brightness 0x00(Minimum) - 0xFF(Maximum)           -       11      -       0
+            //  Left Dot Position	        0-5                                     -       13      -       3
+            //  Right Dot Position          0-5                                     -       14      -       3
+            //  Left Display Digit Switch   See About Note                          -       15      -       3
+            //  Right Display Digit Switch  See About Note                          -       16      -       3
+            //  Data Type                   Double Byte Type                        -       17      -       0x00
+            //  Data Length                 Following data occupies 2 Bytes         -       18      -       0x08
+            //  ACTIVE LCD Left 3 Digit     High 8 bits of Uint16, 000 - 999        -       19      -       0x00
+            //  ACTIVE LCD Left 3 Digit     Low 8 bits of Uint16, 000 - 999         -       20      -       0x00
+            //  ACTIVE LCD Right 3 Digit    High 8 bits of Uint16, 000 - 999        -       21      -       0x00
+            //  ACTIVE LCD Right 3 Digit    Low 8 bits of Uint16, 000 - 999         -       22      -       0x00
+            //  STBY / CRS Left 3 Digit     High 8 bits of Uint16, 000 - 999        -       23      -       0x00
+            //  STBY / CRS Left 3 Digit     Low 8 bits of Uint16, 000 - 999         -       24      -       0x00
+            //  STBY / CRS Right 3 Digit    High 8 bits of Uint16, 000 - 999        -       25      -       0x00
+            //  STBY / CRS Right 3 Digit    Low 8 bits of Uint16, 000 - 999         -       26      -       0x00
+
+            // Set default power state to ON before processing device states.
+            // This may be overridden by subsequent device state logic below.
+            // This ensures that if no device state explicitly sets power off,
+            // the power will remain on by default.
+            //
+            
+            // This is required to make test mode work correctly, as test mode
+            // requires power to be on to light up the single LED and the display.
+            // 
+            // Apparently the RMP Cube doesn't use this
+            // LastOutputBufferState[8] |= 1;
+
+            state.ForEach(item =>
+            {
+                if (item.Type == DeviceType.LcdDisplay)
+                {
+                    var lcdDisplay = item as JoystickOutputDisplay;
+                    if (lcdDisplay == null) return;
+
+                    var textWithoutDot = lcdDisplay.Text.Replace(".", "");
+                    var paddedText = textWithoutDot.PadLeft(lcdDisplay.Cols, '0');
+                    UpdateLcdDisplay(item.Byte, paddedText.Substring(0, (int)Math.Floor(lcdDisplay.Cols / 2.0)));
+                    UpdateLcdDisplay(item.Byte + 1, paddedText.Substring((int)Math.Floor(lcdDisplay.Cols / 2.0)));
+
+                    // Update visible digits based on original text length without dots
+
+                    // update dot position based on first dot position in the original text
+                    return;
+                }
+
+                var itemByte = item.Byte;
+
+                if (itemByte >= 6 && itemByte <= 8)
+                {
+                    if (item.State == 1)
+                    {
+                        LastOutputBufferState[itemByte] |= (byte)(1 << item.Bit);
+                    }
+                    else
+                    {
+                        LastOutputBufferState[itemByte] &= (byte)~(1 << item.Bit);
+                    }
+                }
+                else if (itemByte == 11 || itemByte == 12) // Brightness
+                {
+                    LastOutputBufferState[itemByte] = item.State;
+                }
+            });
+
+            return LastOutputBufferState.Clone() as byte[];
+        }
+
+        protected void UpdateLcdDisplay(int byteIndex, string text)
+        {
+            UInt16 value = 0;
+            bool parsed;
+
+            parsed = Int16.TryParse(text.Trim(), out var signedValue);
+            if (parsed) value = (UInt16)signedValue;
+
+            // Skip invalid text
+            if (!parsed) return;
+
+            // Copy High 8 bit from value
+            LastOutputBufferState[byteIndex] = (byte)(value >> 8);
+            // Copy Low 8 bit from value  
+            LastOutputBufferState[byteIndex + 1] = (byte)(value & 0xFF);
+        }
+
+        public JoystickState ToJoystickState()
+        {
+            //  Name                Note                                Mask    Byte[]  Bit[]   Example
+            //  Head                Constant: 0xF2                              0       -       0xF2
+            //  Head                Constant: 0xE1                              1       -       0xE1
+            //  Head                Constant: 0x06                              2       -       0x06
+            //  Data Type Total     Has 2 Data Type                             3       -       0x02
+            //  Data Type           Bit Type                                    4       -       0x01
+            //  Data Length         Following data occupies 4 Bytes             5       -       0x04
+            //  Transfer Key        Press: 1, Release: 0                0x01    6       0       0
+            //  VHF1 Key            Press: 1, Release: 0                0x02    6       1       0
+            //  VHF2 Key            Press: 1, Release: 0                0x04    6       2       0
+            //  VHF3 Key            Press: 1, Release: 0                0x08    6       3       0
+            //  LOAD Key            Press: 1, Release: 0                0x10    6       4       0
+            //  HF1 Key             Press: 1, Release: 0                0x20    6       5       0
+            //  HF2 Key             Press: 1, Release: 0                0x40    6       6       0
+            //  ATC Key             Press: 1, Release: 0                0x80    6       7       0
+            //  NAV Key             Push: 1, Release: 0                 0x01    7       0       0
+            //  VOR Key             Pull: 1, Release: 0                 0x02    7       1       0
+            //  ILS Key             Push: 1, Release: 0                 0x04    7       2       0
+            //  GLS Key             Pull: 1, Release: 0                 0x08    7       3       0
+            //  MLS Key             Press: 1, Release: 0                0x10    7       4       0
+            //  ADF Key             Press: 1, Release: 0                0x20    7       5       0
+            //  Encoder Key -IDENT  Press: 1, Release: 0                0x40    7       6       0
+            //  Power On            Press: 1, Release: 0                0x80    7       7       1
+            //  Power Off           Press: 1, Release: 0                0x01    8       0       0
+            //  ATC MSG Key         Press: 1, Release: 0                0x02    8       1       0
+            //  AUTO LAND Key       Press: 1, Release: 0                0x04    8       2       0
+            //  Mode Selector -STBY Pointing: 1, Non - pointing: 0      0x08    8       3       1
+            //  Mode Selector -ON   Pointing: 1, Non - pointing: 0      0x10    8       4       0
+            //  Mode Selector -AUTO Pointing: 1, Non - pointing: 0      0x20    8       5       0
+            //  TCAS Mode -STBY     Pointing: 1, Non - pointing: 0      0x40    8       6       1
+            //  TCAS Mode -TA       Pointing: 1, Non - pointing: 0      0x80    8       7       0
+            //  TCAS Mode -TA / RA  Pointing: 1, Non - pointing: 0      0x01    9       0       0
+
+            JoystickState state = new JoystickState();
+
+            // Buttons
+            // copy the button states from the buffer to the Buttons bit by bit starting from byte 6 to byte 9
+            for (int i = 0; i < 26; i++)
+            {
+                int byteIndex = 6 + (i / 8);
+                int bitIndex = i % 8;
+                bool isPressed = (LastInputBufferState[byteIndex] & (1 << bitIndex)) != 0;
+                state.Buttons[i] = isPressed;
+            }
+
+            // Encoders
+            // As long as we don't have proper Encoders, we will map them to buttons
+            state.Buttons[26] = ((sbyte)LastInputBufferState[12]) < 0; // Small Knob Rotate Left
+            state.Buttons[27] = ((sbyte)LastInputBufferState[12]) > 0; // Small Knob Rotate Right
+            state.Buttons[28] = ((sbyte)LastInputBufferState[13]) < 0; // Big Knob Rotate Left
+            state.Buttons[29] = ((sbyte)LastInputBufferState[13]) > 0; // Big Knob Rotate Right
+
+            return state;
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -136,18 +136,6 @@ namespace MobiFlight.Joysticks.WingFlex
             //  STBY / CRS Right 3 Digit    High 8 bits of Uint16, 000 - 999        -       25      -       0x00
             //  STBY / CRS Right 3 Digit    Low 8 bits of Uint16, 000 - 999         -       26      -       0x00
 
-            // Set default power state to ON before processing device states.
-            // This may be overridden by subsequent device state logic below.
-            // This ensures that if no device state explicitly sets power off,
-            // the power will remain on by default.
-            //
-
-            // This is required to make test mode work correctly, as test mode
-            // requires power to be on to light up the single LED and the display.
-            // 
-            // Apparently the RMP Cube doesn't use this
-            // LastOutputBufferState[8] |= 1;
-
             state.ForEach(item =>
             {
                 if (item.Type == DeviceType.LcdDisplay)
@@ -195,11 +183,12 @@ namespace MobiFlight.Joysticks.WingFlex
             // Update visible digits based on original text length without dots
 
             // update dot position based on first dot position in the original text
+            // update active digits
             if (DotByteMapping.ContainsKey(lcdDisplay.Byte))
             {
                 var dotByte = DotByteMapping[lcdDisplay.Byte];
                 // Always clear the dot
-                LastOutputBufferState[dotByte] = 0; 
+                LastOutputBufferState[dotByte] = 0;
                 if (hasDot)
                 {
                     int dotPosition = lcdDisplay.Text.IndexOf(".");
@@ -207,6 +196,16 @@ namespace MobiFlight.Joysticks.WingFlex
                     // example: 123.456 -> dot-position is 3 which is the 3rd digit from the left
                     // this seems to be fine for the resulting dot position too.
                     LastOutputBufferState[dotByte] = (byte)(dotPosition);
+                }
+
+                // enable digits based on length of the text without dots, but only if the text is not empty
+                var digitByte = dotByte + 2;
+                // Always clear the digit enable bits
+                LastOutputBufferState[digitByte] = 0;
+                if (!string.IsNullOrEmpty(textWithoutDot))
+                {
+                    int visibleDigits = textWithoutDot.Length;
+                    LastOutputBufferState[digitByte] |= (byte)(visibleDigits & 0x0F);
                 }
             }
             // continue with next item, as we have already processed the LCD display state

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -205,7 +205,7 @@ namespace MobiFlight.Joysticks.WingFlex
                 if (!string.IsNullOrEmpty(textWithoutDot))
                 {
                     int visibleDigits = textWithoutDot.Length;
-                    LastOutputBufferState[digitByte] |= (byte)(visibleDigits & 0x0F);
+                    LastOutputBufferState[digitByte] = (byte)((1<<visibleDigits) - 1);
                 }
             }
             // continue with next item, as we have already processed the LCD display state

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -437,6 +437,8 @@
     <Compile Include="MobiFlight\Joysticks\VKB\VKBLedContainer.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\BaseCube.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\Dap500.cs" />
+    <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCubeReport.cs" />
+    <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCube.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\EfisCube.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\EfisCubeReport.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\FcuCube.cs" />
@@ -1472,6 +1474,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Joysticks\wingflex\wingflex_efiscube.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\wingflex\wingflex_rmpcube.joystick.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Joysticks\winwing\winwing_ecam.joystick.json">

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
@@ -221,10 +221,13 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0xE7, result[20], "Low byte should be 0xE7");
             Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
             Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+
+            // Assert dot position
+            Assert.AreEqual(0x03, result[13], "Dot position byte should indicate dot after 3rd digit");
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999dot9dot99()
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_99dot99dot99()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -233,7 +236,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
                 Type = DeviceType.LcdDisplay,
                 Byte = 19,
                 Cols = 6,
-                Text = "999.999"
+                Text = "99.99.99"
             };
             var devices = new List<JoystickOutputDevice> { lcdDisplay };
 
@@ -247,6 +250,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0xE7, result[20], "Low byte should be 0xE7");
             Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
             Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+
+            // Assert dot position, only first dot is rendered
+            Assert.AreEqual(0x02, result[13], "Dot position byte should indicate dot after 2rd digit");
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
@@ -170,6 +170,165 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         #endregion
 
         #region LCD Display Tests
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_9()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "9"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
+            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
+            Assert.AreEqual(0x09, result[22], "Low byte should be 0x09");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x01, result[15], "There should be 1 digit set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_99()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "99"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 0 => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 99 => 0x0063, so high byte = 0x00, low byte = 0x63
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
+            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
+            Assert.AreEqual(0x63, result[22], "Low byte should be 0x63");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x03, result[15], "There should be 2 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 0 => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
+            Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x07, result[15], "There should be 3 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_9999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "9999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x09, result[20], "Low byte should be 0x09");
+            Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x0F, result[15], "There should be 4 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_99999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "99999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 99 => 0x0063, so high byte = 0x00, low byte = 0x63
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x63, result[20], "Low byte should be 0x63");
+            Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x1F, result[15], "There should be all 5 digits set");
+        }
 
         [TestMethod]
         public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999999()
@@ -200,7 +359,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0x00, result[13], "There should be no dot set");
 
             // Assert active digits
-            Assert.AreEqual(0x06, result[15], "There should be all 6 digits set");
+            Assert.AreEqual(0x3F, result[15], "There should be all 6 digits set");
         }
 
         [TestMethod]
@@ -232,7 +391,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0x03, result[13], "Dot position byte should indicate dot after 3rd digit");
 
             // Assert active digits
-            Assert.AreEqual(0x06, result[15], "There should be all 6 digits set");
+            Assert.AreEqual(0x3F, result[15], "There should be all 6 digits set");
         }
 
         [TestMethod]
@@ -264,71 +423,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0x02, result[13], "Dot position byte should indicate dot after 2rd digit");
 
             // Assert active digits
-            Assert.AreEqual(0x06, result[15], "There should be all 6 digits set");
-        }
-
-        [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_123()
-        {
-            // Arrange
-            var lcdDisplay = new JoystickOutputDisplay
-            {
-                Name = "Active",
-                Type = DeviceType.LcdDisplay,
-                Byte = 19,
-                Cols = 6,
-                Text = "123"
-            };
-            var devices = new List<JoystickOutputDevice> { lcdDisplay };
-
-            // Act
-            var result = _report.FromOutputDeviceState(devices);
-
-            // Assert
-            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
-            // Right digit group will show 123 => 0x007B, so high byte = 0x00, low byte = 0x7B
-            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
-            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
-            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
-            Assert.AreEqual(0x7B, result[22], "Low byte should be 0x7B");
-
-            // Assert dot position -> no dot!
-            Assert.AreEqual(0x00, result[13], "There should be no dot set");
-
-            // Assert active digits
-            Assert.AreEqual(0x03, result[15], "There should be 3 digits set");
-        }
-
-        [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_9()
-        {
-            // Arrange
-            var lcdDisplay = new JoystickOutputDisplay
-            {
-                Name = "Active",
-                Type = DeviceType.LcdDisplay,
-                Byte = 19,
-                Cols = 6,
-                Text = "9"
-            };
-            var devices = new List<JoystickOutputDevice> { lcdDisplay };
-
-            // Act
-            var result = _report.FromOutputDeviceState(devices);
-
-            // Assert
-            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
-            // Right digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
-            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
-            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
-            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
-            Assert.AreEqual(0x09, result[22], "Low byte should be 0x09");
-
-            // Assert dot position -> no dot!
-            Assert.AreEqual(0x00, result[13], "There should be no dot set");
-
-            // Assert active digits
-            Assert.AreEqual(0x01, result[15], "There should be 1 digit set");
+            Assert.AreEqual(0x3F, result[15], "There should be all 6 digits set");
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
@@ -1,0 +1,427 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace MobiFlight.Joysticks.WingFlex.Tests
+{
+    [TestClass]
+    public class RmpCubeReportTests
+    {
+        private RmpCubeReport _report;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _report = new RmpCubeReport();
+        }
+
+        #region Parse Tests
+
+        [TestMethod]
+        public void Parse_ValidInputBuffer_ReturnsNewReportInstance()
+        {
+            // Arrange
+            var inputBuffer = CreateValidInputBuffer();
+
+            // Act
+            var result = _report.Parse(inputBuffer);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreNotSame(_report, result);
+            Assert.IsInstanceOfType(result, typeof(RmpCubeReport));
+        }
+
+        [TestMethod]
+        public void Parse_NullInputBuffer_ThrowsArgumentException()
+        {
+            // Arrange
+            byte[] inputBuffer = null;
+
+            // Act & Assert - Should throw exception
+            Assert.ThrowsExactly<ArgumentException>(() => _report.Parse(inputBuffer));
+        }
+
+        [TestMethod]
+        public void Parse_EmptyInputBuffer_ThrowsArgumentException()
+        {
+            // Arrange
+            var inputBuffer = new byte[0];
+
+            // Act & Assert - Should throw exception
+            Assert.ThrowsExactly<ArgumentException>(() => _report.Parse(inputBuffer));
+        }
+
+        [TestMethod]
+        public void Parse_WrongLengthInputBuffer_ThrowsArgumentException()
+        {
+            // Arrange
+            var inputBuffer = new byte[1];
+
+            // Act & Assert - Should throw exception
+            Assert.ThrowsExactly<ArgumentException>(() => _report.Parse(inputBuffer));
+        }
+        #endregion
+
+        #region FromOutputDeviceState Tests
+
+        [TestMethod]
+        public void FromOutputDeviceState_EmptyList_ReturnsValidHeader()
+        {
+            // Arrange
+            var devices = new List<JoystickOutputDevice>();
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsGreaterThanOrEqualTo(27, result.Length, "Output buffer should be at least 27 bytes");
+
+            // Check header bytes (with report ID offset)
+            Assert.AreEqual(0xF2, result[0], "Header byte 0 should be 0xF2");
+            Assert.AreEqual(0xE1, result[1], "Header byte 1 should be 0xE1");
+            Assert.AreEqual(0x06, result[2], "Header byte 2 should be 0x06");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LEDOutput_SetsBitCorrectly()
+        {
+            // Arrange
+            var devices = new List<JoystickOutputDevice>
+            {
+                new JoystickOutputDevice
+                {
+                    Type = DeviceType.Output,
+                    Byte = 6,
+                    Bit = 0,
+                    State = 1
+                }
+            };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x01, result[6], "Bit 0 in byte 6 should be set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_MultipleLEDs_SetsCorrectBits()
+        {
+            // Arrange
+            var devices = new List<JoystickOutputDevice>
+            {
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 6, Bit = 0, State = 1 },
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 6, Bit = 2, State = 1 },
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 7, Bit = 1, State = 1 }
+            };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x05, result[6], "Bits 0 and 2 should be set in byte 6 (0x01 | 0x04 = 0x05)");
+            Assert.AreEqual(0x02, result[7], "Bit 1 should be set in byte 7");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LEDOff_ClearsBit()
+        {
+            // Arrange - Create report instance to maintain state
+            var report = new FcuCubeReport();
+
+            var devices = new List<JoystickOutputDevice>
+            {
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 6, Bit = 0, State = 1 }
+            };
+
+            var result1 = report.FromOutputDeviceState(devices);
+
+            // Now turn it off
+            devices[0].State = 0;
+
+            // Act
+            var result2 = report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x01, result1[6], "Bit should initially be set");
+            Assert.AreEqual(0x00, result2[6], "Bit should be cleared when state is 0");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_BrightnessControl_SetsCorrectBytes()
+        {
+            // Arrange
+            var devices = new List<JoystickOutputDevice>
+            {
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 11, State = 128 }, // LCD brightness
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 12, State = 200 }  // Background brightness
+            };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(128, result[11], "LCD brightness should be set correctly");
+            Assert.AreEqual(200, result[12], "Background brightness should be set correctly");
+        }
+
+        #endregion
+
+        #region LCD Display Tests
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "999999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[19], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[20], "Low byte should be 0xE7");
+            Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999dot999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "999.999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[19], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[20], "Low byte should be 0xE7");
+            Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999dot9dot99()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "999.999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[19], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[20], "Low byte should be 0xE7");
+            Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_123()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "123"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 123 => 0x007B, so high byte = 0x00, low byte = 0x7B
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
+            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
+            Assert.AreEqual(0x7B, result[22], "Low byte should be 0x7B");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_9()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "9"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
+            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
+            Assert.AreEqual(0x09, result[22], "Low byte should be 0x09");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_NonVS_HandlesZeroValue()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "1234"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+            _report.FromOutputDeviceState(devices);
+
+            // Now set it to zero
+            lcdDisplay.Text = "0";
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
+            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[22], "Low byte should be 0x00");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_NonVS_HandlesEmptyStringValue()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "1234"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+            _report.FromOutputDeviceState(devices);
+
+            // Now set it to empty string
+            lcdDisplay.Text = "";
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
+            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[22], "Low byte should be 0x00");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_InvalidText_SkipsProcessing()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 19,
+                Cols = 6,
+                Text = "1234"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+            _report.FromOutputDeviceState(devices);
+            lcdDisplay.Text = "ABCD";
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x00, result[19], "High byte should be 0x00");
+            Assert.AreEqual(0x01, result[20], "Low byte should be 0x01");
+            Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
+            Assert.AreEqual(0xEA, result[22], "Low byte should be 0xEA");
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Creates a valid FCU Cube input buffer for testing purposes
+        /// </summary>
+        private byte[] CreateValidInputBuffer()
+        {
+            var buffer = new byte[65]; // Typical size for HID report including the report ID
+            buffer[0] = 0x01; // Report ID
+
+            // Set header
+            buffer[1] = 0xF2;
+            buffer[2] = 0xE1;
+            buffer[3] = 0x06;
+
+            // Set data type and length markers
+            buffer[4] = 0x02; // Data type total
+            buffer[5] = 0x01; // Bit type
+            buffer[6] = 0x04; // Data length for buttons (4 bytes)
+
+            // Buttons in bytes 7-10 (mapped to 6-9 in comments)
+            buffer[7] = 0x00;
+            buffer[8] = 0x00;
+            buffer[9] = 0x00;
+            buffer[10] = 0x00;
+
+            // Encoder section header
+            buffer[11] = 0x02; // Single byte type
+            buffer[12] = 0x02; // 2 bytes of encoder data
+
+            // Encoder values in bytes 12-13 (mapped to 11-12 in comments)
+            buffer[12] = 0x00; // Small encoder
+            buffer[13] = 0x00; // Big encoder
+            
+            return buffer;
+        }
+
+        #endregion
+    }
+}

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
@@ -195,6 +195,12 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0xE7, result[20], "Low byte should be 0xE7");
             Assert.AreEqual(0x03, result[21], "High byte should be 0x03");
             Assert.AreEqual(0xE7, result[22], "Low byte should be 0xE7");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x06, result[15], "There should be all 6 digits set");
         }
 
         [TestMethod]
@@ -224,6 +230,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert dot position
             Assert.AreEqual(0x03, result[13], "Dot position byte should indicate dot after 3rd digit");
+
+            // Assert active digits
+            Assert.AreEqual(0x06, result[15], "There should be all 6 digits set");
         }
 
         [TestMethod]
@@ -253,6 +262,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert dot position, only first dot is rendered
             Assert.AreEqual(0x02, result[13], "Dot position byte should indicate dot after 2rd digit");
+
+            // Assert active digits
+            Assert.AreEqual(0x06, result[15], "There should be all 6 digits set");
         }
 
         [TestMethod]
@@ -279,6 +291,12 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
             Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
             Assert.AreEqual(0x7B, result[22], "Low byte should be 0x7B");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x03, result[15], "There should be 3 digits set");
         }
 
         [TestMethod]
@@ -305,10 +323,16 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
             Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
             Assert.AreEqual(0x09, result[22], "Low byte should be 0x09");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x01, result[15], "There should be 1 digit set");
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_NonVS_HandlesZeroValue()
+        public void FromOutputDeviceState_LcdDisplay_HandlesZeroValue()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -333,10 +357,16 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
             Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
             Assert.AreEqual(0x00, result[22], "Low byte should be 0x00");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x01, result[15], "There should be 1 digit set");
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_NonVS_HandlesEmptyStringValue()
+        public void FromOutputDeviceState_LcdDisplay_HandlesEmptyStringValue()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -361,6 +391,12 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0x00, result[20], "Low byte should be 0x00");
             Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
             Assert.AreEqual(0x00, result[22], "Low byte should be 0x00");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[13], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x00, result[15], "There should be 0 digit set");
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -260,6 +260,7 @@
     <Compile Include="MobiFlight\Joysticks\Bodnar\BodnarBoardTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\Dap500ReportTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\EfisCubeReportTests.cs" />
+    <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCubeReportTests.cs" />
     <Compile Include="MobiFlight\Modifier\ExponentialAverageTests.cs" />
     <Compile Include="MobiFlight\InputEventArgsTests.cs" />
     <Compile Include="MobiFlight\Joysticks\Bodnar\BodnarReportTests.cs" />


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
Add support for WingFlex RMP cube

### Screenshots / recordings
<img width="933" height="676" alt="image" src="https://github.com/user-attachments/assets/4f9762af-a734-483e-833f-d08f963fe172" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] All LEDs can be controlled
- [x] All Inputs are processed
- [x] 6-digits Lcd Screens can be controlled
  - [x] Active (Left) can be set
  - [x] Standby (right) can be set
  - [x] Numeric values are supported
  - [x] If value contains a decimal point it will enable the respective point  

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [ ] ~~Frontend tests~~
- [ ] ~~i18n - All user-facing strings are translated~~
- [x] documentation
  - [x] User docs (docs.mobiflight.com) - @neilenns 

### Notes
This was implemented based on the documentation available at:
https://github.com/wingflexsim/DevDocument/blob/master/docs/A320%20RMP%20CUBE.md
I don't personally own this unit.
Testing was done with [community on Discord](https://discord.com/channels/608690978081210392/1518941525160104107)