### PR TITLE
Show correct preset label

### DIFF
--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -643,7 +643,8 @@
           "Released": "Losgelassen",
           "SelectAxisPlaceholder": "Achse auswählen...",
           "AxisValueLabel": "Achsenwert",
-          "ControllerLabel": "vJoy Joystick {{index}}"
+          "ControllerLabel": "vJoy Joystick {{index}}",
+          "None": "Keiner"
         },
         "Keyboard": {
           "StopScanning": "Suche stoppen",

--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -642,7 +642,8 @@
           "Pressed": "Gedrückt",
           "Released": "Losgelassen",
           "SelectAxisPlaceholder": "Achse auswählen...",
-          "AxisValueLabel": "Achsenwert"
+          "AxisValueLabel": "Achsenwert",
+          "ControllerLabel": "vJoy Joystick {{index}}"
         },
         "Keyboard": {
           "StopScanning": "Suche stoppen",

--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -607,23 +607,25 @@
         },
         "Msfs": {
           "NoneCode": "Keiner",
-          "CodePlaceholder": "RPN-Code eingeben"
+          "CodePlaceholder": "RPN-Code eingeben",
+          "CustomPreset": "Eigenes Preset"
         },
         "Xplane": {
-          "InputTypeLabel": "Eingabetyp:",
+          "InputTypeLabel": "Eingabetyp",
           "SelectInputTypePlaceholder": "Eingabetyp auswählen",
-          "PathLabel": "Pfad:",
+          "PathLabel": "Pfad",
           "PathPlaceholder": "Pfad für DataRef oder Befehl eingeben, oder oben ein Preset auswählen",
           "PathDescription": "Hinweis: Verwende die Indexnotation, um auf Arrays zuzugreifen, z. B. sim/cockpit2/annunciators/fuel_pressure_low[0] für das 1. Triebwerk.",
-          "ValueLabel": "Wert:",
-          "ValuePlaceholder": "Wert eingeben"
+          "ValueLabel": "Wert",
+          "ValuePlaceholder": "Wert eingeben",
+          "CustomPreset": "Eigenes Preset"
         },
         "ProSim": {
           "Title": "ProSim-Eingabeaktion",
           "Description": "Wähle ein Preset, um deine Eingabeaktionen zu konfigurieren.",
-          "PathLabel": "Pfad:",
+          "PathLabel": "Pfad",
           "NoPresetSelected": "Kein Preset ausgewählt",
-          "ParameterLabel": "Parameter (optional):",
+          "ParameterLabel": "Parameter (optional)",
           "ParameterPlaceholder": "Parameter setzen (optional)",
           "ParameterNone": "Kein Parameter"
         },
@@ -645,7 +647,7 @@
         "Keyboard": {
           "StopScanning": "Suche stoppen",
           "ScanForKeyboard": "Tastatur suchen",
-          "KeyComboLabel": "Tastenkombination:",
+          "KeyComboLabel": "Tastenkombination",
           "None": "Keine",
           "ClearInput": "Eingabe löschen"
         },
@@ -661,9 +663,9 @@
         "LuaMacro": {
           "Title": "Lua-Makro-Eingabeaktion",
           "Description": "Rufe dein Lua-Makro mit einem optionalen Parameter auf. Erfordert ein vorhandenes Lua-Makro in FSUIPC.",
-          "MacroNameLabel": "Makroname:",
+          "MacroNameLabel": "Makroname",
           "MacroNamePlaceholder": "Makronamen setzen",
-          "MacroValueLabel": "Makrowert:",
+          "MacroValueLabel": "Makrowert",
           "MacroValuePlaceholder": "Makrowert setzen"
         },
         "Jeehell": {

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -637,7 +637,8 @@
           "Released": "Released",
           "SelectAxisPlaceholder": "Select axis...",
           "AxisValueLabel": "Axis value",
-          "ControllerLabel": "vJoy Joystick {{index}}"
+          "ControllerLabel": "vJoy Joystick {{index}}",
+          "None": "None"
         },
         "Keyboard": {
           "StopScanning": "Stop scanning",

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -601,23 +601,25 @@
         },
         "Msfs": {
           "NoneCode": "None",
-          "CodePlaceholder": "Enter RPN code"
+          "CodePlaceholder": "Enter RPN code",
+          "CustomPreset": "Custom Preset"
         },
         "Xplane": {
-          "InputTypeLabel": "Input Type:",
+          "InputTypeLabel": "Input Type",
           "SelectInputTypePlaceholder": "Select input type",
-          "PathLabel": "Path:",
+          "PathLabel": "Path",
           "PathPlaceholder": "Enter path for DataRef or Command, or select a preset above",
           "PathDescription": "Hint: Use index notation for access of Arrays, e.g. sim/cockpit2/annunciators/fuel_pressure_low[0] for 1st engine.",
-          "ValueLabel": "Value:",
-          "ValuePlaceholder": "Enter value"
+          "ValueLabel": "Value",
+          "ValuePlaceholder": "Enter value",
+          "CustomPreset": "Custom Preset"
         },
         "ProSim": {
           "Title": "ProSim Input Action",
           "Description": "Select a preset to configure your input actions.",
-          "PathLabel": "Path:",
+          "PathLabel": "Path",
           "NoPresetSelected": "No preset selected",
-          "ParameterLabel": "Parameter (optional):",
+          "ParameterLabel": "Parameter (optional)",
           "ParameterPlaceholder": "Set parameter (optional)",
           "ParameterNone": "None"
         },
@@ -639,7 +641,7 @@
         "Keyboard": {
           "StopScanning": "Stop scanning",
           "ScanForKeyboard": "Scan for keyboard",
-          "KeyComboLabel": "Key combo:",
+          "KeyComboLabel": "Key combo",
           "None": "None",
           "ClearInput": "Clear input"
         },
