### PR TITLE
Add remove action to Input Config Wizard

### DIFF
--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -426,7 +426,8 @@
         }
       },
       "Event" : {
-        "Edit": "{{eventLabel}} Aktion bearbeiten"
+        "Edit": "{{eventLabel}} Aktion bearbeiten",
+        "Remove": "{{eventLabel}} Aktion entfernen"
       },
       "button": {
         "Event": {

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -420,7 +420,8 @@
         }
       },
       "Event": {
-        "Edit": "Edit {{eventLabel}} action"
+        "Edit": "Edit {{eventLabel}} action",
+        "Remove": "Remove {{eventLabel}} action"
       },
       "button": {
         "Event": {

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -426,7 +426,8 @@
         }
       },
       "Event" : {
-        "Edit": "Editar acción {{eventLabel}}"
+        "Edit": "Editar acción {{eventLabel}}",
+        "Remove": "Remover acción {{eventLabel}}"
       },
       "button": {
         "Event": {

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -420,7 +420,8 @@
         }
       },
       "Event" : {
-        "Edit": "Muokkaa toimintoa {{eventLabel}}"
+        "Edit": "Muokkaa toimintoa {{eventLabel}}",
+        "Remove": "Poista toimintoa {{eventLabel}}"
       },
       "button": {
         "Event": {

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -420,7 +420,8 @@
         }
       },
       "Event": {
-        "Edit": "Editar ação {{eventLabel}}"
+        "Edit": "Editar ação {{eventLabel}}",
+        "Remove": "Remover ação {{eventLabel}}"
       },
       "button": {
         "Event": {

--- a/src/MobiFlightConnector/frontend/src/components/wizard/ConfigWizard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/ConfigWizard.tsx
@@ -251,10 +251,6 @@ const ConfigWizard = ({
                   buttonOptions={buttonOptions}
                   action={editAction}
                   onActionChange={(action, buttonOptions) => {
-                    console.log("Action updated in ActionEditor:", {
-                      action,
-                      buttonOptions,
-                    })
                     onActionChange?.(action, buttonOptions)
                     setEditAction(action)
                     if (buttonOptions) {

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ActionBindingPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ActionBindingPanel.tsx
@@ -10,7 +10,7 @@ import {
   ButtonTrigger,
   EncoderTrigger,
 } from "@/types/config"
-import { IconEdit, IconPlus } from "@tabler/icons-react"
+import { IconEdit, IconPlus, IconTrash } from "@tabler/icons-react"
 import { useTranslation } from "react-i18next"
 export type ActionTrigger = ButtonTrigger | EncoderTrigger | AnalogTrigger
 export type ActionBindingPanelProps = {
@@ -64,6 +64,15 @@ const ActionBindingPanel = ({
       ...buttonOptions,
     })
   }
+
+  const removeAction = (event: string) => {
+    const updatedTrigger = {
+      ...current,
+      [event]: undefined,
+    }
+    onTriggerChange(updatedTrigger)
+  }
+
   return (
     <div
       data-testid="action-panel"
@@ -71,7 +80,8 @@ const ActionBindingPanel = ({
     >
       <div className="flex flex-col gap-1">
         <div className="text-lg font-semibold">
-          {t(`Dialog.InputConfigWizard.Action.Title`)}</div>
+          {t(`Dialog.InputConfigWizard.Action.Title`)}
+        </div>
         <div className="text-muted-foreground text-sm">
           {t(`Dialog.InputConfigWizard.Action.Description`)}
         </div>
@@ -88,7 +98,7 @@ const ActionBindingPanel = ({
           action?.Type && (
             <div key={event} className="flex flex-col gap-2">
               <div
-                className="hover:bg-accent/30 flex flex-row items-center gap-4 rounded-md p-2"
+                className="group hover:bg-accent/30 flex flex-row items-center gap-4 rounded-md p-2"
                 onDoubleClick={() =>
                   onActionEdit(event, action, (newAction, buttonOptions) =>
                     handleOnActionChange(event, newAction, buttonOptions),
@@ -100,20 +110,34 @@ const ActionBindingPanel = ({
                   <div>{eventLabel}</div>
                 </div>
                 <ActionSummary action={action} />
-                <Button
-                  size={"sm"}
-                  variant="ghost"
-                  onClick={() => {
-                    onActionEdit(event, action, (newAction, buttonOptions) =>
-                      handleOnActionChange(event, newAction, buttonOptions),
-                    )
-                  }}
-                >
-                  <IconEdit />
-                  <span className="sr-only">
-                    {t(`Dialog.InputConfigWizard.Event.Edit`, { eventLabel })}
-                  </span>
-                </Button>
+                <div className="gap1 flex flex-row pt-4">
+                  <Button
+                    size={"sm"}
+                    className="px-2 py-1 h-8 text-red-600 hover:text-red-600 group-hover:visible invisible"
+                    variant="ghost"
+                    onClick={() => removeAction(event)}
+                  >
+                    <IconTrash />
+                    <span className="sr-only">
+                      {t(`Dialog.InputConfigWizard.Event.Delete`, { eventLabel })}
+                    </span>
+                  </Button>
+                  <Button
+                    size={"sm"}
+                    className="px-2 py-1 h-8 group-hover:text-foreground text-muted-foreground"
+                    variant="ghost"
+                    onClick={() => {
+                      onActionEdit(event, action, (newAction, buttonOptions) =>
+                        handleOnActionChange(event, newAction, buttonOptions),
+                      )
+                    }}
+                  >
+                    <IconEdit />
+                    <span className="sr-only">
+                      {t(`Dialog.InputConfigWizard.Event.Edit`, { eventLabel })}
+                    </span>
+                  </Button>
+                </div>
               </div>
               {!isLast && <Separator />}
             </div>
@@ -131,7 +155,7 @@ const ActionBindingPanel = ({
           )
           return (
             !action?.Type && (
-              <Button                
+              <Button
                 key={event}
                 size={"sm"}
                 variant="outline"

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ActionBindingPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ActionBindingPanel.tsx
@@ -119,7 +119,7 @@ const ActionBindingPanel = ({
                   >
                     <IconTrash />
                     <span className="sr-only">
-                      {t(`Dialog.InputConfigWizard.Event.Delete`, { eventLabel })}
+                      {t(`Dialog.InputConfigWizard.Event.Remove`, { eventLabel })}
                     </span>
                   </Button>
                   <Button

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ActionBindingPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ActionBindingPanel.tsx
@@ -68,7 +68,7 @@ const ActionBindingPanel = ({
   const removeAction = (event: string) => {
     const updatedTrigger = {
       ...current,
-      [event]: undefined,
+      [event]: null,
     }
     onTriggerChange(updatedTrigger)
   }

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ActionEditor.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ActionEditor.tsx
@@ -169,7 +169,6 @@ const ActionEditor = ({
   const selectedActionType = action
     ? ActionTypeOptions.find((option) => option.value === action.Type)
     : undefined
-  console.log("Button options in ActionEditor:", buttonOptions)
   return (
     <Card data-testid="action-editor">
       <CardContent className="pt-4">
@@ -269,7 +268,9 @@ const ActionEditor = ({
             <ActionTypeComboBox
               selectedActionType={selectedActionType}
               setSelectedActionType={(option) => {
-                onActionChange({ ...action, Type: option?.value ?? null })
+                onActionChange(option ? { ...action,
+                                          Type: option.value 
+                                        } : null)
               }}
             />
             <CopyPasteActionPanel

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -27,6 +27,21 @@ FCU_HDGKNOB_PRESS:6:FCU Heading Knob Press
 FCU_HDGKNOB_LONGPRESS:7:FCU Heading Knob Long Press
 AP_ENGAGE:8:Autopilot Engage`
 
+const actionTypeOptionLabels = {
+  MSFS2020CustomInputAction: "Microsoft Flight Simulator (all versions)",
+  XplaneInputAction: "X-Plane (all versions)",
+  ProSimInputAction: "ProSim",
+  VariableInputAction: "MobiFlight - Variable",
+  RetriggerInputAction: "MobiFlight - Retrigger switches",
+  KeyInputAction: "MobiFlight - Keyboard Input",
+  VJoyInputAction: "MobiFlight - Virtual Joystick input (vJoy)",
+  FsuipcOffsetInputAction: "FSUIPC - Offset",
+  PmdgEventIdInputAction: "FSUIPC - PMDG - Event ID",
+  LuaMacroInputAction: "FSUIPC - Lua Macro",
+  JeehellInputAction: "FSUIPC - Jeehell - Events",
+  EventIdInputAction: "FSUIPC - EventID",
+} as Record<string, string>
+
 // Helper: open the dialog for a given row and return the action-panel locator
 // (onPress tab is active by default for button inputs)
 const openWizardAndReturnActionPanel = async (
@@ -602,22 +617,6 @@ test.describe("Input Config Wizard - Action Type Panel", () => {
         Features: { ProSim: false, FSUIPC: true },
       },
     ]
-
-    const actionTypeOptionLabels = {
-      MSFS2020CustomInputAction: "Microsoft Flight Simulator (all versions)",
-      XplaneInputAction: "X-Plane (all versions)",
-      ProSimInputAction: "ProSim",
-      VariableInputAction: "MobiFlight - Variable",
-      RetriggerInputAction: "MobiFlight - Retrigger switches",
-      KeyInputAction: "MobiFlight - Keyboard Input",
-      VJoyInputAction: "MobiFlight - Virtual Joystick input (vJoy)",
-      FsuipcOffsetInputAction: "FSUIPC - Offset",
-      PmdgEventIdInputAction: "FSUIPC - PMDG - Event ID",
-      LuaMacroInputAction: "FSUIPC - Lua Macro",
-      JeehellInputAction: "FSUIPC - Jeehell - Events",
-      EventIdInputAction: "FSUIPC - EventID",
-    } as Record<string, string>
-
     const inputActionOption = ActionTypeOptions
 
     for (const projectSettings of projectSettingsToTest) {
@@ -887,7 +886,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -1188,7 +1187,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
       "Button",
@@ -1251,7 +1250,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
       "Button",
@@ -1374,7 +1373,7 @@ test.describe("Input Config Wizard - Variable Input Action Panel", () => {
     const type = "Button"
     const eventType = "On Press"
 
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
       type,
@@ -1436,7 +1435,7 @@ test.describe("Input Config Wizard - Variable Input Action Panel", () => {
     const type = "Button"
     const eventType = "On Press"
 
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
       type,
@@ -1530,7 +1529,7 @@ test.describe("Input Config Wizard - Retrigger Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -1739,7 +1738,7 @@ test.describe("Input Config Wizard - Keyboard Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -1916,7 +1915,7 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -1991,7 +1990,7 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -2109,7 +2108,7 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -2188,7 +2187,7 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -2267,7 +2266,7 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -2344,7 +2343,7 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -2451,7 +2450,7 @@ test.describe("Input Config Wizard - FSUIPC EventID Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -2579,7 +2578,7 @@ test.describe("Input Config Wizard - FSUIPC PMDG EventID Input Action Panel", ()
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -2737,7 +2736,7 @@ test.describe("Input Config Wizard - FSUIPC Jeehell Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -2868,7 +2867,7 @@ test.describe("Input Config Wizard - FSUIPC Lua Macro Input Action Panel", () =>
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -3007,7 +3006,7 @@ test.describe("Input Config Wizard - ProSim Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
     )
@@ -3170,7 +3169,7 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
     const type = "Button"
     const eventType = "On Hold"
 
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
       type,
@@ -3218,7 +3217,7 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
     const type = "Button"
     const eventType = "On Long Release"
 
-    const actionEditor = await CreateNewInputConfigItemAndReturnActionPanel(
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
       type,
@@ -3256,6 +3255,7 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
     configListPage,
     page,
   }) => {
+    test.slow()
     // For all of our 13 different input action config items
     // open and remove the action, then save and verify that the action is removed from the config item
     const maxConfigItems = 13
@@ -3292,12 +3292,101 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
       const commands = await configListPage.mobiFlightPage.getTrackedCommands()
       expect(commands).toBeDefined()
       const payload = commands?.pop()?.payload
-      expect(payload.item.button.onPress).toBeUndefined()
+      expect(payload.item.button.onPress).toBeNull()
       await configListPage.mobiFlightPage.clearTrackedCommands()
     }
   })
+
+  test("Action can be removed correctly using deselecting the action type", async ({
+    configListPage,
+    page,
+  }) => {
+    test.slow()
+    const actionTypeOptions = Object.keys(actionTypeOptionLabels).map(
+      (key) => ({
+        actionTypeOption: key,
+        actionTypeLabel: actionTypeOptionLabels[key],
+      }),
+    )
+
+    for (const { actionTypeOption, actionTypeLabel } of actionTypeOptions) {
+      const projectOptions = {
+        Sim: actionTypeOption != "XplaneInputAction" ? "msfs" : "xplane",
+      } as Partial<Project>
+      const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
+        configListPage,
+        page,
+        "Button",
+        "On Press",
+        projectOptions,
+      )
+
+      const actionTypeComboBox = actionEditor.getByTestId(
+        "action-type-combobox",
+      )
+      // Open the action type combobox
+      await expect(actionTypeComboBox).toBeVisible()
+      await actionTypeComboBox.click()
+
+      const actionInputOption = page.getByRole("option", {
+        name: actionTypeLabel,
+      })
+      // Click on the current action option
+      await expect(actionInputOption).toBeVisible()
+      await actionInputOption.click()
+
+      const backButton = page.getByRole("button", { name: "Go back" })
+      // Close the side panel with back button
+      await expect(backButton).toBeVisible()
+      await backButton.click()
+      await expect(actionEditor).not.toBeVisible()
+
+      // Now the action is stored in the config item
+      // If we save now, it will be saved with the action, so we need to remove it first
+      const actionPanel = page.getByTestId("action-panel")
+      // expect it to become visible
+      // this ensures that react render has completed and, e.g., useEffects have run
+      await expect(actionPanel).toBeVisible()
+
+      const actionEditButton = actionPanel.getByRole("button", {
+        name: "Edit On Press Action",
+      })
+      await expect(actionEditButton).toBeVisible()
+      await actionEditButton.click()
+
+      const actionEditorAfterEdit = page.getByTestId("action-editor")
+      await expect(actionEditorAfterEdit).toBeVisible()
+
+      // Open the action type combobox
+      await expect(actionTypeComboBox).toBeVisible()
+      await actionTypeComboBox.click()
+
+      // Click on the current action option
+      await expect(actionInputOption).toBeVisible()
+      await actionInputOption.click()
+
+      // Close the side panel with back button
+      await expect(backButton).toBeVisible()
+      await backButton.click()
+      await expect(actionEditor).not.toBeVisible()
+
+      await configListPage.mobiFlightPage.trackCommand(
+        "CommandUpdateConfigItem",
+      )
+
+      const saveButton = page.getByRole("button", { name: "Save" })
+      await expect(saveButton).toBeVisible()
+      await saveButton.click()
+
+      const commands = await configListPage.mobiFlightPage.getTrackedCommands()
+      expect(commands).toBeDefined()
+      const payload = commands?.pop()?.payload
+      expect(payload.item.button?.onPress).toBeNull()
+    }
+  })
 })
-async function CreateNewInputConfigItemAndReturnActionPanel(
+
+async function CreateNewInputConfigItemAndReturnActionEditor(
   configListPage: ConfigListPage,
   page: Page,
   type: string = "Button",

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -927,6 +927,33 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
       PresetId: "",
     } as MsfsInputAction)
   })
+
+  test("Existing action can be removed correctly resetting action selection", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionDialog = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      1,
+    )
+    const actionEditButton = actionDialog.getByRole("button", {
+      name: "Remove On Press Action",
+    })
+    await expect(actionEditButton).toBeVisible()
+    await actionEditButton.click()
+
+    await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
+
+    const saveButton = page.getByRole("button", { name: "Save" })
+    await expect(saveButton).toBeVisible()
+    await saveButton.click()
+
+    const commands = await configListPage.mobiFlightPage.getTrackedCommands()
+    expect(commands).toBeDefined()
+    const payload = commands?.pop()?.payload
+    expect(payload.item.button?.onPress).toBeNull()
+  })
 })
 
 test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
@@ -3223,6 +3250,51 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
     expect(commands).toBeDefined()
     const payload = commands?.pop()?.payload
     expect(payload.item.button?.LongReleaseDelay).toBe(500)
+  })
+
+  test("Existing action can be removed correctly using delete button", async ({
+    configListPage,
+    page,
+  }) => {
+    // For all of our 13 different input action config items
+    // open and remove the action, then save and verify that the action is removed from the config item
+    const maxConfigItems = 13
+    for (
+      let currentConfigItemIndex = 1;
+      currentConfigItemIndex <= maxConfigItems;
+      currentConfigItemIndex++
+    ) {
+      const actionDialog = await openWizardAndReturnActionPanel(
+        configListPage,
+        page,
+        currentConfigItemIndex,
+      )
+      const actionEditButton = actionDialog.getByRole("button", {
+        name: "Edit On Press Action",
+      })
+      const deleteActionButton = actionDialog.getByRole("button", {
+        name: "Remove On Press Action",
+      })
+
+      await expect(actionEditButton).toBeVisible()
+      await actionEditButton.hover()
+      await expect(deleteActionButton).toBeVisible()
+      await deleteActionButton.click()
+
+      await configListPage.mobiFlightPage.trackCommand(
+        "CommandUpdateConfigItem",
+      )
+
+      const saveButton = page.getByRole("button", { name: "Save" })
+      await expect(saveButton).toBeVisible()
+      await saveButton.click()
+
+      const commands = await configListPage.mobiFlightPage.getTrackedCommands()
+      expect(commands).toBeDefined()
+      const payload = commands?.pop()?.payload
+      expect(payload.item.button.onPress).toBeUndefined()
+      await configListPage.mobiFlightPage.clearTrackedCommands()
+    }
   })
 })
 async function CreateNewInputConfigItemAndReturnActionPanel(

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -926,33 +926,6 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
       PresetId: "",
     } as MsfsInputAction)
   })
-
-  test("Existing action can be removed correctly resetting action selection", async ({
-    configListPage,
-    page,
-  }) => {
-    const actionDialog = await openWizardAndReturnActionPanel(
-      configListPage,
-      page,
-      1,
-    )
-    const actionEditButton = actionDialog.getByRole("button", {
-      name: "Remove On Press Action",
-    })
-    await expect(actionEditButton).toBeVisible()
-    await actionEditButton.click()
-
-    await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-
-    const saveButton = page.getByRole("button", { name: "Save" })
-    await expect(saveButton).toBeVisible()
-    await saveButton.click()
-
-    const commands = await configListPage.mobiFlightPage.getTrackedCommands()
-    expect(commands).toBeDefined()
-    const payload = commands?.pop()?.payload
-    expect(payload.item.button?.onPress).toBeNull()
-  })
 })
 
 test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -3274,7 +3274,7 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
     configListPage,
     page,
   }) => {
-    test.slow()
+    test.setTimeout(120_000)
     const actionTypeOptions = Object.keys(actionTypeOptionLabels).map(
       (key) => ({
         actionTypeOption: key,


### PR DESCRIPTION
### Summary
It is now possible to remove an assigned action.

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="1668" height="344" alt="image" src="https://github.com/user-attachments/assets/60daefeb-9639-4561-8e79-1ad1317b914e" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] User can remove action via Remove button
- [x] User can remove action by selecting it

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] Frontend tests
- [x] i18n - All user-facing strings are translated
  - [x] core (en,de,es)
  - [x] additional langs
- [ ] documentation
  - [ ] User docs (docs.mobiflight.com) @neilenns 
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3071 
