### PR TITLE
Avoid duplicated aircraft items in list

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/project/Settings/ProjectAircraft.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/Settings/ProjectAircraft.tsx
@@ -227,10 +227,10 @@ const ProjectAircraftDrawer = ({
                   role="listbox"
                   aria-label={t("Project.Form.Aircraft.Dialog.SelectedAircraft.Title")}
                 >
-                  {selectedAircraftWithStats.map((ac, index) => (
+                  {selectedAircraftWithStats.map((ac) => (
                     <AircraftItem
                       role="option"
-                      key={`${index}`}
+                      key={`selected-${ac.Vendor}-${ac.Name}`}
                       aircraft={ac}
                       checked={true}
                       onChecked={removeAircraft}
@@ -270,10 +270,10 @@ const ProjectAircraftDrawer = ({
                   role="listbox"
                   aria-label={t("Project.Form.Aircraft.Dialog.AvailableAircraft.Title")}
                 >
-                  {availableAircraft.map((ac, index) => (
+                  {availableAircraft.map((ac) => (
                     <AircraftItem
                       role="option"
-                      key={`${ac.Vendor}-${ac.Name}-${index}`}
+                      key={`available-${ac.Vendor}-${ac.Name}`}
                       aircraft={ac}
                       checked={ac.selected}
                       onChecked={addAircraft}

--- a/src/MobiFlightConnector/frontend/src/components/project/Settings/ProjectAircraft.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/Settings/ProjectAircraft.tsx
@@ -39,10 +39,7 @@ const AircraftItem = ({
       onClick={() => onChecked(aircraft)}
       {...props}
     >
-      <Checkbox
-        checked={checked}
-        onCheckedChange={() => onChecked(aircraft)}
-      ></Checkbox>
+      <Checkbox checked={checked}></Checkbox>
       <div className="flex grow flex-col font-medium">
         <div className="grow font-medium">
           {aircraft.Name ?? "Unknown Aircraft"}
@@ -217,7 +214,7 @@ const ProjectAircraftDrawer = ({
             )}
           >
             {selectedAircraftWithStats.length === 0 ? (
-              <div className="text-muted-foreground text-sm p-3">
+              <div className="text-muted-foreground p-3 text-sm">
                 {t("Project.Form.Aircraft.Dialog.SelectedAircraft.None")}
               </div>
             ) : (
@@ -225,7 +222,9 @@ const ProjectAircraftDrawer = ({
                 <div
                   className="flex flex-col gap-2 pb-1"
                   role="listbox"
-                  aria-label={t("Project.Form.Aircraft.Dialog.SelectedAircraft.Title")}
+                  aria-label={t(
+                    "Project.Form.Aircraft.Dialog.SelectedAircraft.Title",
+                  )}
                 >
                   {selectedAircraftWithStats.map((ac) => (
                     <AircraftItem
@@ -243,10 +242,14 @@ const ProjectAircraftDrawer = ({
           <Separator className="mt-4 mb-2" />
           <div className="flex flex-col gap-2">
             <div className="flex flex-row items-end justify-between">
-              <div className="text-md font-bold">{t("Project.Form.Aircraft.Dialog.AvailableAircraft.Title")}</div>
+              <div className="text-md font-bold">
+                {t("Project.Form.Aircraft.Dialog.AvailableAircraft.Title")}
+              </div>
               <div className="flex flex-row items-center gap-2">
                 <div className="text-muted-foreground pr-4 text-sm">
-                  {t("Project.Form.Aircraft.Dialog.AvailableAircraft.Count", { count: availableAircraft.length })}
+                  {t("Project.Form.Aircraft.Dialog.AvailableAircraft.Count", {
+                    count: availableAircraft.length,
+                  })}
                 </div>
               </div>
             </div>
@@ -261,14 +264,16 @@ const ProjectAircraftDrawer = ({
           <div className="text-md flex grow">
             <ScrollArea className="grow">
               {availableAircraft.length === 0 ? (
-                <div className="text-muted-foreground text-sm p-3">
+                <div className="text-muted-foreground p-3 text-sm">
                   {t("Project.Form.Aircraft.Dialog.AvailableAircraft.None")}
                 </div>
               ) : (
                 <div
                   className="flex flex-col gap-2 pb-1"
                   role="listbox"
-                  aria-label={t("Project.Form.Aircraft.Dialog.AvailableAircraft.Title")}
+                  aria-label={t(
+                    "Project.Form.Aircraft.Dialog.AvailableAircraft.Title",
+                  )}
                 >
                   {availableAircraft.map((ac) => (
                     <AircraftItem
@@ -318,7 +323,9 @@ const ProjectAircraft = ({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-row items-center gap-2">
-        <Label className="text-base font-semibold">{t("Project.Form.Aircraft.Label")}</Label>
+        <Label className="text-base font-semibold">
+          {t("Project.Form.Aircraft.Label")}
+        </Label>
         <Badge variant={"default"}>{t("General.NewFeature")}</Badge>
       </div>
       <div className="text-muted-foreground text-sm">
@@ -351,7 +358,9 @@ const ProjectAircraft = ({
               onClick={() => navigateToDetailView("aircraft")}
             >
               <IconEdit />
-              <div className="sr-only">{t("Project.Form.Aircraft.EditList")}</div>
+              <div className="sr-only">
+                {t("Project.Form.Aircraft.EditList")}
+              </div>
             </Button>
           </div>
           {detailView && (

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -646,6 +646,70 @@ test.describe("Project settings modal features", () => {
     // we don't check for correct project message
     // this is covered by the "Create new project in modal" test
   })
+
+  test("Clicking on aircraft list checkbox only adds one aircraft at a time", async ({ dashboardPage, page }) => {
+    // this was a bug because of two event handlers firing
+    // https://github.com/MobiFlight/MobiFlight-Connector/issues/3085
+
+    await dashboardPage.gotoPage()
+    await page.route(
+      "*/**/presets/msfs2020_hubhop_presets.json",
+      async (route) => {
+        await route.fulfill({ json: msfsPresetsResponse })
+      },
+    )
+    await page.route(
+      "*/**/presets/xplane_hubhop_presets.json",
+      async (route) => {
+        await route.fulfill({ json: xplanePresetsResponse })
+      },
+    )
+
+    const createProjectButton = page.getByRole("button", { name: "Project" })
+    const createProjectDialog = page.getByRole("dialog", {
+      name: "Create New Project",
+    })
+    const editAircraftButton = createProjectDialog.getByRole("button", {
+      name: "Edit aircraft list",
+    })
+    const projectAircraftDialog = page.getByTestId("project-aircraft-drawer")
+    
+    // create a new project with two aircraft selected
+    await createProjectButton.click()
+    await editAircraftButton.click()
+    await expect(projectAircraftDialog).toBeVisible()
+
+    const selectedAircraftList = projectAircraftDialog.getByRole("listbox", {
+      name: "Selected Aircraft",
+    })
+    const availableAircraftList = projectAircraftDialog.getByRole("listbox", {
+      name: "Available Aircraft",
+    })
+    const selectedAircraftOptions = selectedAircraftList.getByRole("option")
+    const availableAircraftOptions = availableAircraftList.getByRole("option")
+    
+    // verify initial state
+    await expect(selectedAircraftList).toBeVisible()
+    await expect(availableAircraftList).toBeVisible()
+    await expect(selectedAircraftOptions).toHaveCount(2)
+    await expect(availableAircraftOptions).toHaveCount(1)
+    
+    // explicitly click on the checkbox of the first available aircraft option
+    await availableAircraftOptions.first().getByRole("checkbox").click()
+
+    // only one aircraft should be added to the selected list, and 
+    // the available list should be empty
+    await expect(selectedAircraftOptions).toHaveCount(3)
+    await expect(availableAircraftOptions).toHaveCount(0)
+
+    // explicitly click on the checkbox of the first selected aircraft option
+    await selectedAircraftOptions.first().getByRole("checkbox").click()
+
+    // only one aircraft should be removed from the selected list, and 
+    // the available list should have one aircraft
+    await expect(selectedAircraftOptions).toHaveCount(2)
+    await expect(availableAircraftOptions).toHaveCount(1)
+  })
 })
 
 test.describe("Project list view tests", () => {


### PR DESCRIPTION
### Summary
Fix the duplicated aircraft entries in selected or available list in project settings.

### Screenshots / recordings
Before the fix:
<img width="1511" height="1060" alt="Image" src="https://github.com/user-attachments/assets/f65b819f-3b67-49be-a26a-76bf9c2bd4fa" />

After the fix: 
<img width="922" height="1016" alt="20260704-1459-22 8222393" src="https://github.com/user-attachments/assets/142b126e-6c68-42e6-a72c-fec9a94dffa5" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] No duplicated aircraft entries in available list

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] Frontend tests
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~

## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3085