### PR TITLE
WingFlex RMP - Fix second display

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -44,7 +44,7 @@ namespace MobiFlight.Joysticks.WingFlex
         private readonly static Dictionary<byte, byte> DotByteMapping = new Dictionary<byte, byte>
             {
                 { 19, 13 }, // Left LCD
-                { 21, 14 }  // Right LCD
+                { 23, 14 }  // Right LCD
             };
 
         public RmpCubeReport()

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/RmpCubeReport.cs
@@ -205,8 +205,14 @@ namespace MobiFlight.Joysticks.WingFlex
                 if (!string.IsNullOrEmpty(textWithoutDot))
                 {
                     int visibleDigits = textWithoutDot.Length;
-                    LastOutputBufferState[digitByte] = (byte)((1<<visibleDigits) - 1);
+                    LastOutputBufferState[digitByte] = (byte)((1 << visibleDigits) - 1);
                 }
+
+                // enable Displays (Left LCD Switch / Right LCD Switch) based on the byte of the display
+                // Left Display (Byte19) is bit 1, Right Display (Byte 23) is bit 2
+                var bitOffset = lcdDisplay.Byte == 19 ? 1 : 2; 
+                
+                LastOutputBufferState[8] |= (byte)(1 << bitOffset);
             }
             // continue with next item, as we have already processed the LCD display state
             return;

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
@@ -171,7 +171,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
         #region LCD Display Tests
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_9()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_9()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -203,7 +203,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_99()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_99()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -235,7 +235,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_999()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -267,7 +267,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_9999()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_9999()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -299,7 +299,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_99999()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_99999()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -331,7 +331,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999999()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_999999()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -363,7 +363,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_999dot999()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_999dot999()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -395,7 +395,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         }
 
         [TestMethod]
-        public void FromOutputDeviceState_LcdDisplay_ParsesNumericValue_99dot99dot99()
+        public void FromOutputDeviceState_LcdDisplay_L_ParsesNumericValue_99dot99dot99()
         {
             // Arrange
             var lcdDisplay = new JoystickOutputDisplay
@@ -518,6 +518,262 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0x01, result[20], "Low byte should be 0x01");
             Assert.AreEqual(0x00, result[21], "High byte should be 0x00");
             Assert.AreEqual(0xEA, result[22], "Low byte should be 0xEA");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_9()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 6,
+                Text = "9"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show nothing => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[24], "Low byte should be 0x00");
+            Assert.AreEqual(0x00, result[25], "High byte should be 0x00");
+            Assert.AreEqual(0x09, result[26], "Low byte should be 0x09");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[14], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x01, result[16], "There should be 1 digit set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_99()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 6,
+                Text = "99"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 0 => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 99 => 0x0063, so high byte = 0x00, low byte = 0x63
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[24], "Low byte should be 0x00");
+            Assert.AreEqual(0x00, result[25], "High byte should be 0x00");
+            Assert.AreEqual(0x63, result[26], "Low byte should be 0x63");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[14], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x03, result[16], "There should be 2 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 6,
+                Text = "999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 0 => 0x0000, so high byte = 0x00, low byte = 0x00
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x00, result[24], "Low byte should be 0x00");
+            Assert.AreEqual(0x03, result[25], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[26], "Low byte should be 0xE7");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[14], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x07, result[16], "There should be 3 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_9999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 6,
+                Text = "9999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 9 => 0x0009, so high byte = 0x00, low byte = 0x09
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x09, result[24], "Low byte should be 0x09");
+            Assert.AreEqual(0x03, result[25], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[26], "Low byte should be 0xE7");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[14], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x0F, result[16], "There should be 4 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_99999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 6,
+                Text = "99999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 99 => 0x0063, so high byte = 0x00, low byte = 0x63
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x00, result[23], "High byte should be 0x00");
+            Assert.AreEqual(0x63, result[24], "Low byte should be 0x63");
+            Assert.AreEqual(0x03, result[25], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[26], "Low byte should be 0xE7");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[14], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x1F, result[16], "There should be all 5 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_999999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 6,
+                Text = "999999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
+            Assert.AreEqual(0x03, result[25], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[26], "Low byte should be 0xE7");
+
+            // Assert dot position -> no dot!
+            Assert.AreEqual(0x00, result[14], "There should be no dot set");
+
+            // Assert active digits
+            Assert.AreEqual(0x3F, result[16], "There should be all 6 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_999dot999()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 6,
+                Text = "999.999"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
+            Assert.AreEqual(0x03, result[25], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[26], "Low byte should be 0xE7");
+
+            // Assert dot position
+            Assert.AreEqual(0x03, result[14], "Dot position byte should indicate dot after 3rd digit");
+
+            // Assert active digits
+            Assert.AreEqual(0x3F, result[16], "There should be all 6 digits set");
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LcdDisplay_R_ParsesNumericValue_99dot99dot99()
+        {
+            // Arrange
+            var lcdDisplay = new JoystickOutputDisplay
+            {
+                Name = "Active",
+                Type = DeviceType.LcdDisplay,
+                Byte = 23,
+                Cols = 6,
+                Text = "99.99.99"
+            };
+            var devices = new List<JoystickOutputDevice> { lcdDisplay };
+
+            // Act
+            var result = _report.FromOutputDeviceState(devices);
+
+            // Assert
+            // Left digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            // Right digit group will show 999 => 0x03E7, so high byte = 0x03, low byte = 0xE7
+            Assert.AreEqual(0x03, result[23], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[24], "Low byte should be 0xE7");
+            Assert.AreEqual(0x03, result[25], "High byte should be 0x03");
+            Assert.AreEqual(0xE7, result[26], "Low byte should be 0xE7");
+
+            // Assert dot position, only first dot is rendered
+            Assert.AreEqual(0x02, result[14], "Dot position byte should indicate dot after 2rd digit");
+
+            // Assert active digits
+            Assert.AreEqual(0x3F, result[16], "There should be all 6 digits set");
         }
 
         #endregion

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/RmpCubeReportTests.cs
@@ -200,6 +200,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x01, result[15], "There should be 1 digit set");
+            
+            // Assert display enable bits
+            Assert.AreEqual(0x02, result[8], "Left display should be enabled");
         }
 
         [TestMethod]
