### PR TITLE
Add support for WingFlex Overhead Panel

### DIFF
--- a/src/MobiFlightConnector/Joysticks/wingflex/wingflex_ovhdcube.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/wingflex/wingflex_ovhdcube.joystick.json
@@ -1,0 +1,1288 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "OVHD Cube",
+  "VendorId": "0xA716",
+  "ProductId": "0xCB87",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "IR1 NORM"
+    },
+    {
+      "Id": 2,
+      "Type": "Button",
+      "Label": "IR1 PUSH"
+    },
+    {
+      "Id": 3,
+      "Type": "Button",
+      "Label": "IR2 NORM"
+    },
+    {
+      "Id": 4,
+      "Type": "Button",
+      "Label": "IR2 PUSH"
+    },
+    {
+      "Id": 5,
+      "Type": "Button",
+      "Label": "IR3 NORM"
+    },
+    {
+      "Id": 6,
+      "Type": "Button",
+      "Label": "IR3 PUSH"
+    },
+    {
+      "Id": 7,
+      "Type": "Button",
+      "Label": "IR1 OFF"
+    },
+    {
+      "Id": 8,
+      "Type": "Button",
+      "Label": "IR1 NAV"
+    },
+    {
+      "Id": 9,
+      "Type": "Button",
+      "Label": "IR1 ATT"
+    },
+    {
+      "Id": 10,
+      "Type": "Button",
+      "Label": "IR2 OFF"
+    },
+    {
+      "Id": 11,
+      "Type": "Button",
+      "Label": "IR2 NAV"
+    },
+    {
+      "Id": 12,
+      "Type": "Button",
+      "Label": "IR2 ATT"
+    },
+    {
+      "Id": 13,
+      "Type": "Button",
+      "Label": "IR3 OFF"
+    },
+    {
+      "Id": 14,
+      "Type": "Button",
+      "Label": "IR3 NAV"
+    },
+    {
+      "Id": 15,
+      "Type": "Button",
+      "Label": "IR3 ATT"
+    },
+    {
+      "Id": 16,
+      "Type": "Button",
+      "Label": "ENG1 AGENT1 NORM"
+    },
+    {
+      "Id": 17,
+      "Type": "Button",
+      "Label": "ENG1 AGENT1 PUSH"
+    },
+    {
+      "Id": 18,
+      "Type": "Button",
+      "Label": "ENG1 AGENT2 NORM"
+    },
+    {
+      "Id": 19,
+      "Type": "Button",
+      "Label": "ENG1 AGENT2 PUSH"
+    },
+    {
+      "Id": 20,
+      "Type": "Button",
+      "Label": "APU AGENT NORM"
+    },
+    {
+      "Id": 21,
+      "Type": "Button",
+      "Label": "APU AGENT PUSH"
+    },
+    {
+      "Id": 22,
+      "Type": "Button",
+      "Label": "ENG2 AGENT1 NORM"
+    },
+    {
+      "Id": 23,
+      "Type": "Button",
+      "Label": "ENG2 AGENT1 PUSH"
+    },
+    {
+      "Id": 24,
+      "Type": "Button",
+      "Label": "ENG2 AGENT2 NORM"
+    },
+    {
+      "Id": 25,
+      "Type": "Button",
+      "Label": "ENG2 AGENT2 PUSH"
+    },
+    {
+      "Id": 26,
+      "Type": "Button",
+      "Label": "ENG1 FIRE NORM"
+    },
+    {
+      "Id": 27,
+      "Type": "Button",
+      "Label": "ENG1 FIRE POPOUT"
+    },
+    {
+      "Id": 28,
+      "Type": "Button",
+      "Label": "APU FIRE NORM"
+    },
+    {
+      "Id": 29,
+      "Type": "Button",
+      "Label": "APU FIRE POPOUT"
+    },
+    {
+      "Id": 30,
+      "Type": "Button",
+      "Label": "ENG2 FIRE NORM"
+    },
+    {
+      "Id": 31,
+      "Type": "Button",
+      "Label": "ENG2 FIRE POPOUT"
+    },
+    {
+      "Id": 32,
+      "Type": "Button",
+      "Label": "ENG1 FIRE TEST"
+    },
+    {
+      "Id": 33,
+      "Type": "Button",
+      "Label": "APU FIRE TEST"
+    },
+    {
+      "Id": 34,
+      "Type": "Button",
+      "Label": "ENG2 FIRE TEST"
+    },
+    {
+      "Id": 35,
+      "Type": "Button",
+      "Label": "XFEED NORM"
+    },
+    {
+      "Id": 36,
+      "Type": "Button",
+      "Label": "XFEED PUSH"
+    },
+    {
+      "Id": 37,
+      "Type": "Button",
+      "Label": "L TK PUMP1 NORM"
+    },
+    {
+      "Id": 38,
+      "Type": "Button",
+      "Label": "L TK PUMP1 PUSH"
+    },
+    {
+      "Id": 39,
+      "Type": "Button",
+      "Label": "L TK PUMP2 NORM"
+    },
+    {
+      "Id": 40,
+      "Type": "Button",
+      "Label": "L TK PUMP2 PUSH"
+    },
+    {
+      "Id": 41,
+      "Type": "Button",
+      "Label": "CTR TK PUMP1 NORM"
+    },
+    {
+      "Id": 42,
+      "Type": "Button",
+      "Label": "CTR TK PUMP1 PUSH"
+    },
+    {
+      "Id": 43,
+      "Type": "Button",
+      "Label": "MODE SEL NORM"
+    },
+    {
+      "Id": 44,
+      "Type": "Button",
+      "Label": "MODE SEL PUSH"
+    },
+    {
+      "Id": 45,
+      "Type": "Button",
+      "Label": "CTR TK PUMP2 NORM"
+    },
+    {
+      "Id": 46,
+      "Type": "Button",
+      "Label": "CTR TK PUMP2 PUSH"
+    },
+    {
+      "Id": 47,
+      "Type": "Button",
+      "Label": "R TK PUMP1 NORM"
+    },
+    {
+      "Id": 48,
+      "Type": "Button",
+      "Label": "R TK PUMP1 PUSH"
+    },
+    {
+      "Id": 49,
+      "Type": "Button",
+      "Label": "R TK PUMP2 NORM"
+    },
+    {
+      "Id": 50,
+      "Type": "Button",
+      "Label": "R TK PUMP2 PUSH"
+    },
+    {
+      "Id": 51,
+      "Type": "Button",
+      "Label": "COMMERCIAL NORM"
+    },
+    {
+      "Id": 52,
+      "Type": "Button",
+      "Label": "COMMERCIAL PUSH"
+    },
+    {
+      "Id": 53,
+      "Type": "Button",
+      "Label": "BAT1 NORM"
+    },
+    {
+      "Id": 54,
+      "Type": "Button",
+      "Label": "BAT1 PUSH"
+    },
+    {
+      "Id": 55,
+      "Type": "Button",
+      "Label": "BAT2 NORM"
+    },
+    {
+      "Id": 56,
+      "Type": "Button",
+      "Label": "BAT2 PUSH"
+    },
+    {
+      "Id": 57,
+      "Type": "Button",
+      "Label": "APU GEN NORM"
+    },
+    {
+      "Id": 58,
+      "Type": "Button",
+      "Label": "APU GEN PUSH"
+    },
+    {
+      "Id": 59,
+      "Type": "Button",
+      "Label": "EXT PWR"
+    },
+    {
+      "Id": 60,
+      "Type": "Button",
+      "Label": "PACK FLOW LO"
+    },
+    {
+      "Id": 61,
+      "Type": "Button",
+      "Label": "PACK FLOW NORM"
+    },
+    {
+      "Id": 62,
+      "Type": "Button",
+      "Label": "PACK FLOW HI"
+    },
+    {
+      "Id": 63,
+      "Type": "Button",
+      "Label": "COCKPIT PACK 1"
+    },
+    {
+      "Id": 64,
+      "Type": "Button",
+      "Label": "COCKPIT PACK 2"
+    },
+    {
+      "Id": 65,
+      "Type": "Button",
+      "Label": "COCKPIT PACK 3"
+    },
+    {
+      "Id": 66,
+      "Type": "Button",
+      "Label": "COCKPIT PACK 4"
+    },
+    {
+      "Id": 67,
+      "Type": "Button",
+      "Label": "COCKPIT PACK 5"
+    },
+    {
+      "Id": 68,
+      "Type": "Button",
+      "Label": "COCKPIT PACK 6"
+    },
+    {
+      "Id": 69,
+      "Type": "Button",
+      "Label": "COCKPIT PACK 7"
+    },
+    {
+      "Id": 70,
+      "Type": "Button",
+      "Label": "FWD CABIN PACK 1"
+    },
+    {
+      "Id": 71,
+      "Type": "Button",
+      "Label": "FWD CABIN PACK 2"
+    },
+    {
+      "Id": 72,
+      "Type": "Button",
+      "Label": "FWD CABIN PACK 3"
+    },
+    {
+      "Id": 73,
+      "Type": "Button",
+      "Label": "FWD CABIN PACK 4"
+    },
+    {
+      "Id": 74,
+      "Type": "Button",
+      "Label": "FWD CABIN PACK 5"
+    },
+    {
+      "Id": 75,
+      "Type": "Button",
+      "Label": "FWD CABIN PACK 6"
+    },
+    {
+      "Id": 76,
+      "Type": "Button",
+      "Label": "FWD CABIN PACK 7"
+    },
+    {
+      "Id": 77,
+      "Type": "Button",
+      "Label": "AFT CABIN PACK 1"
+    },
+    {
+      "Id": 78,
+      "Type": "Button",
+      "Label": "AFT CABIN PACK 2"
+    },
+    {
+      "Id": 79,
+      "Type": "Button",
+      "Label": "AFT CABIN PACK 3"
+    },
+    {
+      "Id": 80,
+      "Type": "Button",
+      "Label": "AFT CABIN PACK 4"
+    },
+    {
+      "Id": 81,
+      "Type": "Button",
+      "Label": "AFT CABIN PACK 5"
+    },
+    {
+      "Id": 82,
+      "Type": "Button",
+      "Label": "AFT CABIN PACK 6"
+    },
+    {
+      "Id": 83,
+      "Type": "Button",
+      "Label": "AFT CABIN PACK 7"
+    },
+    {
+      "Id": 84,
+      "Type": "Button",
+      "Label": "PACK1 NORM"
+    },
+    {
+      "Id": 85,
+      "Type": "Button",
+      "Label": "PACK1 PUSH"
+    },
+    {
+      "Id": 86,
+      "Type": "Button",
+      "Label": "APU BLEED NORM"
+    },
+    {
+      "Id": 87,
+      "Type": "Button",
+      "Label": "APU BLEED PUSH"
+    },
+    {
+      "Id": 88,
+      "Type": "Button",
+      "Label": "PACK2 NORM"
+    },
+    {
+      "Id": 89,
+      "Type": "Button",
+      "Label": "PACK2 PUSH"
+    },
+    {
+      "Id": 90,
+      "Type": "Button",
+      "Label": "HOT AIR NORM"
+    },
+    {
+      "Id": 91,
+      "Type": "Button",
+      "Label": "HOT AIR PUSH"
+    },
+    {
+      "Id": 92,
+      "Type": "Button",
+      "Label": "AFT ISOL VALVE NORM"
+    },
+    {
+      "Id": 93,
+      "Type": "Button",
+      "Label": "AFT ISOL VALVE PUSH"
+    },
+    {
+      "Id": 94,
+      "Type": "Button",
+      "Label": "CARGO PACK 1"
+    },
+    {
+      "Id": 95,
+      "Type": "Button",
+      "Label": "CARGO PACK 2"
+    },
+    {
+      "Id": 96,
+      "Type": "Button",
+      "Label": "CARGO PACK 3"
+    },
+    {
+      "Id": 97,
+      "Type": "Button",
+      "Label": "CARGO PACK 4"
+    },
+    {
+      "Id": 98,
+      "Type": "Button",
+      "Label": "CARGO PACK 5"
+    },
+    {
+      "Id": 99,
+      "Type": "Button",
+      "Label": "CARGO PACK 6"
+    },
+    {
+      "Id": 100,
+      "Type": "Button",
+      "Label": "CARGO PACK 7"
+    },
+    {
+      "Id": 101,
+      "Type": "Button",
+      "Label": "ANTI-ICE WING NORM"
+    },
+    {
+      "Id": 102,
+      "Type": "Button",
+      "Label": "ANTI-ICE WING PUSH"
+    },
+    {
+      "Id": 103,
+      "Type": "Button",
+      "Label": "ANTI-ICE ENG1 NORM"
+    },
+    {
+      "Id": 104,
+      "Type": "Button",
+      "Label": "ANTI-ICE ENG1 PUSH"
+    },
+    {
+      "Id": 105,
+      "Type": "Button",
+      "Label": "ANTI-ICE ENG2 NORM"
+    },
+    {
+      "Id": 106,
+      "Type": "Button",
+      "Label": "ANTI-ICE ENG2 PUSH"
+    },
+    {
+      "Id": 107,
+      "Type": "Button",
+      "Label": "WINDOW HEAT NORM"
+    },
+    {
+      "Id": 108,
+      "Type": "Button",
+      "Label": "WINDOW HEAT PUSH"
+    },
+    {
+      "Id": 109,
+      "Type": "Button",
+      "Label": "CREW SUPPLY NORM"
+    },
+    {
+      "Id": 110,
+      "Type": "Button",
+      "Label": "CREW SUPPLY PUSH"
+    },
+    {
+      "Id": 111,
+      "Type": "Button",
+      "Label": "GND CTL"
+    },
+    {
+      "Id": 112,
+      "Type": "Button",
+      "Label": "CVR TEST"
+    },
+    {
+      "Id": 113,
+      "Type": "Button",
+      "Label": "CALLS ALL"
+    },
+    {
+      "Id": 114,
+      "Type": "Button",
+      "Label": "WIPER OFF"
+    },
+    {
+      "Id": 115,
+      "Type": "Button",
+      "Label": "WIPER SLOW"
+    },
+    {
+      "Id": 116,
+      "Type": "Button",
+      "Label": "WIPER FAST"
+    },
+    {
+      "Id": 117,
+      "Type": "Button",
+      "Label": "STROBE OFF"
+    },
+    {
+      "Id": 118,
+      "Type": "Button",
+      "Label": "STROBE AUTO"
+    },
+    {
+      "Id": 119,
+      "Type": "Button",
+      "Label": "STROBE ON"
+    },
+    {
+      "Id": 120,
+      "Type": "Button",
+      "Label": "BEACON OFF"
+    },
+    {
+      "Id": 121,
+      "Type": "Button",
+      "Label": "BEACON ON"
+    },
+    {
+      "Id": 122,
+      "Type": "Button",
+      "Label": "WING OFF"
+    },
+    {
+      "Id": 123,
+      "Type": "Button",
+      "Label": "WING ON"
+    },
+    {
+      "Id": 124,
+      "Type": "Button",
+      "Label": "NAV & LOGO OFF"
+    },
+    {
+      "Id": 125,
+      "Type": "Button",
+      "Label": "NAV & LOGO 1"
+    },
+    {
+      "Id": 126,
+      "Type": "Button",
+      "Label": "NAV & LOGO 2"
+    },
+    {
+      "Id": 127,
+      "Type": "Button",
+      "Label": "RWY TURN-OFF OFF"
+    },
+    {
+      "Id": 128,
+      "Type": "Button",
+      "Label": "RWY TURN-OFF ON"
+    },
+    {
+      "Id": 129,
+      "Type": "Button",
+      "Label": "LAND L RETRACT"
+    },
+    {
+      "Id": 130,
+      "Type": "Button",
+      "Label": "LAND L OFF"
+    },
+    {
+      "Id": 131,
+      "Type": "Button",
+      "Label": "LAND L ON"
+    },
+    {
+      "Id": 132,
+      "Type": "Button",
+      "Label": "LAND R RETRACT"
+    },
+    {
+      "Id": 133,
+      "Type": "Button",
+      "Label": "LAND R OFF"
+    },
+    {
+      "Id": 134,
+      "Type": "Button",
+      "Label": "LAND R ON"
+    },
+    {
+      "Id": 135,
+      "Type": "Button",
+      "Label": "NOSE OFF"
+    },
+    {
+      "Id": 136,
+      "Type": "Button",
+      "Label": "NOSE TAXI"
+    },
+    {
+      "Id": 137,
+      "Type": "Button",
+      "Label": "NOSE T.O"
+    },
+    {
+      "Id": 138,
+      "Type": "Button",
+      "Label": "APU MASTER NORM"
+    },
+    {
+      "Id": 139,
+      "Type": "Button",
+      "Label": "APU MASTER PUSH"
+    },
+    {
+      "Id": 140,
+      "Type": "Button",
+      "Label": "APU START"
+    },
+    {
+      "Id": 141,
+      "Type": "Button",
+      "Label": "STBY COMPASS OFF"
+    },
+    {
+      "Id": 142,
+      "Type": "Button",
+      "Label": "STBY COMPASS ON"
+    },
+    {
+      "Id": 143,
+      "Type": "Button",
+      "Label": "DOME OFF"
+    },
+    {
+      "Id": 144,
+      "Type": "Button",
+      "Label": "DOME DIM"
+    },
+    {
+      "Id": 145,
+      "Type": "Button",
+      "Label": "DOME BRT"
+    },
+    {
+      "Id": 146,
+      "Type": "Button",
+      "Label": "ANN LT DIM"
+    },
+    {
+      "Id": 147,
+      "Type": "Button",
+      "Label": "ANN LT BRT"
+    },
+    {
+      "Id": 148,
+      "Type": "Button",
+      "Label": "ANN LT TEST"
+    },
+    {
+      "Id": 149,
+      "Type": "Button",
+      "Label": "SEAT BELTS OFF"
+    },
+    {
+      "Id": 150,
+      "Type": "Button",
+      "Label": "SEAT BELTS ON"
+    },
+    {
+      "Id": 151,
+      "Type": "Button",
+      "Label": "NO SMOKING OFF"
+    },
+    {
+      "Id": 152,
+      "Type": "Button",
+      "Label": "NO SMOKING AUTO"
+    },
+    {
+      "Id": 153,
+      "Type": "Button",
+      "Label": "NO SMOKING ON"
+    },
+    {
+      "Id": 154,
+      "Type": "Button",
+      "Label": "EMER EXIT KEY NORN"
+    },
+    {
+      "Id": 155,
+      "Type": "Button",
+      "Label": "EMER EXIT KEY PUSH"
+    },
+    {
+      "Id": 156,
+      "Type": "Button",
+      "Label": "EMER EXIT LT OFF"
+    },
+    {
+      "Id": 157,
+      "Type": "Button",
+      "Label": "EMER EXIT LT ARM"
+    },
+    {
+      "Id": 158,
+      "Type": "Button",
+      "Label": "EMER EXIT LT ON"
+    },
+    {
+      "Id": 159,
+      "Type": "Button",
+      "Label": "RAIN RPLNT"
+    },
+    {
+      "Id": 48,
+      "Type": "Axis",
+      "Label": "OVHD INTEG LT"
+    }
+  ],
+  "Outputs": [
+    {
+      "Label": "ON BAT",
+      "Id": "on.bat",
+      "Byte": 6,
+      "Bit": 0
+    },
+    {
+      "Label": "IR1 U",
+      "Id": "ir1.u",
+      "Byte": 6,
+      "Bit": 1
+    },
+    {
+      "Label": "IR1 L",
+      "Id": "ir1.l",
+      "Byte": 6,
+      "Bit": 2
+    },
+    {
+      "Label": "IR2 U",
+      "Id": "ir2.u",
+      "Byte": 6,
+      "Bit": 3
+    },
+    {
+      "Label": "IR2 L",
+      "Id": "ir2.l",
+      "Byte": 6,
+      "Bit": 4
+    },
+    {
+      "Label": "IR3 U",
+      "Id": "ir3.u",
+      "Byte": 6,
+      "Bit": 5
+    },
+    {
+      "Label": "IR3 L",
+      "Id": "ir3.l",
+      "Byte": 6,
+      "Bit": 6
+    },
+    {
+      "Label": "ENG1 FIRE L",
+      "Id": "eng1.fire.l",
+      "Byte": 6,
+      "Bit": 7
+    },
+    {
+      "Label": "ENG1 FIRE R",
+      "Id": "eng1.fire.r",
+      "Byte": 7,
+      "Bit": 0
+    },
+    {
+      "Label": "APU FIRE L",
+      "Id": "apu.fire.l",
+      "Byte": 7,
+      "Bit": 1
+    },
+    {
+      "Label": "APU FIRE R",
+      "Id": "apu.fire.r",
+      "Byte": 7,
+      "Bit": 2
+    },
+    {
+      "Label": "ENG2 FIRE L",
+      "Id": "eng2.fire.l",
+      "Byte": 7,
+      "Bit": 3
+    },
+    {
+      "Label": "ENG2 FIRE R",
+      "Id": "eng2.fire.r",
+      "Byte": 7,
+      "Bit": 4
+    },
+    {
+      "Label": "ENG1 AGENT1 U",
+      "Id": "eng1.agent1.u",
+      "Byte": 7,
+      "Bit": 5
+    },
+    {
+      "Label": "ENG1 AGENT1 L",
+      "Id": "eng1.agent1.l",
+      "Byte": 7,
+      "Bit": 6
+    },
+    {
+      "Label": "ENG1 AGENT2 U",
+      "Id": "eng1.agent2.u",
+      "Byte": 7,
+      "Bit": 7
+    },
+    {
+      "Label": "ENG1 AGENT2 L",
+      "Id": "eng1.agent2.l",
+      "Byte": 8,
+      "Bit": 0
+    },
+    {
+      "Label": "APU AGENT U",
+      "Id": "apu.agent.u",
+      "Byte": 8,
+      "Bit": 1
+    },
+    {
+      "Label": "APU AGENT L",
+      "Id": "apu.agent.l",
+      "Byte": 8,
+      "Bit": 2
+    },
+    {
+      "Label": "ENG2 AGENT1 U",
+      "Id": "eng2.agent1.u",
+      "Byte": 8,
+      "Bit": 3
+    },
+    {
+      "Label": "ENG2 AGENT1 L",
+      "Id": "eng2.agent1.l",
+      "Byte": 8,
+      "Bit": 4
+    },
+    {
+      "Label": "ENG2 AGENT2 U",
+      "Id": "eng2.agent2.u",
+      "Byte": 8,
+      "Bit": 5
+    },
+    {
+      "Label": "ENG2 AGENT2 L",
+      "Id": "eng2.agent2.l",
+      "Byte": 8,
+      "Bit": 6
+    },
+    {
+      "Label": "XFEED U",
+      "Id": "xfeed.u",
+      "Byte": 8,
+      "Bit": 7
+    },
+    {
+      "Label": "XFEED L",
+      "Id": "xfeed.l",
+      "Byte": 9,
+      "Bit": 0
+    },
+    {
+      "Label": "L TK PUMP1 U",
+      "Id": "l.tk.pump1.u",
+      "Byte": 9,
+      "Bit": 1
+    },
+    {
+      "Label": "L TK PUMP1 L",
+      "Id": "l.tk.pump1.l",
+      "Byte": 9,
+      "Bit": 2
+    },
+    {
+      "Label": "L TK PUMP2 U",
+      "Id": "l.tk.pump2.u",
+      "Byte": 9,
+      "Bit": 3
+    },
+    {
+      "Label": "L TK PUMP2 L",
+      "Id": "l.tk.pump2.l",
+      "Byte": 9,
+      "Bit": 4
+    },
+    {
+      "Label": "C TK PUMP1 U",
+      "Id": "c.tk.pump1.u",
+      "Byte": 9,
+      "Bit": 5
+    },
+    {
+      "Label": "C TK PUMP1 L",
+      "Id": "c.tk.pump1.l",
+      "Byte": 9,
+      "Bit": 6
+    },
+    {
+      "Label": "MODE SEL U",
+      "Id": "mode.sel.u",
+      "Byte": 9,
+      "Bit": 7
+    },
+    {
+      "Label": "MODE SEL L",
+      "Id": "mode.sel.l",
+      "Byte": 10,
+      "Bit": 0
+    },
+    {
+      "Label": "C TK PUMP2 U",
+      "Id": "c.tk.pump2.u",
+      "Byte": 10,
+      "Bit": 1
+    },
+    {
+      "Label": "C TK PUMP2 L",
+      "Id": "c.tk.pump2.l",
+      "Byte": 10,
+      "Bit": 2
+    },
+    {
+      "Label": "R TK PUMP1 U",
+      "Id": "r.tk.pump1.u",
+      "Byte": 10,
+      "Bit": 3
+    },
+    {
+      "Label": "R TK PUMP1 L",
+      "Id": "r.tk.pump1.l",
+      "Byte": 10,
+      "Bit": 4
+    },
+    {
+      "Label": "R TK PUMP2 U",
+      "Id": "r.tk.pump2.u",
+      "Byte": 10,
+      "Bit": 5
+    },
+    {
+      "Label": "R TK PUMP2 L",
+      "Id": "r.tk.pump2.l",
+      "Byte": 10,
+      "Bit": 6
+    },
+    {
+      "Label": "COMMERCIAL L",
+      "Id": "commercial.l",
+      "Byte": 10,
+      "Bit": 7
+    },
+    {
+      "Label": "BAT1 U",
+      "Id": "bat1.u",
+      "Byte": 11,
+      "Bit": 0
+    },
+    {
+      "Label": "BAT1 L",
+      "Id": "bat1.l",
+      "Byte": 11,
+      "Bit": 1
+    },
+    {
+      "Label": "BAT2 U",
+      "Id": "bat2.u",
+      "Byte": 11,
+      "Bit": 2
+    },
+    {
+      "Label": "BAT2 L",
+      "Id": "bat2.l",
+      "Byte": 11,
+      "Bit": 3
+    },
+    {
+      "Label": "APU GEN U",
+      "Id": "apu.gen.u",
+      "Byte": 11,
+      "Bit": 4
+    },
+    {
+      "Label": "APU GEN L",
+      "Id": "apu.gen.l",
+      "Byte": 11,
+      "Bit": 5
+    },
+    {
+      "Label": "EXT PWR U",
+      "Id": "ext.pwr.u",
+      "Byte": 11,
+      "Bit": 6
+    },
+    {
+      "Label": "EXT PWR L",
+      "Id": "ext.pwr.l",
+      "Byte": 11,
+      "Bit": 7
+    },
+    {
+      "Label": "PACK1 U",
+      "Id": "pack1.u",
+      "Byte": 12,
+      "Bit": 0
+    },
+    {
+      "Label": "PACK1 L",
+      "Id": "pack1.l",
+      "Byte": 12,
+      "Bit": 1
+    },
+    {
+      "Label": "PACK2 U",
+      "Id": "pack2.u",
+      "Byte": 12,
+      "Bit": 2
+    },
+    {
+      "Label": "PACK2 L",
+      "Id": "pack2.l",
+      "Byte": 12,
+      "Bit": 3
+    },
+    {
+      "Label": "APU BLEED U",
+      "Id": "apu.bleed.u",
+      "Byte": 12,
+      "Bit": 4
+    },
+    {
+      "Label": "APU BLEED L",
+      "Id": "apu.bleed.l",
+      "Byte": 12,
+      "Bit": 5
+    },
+    {
+      "Label": "HOT AIR U",
+      "Id": "hot.air.u",
+      "Byte": 12,
+      "Bit": 6
+    },
+    {
+      "Label": "HOT AIR L",
+      "Id": "hot.air.l",
+      "Byte": 12,
+      "Bit": 7
+    },
+    {
+      "Label": "AFT ISOL VALVE U",
+      "Id": "aft.isol.valve.u",
+      "Byte": 13,
+      "Bit": 0
+    },
+    {
+      "Label": "AFT ISOL VALVE L",
+      "Id": "aft.isol.valve.l",
+      "Byte": 13,
+      "Bit": 1
+    },
+    {
+      "Label": "ANTI-ICE WING U",
+      "Id": "anti.ice.wing.u",
+      "Byte": 13,
+      "Bit": 2
+    },
+    {
+      "Label": "ANTI-ICE WING L",
+      "Id": "anti.ice.wing.l",
+      "Byte": 13,
+      "Bit": 3
+    },
+    {
+      "Label": "ANTI-ICE ENG1 U",
+      "Id": "anti.ice.eng1.u",
+      "Byte": 13,
+      "Bit": 4
+    },
+    {
+      "Label": "ANTI-ICE ENG1 L",
+      "Id": "anti.ice.eng1.l",
+      "Byte": 13,
+      "Bit": 5
+    },
+    {
+      "Label": "ANTI-ICE ENG2 U",
+      "Id": "anti.ice.eng2.u",
+      "Byte": 13,
+      "Bit": 6
+    },
+    {
+      "Label": "ANTI-ICE ENG2 L",
+      "Id": "anti.ice.eng2.l",
+      "Byte": 13,
+      "Bit": 7
+    },
+    {
+      "Label": "WINDOW HEAT L",
+      "Id": "window.heat.l",
+      "Byte": 14,
+      "Bit": 0
+    },
+    {
+      "Label": "CREW SUPPLY L",
+      "Id": "crew.supply.l",
+      "Byte": 14,
+      "Bit": 1
+    },
+    {
+      "Label": "APU MASTER U",
+      "Id": "apu.master.u",
+      "Byte": 14,
+      "Bit": 2
+    },
+    {
+      "Label": "APU MASTER L",
+      "Id": "apu.master.l",
+      "Byte": 14,
+      "Bit": 3
+    },
+    {
+      "Label": "APU START U",
+      "Id": "apu.start.u",
+      "Byte": 14,
+      "Bit": 4
+    },
+    {
+      "Label": "APU START L",
+      "Id": "apu.start.l",
+      "Byte": 14,
+      "Bit": 5
+    },
+    {
+      "Label": "EMER EXIT LT L",
+      "Id": "emer.exit.lt.l",
+      "Byte": 14,
+      "Bit": 6
+    },
+    {
+      "Label": "EXT_LT_STROBE_AUTO",
+      "Id": "ext.lt.strobe.auto",
+      "Byte": 14,
+      "Bit": 7
+    },
+    {
+      "Label": "VOLT DISPLAY L",
+      "Id": "volt.display.l",
+      "Byte": 15,
+      "Bit": 0
+    },
+    {
+      "Label": "VOLT DISPLAY R",
+      "Id": "volt.display.r",
+      "Byte": 15,
+      "Bit": 1
+    },
+    {
+      "Label": "Panel Brightness",
+      "Id": "brightness.panel",
+      "Byte": 18,
+      "Bit": 0
+    },
+    {
+      "Label": "Volt L Brightness",
+      "Id": "brightness.volt.l",
+      "Byte": 19,
+      "Bit": 0
+    },
+    {
+      "Label": "Volt R Brightness",
+      "Id": "brightness.volt.r",
+      "Byte": 20,
+      "Bit": 0
+    },
+    {
+      "Label": "Volt L Display",
+      "Id": "volt.l.display",
+      "Type": "LcdDisplay",
+      "Byte": 23,
+      "Cols": 3,
+      "Lines": 1
+    },
+    {
+      "Label": "Volt R Display",
+      "Id": "volt.r.display",
+      "Type": "LcdDisplay",
+      "Byte": 25,
+      "Cols": 3,
+      "Lines": 1
+    }
+  ]
+}