@@ -655,9 +657,9 @@
         "LuaMacro": {
           "Title": "Lua Macro Input Action",
           "Description": "Invoke your Lua macro with an optional parameter. Requires an existing Lua macro in FSUIPC.",
-          "MacroNameLabel": "Macro Name:",
+          "MacroNameLabel": "Macro Name",
           "MacroNamePlaceholder": "Set macro name",
-          "MacroValueLabel": "Macro Value:",
+          "MacroValueLabel": "Macro Value",
           "MacroValuePlaceholder": "Set macro value"
         },
         "Jeehell": {

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -636,7 +636,8 @@
           "Pressed": "Pressed",
           "Released": "Released",
           "SelectAxisPlaceholder": "Select axis...",
-          "AxisValueLabel": "Axis value"
+          "AxisValueLabel": "Axis value",
+          "ControllerLabel": "vJoy Joystick {{index}}"
         },
         "Keyboard": {
           "StopScanning": "Stop scanning",

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -643,7 +643,8 @@
           "Released": "Soltado",
           "SelectAxisPlaceholder": "Seleccionar eje...",
           "AxisValueLabel": "Valor del eje",
-          "ControllerLabel": "vJoy Joystick {{index}}"
+          "ControllerLabel": "vJoy Joystick {{index}}",
+          "None": "Ninguno"
         },
         "Keyboard": {
           "StopScanning": "Detener búsqueda",

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -607,23 +607,25 @@
         },
         "Msfs": {
           "NoneCode": "Ninguno",
-          "CodePlaceholder": "Ingresar código RPN"
+          "CodePlaceholder": "Ingresar código RPN",
+          "CustomPreset": "Preset personalizado"
         },
         "Xplane": {
-          "InputTypeLabel": "Tipo de entrada:",
+          "InputTypeLabel": "Tipo de entrada",
           "SelectInputTypePlaceholder": "Seleccionar tipo de entrada",
-          "PathLabel": "Ruta:",
+          "PathLabel": "Ruta",
           "PathPlaceholder": "Ingresa la ruta para DataRef o Comando, o selecciona un preset arriba",
           "PathDescription": "Nota: Usa la notación de índice para acceder a los arrays, p. ej., sim/cockpit2/annunciators/fuel_pressure_low[0] para el 1er motor.",
-          "ValueLabel": "Valor:",
-          "ValuePlaceholder": "Ingresa el valor"
+          "ValueLabel": "Valor",
+          "ValuePlaceholder": "Ingresa el valor",
+          "CustomPreset": "Preset personalizado"
         },
         "ProSim": {
           "Title": "Acción de entrada ProSim",
           "Description": "Selecciona un preset para configurar tus acciones de entrada.",
-          "PathLabel": "Ruta:",
+          "PathLabel": "Ruta",
           "NoPresetSelected": "No hay preset seleccionado",
-          "ParameterLabel": "Parámetro (opcional):",
+          "ParameterLabel": "Parámetro (opcional)",
           "ParameterPlaceholder": "Establecer parámetro (opcional)",
           "ParameterNone": "Ninguno"
         },
@@ -645,7 +647,7 @@
         "Keyboard": {
           "StopScanning": "Detener búsqueda",
           "ScanForKeyboard": "Buscar teclado",
-          "KeyComboLabel": "Combinación de teclas:",
+          "KeyComboLabel": "Combinación de teclas",
           "None": "Ninguno",
           "ClearInput": "Borrar entrada"
         },
@@ -661,9 +663,9 @@
         "LuaMacro": {
           "Title": "Acción de entrada de macro Lua",
           "Description": "Invoca tu macro Lua con un parámetro opcional. Requiere una macro Lua existente en FSUIPC.",
-          "MacroNameLabel": "Nombre de macro:",
+          "MacroNameLabel": "Nombre de macro",
           "MacroNamePlaceholder": "Establecer nombre de macro",
-          "MacroValueLabel": "Valor de macro:",
+          "MacroValueLabel": "Valor de macro",
           "MacroValuePlaceholder": "Establecer valor de macro"
         },
         "Jeehell": {

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -642,7 +642,8 @@
           "Pressed": "Presionado",
           "Released": "Soltado",
           "SelectAxisPlaceholder": "Seleccionar eje...",
-          "AxisValueLabel": "Valor del eje"
+          "AxisValueLabel": "Valor del eje",
+          "ControllerLabel": "vJoy Joystick {{index}}"
         },
         "Keyboard": {
           "StopScanning": "Detener búsqueda",

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -636,7 +636,8 @@
           "Pressed": "Painettu",
           "Released": "Vapautettu",
           "SelectAxisPlaceholder": "Valitse akseli...",
-          "AxisValueLabel": "Akseliarvo"
+          "AxisValueLabel": "Akseliarvo",
+          "ControllerLabel": "vJoy Joystick {{index}}"
         },
         "Keyboard": {
           "StopScanning": "Lopeta etsintä",

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -637,7 +637,8 @@
           "Released": "Vapautettu",
           "SelectAxisPlaceholder": "Valitse akseli...",
           "AxisValueLabel": "Akseliarvo",
-          "ControllerLabel": "vJoy Joystick {{index}}"
+          "ControllerLabel": "vJoy Joystick {{index}}",
+          "None": "Ei mitään"
         },
         "Keyboard": {
           "StopScanning": "Lopeta etsintä",

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -601,23 +601,25 @@
         },
         "Msfs": {
           "NoneCode": "Ei mitään",
-          "CodePlaceholder": "Syötä RPN-koodi"
+          "CodePlaceholder": "Syötä RPN-koodi",
+          "CustomPreset": "Mukautettu esiasetus"
         },
         "Xplane": {
-          "InputTypeLabel": "Syötetyyppi:",
+          "InputTypeLabel": "Syötetyyppi",
           "SelectInputTypePlaceholder": "Valitse syötetyyppi",
-          "PathLabel": "Polku:",
+          "PathLabel": "Polku",
           "PathPlaceholder": "Syötä polku DataRefille tai komennolle, tai valitse esiasetus yltä",
           "PathDescription": "Vihje: Käytä indeksi-notaatiota taulukoiden käsittelyyn, esim. sim/cockpit2/annunciators/fuel_pressure_low[0] ensimmäiselle moottorille.",
-          "ValueLabel": "Arvo:",
-          "ValuePlaceholder": "Syötä arvo"
+          "ValueLabel": "Arvo",
+          "ValuePlaceholder": "Syötä arvo",
+          "CustomPreset": "Mukautettu esiasetus"
         },
         "ProSim": {
           "Title": "ProSim-syötetoiminto",
           "Description": "Valitse esiasetus syötetoimintojesi määrittämiseksi.",
-          "PathLabel": "Polku:",
+          "PathLabel": "Polku",
           "NoPresetSelected": "Ei esiasetusta valittuna",
-          "ParameterLabel": "Parametri (valinnainen):",
+          "ParameterLabel": "Parametri (valinnainen)",
           "ParameterPlaceholder": "Aseta parametri (valinnainen)",
           "ParameterNone": "Ei mitään"
         },