@@ -232,6 +235,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x03, result[15], "There should be 2 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x02, result[8], "Left display should be enabled");
         }
 
         [TestMethod]
@@ -264,6 +270,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x07, result[15], "There should be 3 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x02, result[8], "Left display should be enabled");
         }
 
         [TestMethod]
@@ -296,6 +305,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x0F, result[15], "There should be 4 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x02, result[8], "Left display should be enabled");
         }
 
         [TestMethod]
@@ -328,6 +340,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x1F, result[15], "There should be all 5 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x02, result[8], "Left display should be enabled");
         }
 
         [TestMethod]
@@ -360,6 +375,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x3F, result[15], "There should be all 6 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x02, result[8], "Left display should be enabled");
         }
 
         [TestMethod]
@@ -392,6 +410,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x3F, result[15], "There should be all 6 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x02, result[8], "Left display should be enabled");
         }
 
         [TestMethod]
@@ -424,6 +445,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x3F, result[15], "There should be all 6 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x02, result[8], "Left display should be enabled");
         }
 
         [TestMethod]
@@ -550,6 +574,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x01, result[16], "There should be 1 digit set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x04, result[8], "Right display should be enabled");
         }
 
         [TestMethod]
@@ -582,6 +609,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x03, result[16], "There should be 2 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x04, result[8], "Right display should be enabled");
         }
 
         [TestMethod]
@@ -614,6 +644,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x07, result[16], "There should be 3 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x04, result[8], "Right display should be enabled");
         }
 
         [TestMethod]
@@ -646,6 +679,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x0F, result[16], "There should be 4 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x04, result[8], "Right display should be enabled");
         }
 
         [TestMethod]
@@ -678,6 +714,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x1F, result[16], "There should be all 5 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x04, result[8], "Right display should be enabled");
         }
 
         [TestMethod]
@@ -710,6 +749,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x3F, result[16], "There should be all 6 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x04, result[8], "Right display should be enabled");
         }
 
         [TestMethod]
@@ -742,6 +784,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x3F, result[16], "There should be all 6 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x04, result[8], "Right display should be enabled");
         }
 
         [TestMethod]
@@ -774,6 +819,9 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Assert active digits
             Assert.AreEqual(0x3F, result[16], "There should be all 6 digits set");
+
+            // Assert display enable bits
+            Assert.AreEqual(0x04, result[8], "Right display should be enabled");
         }
 
         #endregion


### PR DESCRIPTION
### Summary
This PR makes the right LCD display work as expected. During #3069 we used the wrong byte offset for the right display.

### Acceptance criteria
- [x] Second display shows correct data
- [x] User doesn't have to explicitly enable displays anymore, this happens automatically

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
      
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3076 