--- a/src/MobiFlightConnector/Joysticks/wingflex/wingflex_ovhdcube.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/wingflex/wingflex_ovhdcube.joystick.json
@@ -1239,36 +1239,6 @@
       "Bit": 7
     },
     {
-      "Label": "VOLT DISPLAY L",
-      "Id": "volt.display.l",
-      "Byte": 15,
-      "Bit": 0
-    },
-    {
-      "Label": "VOLT DISPLAY R",
-      "Id": "volt.display.r",
-      "Byte": 15,
-      "Bit": 1
-    },
-    {
-      "Label": "Panel Brightness",
-      "Id": "brightness.panel",
-      "Byte": 18,
-      "Bit": 0
-    },
-    {
-      "Label": "Volt L Brightness",
-      "Id": "brightness.volt.l",
-      "Byte": 19,
-      "Bit": 0
-    },
-    {
-      "Label": "Volt R Brightness",
-      "Id": "brightness.volt.r",
-      "Byte": 20,
-      "Bit": 0
-    },
-    {
       "Label": "Volt L Display",
       "Id": "volt.l.display",
       "Type": "LcdDisplay",

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Bodnar/BodnarReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Bodnar/BodnarReport.cs
@@ -1,4 +1,3 @@
-using SharpDX.DirectInput;
 using System;
 using System.Collections.Generic;
 

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/HidControllerFactory.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/HidControllerFactory.cs
@@ -16,6 +16,7 @@ namespace MobiFlight.Joysticks
                 case "RMP Cube":
                 case "EFIS Cube":
                 case "FCU Cube":
+                case "OVHD Cube":
                     return true;
             }
 