@@ -639,7 +641,7 @@
         "Keyboard": {
           "StopScanning": "Lopeta etsintä",
           "ScanForKeyboard": "Etsi näppäimistöä",
-          "KeyComboLabel": "Näppäinyhdistelmä:",
+          "KeyComboLabel": "Näppäinyhdistelmä",
           "None": "Ei mitään",
           "ClearInput": "Tyhjennä syöte"
         },
@@ -655,9 +657,9 @@
         "LuaMacro": {
           "Title": "Lua-makro-syötetoiminto",
           "Description": "Kutsu Lua-makroasi valinnaisella parametrilla. Vaatii olemassa olevan Lua-makron FSUIPC:ssä.",
-          "MacroNameLabel": "Makron nimi:",
+          "MacroNameLabel": "Makron nimi",
           "MacroNamePlaceholder": "Aseta makron nimi",
-          "MacroValueLabel": "Makron arvo:",
+          "MacroValueLabel": "Makron arvo",
           "MacroValuePlaceholder": "Aseta makron arvo"
         },
         "Jeehell": {

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -601,23 +601,25 @@
         },
         "Msfs": {
           "NoneCode": "Nenhum",
-          "CodePlaceholder": "Digite o código RPN"
+          "CodePlaceholder": "Digite o código RPN",
+          "CustomPreset": "Predefinição personalizada"
         },
         "Xplane": {
-          "InputTypeLabel": "Tipo de Entrada:",
+          "InputTypeLabel": "Tipo de Entrada",
           "SelectInputTypePlaceholder": "Selecionar tipo de entrada",
-          "PathLabel": "Caminho:",
+          "PathLabel": "Caminho",
           "PathPlaceholder": "Digite o caminho para DataRef ou Comando, ou selecione uma predefinição acima",
           "PathDescription": "Dica: Use a notação de índice para acessar Arrays, por exemplo, sim/cockpit2/annunciators/fuel_pressure_low[0] para o 1º motor.",
-          "ValueLabel": "Valor:",
-          "ValuePlaceholder": "Digite o valor"
+          "ValueLabel": "Valor",
+          "ValuePlaceholder": "Digite o valor",
+          "CustomPreset": "Predefinição personalizada"
         },
         "ProSim": {
           "Title": "Ação de Entrada ProSim",
           "Description": "Selecione uma predefinição para configurar suas ações de entrada.",
-          "PathLabel": "Caminho:",
+          "PathLabel": "Caminho",
           "NoPresetSelected": "Nenhuma predefinição selecionada",
-          "ParameterLabel": "Parâmetro (opcional):",
+          "ParameterLabel": "Parâmetro (opcional)",
           "ParameterPlaceholder": "Definir parâmetro (opcional)",
           "ParameterNone": "Nenhum"
         },
@@ -639,7 +641,7 @@
         "Keyboard": {
           "StopScanning": "Parar de escanear",
           "ScanForKeyboard": "Escanear teclado...",
-          "KeyComboLabel": "Combinação de teclas:",
+          "KeyComboLabel": "Combinação de teclas",
           "None": "Nenhum",
           "ClearInput": "Limpar entrada"
         },
