### PR TITLE
Edit config name in wizard

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/InlineEditLabel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/InlineEditLabel.tsx
@@ -108,6 +108,7 @@ export const InlineEditLabel = forwardRef<
         onBlur={handleSave}
         onKeyDown={handleKeyDown}
         onDoubleClick={(e) => e.stopPropagation()}
+        data-prevent-modal-close-on-escape="true"
       />
     ) : (
       <span

--- a/src/MobiFlightConnector/frontend/src/components/InlineEditLabel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/InlineEditLabel.tsx
@@ -115,7 +115,6 @@ export const InlineEditLabel = forwardRef<
         role="button"
         onDoubleClick={(e) => handleDoubleClick(e)}
         onKeyDown={handleKeyDown}
-        tabIndex={0}
         className={cn(
           `cursor-pointer px-2 font-semibold`,
           `ring-offset-background focus-visible:ring-ring focus-visible:ring-offset-muted focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden`,

--- a/src/MobiFlightConnector/frontend/src/components/controllers/ControllerBindingsDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/controllers/ControllerBindingsDialog.tsx
@@ -131,7 +131,7 @@ const ControllerBindingsDialog = ({
           <DialogTitle className="text-2xl">
             {t("Dialog.ControllerBinding.Title")}
           </DialogTitle>
-          <DialogDescription className="text-md vsm:block hidden">
+          <DialogDescription className="vsm:block hidden">
             {t("Dialog.ControllerBinding.Description")}
           </DialogDescription>
         </DialogHeader>

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
@@ -121,7 +121,7 @@ const ProjectForm = ({
               ? t("Project.Form.Title.Edit")
               : t("Project.Form.Title.New")}
           </DialogTitle>
-          <DialogDescription className="text-md">
+          <DialogDescription>
             {t("Project.Form.Description")}
           </DialogDescription>
         </DialogHeader>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
@@ -61,7 +61,7 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
         className="vlg:min-h-[80%] flex min-h-full flex-col justify-between overflow-x-hidden overflow-y-auto select-none sm:max-w-full lg:max-w-300"
       >
         <DialogHeader>
-          <DialogTitle className="flex flex-row items-center gap-2 text-2xl">
+          <DialogTitle className="flex flex-row items-center gap-2 text-2xl" data-testid="dialog-config-name">
             {t("Dialog.InputConfigWizard.Title")}{" "}
             <IconChevronRight className="mt-1" />
             <InlineEditLabel

--- a/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
@@ -1,3 +1,4 @@
+import { InlineEditLabel } from "@/components/InlineEditLabel"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -11,6 +12,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import ConfigWizard from "@/components/wizard/ConfigWizard"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { useProjectStore } from "@/stores/projectStore"
+import { IconChevronRight } from "@tabler/icons-react"
 import { useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
@@ -50,17 +52,30 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
   return (
     <Dialog open={true} onOpenChange={closeDialog}>
       <DialogContent
-        onKeyDown={(e) => {
-          e.stopPropagation()
+        onEscapeKeyDown={(e) => {
+          if ((e.target as HTMLElement).dataset.preventModalCloseOnEscape) {
+            e.preventDefault()
+          }
         }}
         ref={containerRef}
         className="vlg:min-h-[80%] flex min-h-full flex-col justify-between overflow-x-hidden overflow-y-auto select-none sm:max-w-full lg:max-w-300"
       >
         <DialogHeader>
-          <DialogTitle className="text-2xl">
-            {t("Dialog.InputConfigWizard.Title")}
+          <DialogTitle className="flex flex-row items-center gap-2 text-2xl">
+            {t("Dialog.InputConfigWizard.Title")}{" "}
+            <IconChevronRight className="mt-1" />
+            <InlineEditLabel
+              labelClassName="text-2xl px-4.5 -ml-5"
+              inputClassName="h-8 w-fit text-2xl! -ml-3 h-12 -my-2"
+              value={currentConfigItem?.Name || ""}
+              onSave={(newName) => {
+                if (currentConfigItem) {
+                  setCurrentConfigItem({ ...currentConfigItem, Name: newName })
+                }
+              }}
+            />
           </DialogTitle>
-          <DialogDescription className="text-md vsm:block hidden">
+          <DialogDescription className="text-md hidden">
             {t("Dialog.InputConfigWizard.Description")}
           </DialogDescription>
         </DialogHeader>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
@@ -1,4 +1,4 @@
-import { InlineEditLabel } from "@/components/InlineEditLabel"
+import { InlineEditLabel, InlineEditLabelRef } from "@/components/InlineEditLabel"
 import { Button } from "@/components/ui/button"
 import {
   Dialog,
@@ -13,7 +13,7 @@ import ConfigWizard from "@/components/wizard/ConfigWizard"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { useProjectStore } from "@/stores/projectStore"
 import { IconChevronRight } from "@tabler/icons-react"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 import { useNavigate } from "react-router"
 
@@ -46,12 +46,25 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
   }
 
   const containerRef = useRef<HTMLDivElement>(null)
+  const inlineEditRef = useRef<InlineEditLabelRef>(null)
 
   const [currentConfigItem, setCurrentConfigItem] = useState(configItem)
+
+  const defaultLabel = t("ConfigList.Actions.InputConfigItem.DefaultName")
+
+  useEffect(() => {
+    setTimeout(() => {
+      if (configItem?.Name === defaultLabel) {
+        inlineEditRef.current?.startEditing()
+      }
+    }, 500)
+  }, [inlineEditRef, configItem, defaultLabel])
 
   return (
     <Dialog open={true} onOpenChange={closeDialog}>
       <DialogContent
+        // prevents focusing on the inactive inline edit label
+       
         onEscapeKeyDown={(e) => {
           if ((e.target as HTMLElement).dataset.preventModalCloseOnEscape) {
             e.preventDefault()
@@ -61,7 +74,7 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
         className="vlg:min-h-[80%] flex min-h-full flex-col justify-between overflow-x-hidden overflow-y-auto select-none sm:max-w-full lg:max-w-300"
       >
         <DialogHeader>
-          <DialogTitle className="flex flex-row items-center gap-2 text-2xl" data-testid="dialog-config-name">
+          <DialogTitle  tabIndex={undefined} className="flex flex-row items-center gap-2 text-2xl" data-testid="dialog-config-name">
             {t("Dialog.InputConfigWizard.Title")}{" "}
             <IconChevronRight className="mt-1" />
             <InlineEditLabel
@@ -73,6 +86,7 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
                   setCurrentConfigItem({ ...currentConfigItem, Name: newName })
                 }
               }}
+              ref={inlineEditRef}
             />
           </DialogTitle>
           <DialogDescription className="vsm:block hidden">

--- a/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
@@ -75,7 +75,7 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
               }}
             />
           </DialogTitle>
-          <DialogDescription className="text-md hidden">
+          <DialogDescription className="vsm:block hidden">
             {t("Dialog.InputConfigWizard.Description")}
           </DialogDescription>
         </DialogHeader>

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -184,6 +184,39 @@ test.describe("General Input Config Wizard Tests", () => {
   })
 })
 
+test.describe("Input Config Wizard - Edit name", () => {
+  test("Editing name works correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.addNewConfigItem("InputConfigItem", 0, "inputaction")
+    await expect(page.getByText("Edit Input Configuration")).toBeVisible()
+
+    // click on the Name label to enter edit mode
+    const nameLabel = page.getByTestId("dialog-config-name").getByRole("button")
+    const nameInput = page.getByTestId("dialog-config-name").getByRole("textbox")
+    const testLabel = "My new input config"
+    
+    await expect(nameInput).not.toBeVisible()
+    await expect(nameLabel).toBeVisible()
+    await nameLabel.click()
+    
+    await expect(nameInput).toBeVisible()
+    await nameInput.fill(testLabel)
+
+    await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
+
+    const saveButton = page.getByRole("button", { name: "Save" })
+    await expect(saveButton).toBeVisible()
+    await saveButton.click()
+
+    const commands = await configListPage.mobiFlightPage.getTrackedCommands()
+    expect(commands).toBeDefined()
+    const payload = commands?.pop()?.payload
+    expect(payload.item.Name).toEqual(testLabel)
+  })
+})
+
 test.describe("Input Config Wizard - Trigger Panel", () => {
   test("Trigger panel interactions work correctly - Scan for input", async ({
     configListPage,

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -185,22 +185,28 @@ test.describe("General Input Config Wizard Tests", () => {
 })
 
 test.describe("Input Config Wizard - Edit name", () => {
-  test("Editing name works correctly", async ({
-    configListPage,
-    page,
-  }) => {
+  test("Editing name works correctly", async ({ configListPage, page }) => {
+    // Add new config
+    const addInputConfigButton = page.getByRole("button", {
+      name: "Add Input Config",
+    })
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData("inputaction")
+    await addInputConfigButton.click()
     await configListPage.addNewConfigItem("InputConfigItem", 0, "inputaction")
     await expect(page.getByText("Edit Input Configuration")).toBeVisible()
 
     // click on the Name label to enter edit mode
     const nameLabel = page.getByTestId("dialog-config-name").getByRole("button")
-    const nameInput = page.getByTestId("dialog-config-name").getByRole("textbox")
+    const nameInput = page
+      .getByTestId("dialog-config-name")
+      .getByRole("textbox")
     const testLabel = "My new input config"
-    
+
     await expect(nameInput).not.toBeVisible()
     await expect(nameLabel).toBeVisible()
-    await nameLabel.click()
-    
+    await nameLabel.dblclick()
+
     await expect(nameInput).toBeVisible()
     await nameInput.fill(testLabel)
 
@@ -1072,7 +1078,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
       page,
       2,
       undefined,
-      { Sim: "xplane" }
+      { Sim: "xplane" },
     )
 
     const actionEditButton = actionDialog.getByRole("button", {

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -634,6 +634,7 @@ test.describe("Input Config Wizard - Action Type Panel", () => {
     configListPage,
     page,
   }) => {
+    test.slow()
     const projectSettingsToTest: Partial<Project>[] = [
       {
         Sim: "msfs",
@@ -3214,6 +3215,7 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
     configListPage,
     page,
   }) => {
+    test.slow()
     const actionTestData = [
       {
         type: "Button",


### PR DESCRIPTION
### Summary
You can now edit the config name directly inside the config wizard.

### Screenshots / recordings
<img width="1739" height="1345" alt="image" src="https://github.com/user-attachments/assets/855eac5f-19d7-4263-b0f3-a9789af08d29" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] The config name title is displayed inside the wizard
- [x] Double click allows for editing - similar to project title, and tab labels

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] Frontend tests
- [x] ~~i18n - All user-facing strings are translated~~
- [ ] documentation
  - [ ] User docs (docs.mobiflight.com) (@neilenns)
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes 3053