@@ -34,6 +35,9 @@ namespace MobiFlight.Joysticks
                     break;
                 case "FCU Cube":
                     result = new WingFlex.FcuCube(definition);
+                    break;
+                case "OVHD Cube":
+                    result = new WingFlex.OvhdCube(definition);
                     break;
             }
 

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
@@ -5,6 +5,7 @@ using SharpDX.DirectInput;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using JoystickState = MobiFlight.Joysticks.JoystickState;
 
 namespace MobiFlight
 {
@@ -329,7 +330,7 @@ namespace MobiFlight
             {
                 DIJoystick.Poll();
 
-                JoystickState newState = DIJoystick.GetCurrentState();
+                JoystickState newState = JoystickState.Create(DIJoystick.GetCurrentState());
                 lock (StateLock)
                 {
                     UpdateButtons(newState);

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickState.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickState.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections;
+
+namespace MobiFlight.Joysticks
+{
+    public class JoystickState
+    {
+        public int X { get; set; }
+
+        public int Y { get; set; }
+        public int Z { get; set; }
+
+        public int RotationX { get; set; }
+
+        public int RotationY { get; set; }
+        public int RotationZ { get; set; }
+
+        public int[] Sliders { get; internal set; }
+
+        public int[] PointOfViewControllers { get; internal set; }
+        public BitArray Buttons { get; protected set; }
+
+        public JoystickState()
+        {
+            Buttons = new BitArray(256);
+            Sliders = new int[2];
+            PointOfViewControllers = new int[4];
+        }
+
+        static public JoystickState Create(SharpDX.DirectInput.JoystickState state)
+        {
+            JoystickState joystickState = new JoystickState
+            {
+                X = state.X,
+                Y = state.Y,
+                Z = state.Z,
+                RotationX = state.RotationX,
+                RotationY = state.RotationY,
+                RotationZ = state.RotationZ,
+                Sliders = state.Sliders,
+                PointOfViewControllers = state.PointOfViewControllers,
+                Buttons = new BitArray(state.Buttons)
+            };
+
+            return joystickState;
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCube.cs
@@ -1,0 +1,32 @@
+﻿namespace MobiFlight.Joysticks.WingFlex
+{
+    internal class OvhdCube : BaseCube
+    {
+        /// <summary>
+        /// Provide same instance name as defined in the definition file.
+        /// Also works if Defintion file is not set yet.
+        /// </summary>
+        public override string Name
+        {
+            get { return Definition?.InstanceName ?? "OVHD Cube"; }
+        }
+
+        /// <summary>
+        /// Provides Serial including prefix.
+        /// Serial information is provided through Device.Net
+        /// </summary>
+        public override string Serial
+        {
+            get { return $"{Joystick.SerialPrefix}{Device?.ConnectedDeviceDefinition?.SerialNumber}" ?? "OVHD-CUBE-1234-ABCD-12345678"; }
+        }
+
+        /// <summary>
+        /// The constructor.
+        /// </summary>
+        /// <param name="definition">joystick definition file.</param>
+        public OvhdCube(JoystickDefinition definition) 
+            : base(new OvhdCubeReport(), definition)
+        {
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCube.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCube.cs
@@ -12,15 +12,6 @@
         }
 
         /// <summary>
-        /// Provides Serial including prefix.
-        /// Serial information is provided through Device.Net
-        /// </summary>
-        public override string Serial
-        {
-            get { return $"{Joystick.SerialPrefix}{Device?.ConnectedDeviceDefinition?.SerialNumber}" ?? "OVHD-CUBE-1234-ABCD-12345678"; }
-        }
-
-        /// <summary>
         /// The constructor.
         /// </summary>
         /// <param name="definition">joystick definition file.</param>

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCubeReport.cs
@@ -37,6 +37,9 @@ namespace MobiFlight.Joysticks.WingFlex
         private byte[] LastInputBufferState = new byte[64];
         private byte[] LastOutputBufferState = new byte[64];
 
+        const byte VOLT_DISPLAY_LEFT = 23;
+        const byte VOLT_DISPLAY_RIGHT = 25;
+
         public OvhdCubeReport()
         {
             InitLastInputBufferState();
@@ -199,7 +202,7 @@ namespace MobiFlight.Joysticks.WingFlex
                 // Background Brightness = 18
                 // Volt L Light Brightness = 19
                 // Volt R Light Brightness = 20
-                else if (itemByte == 18 || itemByte == 19 || itemByte == 20) 
+                else if (itemByte == 18 || itemByte == 19 || itemByte == 20)
                 {
                     LastOutputBufferState[itemByte] = item.State;
                 }
@@ -217,6 +220,17 @@ namespace MobiFlight.Joysticks.WingFlex
             var text = lcdDisplay.Text.Replace(".", "");
             var paddedText = text.PadLeft(lcdDisplay.Cols, '0');
             UpdateLcdDisplay(item.Byte, paddedText);
+
+            if (lcdDisplay.Byte == VOLT_DISPLAY_LEFT)
+            {
+                // enable the volt display left
+                LastOutputBufferState[15] |= (byte)(1);
+            }
+            else if (lcdDisplay.Byte == VOLT_DISPLAY_RIGHT)
+            {
+                // enable the volt display right
+                LastOutputBufferState[15] |= (byte)(2);
+            }
 
             // continue with next item,
             // as we have already processed the LCD display state

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCubeReport.cs
@@ -38,12 +38,6 @@ namespace MobiFlight.Joysticks.WingFlex
         private byte[] LastInputBufferState = new byte[64];
         private byte[] LastOutputBufferState = new byte[64];
 
-        private readonly static Dictionary<byte, byte> DotByteMapping = new Dictionary<byte, byte>
-            {
-                { 19, 13 }, // Left LCD
-                { 21, 14 }  // Right LCD
-            };
-
         public OvhdCubeReport()
         {
             InitLastInputBufferState();

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCubeReport.cs
@@ -1,5 +1,4 @@
-﻿using SharpDX.DirectInput;
-using System;
+﻿using System;
 using System.Collections.Generic;
 
 namespace MobiFlight.Joysticks.WingFlex

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/OvhdCubeReport.cs
@@ -1,0 +1,442 @@
+﻿using SharpDX.DirectInput;
+using System;
+using System.Collections.Generic;
+
+namespace MobiFlight.Joysticks.WingFlex
+{
+    internal class OvhdCubeReport : ICubeReport
+    {
+        // -                Head                         Constant: 0xF2                          -       0       -       0xF2
+        // -                Head                         Constant: 0xE1                          -       1       -       0xE1
+        // -                Head                         Constant: 0x07                          -       2       -       0x07
+        private readonly static byte[] InputHeader = new byte[] { 0xF2, 0xE1, 0x07 };
+        // -                Data Type Total              Has 2 Data Type                         -       3       -       0x02
+        // -                Data Type                    Bit Type                                -       4       -       0x01
+        // -                Data Length                  Following data occupies 20 Bytes        -       5       -       0x14
+        private readonly static byte[] InputBitSection = new byte[] { 0x02, 0x01, 0x14 };
+        // -                Data Type                    Single Byte Type                        -       10      -       0x02
+        // -                Data Length                  Following data occupies 1 Bytes         -       11      -       0x01
+        private readonly static byte[] InputByteSection = new byte[] { 0x02, 0x01 };
+
+        // -                Head                         Constant: 0xF2                          -       0       -       0xF2
+        // -                Head                         Constant: 0xE1                          -       1       -       0xE1
+        // -                Head                         Constant: 0x07                          -       2       -       0x07
+        private readonly static byte[] OutputHeader = new byte[] { 0xF2, 0xE1, 0x07 };
+        // -                Data Type Total              Has 3 Data Type                         -       3       -       0x03
+        // -                Data Type                    Bit Type                                -       4       -       0x01
+        // -                Data Length                  Following data occupies 10 Bytes        -       5       -       0x0A
+        private readonly static byte[] OutputBitSection = new byte[] { 0x03, 0x01, 0x0A };
+        // -                Data Type                    Single Byte Type                        -       16       -      0x02
+        // -                Data Length                  Following data occupies 3 Bytes         -       17      -       0x03
+        // Output           Background Light Brightness  0x00(Minimum)~0xFF(Maximum)             -       18      -       0
+        // Output           VOLT Light Left Brightness   0x00(Minimum)~0xFF(Maximum)             -       19      -       0
+        // Output           VOLT Light Right Brightness  0x00(Minimum)~0xFF(Maximum)             -       20      -       0
+        //                  Data Type                    Double Byte Type                        -       21      -       0x03
+        //                  Data Length                  Following data occupies 8 Bytes         -       22      -       0x04
+        private readonly static byte[] OutputByteSection = new byte[] { 0x02, 0x03, 0, 0, 0, 0x03, 0x04 };
+
+        private byte[] LastInputBufferState = new byte[64];
+        private byte[] LastOutputBufferState = new byte[64];
+
+        private readonly static Dictionary<byte, byte> DotByteMapping = new Dictionary<byte, byte>
+            {
+                { 19, 13 }, // Left LCD
+                { 21, 14 }  // Right LCD
+            };
+
+        public OvhdCubeReport()
+        {
+            InitLastInputBufferState();
+            InitLastOutputBufferState();
+        }
+        private void InitLastInputBufferState()
+        {
+            Buffer.BlockCopy(InputHeader, 0, LastInputBufferState, 0, InputHeader.Length);
+            Buffer.BlockCopy(InputBitSection, 0, LastInputBufferState, 3, InputBitSection.Length);
+            Buffer.BlockCopy(InputByteSection, 0, LastInputBufferState, 10, InputByteSection.Length);
+        }
+
+        private void InitLastOutputBufferState()
+        {
+            Buffer.BlockCopy(OutputHeader, 0, LastOutputBufferState, 0, OutputHeader.Length);
+            Buffer.BlockCopy(OutputBitSection, 0, LastOutputBufferState, 3, OutputBitSection.Length);
+            Buffer.BlockCopy(OutputByteSection, 0, LastOutputBufferState, 16, OutputByteSection.Length);
+        }
+
+        public void CopyFromInputBuffer(byte[] inputBuffer)
+        {
+            if (inputBuffer == null || inputBuffer.Length < LastInputBufferState.Length)
+            {
+                throw new ArgumentException($"Invalid input buffer length. Expected {LastInputBufferState.Length}, got {inputBuffer?.Length ?? 0}");
+            }
+            LastInputBufferState = (byte[])inputBuffer?.Clone();
+        }
+
+        public ICubeReport Parse(byte[] inputBuffer)
+        {
+            var result = new OvhdCubeReport();
+            result.CopyFromInputBuffer(inputBuffer);
+
+            return result;
+        }
+
+        public byte[] FromOutputDeviceState(List<JoystickOutputDevice> state)
+        {
+            //  OUTPUT DATA STRUCTURE - OVHD Cube Output Report
+            //  Name                        Note                                    Mask    Byte[]  Bit[]  Example
+            //  Head                        Constant: 0xF2                                  0       -      0xF2
+            //  Head                        Constant: 0xE1                                  1       -      0xE1
+            //  Head                        Constant: 0x07                                  2       -      0x07
+            //  Data Type Total             Has 3 Data Type                                 3       -      0x03
+            //  Data Type                   Bit Type                                        4       -      0x01
+            //  Data Length                 Following data occupies 10 Bytes                5       -      0x0A
+            //  ON BAT                      On: 1, Off: 0                           0x01    6       0      1
+            //  IR1 U                       On: 1, Off: 0                           0x02    6       1      1
+            //  IR1 L                       On: 1, Off: 0                           0x04    6       2      1
+            //  IR2 U                       On: 1, Off: 0                           0x08    6       3      1
+            //  IR2 L                       On: 1, Off: 0                           0x10    6       4      1
+            //  IR3 U                       On: 1, Off: 0                           0x20    6       5      1
+            //  IR3 L                       On: 1, Off: 0                           0x40    6       6      1
+            //  ENG1 FIRE L                 On: 1, Off: 0                           0x80    6       7      1
+            //  ENG1 FIRE R                 On: 1, Off: 0                           0x01    7       0      1
+            //  APU FIRE L                  On: 1, Off: 0                           0x02    7       1      1
+            //  APU FIRE R                  On: 1, Off: 0                           0x04    7       2      1
+            //  ENG2 FIRE L                 On: 1, Off: 0                           0x08    7       3      1
+            //  ENG2 FIRE R                 On: 1, Off: 0                           0x10    7       4      1
+            //  ENG1 AGENT1 U               On: 1, Off: 0                           0x20    7       5      1
+            //  ENG1 AGENT1 L               On: 1, Off: 0                           0x40    7       6      1
+            //  ENG1 AGENT2 U               On: 1, Off: 0                           0x80    7       7      0
+            //  ENG1 AGENT2 L               On: 1, Off: 0                           0x01    8       0      1
+            //  APU AGENT U                 On: 1, Off: 0                           0x02    8       1      1
+            //  APU AGENT L                 On: 1, Off: 0                           0x04    8       2      1
+            //  ENG2 AGENT1 U               On: 1, Off: 0                           0x08    8       3      0
+            //  ENG2 AGENT1 L               On: 1, Off: 0                           0x10    8       4      0
+            //  ENG2 AGENT2 U               On: 1, Off: 0                           0x20    8       5      0
+            //  ENG2 AGENT2 L               On: 1, Off: 0                           0x40    8       6      0
+            //  XFEED U                     On: 1, Off: 0                           0x80    8       7      0
+            //  XFEED L                     On: 1, Off: 0                           0x01    9       0      1
+            //  L TK PUMP1 U                On: 1, Off: 0                           0x02    9       1      1
+            //  L TK PUMP1 L                On: 1, Off: 0                           0x04    9       2      1
+            //  L TK PUMP2 U                On: 1, Off: 0                           0x08    9       3      0
+            //  L TK PUMP2 L                On: 1, Off: 0                           0x10    9       4      0
+            //  C TK PUMP1 U                On: 1, Off: 0                           0x20    9       5      0
+            //  C TK PUMP1 L                On: 1, Off: 0                           0x40    9       6      0
+            //  MODE SEL U                  On: 1, Off: 0                           0x80    9       7      0
+            //  MODE SEL L                  On: 1, Off: 0                           0x01    10      0      1
+            //  C TK PUMP2 U                On: 1, Off: 0                           0x02    10      1      1
+            //  C TK PUMP2 L                On: 1, Off: 0                           0x04    10      2      1
+            //  R TK PUMP1 U                On: 1, Off: 0                           0x08    10      3      0
+            //  R TK PUMP1 L                On: 1, Off: 0                           0x10    10      4      0
+            //  R TK PUMP2 U                On: 1, Off: 0                           0x20    10      5      0
+            //  R TK PUMP2 L                On: 1, Off: 0                           0x40    10      6      0
+            //  COMMERCIAL L                On: 1, Off: 0                           0x80    10      7      0
+            //  BAT1 U                      On: 1, Off: 0                           0x01    11      0      1
+            //  BAT1 L                      On: 1, Off: 0                           0x02    11      1      1
+            //  BAT2 U                      On: 1, Off: 0                           0x04    11      2      1
+            //  BAT2 L                      On: 1, Off: 0                           0x08    11      3      0
+            //  APU GEN U                   On: 1, Off: 0                           0x10    11      4      0
+            //  APU GEN L                   On: 1, Off: 0                           0x20    11      5      0
+            //  EXT PWR U                   On: 1, Off: 0                           0x40    11      6      0
+            //  EXT PWR L                   On: 1, Off: 0                           0x80    11      7      0
+            //  PACK1 U                     On: 1, Off: 0                           0x01    12      0      1
+            //  PACK1 L                     On: 1, Off: 0                           0x02    12      1      1
+            //  PACK2 U                     On: 1, Off: 0                           0x04    12      2      1
+            //  PACK2 L                     On: 1, Off: 0                           0x08    12      3      0
+            //  APU BLEED U                 On: 1, Off: 0                           0x10    12      4      0
+            //  APU BLEED L                 On: 1, Off: 0                           0x20    12      5      0
+            //  HOT AIR U                   On: 1, Off: 0                           0x40    12      6      0
+            //  HOT AIR L                   On: 1, Off: 0                           0x80    12      7      0
+            //  AFT ISOL VALVE U            On: 1, Off: 0                           0x01    13      0      1
+            //  AFT ISOL VALVE L            On: 1, Off: 0                           0x02    13      1      1
+            //  ANTI-ICE WING U             On: 1, Off: 0                           0x04    13      2      1
+            //  ANTI-ICE WING L             On: 1, Off: 0                           0x08    13      3      0
+            //  ANTI-ICE ENG1 U             On: 1, Off: 0                           0x10    13      4      0
+            //  ANTI-ICE ENG1 L             On: 1, Off: 0                           0x20    13      5      0
+            //  ANTI-ICE ENG2 U             On: 1, Off: 0                           0x40    13      6      0
+            //  ANTI-ICE ENG2 L             On: 1, Off: 0                           0x80    13      7      0
+            //  WINDOW HEAT L               On: 1, Off: 0                           0x01    14      0      1
+            //  CREW SUPPLY L               On: 1, Off: 0                           0x02    14      1      1
+            //  APU MASTER U                On: 1, Off: 0                           0x04    14      2      1
+            //  APU MASTER L                On: 1, Off: 0                           0x08    14      3      0
+            //  APU START U                 On: 1, Off: 0                           0x10    14      4      0
+            //  APU START L                 On: 1, Off: 0                           0x20    14      5      0
+            //  EMER EXIT LT L              On: 1, Off: 0                           0x40    14      6      0
+            //  EXT_LT_STROBE_AUTO          On: 1, Off: 0                           0x80    14      7      0
+            //  VOLT DISPLAY L              On: 1, Off: 0                           0x01    15      0      1
+            //  VOLT DISPLAY R              On: 1, Off: 0                           0x02    15      1      1
+            //  (Reserved)                  -                                       0x04    15      2      1
+            //  (Reserved)                  -                                       0x08    15      3      0
+            //  (Reserved)                  -                                       0x10    15      4      0
+            //  (Reserved)                  -                                       0x20    15      5      0
+            //  (Reserved)                  -                                       0x40    15      6      0
+            //  (Reserved)                  -                                       0x80    15      7      0
+            //  Data Type                   Single Byte Type                        -       16      -      0x02
+            //  Data Length                 Following data occupies 3 Bytes         -       17      -      0x03
+            //  Background Light Brightness 0x00(Minimum)-0xFF(Maximum)             -       18      -      0
+            //  VOLT LIGHT Left Brightness  0x00(Minimum)-0xFF(Maximum)             -       19      -      0
+            //  VOLT LIGHT Right Brightness 0x00(Minimum)-0xFF(Maximum)             -       20      -      0
+            //  Data Type                   Double Byte Type                        -       21      -      0x03
+            //  Data Length                 Following data occupies 8 Bytes         -       22      -      0x04
+            //  VOLT DISPLAY VALUE L        High 8 bit of Uint16                    -       23      -      0x00
+            //  VOLT DISPLAY VALUE L        Low 8 bit of Uint16                     -       24      -      0x00
+            //  VOLT DISPLAY VALUE R        High 8 bit of Uint16                    -       25      -      0x00
+            //  VOLT DISPLAY VALUE R        Low 8 bit of Uint16                     -       26      -      0x00
+
+            state.ForEach(item =>
+            {
+                if (item.Type == DeviceType.LcdDisplay)
+                {
+                    UpdateLcdDisplayOutputState(item);
+                    return;
+                }
+
+                var itemByte = item.Byte;
+
+                if (itemByte >= 6 && itemByte <= 15)
+                {
+                    if (item.State == 1)
+                    {
+                        LastOutputBufferState[itemByte] |= (byte)(1 << item.Bit);
+                    }
+                    else
+                    {
+                        LastOutputBufferState[itemByte] &= (byte)~(1 << item.Bit);
+                    }
+                }
+                // Background Brightness = 18
+                // Volt L Light Brightness = 19
+                // Volt R Light Brightness = 20
+                else if (itemByte == 18 || itemByte == 19 || itemByte == 20) 
+                {
+                    LastOutputBufferState[itemByte] = item.State;
+                }
+            });
+
+            return LastOutputBufferState.Clone() as byte[];
+        }
+
+        private void UpdateLcdDisplayOutputState(JoystickOutputDevice item)
+        {
+
+            var lcdDisplay = item as JoystickOutputDisplay;
+            if (lcdDisplay == null) return;
+
+            var text = lcdDisplay.Text.Replace(".", "");
+            var paddedText = text.PadLeft(lcdDisplay.Cols, '0');
+            UpdateLcdDisplay(item.Byte, paddedText);
+
+            // continue with next item,
+            // as we have already processed the LCD display state
+            return;
+        }
+
+        protected void UpdateLcdDisplay(int byteIndex, string text)
+        {
+            UInt16 value = 0;
+            bool parsed;
+
+            parsed = Int16.TryParse(text.Trim(), out var signedValue);
+            if (parsed) value = (UInt16)signedValue;
+
+            // Skip invalid text
+            if (!parsed) return;
+
+            // Copy High 8 bit from value
+            LastOutputBufferState[byteIndex] = (byte)(value >> 8);
+            // Copy Low 8 bit from value  
+            LastOutputBufferState[byteIndex + 1] = (byte)(value & 0xFF);
+        }
+
+        public JoystickState ToJoystickState()
+        {
+            // Name                 Note                                Mask    Byte[]  Bit[]  Example
+            // Head                 Constant: 0xF2                              0       -      0xF2
+            // Head                 Constant: 0xE1                              1       -      0xE1
+            // Head                 Constant: 0x07                              2       -      0x07
+            // Data Type Total      Has 2 Data Type                             3       -      0x02
+            // Data Type            Bit Type                                    4       -      0x01
+            // Data Length          Following data occupies 20 Bytes            5       -      0x14
+            // IR1 NORM             Press: 1, Release: 0                0x01    6       0      1
+            // IR1 PUSH             Press: 1, Release: 0                0x02    6       1      1
+            // IR2 NORM             Press: 1, Release: 0                0x04    6       2      1
+            // IR2 PUSH             Press: 1, Release: 0                0x08    6       3      1
+            // IR3 NORM             Press: 1, Release: 0                0x10    6       4      1
+            // IR3 PUSH             Press: 1, Release: 0                0x20    6       5      1
+            // IR1 OFF              Press: 1, Release: 0                0x40    6       6      1
+            // IR1 NAV              Press: 1, Release: 0                0x80    6       7      1
+            // IR1 ATT              Press: 1, Release: 0                0x01    7       0      1
+            // IR2 OFF              Press: 1, Release: 0                0x02    7       1      1
+            // IR2 NAV              Press: 1, Release: 0                0x04    7       2      1
+            // IR2 ATT              Press: 1, Release: 0                0x08    7       3      1
+            // IR3 OFF              Press: 1, Release: 0                0x10    7       4      1
+            // IR3 NAV              Press: 1, Release: 0                0x20    7       5      1
+            // IR3 ATT              Press: 1, Release: 0                0x40    7       6      1
+            // ENG1 AGENT1 NORM     Press: 1, Release: 0                0x80    7       7      1
+            // ENG1 AGENT1 PUSH     Press: 1, Release: 0                0x01    8       0      1
+            // ENG1 AGENT2 NORM     Press: 1, Release: 0                0x02    8       1      1
+            // ENG1 AGENT2 PUSH     Press: 1, Release: 0                0x04    8       2      1
+            // APU AGENT NORM       Press: 1, Release: 0                0x08    8       3      0
+            // APU AGENT PUSH       Press: 1, Release: 0                0x10    8       4      0
+            // ENG2 AGENT1 NORM     Press: 1, Release: 0                0x20    8       5      0
+            // ENG2 AGENT1 PUSH     Press: 1, Release: 0                0x40    8       6      0
+            // ENG2 AGENT2 NORM     Press: 1, Release: 0                0x80    8       7      0
+            // ENG2 AGENT2 PUSH     Press: 1, Release: 0                0x01    9       0      1
+            // ENG1 FIRE NORM       Press: 1, Release: 0                0x02    9       1      1
+            // ENG1 FIRE POPOUT     Press: 1, Release: 0                0x04    9       2      1
+            // APU FIRE NORM        Press: 1, Release: 0                0x08    9       3      0
+            // APU FIRE POPOUT      Press: 1, Release: 0                0x10    9       4      0
+            // ENG2 FIRE NORM       Press: 1, Release: 0                0x20    9       5      0
+            // ENG2 FIRE POPOUT     Press: 1, Release: 0                0x40    9       6      0
+            // ENG1 FIRE TEST       Press: 1, Release: 0                0x80    9       7      0
+            // APU FIRE TEST        Press: 1, Release: 0                0x01    10      0      1
+            // ENG2 FIRE TEST       Press: 1, Release: 0                0x02    10      1      1
+            // XFEED NORM           Press: 1, Release: 0                0x04    10      2      1
+            // XFEED PUSH           Press: 1, Release: 0                0x08    10      3      0
+            // L TK PUMP1 NORM      Press: 1, Release: 0                0x10    10      4      0
+            // L TK PUMP1 PUSH      Press: 1, Release: 0                0x20    10      5      0
+            // L TK PUMP2 NORM      Press: 1, Release: 0                0x40    10      6      0
+            // L TK PUMP2 PUSH      Press: 1, Release: 0                0x80    10      7      0
+            // CTR TK PUMP1 NORM    Press: 1, Release: 0                0x01    11      0      1
+            // CTR TK PUMP1 PUSH    Press: 1, Release: 0                0x02    11      1      1
+            // MODE SEL NORM        Press: 1, Release: 0                0x04    11      2      1
+            // MODE SEL PUSH        Press: 1, Release: 0                0x08    11      3      0
+            // CTR TK PUMP2 NORM    Press: 1, Release: 0                0x10    11      4      0
+            // CTR TK PUMP2 PUSH    Press: 1, Release: 0                0x20    11      5      0
+            // R TK PUMP1 NORM      Press: 1, Release: 0                0x40    11      6      0
+            // R TK PUMP1 PUSH      Press: 1, Release: 0                0x80    11      7      0
+            // R TK PUMP2 NORM      Press: 1, Release: 0                0x01    12      0      1
+            // R TK PUMP2 PUSH      Press: 1, Release: 0                0x02    12      1      1
+            // COMMERCIAL NORM      Press: 1, Release: 0                0x04    12      2      1
+            // COMMERCIAL PUSH      Press: 1, Release: 0                0x08    12      3      0
+            // BAT1 NORM            Press: 1, Release: 0                0x10    12      4      0
+            // BAT1 PUSH            Press: 1, Release: 0                0x20    12      5      0
+            // BAT2 NORM            Press: 1, Release: 0                0x40    12      6      0
+            // BAT2 PUSH            Press: 1, Release: 0                0x80    12      7      0
+            // APU GEN NORM         Press: 1, Release: 0                0x01    13      0      1
+            // APU GEN PUSH         Press: 1, Release: 0                0x02    13      1      1
+            // EXT PWR              Press: 1, Release: 0                0x04    13      2      1
+            // PACK FLOW LO         Press: 1, Release: 0                0x08    13      3      0
+            // PACK FLOW NORM       Press: 1, Release: 0                0x10    13      4      0
+            // PACK FLOW HI         Press: 1, Release: 0                0x20    13      5      0
+            // COCKPIT PACK 1       Press: 1, Release: 0                0x40    13      6      0
+            // COCKPIT PACK 2       Press: 1, Release: 0                0x80    13      7      0
+            // COCKPIT PACK 3       Press: 1, Release: 0                0x01    14      0      1
+            // COCKPIT PACK 4       Press: 1, Release: 0                0x02    14      1      1
+            // COCKPIT PACK 5       Press: 1, Release: 0                0x04    14      2      1
+            // COCKPIT PACK 6       Press: 1, Release: 0                0x08    14      3      0
+            // COCKPIT PACK 7       Press: 1, Release: 0                0x10    14      4      0
+            // FWD CABIN PACK 1     Press: 1, Release: 0                0x20    14      5      0
+            // FWD CABIN PACK 2     Press: 1, Release: 0                0x40    14      6      0
+            // FWD CABIN PACK 3     Press: 1, Release: 0                0x80    14      7      0
+            // FWD CABIN PACK 4     Press: 1, Release: 0                0x01    15      0      1
+            // FWD CABIN PACK 5     Press: 1, Release: 0                0x02    15      1      1
+            // FWD CABIN PACK 6     Press: 1, Release: 0                0x04    15      2      1
+            // FWD CABIN PACK 7     Press: 1, Release: 0                0x08    15      3      0
+            // AFT CABIN PACK 1     Press: 1, Release: 0                0x10    15      4      0
+            // AFT CABIN PACK 2     Press: 1, Release: 0                0x20    15      5      0
+            // AFT CABIN PACK 3     Press: 1, Release: 0                0x40    15      6      0
+            // AFT CABIN PACK 4     Press: 1, Release: 0                0x80    15      7      0
+            // AFT CABIN PACK 5     Press: 1, Release: 0                0x01    16      0      1
+            // AFT CABIN PACK 6     Press: 1, Release: 0                0x02    16      1      1
+            // AFT CABIN PACK 7     Press: 1, Release: 0                0x04    16      2      1
+            // PACK1 NORM           Press: 1, Release: 0                0x08    16      3      0
+            // PACK1 PUSH           Press: 1, Release: 0                0x10    16      4      0
+            // APU BLEED NORM       Press: 1, Release: 0                0x20    16      5      0
+            // APU BLEED PUSH       Press: 1, Release: 0                0x40    16      6      0
+            // PACK2 NORM           Press: 1, Release: 0                0x80    16      7      0
+            // PACK2 PUSH           Press: 1, Release: 0                0x01    17      0      1
+            // HOT AIR NORM         Press: 1, Release: 0                0x02    17      1      1
+            // HOT AIR PUSH         Press: 1, Release: 0                0x04    17      2      1
+            // AFT ISOL VALVE NORM  Press: 1, Release: 0                0x08    17      3      0
+            // AFT ISOL VALVE PUSH  Press: 1, Release: 0                0x10    17      4      0
+            // CARGO PACK 1         Press: 1, Release: 0                0x20    17      5      0
+            // CARGO PACK 2         Press: 1, Release: 0                0x40    17      6      0
+            // CARGO PACK 3         Press: 1, Release: 0                0x80    17      7      0
+            // CARGO PACK 4         Press: 1, Release: 0                0x01    18      0      1
+            // CARGO PACK 5         Press: 1, Release: 0                0x02    18      1      1
+            // CARGO PACK 6         Press: 1, Release: 0                0x04    18      2      1
+            // CARGO PACK 7         Press: 1, Release: 0                0x08    18      3      0
+            // ANTI-ICE WING NORM   Press: 1, Release: 0                0x10    18      4      0
+            // ANTI-ICE WING PUSH   Press: 1, Release: 0                0x20    18      5      0
+            // ANTI-ICE ENG1 NORM   Press: 1, Release: 0                0x40    18      6      0
+            // ANTI-ICE ENG1 PUSH   Press: 1, Release: 0                0x80    18      7      0
+            // ANTI-ICE ENG2 NORM   Press: 1, Release: 0                0x01    19      0      1
+            // ANTI-ICE ENG2 PUSH   Press: 1, Release: 0                0x02    19      1      1
+            // WINDOW HEAT NORM     Press: 1, Release: 0                0x04    19      2      1
+            // WINDOW HEAT PUSH     Press: 1, Release: 0                0x08    19      3      0
+            // CREW SUPPLY NORM     Press: 1, Release: 0                0x10    19      4      0
+            // CREW SUPPLY PUSH     Press: 1, Release: 0                0x20    19      5      0
+            // GND CTL              Press: 1, Release: 0                0x40    19      6      0
+            // CVR TEST             Press: 1, Release: 0                0x80    19      7      0
+            // CALLS ALL            Press: 1, Release: 0                0x01    20      0      1
+            // WIPER OFF            Press: 1, Release: 0                0x02    20      1      1
+            // WIPER SLOW           Press: 1, Release: 0                0x04    20      2      1
+            // WIPER FAST           Press: 1, Release: 0                0x08    20      3      0
+            // STROBE OFF           Press: 1, Release: 0                0x10    20      4      0
+            // STROBE AUTO          Press: 1, Release: 0                0x20    20      5      0
+            // STROBE ON            Press: 1, Release: 0                0x40    20      6      0
+            // BEACON OFF           Press: 1, Release: 0                0x80    20      7      0
+            // BEACON ON            Press: 1, Release: 0                0x01    21      0      1
+            // WING OFF             Press: 1, Release: 0                0x02    21      1      1
+            // WING ON              Press: 1, Release: 0                0x04    21      2      1
+            // NAV & LOGO OFF       Press: 1, Release: 0                0x08    21      3      0
+            // NAV & LOGO 1         Press: 1, Release: 0                0x10    21      4      0
+            // NAV & LOGO 2         Press: 1, Release: 0                0x20    21      5      0
+            // RWY TURN-OFF OFF     Press: 1, Release: 0                0x40    21      6      0
+            // RWY TURN-OFF ON      Press: 1, Release: 0                0x80    21      7      0
+            // LAND L RETRACT       Press: 1, Release: 0                0x01    22      0      1
+            // LAND L OFF           Press: 1, Release: 0                0x02    22      1      1
+            // LAND L ON            Press: 1, Release: 0                0x04    22      2      1
+            // LAND R RETRACT       Press: 1, Release: 0                0x08    22      3      0
+            // LAND R OFF           Press: 1, Release: 0                0x10    22      4      0
+            // LAND R ON            Press: 1, Release: 0                0x20    22      5      0
+            // NOSE OFF             Press: 1, Release: 0                0x40    22      6      0
+            // NOSE TAXI            Press: 1, Release: 0                0x80    22      7      0
+            // NOSE T.O             Press: 1, Release: 0                0x01    23      0      1
+            // APU MASTER NORM      Press: 1, Release: 0                0x02    23      1      1
+            // APU MASTER PUSH      Press: 1, Release: 0                0x04    23      2      1
+            // APU START            Press: 1, Release: 0                0x08    23      3      0
+            // STBY COMPASS OFF     Press: 1, Release: 0                0x10    23      4      0
+            // STBY COMPASS ON      Press: 1, Release: 0                0x20    23      5      0
+            // DOME OFF             Press: 1, Release: 0                0x40    23      6      0
+            // DOME DIM             Press: 1, Release: 0                0x80    23      7      0
+            // DOME BRT             Press: 1, Release: 0                0x01    24      0      1
+            // ANN LT DIM           Press: 1, Release: 0                0x02    24      1      1
+            // ANN LT BRT           Press: 1, Release: 0                0x04    24      2      1
+            // ANN LT TEST          Press: 1, Release: 0                0x08    24      3      0
+            // SEAT BELTS OFF       Press: 1, Release: 0                0x10    24      4      0
+            // SEAT BELTS ON        Press: 1, Release: 0                0x20    24      5      0
+            // NO SMOKING OFF       Press: 1, Release: 0                0x40    24      6      0
+            // NO SMOKING AUTO      Press: 1, Release: 0                0x80    24      7      0
+            // NO SMOKING ON        Press: 1, Release: 0                0x01    25      0      1
+            // EMER EXIT KEY NORN   Press: 1, Release: 0                0x02    25      1      1
+            // EMER EXIT KEY PUSH   Press: 1, Release: 0                0x04    25      2      1
+            // EMER EXIT LT OFF     Press: 1, Release: 0                0x08    25      3      0
+            // EMER EXIT LT ARM     Press: 1, Release: 0                0x10    25      4      0
+            // EMER EXIT LT ON      Press: 1, Release: 0                0x20    25      5      0
+            // RAIN RPLNT           Press: 1, Release: 0                0x40    25      6      0
+            // (Reserved)           -                                   0x80    25      7      0
+            // Data Type            Single Byte Type                    -       26      -      0x02
+            // Data Length          Following data occupies 6 Bytes     -       27      -      0x01
+            // OVHD INTEG LT        0x00-0xFF(255)                      -       28      -      0
+
+            JoystickState state = new JoystickState();
+
+            // Buttons
+            // copy the button states from the buffer to the Buttons bit by bit starting from byte 6 to byte 9
+            for (int i = 0; i < 159; i++)
+            {
+                int byteIndex = 6 + (i / 8);
+                int bitIndex = i % 8;
+                bool isPressed = (LastInputBufferState[byteIndex] & (1 << bitIndex)) != 0;
+                state.Buttons[i] = isPressed;
+            }
+
+            // Axes
+            // Overhead Integ Light Brightness
+            state.X = LastInputBufferState[28];
+
+            return state;
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -383,6 +383,7 @@
     <Compile Include="MobiFlight\ConfigExtensions.cs" />
     <Compile Include="MobiFlight\ConfigRefValue.cs" />
     <Compile Include="MobiFlight\DeviceReferenceFactory.cs" />
+    <Compile Include="MobiFlight\Joysticks\JoystickState.cs" />
     <Compile Include="MobiFlight\Firmware\Compatibility\LedModuleDeprecated.cs" />
     <Compile Include="MobiFlight\Firmware\Compatibility\StepperDeprecatedV2.cs" />
     <Compile Include="MobiFlight\Firmware\IBaseDevice.cs" />

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -437,6 +437,8 @@
     <Compile Include="MobiFlight\Joysticks\VKB\VKBLedContainer.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\BaseCube.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\Dap500.cs" />
+    <Compile Include="MobiFlight\Joysticks\WingFlex\OvhdCube.cs" />
+    <Compile Include="MobiFlight\Joysticks\WingFlex\OvhdCubeReport.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCubeReport.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCube.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\EfisCube.cs" />
@@ -1474,6 +1476,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Joysticks\wingflex\wingflex_efiscube.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\wingflex\wingflex_ovhdcube.joystick.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="Joysticks\wingflex\wingflex_rmpcube.joystick.json">

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/Bodnar/BodnarBoardTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/Bodnar/BodnarBoardTests.cs
@@ -4,6 +4,7 @@ using MobiFlight.Joysticks.Bodnar;
 using SharpDX.DirectInput;
 using System.Collections.Generic;
 using DeviceType = MobiFlight.DeviceType;
+using JoystickState = MobiFlight.Joysticks.JoystickState;
 
 namespace MobiFlightUnitTests.MobiFlight.Joysticks.Bodnar
 {

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/OvhdCubeReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/OvhdCubeReportTests.cs
@@ -174,53 +174,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         #region LCD Display Tests
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999()
-        {
-            // Arrange
-            var lcdDisplay = new JoystickOutputDisplay
-            {
-                Name = "Active",
-                Type = DeviceType.LcdDisplay,
-                Byte = 23,
-                Cols = 3,
-                Text = "999"
-            };
-            var devices = new List<JoystickOutputDevice> { lcdDisplay };
-
-            // Act
-            var result = _report.FromOutputDeviceState(devices);
-
-            // Assert
-            // Digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
-            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
-            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
-        }
-
-        [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999dot999()
-        {
-            // Arrange
-            var lcdDisplay = new JoystickOutputDisplay
-            {
-                Name = "Active",
-                Type = DeviceType.LcdDisplay,
-                Byte = 23,
-                Cols = 3,
-                Text = "9.99"
-            };
-            var devices = new List<JoystickOutputDevice> { lcdDisplay };
-
-            // Act
-            var result = _report.FromOutputDeviceState(devices);
-
-            // Assert
-            // Digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
-            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
-            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
-        }
-
-        [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_9()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_9()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -241,6 +195,194 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             // Right digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
             Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
             Assert.AreEqual(0x09, result[24], "Low byte should be 0x09");
+
+            // And the Volt Display L has to be turned on
+            Assert.AreEqual(0x01, result[15], "Volt Display L should be turned on");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_99()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "99"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 99 => 0x0063, so high byte = 0x00, low byte = 0x63
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x63, result[24], "Low byte should be 0x63");
+
+            // And the Volt Display L has to be turned on
+            Assert.AreEqual(0x01, result[15], "Volt Display L should be turned on");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
+
+            // And the Volt Display L has to be turned on
+            Assert.AreEqual(0x01, result[15], "Volt Display L should be turned on");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_99dot9()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "99.9"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
+
+            // And the Volt Display L has to be turned on
+            Assert.AreEqual(0x01, result[15], "Volt Display L should be turned on");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_9()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 25,
+                Cols = 3,
+                Text = "9"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
+            Assert.AreEqual(0x00, result[25], "High byte should be 0x00");
+            Assert.AreEqual(0x09, result[26], "Low byte should be 0x09");
+
+            // And the Volt Display R has to be turned on
+            Assert.AreEqual(0x02, result[15], "Volt Display R should be turned on");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_99()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 25,
+                Cols = 3,
+                Text = "99"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 99 => 0x0063, so high byte = 0x00, low byte = 0x63
+            Assert.AreEqual(0x00, result[25], "High byte should be 0x00");
+            Assert.AreEqual(0x63, result[26], "Low byte should be 0x63");
+
+            // And the Volt Display R has to be turned on
+            Assert.AreEqual(0x02, result[15], "Volt Display R should be turned on");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 25,
+                Cols = 3,
+                Text = "999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[25], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[26], "Low byte should be 0xE7");
+
+            // And the Volt Display R has to be turned on
+            Assert.AreEqual(0x02, result[15], "Volt Display R should be turned on");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_99dot9()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 25,
+                Cols = 3,
+                Text = "99.9"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[25], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[26], "Low byte should be 0xE7");
+
+            // And the Volt Display R has to be turned on
+            Assert.AreEqual(0x02, result[15], "Volt Display R should be turned on");
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/OvhdCubeReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/OvhdCubeReportTests.cs
@@ -1,0 +1,358 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+
+namespace MobiFlight.Joysticks.WingFlex.Tests
+{
+    [TestClass]
+    public class OvhdCubeReportTests
+    {
+        private OvhdCubeReport _report;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _report = new OvhdCubeReport();
+        }
+
+        #region Parse Tests
+
+        [TestMethod]
+        public void Parse_ValidInputBuffer_ReturnsNewReportInstance()
+        {
+            // Arrange
+            var inputBuffer = CreateValidInputBuffer();
+
+            // Act
+            var result = _report.Parse(inputBuffer);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreNotSame(_report, result);
+            Assert.IsInstanceOfType(result, typeof(OvhdCubeReport));
+        }
+
+        [TestMethod]
+        public void Parse_NullInputBuffer_ThrowsArgumentException()
+        {
+            // Arrange
+            byte[] inputBuffer = null;
+
+            // Act & Assert - Should throw exception
+            Assert.ThrowsExactly<ArgumentException>(() => _report.Parse(inputBuffer));
+        }
+
+        [TestMethod]
+        public void Parse_EmptyInputBuffer_ThrowsArgumentException()
+        {
+            // Arrange
+            var inputBuffer = new byte[0];
+
+            // Act & Assert - Should throw exception
+            Assert.ThrowsExactly<ArgumentException>(() => _report.Parse(inputBuffer));
+        }
+
+        [TestMethod]
+        public void Parse_WrongLengthInputBuffer_ThrowsArgumentException()
+        {
+            // Arrange
+            var inputBuffer = new byte[1];
+
+            // Act & Assert - Should throw exception
+            Assert.ThrowsExactly<ArgumentException>(() => _report.Parse(inputBuffer));
+        }
+        #endregion
+
+        #region FromOutputDeviceState Tests
+
+        [TestMethod]
+        public void FromOutputDeviceState_EmptyList_ReturnsValidHeader()
+        {
+            // Arrange
+            var devices = new List<JoystickOutputDevice>();
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsGreaterThanOrEqualTo(27, result.Length, "Output buffer should be at least 27 bytes");
+
+            // Check header bytes (with report ID offset)
+            Assert.AreEqual(0xF2, result[0], "Header byte 0 should be 0xF2");
+            Assert.AreEqual(0xE1, result[1], "Header byte 1 should be 0xE1");
+            Assert.AreEqual(0x07, result[2], "Header byte 2 should be 0x07");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LEDOutput_SetsBitCorrectly()
+        {
+            // Arrange
+            var devices = new List<JoystickOutputDevice>
+            {
+                new JoystickOutputDevice
+                {
+                    Type = DeviceType.Output,
+                    Byte = 6,
+                    Bit = 0,
+                    State = 1
+                }
+            };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x01, result[6], "Bit 0 in byte 6 should be set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_MultipleLEDs_SetsCorrectBits()
+        {
+            // Arrange
+            var devices = new List<JoystickOutputDevice>
+            {
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 6, Bit = 0, State = 1 },
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 6, Bit = 2, State = 1 },
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 7, Bit = 1, State = 1 }
+            };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x05, result[6], "Bits 0 and 2 should be set in byte 6 (0x01 | 0x04 = 0x05)");
+            Assert.AreEqual(0x02, result[7], "Bit 1 should be set in byte 7");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LEDOff_ClearsBit()
+        {
+            // Arrange - Create report instance to maintain state
+            var report = new FcuCubeReport();
+
+            var devices = new List<JoystickOutputDevice>
+            {
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 6, Bit = 0, State = 1 }
+            };
+
+            var result1 = report.FromOutputDeviceState(devices);
+
+            // Now turn it off
+            devices[0].State = 0;
+
+            // Act
+            var result2 = report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x01, result1[6], "Bit should initially be set");
+            Assert.AreEqual(0x00, result2[6], "Bit should be cleared when state is 0");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_BrightnessControl_SetsCorrectBytes()
+        {
+            // Arrange
+            var devices = new List<JoystickOutputDevice>
+            {
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 18, State = 64 }, // Background
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 19, State = 128 },// Volt L
+                new JoystickOutputDevice { Type = DeviceType.Output, Byte = 20, State = 192 } // Volt R
+            };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(64, result[18], "Background brightness should be set correctly");
+            Assert.AreEqual(128, result[19], "Volt L brightness should be set correctly");
+            Assert.AreEqual(192, result[20], "Volt R brightness should be set correctly");
+        }
+
+        #endregion
+
+        #region LCD Display Tests
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999dot999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "9.99"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_9()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "9"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x09, result[24], "Low byte should be 0x09");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_HandlesZeroValue()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "123"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+            _report.FromOutputDeviceState(devices);
+
+            // Now set it to zero
+            lcdDisplay.Text = "0";
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[24], "Low byte should be 0x00");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_HandlesEmptyStringValue()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "123"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+            _report.FromOutputDeviceState(devices);
+
+            // Now set it to empty string
+            lcdDisplay.Text = "";
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[24], "Low byte should be 0x00");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_InvalidText_SkipsProcessing()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 3,
+                Text = "123"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+            _report.FromOutputDeviceState(devices);
+            lcdDisplay.Text = "ABCD";
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x7B, result[24], "Low byte should be 0x7B");
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        /// <summary>
+        /// Creates a valid FCU Cube input buffer for testing purposes
+        /// </summary>
+        private byte[] CreateValidInputBuffer()
+        {
+            var buffer = new byte[65]; // Typical size for HID report including the report ID
+            buffer[0] = 0x01; // Report ID
+
+            // Set header
+            buffer[1] = 0xF2;
+            buffer[2] = 0xE1;
+            buffer[3] = 0x07;
+
+            // Set data type and length markers
+            buffer[4] = 0x02; // Data type total
+            buffer[5] = 0x01; // Bit type
+            buffer[6] = 0x14; // Data length for buttons (20 bytes)
+
+            // Buttons in bytes 7-26 (mapped to 6-25 in comments)
+            for (int i = 7; i <= 26; i++)
+            {
+                buffer[i] = 0x00;
+            }
+
+            // Axis value
+            buffer[29] = 0x00; // OVHD INTEG LT
+
+            return buffer;
+        }
+
+        #endregion
+    }
+}

--- a/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -260,6 +260,7 @@
     <Compile Include="MobiFlight\Joysticks\Bodnar\BodnarBoardTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\Dap500ReportTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\EfisCubeReportTests.cs" />
+    <Compile Include="MobiFlight\Joysticks\WingFlex\OvhdCubeReportTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCubeReportTests.cs" />
     <Compile Include="MobiFlight\Modifier\ExponentialAverageTests.cs" />
     <Compile Include="MobiFlight\InputEventArgsTests.cs" />


### PR DESCRIPTION
### Summary
This PR adds support for WingFlex Overhead Panel

### Screenshots / recordings
<img width="1133" height="1114" alt="image" src="https://github.com/user-attachments/assets/76b591c0-0da6-4f7e-92f2-717e657831db" />


### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] All button inputs are working
- [x] All potentiometers are working
- [x] All outputs are working
- [x] All brightness controls are working
- [x] All Displays are working

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [x] ~~Frontend tests~~
- [x] ~~i18n - All user-facing strings are translated~~
- [x] documentation
  - [x] User docs (docs.mobiflight.com) (@neilenns)
  
### Notes
Implementation based on https://github.com/wingflexsim/DevDocument/blob/master/docs/A320%20OVHD%20CUBE.md

I don't personally own one of these.