@@ -654,10 +656,10 @@
         },
         "LuaMacro": {
           "Title": "Ação de Entrada Lua Macro",
-          "Description": "Invoke your Lua macro with an optional parameter. Requires an existing Lua macro in FSUIPC.",
-          "MacroNameLabel": "Nome da Macro:",
+          "Description": "Chame sua macro Lua com um parâmetro opcional. Requer uma macro Lua existente no FSUIPC.",
+          "MacroNameLabel": "Nome da Macro",
           "MacroNamePlaceholder": "Definir nome da macro",
-          "MacroValueLabel": "Valor da Macro:",
+          "MacroValueLabel": "Valor da Macro",
           "MacroValuePlaceholder": "Definir valor da macro"
         },
         "Jeehell": {

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -636,7 +636,8 @@
           "Pressed": "Pressionado",
           "Released": "Liberado",
           "SelectAxisPlaceholder": "Selecionar eixo...",
-          "AxisValueLabel": "Valor do eixo"
+          "AxisValueLabel": "Valor do eixo",
+          "ControllerLabel": "vJoy Joystick {{index}}"
         },
         "Keyboard": {
           "StopScanning": "Parar de escanear",

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -637,7 +637,8 @@
           "Released": "Liberado",
           "SelectAxisPlaceholder": "Selecionar eixo...",
           "AxisValueLabel": "Valor do eixo",
-          "ControllerLabel": "vJoy Joystick {{index}}"
+          "ControllerLabel": "vJoy Joystick {{index}}",
+          "None": "Nenhum"
         },
         "Keyboard": {
           "StopScanning": "Parar de escanear",

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -5,6 +5,8 @@ import { Label } from "@/components/ui/label"
 import { useTranslation } from "react-i18next"
 import { Separator } from "@/components/ui/separator"
 import CodeValueLabel from "@/components/wizard/components/CodeValueLabel"
+import { fetchHubHopPresets } from "@/lib/configWizard"
+import { useQuery } from "@tanstack/react-query"
 
 export type MsfsInputActionPanelProps = {
   variant: "summary" | "details"
@@ -18,6 +20,13 @@ const MsfsInputActionPanel = ({
   onConfigChange,
 }: MsfsInputActionPanelProps) => {
   const { t } = useTranslation()
+    const { data: presets = [] /*, isLoading */ } = useQuery({
+    queryKey: ["msfs-presets"],
+    queryFn: () => fetchHubHopPresets("msfs"),
+    // presets don't change at runtime; HubHopState drives invalidation
+    staleTime: Infinity,
+  })
+  const presetLabel = presets.find((p) => p.id === config?.PresetId)?.label ?? null
 
   if (variant === "summary") {
     return (
@@ -26,7 +35,7 @@ const MsfsInputActionPanel = ({
           <Label htmlFor="preset">
             {t("Dialog.InputConfigWizard.InputActions.Common.PresetLabel")}:
           </Label>
-          <div className="text-sm">AP Panel Heading Hold</div>
+          <div className="text-sm">{presetLabel ?? t("Dialog.InputConfigWizard.InputActions.Msfs.CustomPreset")}</div>
         </div>
         <div className="flex grow flex-col gap-1">
           <Label htmlFor="code">

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -20,13 +20,14 @@ const MsfsInputActionPanel = ({
   onConfigChange,
 }: MsfsInputActionPanelProps) => {
   const { t } = useTranslation()
-    const { data: presets = [] /*, isLoading */ } = useQuery({
+  const { data: presets = [] /*, isLoading */ } = useQuery({
     queryKey: ["msfs-presets"],
     queryFn: () => fetchHubHopPresets("msfs"),
     // presets don't change at runtime; HubHopState drives invalidation
     staleTime: Infinity,
   })
-  const presetLabel = presets.find((p) => p.id === config?.PresetId)?.label ?? null
+  const presetLabel =
+    presets.find((p) => p.id === config?.PresetId)?.label ?? null
 
   if (variant === "summary") {
     return (
@@ -35,7 +36,10 @@ const MsfsInputActionPanel = ({
           <Label htmlFor="preset">
             {t("Dialog.InputConfigWizard.InputActions.Common.PresetLabel")}:
           </Label>
-          <div className="text-sm">{presetLabel ?? t("Dialog.InputConfigWizard.InputActions.Msfs.CustomPreset")}</div>
+          <div className="text-sm">
+            {presetLabel ??
+              t("Dialog.InputConfigWizard.InputActions.Msfs.CustomPreset")}
+          </div>
         </div>
         <div className="flex grow flex-col gap-1">
           <Label htmlFor="code">

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VJoyInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VJoyInputActionPanel.tsx
@@ -66,6 +66,12 @@ const VJoyInputActionPanel = ({
 
   const activeTab = config?.axisString ? "axis" : "button"
 
+  const controllerLabel = config?.vJoyID
+    ? t("Dialog.InputConfigWizard.InputActions.VJoy.ControllerLabel", {
+        index: config?.vJoyID,
+      })
+    : t("Dialog.InputConfigWizard.InputActions.VJoy.None")
+
   if (variant === "summary") {
     return (
       <div className="flex grow flex-row items-center justify-between gap-8">
@@ -73,9 +79,7 @@ const VJoyInputActionPanel = ({
           <Label>
             {t("Dialog.InputConfigWizard.InputActions.VJoy.Controller")}:
           </Label>
-          <div className="text-sm">{t("Dialog.InputConfigWizard.InputActions.VJoy.ControllerLabel", {
-              index: config?.vJoyID,
-            })}</div>
+          <div className="text-sm">{controllerLabel}</div>
         </div>
         <div className="flex flex-col gap-1">
           <Label>
@@ -105,9 +109,7 @@ const VJoyInputActionPanel = ({
             <Label>
               {t("Dialog.InputConfigWizard.InputActions.VJoy.AxisValueLabel")}
             </Label>
-            <CodeValueLabel>
-              {config?.sendValue ?? "-"}
-            </CodeValueLabel>
+            <CodeValueLabel>{config?.sendValue ?? "-"}</CodeValueLabel>
           </div>
         )}
       </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VJoyInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VJoyInputActionPanel.tsx
@@ -40,7 +40,9 @@ const VJoyInputActionPanel = ({
   }
 
   const vJoyOptions = vJoyDefinitions.map((def) => ({
-    label: `vJoy Device ${def.Id}`,
+    label: t("Dialog.InputConfigWizard.InputActions.VJoy.ControllerLabel", {
+      index: def.Id,
+    }),
     value: def.Id,
   }))
 
@@ -71,7 +73,9 @@ const VJoyInputActionPanel = ({
           <Label>
             {t("Dialog.InputConfigWizard.InputActions.VJoy.Controller")}:
           </Label>
-          <div className="text-sm">{selectedDeviceOption?.label}</div>
+          <div className="text-sm">{t("Dialog.InputConfigWizard.InputActions.VJoy.ControllerLabel", {
+              index: config?.vJoyID,
+            })}</div>
         </div>
         <div className="flex flex-col gap-1">
           <Label>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -30,7 +30,7 @@ const XplaneInputActionPanel = ({
   })
 
   const presetLabel = presets.find((p) => p.code === config?.Path)?.label ?? null
-
+  
   if (variant === "summary") {
     return (
       <div className="flex grow flex-row items-center gap-8">

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -2,8 +2,10 @@ import ComboBox from "@/components/ComboBox"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import CodeValueLabel from "@/components/wizard/components/CodeValueLabel"
-import XplanePresetPanel from "@/components/wizard/components/InputActions/XplanePresetPanel"
+import XplanePresetPanel, { XplanePreset } from "@/components/wizard/components/InputActions/XplanePresetPanel"
+import { fetchHubHopPresets } from "@/lib/configWizard"
 import { XplaneInputAction } from "@/types/config"
+import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 
 const CODE_TYPE_OPTIONS: ("DataRef" | "Command")[] = ["DataRef", "Command"]
@@ -21,6 +23,14 @@ const XplaneInputActionPanel = ({
 }: XplaneInputActionPanelProps) => {
   const { t } = useTranslation()
 
+  const { data: presets = [] } = useQuery({
+    queryKey: ["xplane-presets"],
+    queryFn: () => fetchHubHopPresets("xplane") as Promise<XplanePreset[]>,
+    staleTime: Infinity,
+  })
+
+  const presetLabel = presets.find((p) => p.code === config?.Path)?.label ?? null
+
   if (variant === "summary") {
     return (
       <div className="flex grow flex-row items-center gap-8">
@@ -28,7 +38,7 @@ const XplaneInputActionPanel = ({
           <Label htmlFor="preset">
             {t("Dialog.InputConfigWizard.InputActions.Common.PresetLabel")}:
           </Label>
-          <div className="text-sm">AP Panel Heading Hold</div>
+          <div className="text-sm">{presetLabel ?? t("Dialog.InputConfigWizard.InputActions.Xplane.CustomPreset")}</div>
         </div>
         <div className="flex grow flex-col gap-1">
           <Label htmlFor="code">

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2479,7 +2479,7 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     await expect(actionPanel.getByText("True", { exact: true })).toBeVisible()
 
     // The value is shown in the summary
-    await expect(actionPanel.getByText("$+123123123123", { exact: true })).toBeVisible()
+    await expect(actionPanel.getByText("$+123", { exact: true })).toBeVisible()
   })
 
   test("BCDMode and Mask Visibility are displayed correctly based on type", async ({
@@ -3136,7 +3136,7 @@ test.describe("Input Config Wizard - FSUIPC Jeehell Input Action Panel", () => {
 
     // The function name is shown in the summary
     await expect(
-      actionPanel.getByText("FO QNH", { exact: true }),
+      actionPanel.getByText("FCU_HDGKNOB_PRESS", { exact: true }),
     ).toBeVisible()
 
     // The value is shown in the summary

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -838,7 +838,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     // now all options are available
     await expect(countLabel).toHaveText("4 preset(s) found")
 
-    // Filter by a exact preset name -> 1 preset found
+    // Filter by an exact preset name -> 1 preset found
     await filterInput.fill("AP_PANEL_HEADING_HOLD")
     await expect(countLabel).toHaveText("1 preset(s) found")
 
@@ -846,7 +846,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await filterInput.fill("NonExistingPreset")
     await expect(countLabel).toHaveText("0 preset(s) found")
 
-    // Reset the filter -> all presets are available again202
+    // Reset the filter -> all presets are available again
     await filterInput.fill("")
     await expect(countLabel).toHaveText("4 preset(s) found")
   })
@@ -1347,7 +1347,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
         name: "Reset filters",
       })
 
-      // make sure we have all options avaible by resetting filters
+      // make sure we have all options available by resetting filters
       await resetFiltersButton.click()
 
       await expect(countLabel).toHaveText(
@@ -3421,7 +3421,7 @@ test.describe("Input Config Wizard - ProSim Input Action Panel", () => {
     const actionPanel = await openWizardAndReturnActionPanel(
       configListPage,
       page,
-      12,
+      13,
     )
 
     // Action type is shown in the summary
@@ -3429,11 +3429,11 @@ test.describe("Input Config Wizard - ProSim Input Action Panel", () => {
 
     // The preset path is shown in the summary
     await expect(
-      actionPanel.getByText("TestMacro", { exact: true }),
+      actionPanel.getByText("prosim.test.path", { exact: true }),
     ).toBeVisible()
 
     // The optional parameter value is shown in the summary
-    await expect(actionPanel.getByText("TestValue", { exact: true })).toBeVisible()
+    await expect(actionPanel.getByText("$", { exact: true })).toBeVisible()
   })
 
   test("With presets loaded: filter and select updates the path", async ({

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -774,7 +774,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await expect(
       actionEditor
         .getByRole("combobox")
-        .filter({ hasText: "AP_PANEL_HEADING_HOLD" }),
+        .getByText("AP_PANEL_HEADING_HOLD_TEST", { exact: true }),
     ).toBeVisible()
     // The preset has no description in the mock data
     await expect(
@@ -784,6 +784,29 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await expect(
       actionEditor.getByRole("textbox", { name: "Enter RPN code" }),
     ).toHaveValue("(>K:AP_PANEL_HEADING_HOLD)")
+  })
+
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      1,
+    )
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("MSFS Preset")).toBeVisible()
+
+    // The preset label is shown in the summary
+    await expect(
+      actionPanel.getByText("AP_PANEL_HEADING_HOLD_TEST", { exact: true }),
+    ).toBeVisible()
+
+    // The code is shown in the summary
+    await expect(
+      actionPanel.getByText("(>K:AP_PANEL_HEADING_HOLD)", { exact: true }),
+    ).toBeVisible()
   })
 
   test("Preset filter narrows the list and the count updates", async ({
@@ -804,15 +827,26 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     const actionEditor = page.getByTestId("action-editor")
     const filterInput = actionEditor.getByPlaceholder("Filter presets")
     const countLabel = actionEditor.getByRole("status")
+    const resetFiltersButton = actionEditor.getByRole("button", {
+      name: "Reset filters",
+    })
 
+    // we will have only 1 preset available because of the test data filtering
+    await expect(countLabel).toHaveText("1 preset(s) found")
+    await resetFiltersButton.click()
+
+    // now all options are available
     await expect(countLabel).toHaveText("4 preset(s) found")
 
+    // Filter by a exact preset name -> 1 preset found
     await filterInput.fill("AP_PANEL_HEADING_HOLD")
     await expect(countLabel).toHaveText("1 preset(s) found")
 
+    // filter by a non-existing preset name -> 0 presets found
     await filterInput.fill("NonExistingPreset")
     await expect(countLabel).toHaveText("0 preset(s) found")
 
+    // Reset the filter -> all presets are available again202
     await filterInput.fill("")
     await expect(countLabel).toHaveText("4 preset(s) found")
   })
@@ -835,10 +869,16 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
 
     const actionEditor = page.getByTestId("action-editor")
 
+    // reset filters to really have all options available
+    const resetFiltersButton = actionEditor.getByRole("button", {
+      name: "Reset filters",
+    })
+    await resetFiltersButton.click()
+
     // Open the preset ComboBox (currently shows the selected preset)
     await actionEditor
       .getByRole("combobox")
-      .filter({ hasText: "AP_PANEL_HEADING_HOLD" })
+      .getByText("AP_PANEL_HEADING_HOLD_TEST", { exact: true })
       .click()
     await page.getByRole("option", { name: "AS1000_PFD_VOL_1_DEC" }).click()
     // Code field updates to the new preset's command
@@ -872,8 +912,9 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
       name: "Reset filters",
     })
 
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("1 preset(s) found")
     await resetFiltersButton.click()
+    await expect(countLabel).toHaveText("4 preset(s) found")
 
     const optionsList = page.getByRole("listbox")
 
@@ -959,10 +1000,10 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
         name: "Reset filters",
       })
 
+      await resetFiltersButton.click()
       await expect(countLabel).toHaveText(
         `${settings.ExpectedPresetCount} preset(s) found`,
       )
-      await resetFiltersButton.click()
 
       const optionsList = page.getByRole("listbox")
       const vendorOptions = optionsList.getByRole("option")
@@ -1028,7 +1069,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    const actionDialog = await openWizardAndReturnActionPanel(
+    const actionPanel = await openWizardAndReturnActionPanel(
       configListPage,
       page,
       2,
@@ -1036,7 +1077,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
       { Sim: "xplane" },
     )
 
-    const actionEditButton = actionDialog.getByRole("button", {
+    const actionEditButton = actionPanel.getByRole("button", {
       name: "Edit On Press Action",
     })
     await expect(actionEditButton).toBeVisible()
@@ -1070,6 +1111,34 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     ).toHaveValue("laminar/B738/knob/land_alt_press_dn")
   })
 
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      2,
+      undefined,
+      { Sim: "xplane" },
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("X-Plane preset")).toBeVisible()
+
+    // The preset label is shown in the summary
+    await expect(
+      actionPanel.getByText("land_alt_press_dn", { exact: true }),
+    ).toBeVisible()
+
+    // The code is shown in the summary
+    await expect(
+      actionPanel.getByText("laminar/B738/knob/land_alt_press_dn", {
+        exact: true,
+      }),
+    ).toBeVisible()
+  })
+
   test("Preset filter narrows the list and the count updates", async ({
     configListPage,
     page,
@@ -1093,14 +1162,25 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     const filterInput = actionEditor.getByPlaceholder("Filter presets")
     const countLabel = actionEditor.getByRole("status")
 
+    // we will have only 1 preset available because of the test data filtering
+    await expect(countLabel).toHaveText("1 preset(s) found")
+
+    // reset filters to have all options available
+    const resetFiltersButton = actionEditor.getByRole("button", {
+      name: "Reset filters",
+    })
+    await resetFiltersButton.click()
     await expect(countLabel).toHaveText("4 preset(s) found")
 
+    // Filter by exact preset label -> 1 preset should be found
     await filterInput.fill("land_alt_press_dn")
     await expect(countLabel).toHaveText("1 preset(s) found")
 
+    // Filter by a non-existing preset label -> 0 presets should be found
     await filterInput.fill("NoMatch")
     await expect(countLabel).toHaveText("0 preset(s) found")
 
+    // Clear the filter -> all presets should be found
     await filterInput.fill("")
     await expect(countLabel).toHaveText("4 preset(s) found")
   })
@@ -1122,6 +1202,10 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await actionEditButton.click()
 
     const actionEditor = page.getByTestId("action-editor")
+    const resetFiltersButton = actionEditor.getByRole("button", {
+      name: "Reset filters",
+    })
+    await resetFiltersButton.click()
 
     // Select a DataRef preset (different code type)
     await actionEditor
@@ -1166,8 +1250,13 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
       name: "Reset filters",
     })
 
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    // initially only 1 preset is available 
+    // because of current test data filtering
+    await expect(countLabel).toHaveText("1 preset(s) found")
+
+    // now reset all filters to show all options
     await resetFiltersButton.click()
+    await expect(countLabel).toHaveText("4 preset(s) found")
 
     const optionsList = page.getByRole("listbox")
 
@@ -1258,10 +1347,12 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
         name: "Reset filters",
       })
 
+      // make sure we have all options avaible by resetting filters
+      await resetFiltersButton.click()
+
       await expect(countLabel).toHaveText(
         `${settings.ExpectedPresetCount} preset(s) found`,
       )
-      await resetFiltersButton.click()
 
       const optionsList = page.getByRole("listbox")
       const vendorOptions = optionsList.getByRole("option")
@@ -1772,7 +1863,7 @@ test.describe("Input Config Wizard - Keyboard Input Action Panel", () => {
         .getByRole("combobox")
         .filter({ hasText: "MobiFlight - Keyboard Input" }),
     ).toBeVisible()
-    await expect(actionEditor.getByText("Key combo:None")).toBeVisible()
+    await expect(actionEditor.getByText("Key comboNone")).toBeVisible()
   })
 
   test("Loaded config data is displayed correctly", async ({
@@ -2950,10 +3041,10 @@ test.describe("Input Config Wizard - FSUIPC Lua Macro Input Action Panel", () =>
         .filter({ hasText: "FSUIPC - Lua Macro" }),
     ).toBeVisible()
     await expect(
-      actionEditor.getByRole("textbox", { name: "Macro Name:" }),
+      actionEditor.getByRole("textbox", { name: "Macro Name" }),
     ).toHaveValue("TestMacro")
     await expect(
-      actionEditor.getByRole("textbox", { name: "Macro Value:" }),
+      actionEditor.getByRole("textbox", { name: "Macro Value" }),
     ).toHaveValue("TestValue")
   })
 
@@ -2976,10 +3067,10 @@ test.describe("Input Config Wizard - FSUIPC Lua Macro Input Action Panel", () =>
     const actionEditor = page.getByTestId("action-editor")
 
     const macroNameInput = actionEditor.getByRole("textbox", {
-      name: "Macro Name:",
+      name: "Macro Name",
     })
     const macroValueInput = actionEditor.getByRole("textbox", {
-      name: "Macro Value:",
+      name: "Macro Value",
     })
 
     await macroNameInput.fill("UpdatedMacro")
@@ -3010,11 +3101,11 @@ test.describe("Input Config Wizard - FSUIPC Lua Macro Input Action Panel", () =>
     await expect(actionTypeOption).not.toBeVisible()
 
     // Provide specific user input
-    const macroNameInput = actionEditor.getByLabel("Macro Name:")
+    const macroNameInput = actionEditor.getByLabel("Macro Name")
     await expect(macroNameInput).toBeVisible()
     await macroNameInput.fill("MACRO NAME")
 
-    const macroValueInput = actionEditor.getByLabel("Macro Value:")
+    const macroValueInput = actionEditor.getByLabel("Macro Value")
     await expect(macroValueInput).toBeVisible()
     await macroValueInput.fill("MACRO VALUE")
     // End: provide specific user input

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -1250,7 +1250,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
       name: "Reset filters",
     })
 
-    // initially only 1 preset is available 
+    // initially only 1 preset is available
     // because of current test data filtering
     await expect(countLabel).toHaveText("1 preset(s) found")
 
@@ -1583,6 +1583,32 @@ test.describe("Input Config Wizard - Variable Input Action Panel", () => {
     ).toHaveValue("$")
   })
 
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      3,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("Variable")).toBeVisible()
+
+    // The variable name is shown in the summary
+    await expect(
+      actionPanel.getByText("MyVarnumber", { exact: true }),
+    ).toBeVisible()
+
+    // The code is shown in the summary
+    await expect(
+      actionPanel.getByText("$", {
+        exact: true,
+      }),
+    ).toBeVisible()
+  })
+
   test("Newly created (number) Variable config values are saved correctly", async ({
     configListPage,
     page,
@@ -1742,6 +1768,25 @@ test.describe("Input Config Wizard - Retrigger Input Action Panel", () => {
     ).toBeVisible()
   })
 
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      4,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("Retrigger")).toBeVisible()
+
+    // The note is shown in the summary
+    await expect(
+      actionPanel.getByText("Note:Sync input devices with sim.", { exact: true }),
+    ).toBeVisible()
+  })
+
   test("Newly created retrigger config values are saved correctly", async ({
     configListPage,
     page,
@@ -1864,6 +1909,25 @@ test.describe("Input Config Wizard - Keyboard Input Action Panel", () => {
         .filter({ hasText: "MobiFlight - Keyboard Input" }),
     ).toBeVisible()
     await expect(actionEditor.getByText("Key comboNone")).toBeVisible()
+  })
+
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      5,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("Keyboard")).toBeVisible()
+
+    // The variable name is shown in the summary
+    await expect(
+      actionPanel.getByText("Ctrl + Alt + Shift + D", { exact: true }),
+    ).toBeVisible()
   })
 
   test("Loaded config data is displayed correctly", async ({
@@ -2063,7 +2127,7 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
         .filter({ hasText: "MobiFlight - Virtual Joystick input (vJoy)" }),
     ).toBeVisible()
     await expect(
-      actionEditor.getByRole("combobox").filter({ hasText: "vJoy Device 1" }),
+      actionEditor.getByRole("combobox").filter({ hasText: "vJoy Joystick 1" }),
     ).toBeVisible()
     await expect(
       actionEditor.getByRole("tab", { name: "button" }),
@@ -2076,6 +2140,68 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
     await expect(
       actionEditor.getByTestId("vjoy-button-command-state"),
     ).toHaveText("Pressed")
+  })
+
+  test("Summary information is displayed correctly (Button)", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      6,
+    )
+
+    // Publish the vJoy definitions so the panel can render the correct labels
+    await configListPage.mobiFlightPage.publishMessage(vJoyDefinitions)
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("vJoy", {exact: true})).toBeVisible()
+
+    // The controller name is shown in the summary
+    await expect(
+      actionPanel.getByText("vJoy Joystick 1", { exact: true }),
+    ).toBeVisible()
+
+    // The device name is shown in the summary
+    await expect(
+      actionPanel.getByText("Button 4", { exact: true }),
+    ).toBeVisible()
+
+    // The button state is shown in the summary
+    await expect(
+      actionPanel.getByText("Pressed", {
+        exact: true,
+      }),
+    ).toBeVisible()
+  })
+
+  test("Summary information is displayed correctly (Axis)", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      7,
+    )
+
+    // Publish the vJoy definitions so the panel can render the correct labels
+    await configListPage.mobiFlightPage.publishMessage(vJoyDefinitions)
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("vJoy", {exact: true})).toBeVisible()
+
+    // The controller name is shown in the summary
+    await expect(
+      actionPanel.getByText("vJoy Joystick 1", { exact: true }),
+    ).toBeVisible()
+
+    // The device name is shown in the summary
+    await expect(actionPanel.getByText("Axis Z", { exact: true })).toBeVisible()
+
+    // The axis value is shown in the summary
+    await expect(actionPanel.getByText("1024", { exact: true })).toBeVisible()
   })
 
   test("Axis config: device, axis and send value are displayed correctly", async ({
@@ -2115,7 +2241,7 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
         .filter({ hasText: "MobiFlight - Virtual Joystick input (vJoy)" }),
     ).toBeVisible()
     await expect(
-      actionEditor.getByRole("combobox").filter({ hasText: "vJoy Device 1" }),
+      actionEditor.getByRole("combobox").filter({ hasText: "vJoy Joystick 1" }),
     ).toBeVisible()
     await expect(
       actionEditor.getByRole("tab", { name: "axis" }),
@@ -2157,9 +2283,9 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
       .filter({ hasText: "Select vJoy device" })
     await expect(vJoyDeviceComboBox).toBeVisible()
     await vJoyDeviceComboBox.click()
-    await page.getByRole("option", { name: "vJoy Device 1" }).click()
+    await page.getByRole("option", { name: "vJoy Joystick 1" }).click()
     await expect(
-      page.getByRole("option", { name: "vJoy Device 1" }),
+      page.getByRole("option", { name: "vJoy Joystick 1" }),
     ).not.toBeVisible()
 
     const typeTab = actionEditor.getByRole("tab", { name: "button" })
@@ -2232,9 +2358,9 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
       .filter({ hasText: "Select vJoy device" })
     await expect(vJoyDeviceComboBox).toBeVisible()
     await vJoyDeviceComboBox.click()
-    await page.getByRole("option", { name: "vJoy Device 1" }).click()
+    await page.getByRole("option", { name: "vJoy Joystick 1" }).click()
     await expect(
-      page.getByRole("option", { name: "vJoy Device 1" }),
+      page.getByRole("option", { name: "vJoy Joystick 1" }),
     ).not.toBeVisible()
 
     const typeTab = actionEditor.getByRole("tab", { name: "axis" })
@@ -2319,6 +2445,41 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
     // BcdMode=true
     const bcdModeSwitch = actionEditor.getByRole("switch").filter()
     await expect(bcdModeSwitch).toHaveAttribute("aria-checked", "true")
+  })
+
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      8,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("FSUIPC Offset")).toBeVisible()
+
+    // The Size is shown in the summary
+    await expect(
+      actionPanel.getByText("4", { exact: true }),
+    ).toBeVisible()
+
+    // The Offset is shown in the summary
+    await expect(
+      actionPanel.getByText("66CC", { exact: true }),
+    ).toBeVisible()
+    
+    // The mask is shown in the summary
+    await expect(
+      actionPanel.getByText("AABBCCDDEE", { exact: true }),
+    ).toBeVisible()
+
+    // The BCD mode is shown in the summary
+    await expect(actionPanel.getByText("True", { exact: true })).toBeVisible()
+
+    // The value is shown in the summary
+    await expect(actionPanel.getByText("$+123123123123", { exact: true })).toBeVisible()
   })
 
   test("BCDMode and Mask Visibility are displayed correctly based on type", async ({
@@ -2663,6 +2824,28 @@ test.describe("Input Config Wizard - FSUIPC EventID Input Action Panel", () => {
     ).toBeVisible()
   })
 
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      9,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("EventID")).toBeVisible()
+
+    // The event ID is shown in the summary
+    await expect(
+      actionPanel.getByText("68036", { exact: true }),
+    ).toBeVisible()
+
+    // The custom param is shown in the summary
+    await expect(actionPanel.getByText("0", { exact: true })).toBeVisible()
+  })
+
   test("Newly created FSUIPC EventID Input Action config values are saved correctly", async ({
     configListPage,
     page,
@@ -2791,6 +2974,28 @@ test.describe("Input Config Wizard - FSUIPC PMDG EventID Input Action Panel", ()
     ).toBeVisible()
   })
 
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      10,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("PMDG Event ID")).toBeVisible()
+
+    // The event ID is shown in the summary
+    await expect(
+      actionPanel.getByText("69648", { exact: true }),
+    ).toBeVisible()
+
+    // The mouse parameter is shown in the summary
+    await expect(actionPanel.getByText("MOUSE_FLAG_LEFTSINGLE", { exact: true })).toBeVisible()
+  })
+
   test("Newly created FSUIPC PMDG EventID Input Action config values are saved correctly", async ({
     configListPage,
     page,
@@ -2914,6 +3119,28 @@ test.describe("Input Config Wizard - FSUIPC Jeehell Input Action Panel", () => {
     await expect(
       actionEditor.getByRole("textbox", { name: "Value" }),
     ).toHaveValue("1")
+  })
+
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      11,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("Jeehell Events")).toBeVisible()
+
+    // The function name is shown in the summary
+    await expect(
+      actionPanel.getByText("FO QNH", { exact: true }),
+    ).toBeVisible()
+
+    // The value is shown in the summary
+    await expect(actionPanel.getByText("1", { exact: true })).toBeVisible()
   })
 
   test("Selecting a preset updates the function and description", async ({
@@ -3048,6 +3275,28 @@ test.describe("Input Config Wizard - FSUIPC Lua Macro Input Action Panel", () =>
     ).toHaveValue("TestValue")
   })
 
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      12,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("Lua Macro")).toBeVisible()
+
+    // The macro name is shown in the summary
+    await expect(
+      actionPanel.getByText("TestMacro", { exact: true }),
+    ).toBeVisible()
+
+    // The macro value is shown in the summary
+    await expect(actionPanel.getByText("TestValue", { exact: true })).toBeVisible()
+  })
+
   test("Editing macro name and value updates the fields", async ({
     configListPage,
     page,
@@ -3163,6 +3412,28 @@ test.describe("Input Config Wizard - ProSim Input Action Panel", () => {
       key: "CommandRefreshPresets",
       payload: { type: "prosim" },
     })
+  })
+
+  test("Summary information is displayed correctly", async ({
+    configListPage,
+    page,
+  }) => {
+    const actionPanel = await openWizardAndReturnActionPanel(
+      configListPage,
+      page,
+      12,
+    )
+
+    // Action type is shown in the summary
+    await expect(actionPanel.getByText("ProSim Preset")).toBeVisible()
+
+    // The preset path is shown in the summary
+    await expect(
+      actionPanel.getByText("TestMacro", { exact: true }),
+    ).toBeVisible()
+
+    // The optional parameter value is shown in the summary
+    await expect(actionPanel.getByText("TestValue", { exact: true })).toBeVisible()
   })
 
   test("With presets loaded: filter and select updates the path", async ({

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction.testdata.json
@@ -466,8 +466,8 @@
                         "onHold": null,
                         "onLongRelease": null,
                         "onPress": {
-                            "Expression": "",
-                            "Path": "",
+                            "Expression": "$",
+                            "Path": "prosim.test.path",
                             "Type": "ProSimInputAction"
                         },
                         "onRelease": null

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
@@ -50,7 +50,7 @@
     "aircraft": "Generic",
     "system": "Autopilot",
     "code": "(>K:AP_PANEL_HEADING_HOLD)",
-    "label": "AP_PANEL_HEADING_HOLD",
+    "label": "AP_PANEL_HEADING_HOLD_TEST",
     "presetType": "Input",
     "version": 2,
     "status": "Updated",


### PR DESCRIPTION
### Summary
For MSFS and Xplane, the correct preset labels are now displayed.

### Screenshots / recordings
<img width="1509" height="310" alt="image" src="https://github.com/user-attachments/assets/b8a2b533-680f-4376-b7b7-03dfee80ce5f" />

### Acceptance criteria
- [x] Preset labels are displayed in summary
  - [x] MSFS
  - [x] XPlane 
- [x] It shows "Custom preset" if the preset was modified or created from scratch
- [x] vJoy shows Controller information even if no vJoy joysticks are configured on the PC

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] Frontend tests
  - [x] Added playwright tests for summary panels 
- [x] i18n - All user-facing strings are translated
  - [x] core (en,de,es)
  - [x] additional langs
- [x] ~~documentation~~

## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3082
