### PR TITLE
Presets show potentiometer type presets for MSFS and XPlane

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/project/Settings/ProjectAircraft.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/Settings/ProjectAircraft.tsx
@@ -59,9 +59,6 @@ const AircraftItem = ({
 
 type AircraftStats = {
   Count: number
-  Input: boolean
-  Output: boolean
-  Potentiometer: boolean
 }
 
 type AircraftInfoWithStats = AircraftInfo & AircraftStats
@@ -108,19 +105,12 @@ const ProjectAircraftDrawer = ({
 
     if (existing) {
       existing.Count += 1
-      existing.Input = existing.Input || p.presetType === "input"
-      existing.Output = existing.Output || p.presetType === "output"
-      existing.Potentiometer =
-        existing.Potentiometer || p.presetType === "potentiometer"
       return
     }
     aircarftStatsMap.set(key, {
       Vendor: p.vendor,
       Name: p.aircraft,
-      Count: 1,
-      Input: p.presetType === "input",
-      Output: p.presetType === "output",
-      Potentiometer: p.presetType === "potentiometer",
+      Count: 1
     })
   })
 

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -42,7 +42,7 @@ const MsfsPresetPanel = ({
   const { project } = useProjectStore()
 
   const validPresetTypes =
-    variant === "input" ? ["input", "potentiometer"] : ["output"]
+    variant === "input" ? ["input", "input (potentiometer)"] : ["output"]
 
   const { data: presets = [] /*, isLoading */ } = useQuery({
     queryKey: ["msfs-presets"],

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -24,7 +24,7 @@ export type Preset = {
   updatedBy?: string
   reported?: number
   score?: number
-  presetType: "input" | "output" | "potentiometer"
+  presetType: "Input" | "Output" | "Input (Potentiometer)"
 }
 
 export type MsfsPresetPanelProps = {

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
@@ -44,7 +44,7 @@ const XplanePresetPanel = ({
 
   const validPresetTypes =
     variant === "input"
-      ? ["input", "inputoutput", "potentiometer"]
+      ? ["input", "inputoutput", "input (potentiometer)"]
       : ["output", "inputoutput"]
 
   const { data: presets = [] } = useQuery({

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
@@ -24,7 +24,7 @@ export type XplanePreset = {
   updatedBy?: string
   reported?: number
   score?: number
-  presetType: "input" | "output" | "inputoutput" | "potentiometer"
+  presetType: "Input" | "Output" | "InputOutput" | "Input (Potentiometer)"
   codeType: "DataRef" | "Command"
 }
 

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2212,7 +2212,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
       name: "Reset filters",
     })
     await resetFiltersButton.click()
-    await expect(countLabel).toHaveText("7 preset(s) found")
+    await expect(countLabel).toHaveText("6 preset(s) found")
 
     // Filter by exact preset label -> 1 preset should be found
     await filterInput.fill("land_alt_press_dn")
@@ -2224,7 +2224,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     // Clear the filter -> all presets should be found
     await filterInput.fill("")
-    await expect(countLabel).toHaveText("7 preset(s) found")
+    await expect(countLabel).toHaveText("6 preset(s) found")
   })
 
   test("Selecting a preset updates the code field and input type", async ({
@@ -2298,7 +2298,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     // now reset all filters to show all options
     await resetFiltersButton.click()
-    await expect(countLabel).toHaveText("7 preset(s) found")
+    await expect(countLabel).toHaveText("6 preset(s) found")
 
     const optionsList = page.getByRole("listbox")
 
@@ -2348,7 +2348,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await expect(resetFiltersButton).toBeVisible()
     await resetFiltersButton.click()
 
-    await expect(countLabel).toHaveText("7 preset(s) found")
+    await expect(countLabel).toHaveText("6 preset(s) found")
   })
 
   test("Preset list honors aircraft settings", async ({
@@ -2356,7 +2356,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     page,
   }) => {
     const testSettings = [
-      { Aircraft: [], ExpectedPresetCount: 7, ExpectedVendorCount: 3 },
+      { Aircraft: [], ExpectedPresetCount: 6, ExpectedVendorCount: 3 },
       {
         Aircraft: [{ Vendor: "Laminar Research", Name: "Boeing 737-800" }],
         ExpectedPresetCount: 2,

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -1878,7 +1878,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await resetFiltersButton.click()
 
     // now all options are available
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("5 preset(s) found")
 
     // Filter by an exact preset name -> 1 preset found
     await filterInput.fill("AP_PANEL_HEADING_HOLD")
@@ -1890,7 +1890,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
 
     // Reset the filter -> all presets are available again
     await filterInput.fill("")
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("5 preset(s) found")
   })
 
   test("Selecting a preset updates the code field and description", async ({
@@ -1956,7 +1956,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
 
     await expect(countLabel).toHaveText("1 preset(s) found")
     await resetFiltersButton.click()
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("5 preset(s) found")
 
     const optionsList = page.getByRole("listbox")
 
@@ -1971,7 +1971,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await vendorOption.click()
     await expect(vendorOption).not.toBeVisible()
 
-    await expect(countLabel).toHaveText("3 preset(s) found")
+    await expect(countLabel).toHaveText("4 preset(s) found")
 
     // Select an aircraft filter
     await actionEditor
@@ -1984,7 +1984,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await aircraftOption.click()
     await expect(aircraftOption).not.toBeVisible() // Should be removed from options since it's already selected as a filter
 
-    await expect(countLabel).toHaveText("2 preset(s) found")
+    await expect(countLabel).toHaveText("3 preset(s) found")
 
     // Select a system filter
     await actionEditor
@@ -2002,7 +2002,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await expect(resetFiltersButton).toBeVisible()
     await resetFiltersButton.click()
 
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("5 preset(s) found")
   })
 
   test("Preset list honors aircraft settings", async ({
@@ -2010,10 +2010,10 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     page,
   }) => {
     const testSettings = [
-      { Aircraft: [], ExpectedPresetCount: 4, ExpectedVendorCount: 2 },
+      { Aircraft: [], ExpectedPresetCount: 5, ExpectedVendorCount: 2 },
       {
         Aircraft: [{ Vendor: "Microsoft", Name: "Generic" }],
-        ExpectedPresetCount: 2,
+        ExpectedPresetCount: 3,
         ExpectedVendorCount: 1,
       },
     ]
@@ -2212,7 +2212,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
       name: "Reset filters",
     })
     await resetFiltersButton.click()
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("7 preset(s) found")
 
     // Filter by exact preset label -> 1 preset should be found
     await filterInput.fill("land_alt_press_dn")
@@ -2224,7 +2224,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     // Clear the filter -> all presets should be found
     await filterInput.fill("")
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("7 preset(s) found")
   })
 
   test("Selecting a preset updates the code field and input type", async ({
@@ -2298,7 +2298,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     // now reset all filters to show all options
     await resetFiltersButton.click()
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("7 preset(s) found")
 
     const optionsList = page.getByRole("listbox")
 
@@ -2315,7 +2315,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await vendorOption.click()
     await expect(vendorOption).not.toBeVisible()
 
-    await expect(countLabel).toHaveText("3 preset(s) found")
+    await expect(countLabel).toHaveText("4 preset(s) found")
 
     // Select an aircraft filter
     await actionEditor
@@ -2348,7 +2348,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await expect(resetFiltersButton).toBeVisible()
     await resetFiltersButton.click()
 
-    await expect(countLabel).toHaveText("4 preset(s) found")
+    await expect(countLabel).toHaveText("7 preset(s) found")
   })
 
   test("Preset list honors aircraft settings", async ({
@@ -2356,7 +2356,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     page,
   }) => {
     const testSettings = [
-      { Aircraft: [], ExpectedPresetCount: 4, ExpectedVendorCount: 2 },
+      { Aircraft: [], ExpectedPresetCount: 7, ExpectedVendorCount: 3 },
       {
         Aircraft: [{ Vendor: "Laminar Research", Name: "Boeing 737-800" }],
         ExpectedPresetCount: 2,

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
@@ -60,5 +60,20 @@
     "reported": null,
     "score": null,
     "id": "cf0526c0-da69-404f-a570-9f9d54d2803c"
+  },
+  {
+    "path": "Microsoft.Generic.Controls.Axis Elevator Set",
+    "vendor": "Microsoft",
+    "aircraft": "Generic",
+    "system": "Controls",
+    "code": "@ 32.0293 * 16383 - -16383 max 16383 min (>K:AXIS_ELEVATOR_SET)",
+    "label": "Axis Elevator Set",
+    "presetType": "Input (Potentiometer)",
+    "status": "Submitted",
+    "createdDate": "2022-03-29T00:28:58.661Z",
+    "author": "Jaime Leon",
+    "description": "New axis event.  Sets elevator position (-16383 to +16383)\nIntended for potentiometer analog input.\n",
+    "version": 1,
+    "id": "b97129fa-9955-4da9-a40b-d7cd03dad49b"
   }
 ]

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/xplanepresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/xplanepresets.testdata.json
@@ -54,5 +54,50 @@
     "createdDate": "2021-08-01T00:00:00.000Z",
     "presetType": "input",
     "codeType": "DataRef"
+  },
+  {
+    "id": "xp-004",
+    "vendor": "ACME Vendor",
+    "aircraft": "Boeing 737-800",
+    "system": "Instruments",
+    "label": "another_dataref",
+    "description": "Test DataRef Preset 2",
+    "code": "laminar/B738/test/dataref",
+    "version": 1,
+    "status": "Submitted",
+    "createdDate": "2021-08-01T00:00:00.000Z",
+    "presetType": "input",
+    "codeType": "DataRef"
+  },
+  {
+    "vendor": "Laminar Research",
+    "aircraft": "AKD G650",
+    "system": "Lights",
+    "label": "AKD/Lights/left_console_switch",
+    "code": "AKD/Lights/left_console_switch",
+    "presetType": "Input (Potentiometer)",
+    "codeType": "DataRef",
+    "status": "Updated",
+    "createdDate": "2025-02-04T20:51:26.411Z",
+    "author": "Marvin Brooks",
+    "updatedBy": "Marvin Brooks",
+    "description": "Controls Left Console PNL LTS",
+    "version": 3,
+    "id": "93d16953-5a4d-4130-805f-4c8d66f9cd02"
+  },
+  {
+    "vendor": "IXEG",
+    "aircraft": "B737-300",
+    "system": "Autopilot",
+    "code": "ixeg/733/MCP/mcp_vs_dial_ann",
+    "label": "IXEG B733 MCP VS Display",
+    "presetType": "InputOutput",
+    "codeType": "DataRef",
+    "status": "Submitted",
+    "createdDate": "2025-06-06T12:25:50.983Z",
+    "author": "Andrew Spink",
+    "description": "MCP VS Display can be used as output & input",
+    "version": 1,
+    "id": "94100694-dda7-4c08-8130-c58f16712d06"
   }
 ]

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/xplanepresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/xplanepresets.testdata.json
@@ -56,20 +56,6 @@
     "codeType": "DataRef"
   },
   {
-    "id": "xp-004",
-    "vendor": "ACME Vendor",
-    "aircraft": "Boeing 737-800",
-    "system": "Instruments",
-    "label": "another_dataref",
-    "description": "Test DataRef Preset 2",
-    "code": "laminar/B738/test/dataref",
-    "version": 1,
-    "status": "Submitted",
-    "createdDate": "2021-08-01T00:00:00.000Z",
-    "presetType": "input",
-    "codeType": "DataRef"
-  },
-  {
     "vendor": "Laminar Research",
     "aircraft": "AKD G650",
     "system": "Lights",


### PR DESCRIPTION
### Summary
Input for potentiometers are also displayed now (like in the old dialog).

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Presets with "Input (potentiometer)" type are displayed
  - [x] MSFS
  - [x] XPlane

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] Frontend tests
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3097