### PR TITLE
Fix scan for input for input multiplexer and input shift register

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
@@ -381,12 +381,12 @@ namespace MobiFlight
 
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
-                        Controller = new Base.Controller() { Serial = Serial, Name = Name },
-                        Device = new Base.DeviceReference() { Type = POV[index].Type, Name = POV[index].Name, Label = POV[index].Label },
+                        Controller = new Controller() { Serial = Serial, Name = Name },
+                        Device = new DeviceReference() { Type = POV[index].Type, Name = POV[index].Name, Label = POV[index].Label },
                         InputType = DeviceType.Button,
                         Value = (int)MobiFlightButton.InputEvent.RELEASE
                     });
-                }
+                }   
                 ;
 
                 if (newValue > -1)
@@ -396,8 +396,8 @@ namespace MobiFlight
 
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
-                        Controller = new Base.Controller() { Serial = Serial, Name = Name },
-                        Device = new Base.DeviceReference() { Type = POV[index].Type, Name = POV[index].Name, Label = POV[index].Label },
+                        Controller = new Controller() { Serial = Serial, Name = Name },
+                        Device = new DeviceReference() { Type = POV[index].Type, Name = POV[index].Name, Label = POV[index].Label },
                         InputType = DeviceType.Button,
                         Value = (int)MobiFlightButton.InputEvent.PRESS
                     });
@@ -421,8 +421,8 @@ namespace MobiFlight
                 if (!StateExists() || oldValue != newValue)
                     OnButtonPressed?.Invoke(this, new InputEventArgs()
                     {
-                        Controller = new Base.Controller() { Name = this.Name, Serial = this.Serial },
-                        Device = new Base.DeviceReference() { Type = Axes[CurrentAxis].Type, Name = Axes[CurrentAxis].Name, Label = Axes[CurrentAxis].Label },
+                        Controller = new Controller() { Name = this.Name, Serial = this.Serial },
+                        Device = new DeviceReference() { Type = Axes[CurrentAxis].Type, Name = Axes[CurrentAxis].Name, Label = Axes[CurrentAxis].Label },
                         InputType = DeviceType.AnalogInput,
                         Value = newValue
                     });
@@ -440,8 +440,8 @@ namespace MobiFlight
                     if (newState.Buttons[i] || (State != null))
                         OnButtonPressed?.Invoke(this, new InputEventArgs()
                         {
-                            Controller = new Base.Controller() { Name = this.Name, Serial = this.Serial },
-                            Device = new Base.DeviceReference() { Type = Buttons[i].Type, Name = Buttons[i].Name, Label = Buttons[i].Label },
+                            Controller = new Controller() { Name = this.Name, Serial = this.Serial },
+                            Device = new DeviceReference() { Type = Buttons[i].Type, Name = Buttons[i].Name, Label = Buttons[i].Label },
                             InputType = DeviceType.Button,
                             Value = newState.Buttons[i] ? 0 : 1
                         });

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
@@ -612,8 +612,8 @@ namespace MobiFlight
             if (OnInputDeviceAction != null)
                 OnInputDeviceAction(this, new InputEventArgs()
                 {
-                    Controller = new Base.Controller() { Serial = this.Serial, Name = this.Name },
-                    Device = new Base.DeviceReference() {Type = DeviceType.Encoder, Name = enc, Label = enc},
+                    Controller = new Controller() { Serial = this.Serial, Name = this.Name },
+                    Device = new DeviceReference() {Type = DeviceType.Encoder, Name = enc, Label = enc},
                     InputType = DeviceType.Encoder,
                     Value = value
                 });
@@ -641,8 +641,8 @@ namespace MobiFlight
             if (OnInputDeviceAction != null)
                 OnInputDeviceAction(this, new InputEventArgs()
                 {
-                    Controller = new Base.Controller() { Serial = this.Serial, Name = Name },
-                    Device = new Base.DeviceReference() { Type = DeviceType.Button, Name = $"{deviceId}:{strChannel}", Label = $"{deviceId}:{strChannel}" },
+                    Controller = new Controller() { Serial = this.Serial, Name = Name },
+                    Device = new DeviceReference() { Type = DeviceType.Button, Name = $"{deviceId}:{strChannel}", Label = $"{deviceId}:{strChannel}" },
                     InputType = DeviceType.Button,
                     Value = state
                 });
@@ -690,8 +690,8 @@ namespace MobiFlight
 
             OnInputDeviceAction?.Invoke(this, new InputEventArgs()
             {
-                Controller = new Base.Controller() { Serial = this.Serial, Name = Name },
-                Device = new Base.DeviceReference() { Type = DeviceType.Button, Name = button, Label = button },
+                Controller = new Controller() { Serial = this.Serial, Name = Name },
+                Device = new DeviceReference() { Type = DeviceType.Button, Name = button, Label = button },
                 InputType = DeviceType.Button,
                 Value = state
             });
@@ -711,8 +711,8 @@ namespace MobiFlight
             
             OnInputDeviceAction?.Invoke(this, new InputEventArgs()
             {
-                Controller = new Base.Controller() { Serial = this.Serial, Name = Name },
-                Device = new Base.DeviceReference() { Type = DeviceType.AnalogInput, Name = name, Label = name },
+                Controller = new Controller() { Serial = this.Serial, Name = Name },
+                Device = new DeviceReference() { Type = DeviceType.AnalogInput, Name = name, Label = name },
                 InputType = DeviceType.AnalogInput,
                 Value = value
             });

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
@@ -642,7 +642,7 @@ namespace MobiFlight
                 OnInputDeviceAction(this, new InputEventArgs()
                 {
                     Controller = new Base.Controller() { Serial = this.Serial, Name = Name },
-                    Device = new Base.DeviceReference() { Type = DeviceType.InputShiftRegister, Name = $"{deviceId}:{strChannel}", Label = $"{deviceId} - {strChannel}" },
+                    Device = new Base.DeviceReference() { Type = DeviceType.Button, Name = $"{deviceId}:{strChannel}", Label = $"{deviceId}:{strChannel}" },
                     InputType = DeviceType.Button,
                     Value = state
                 });
@@ -665,12 +665,12 @@ namespace MobiFlight
                 Log.Instance.log($"Unable to convert {strState} to an integer.", LogSeverity.Error);
                 return;
             }
-
+            
             if (OnInputDeviceAction != null)
                 OnInputDeviceAction(this, new InputEventArgs()
                 {
-                    Controller = new Base.Controller() { Serial = this.Serial, Name = Name },
-                    Device = new Base.DeviceReference() { Type = DeviceType.InputMultiplexer, Name = $"{deviceId}:{subId}", Label = $"{deviceId} - {subId}" },
+                    Controller = new Controller() { Serial = this.Serial, Name = Name },
+                    Device =  new DeviceReference() { Type = DeviceType.Button, Name = $"{deviceId}:{subId}", Label = $"{deviceId}:{subId}" },
                     InputType = DeviceType.Button,
                     Value = state
                 });

--- a/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleTests.cs
@@ -1,7 +1,9 @@
+using CommandMessenger;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace MobiFlight.Tests
 {
@@ -333,7 +335,6 @@ namespace MobiFlight.Tests
             Assert.Fail();
         }
 
-
         [TestMethod()]
         [Ignore]
         public void GetPinsTest()
@@ -359,6 +360,202 @@ namespace MobiFlight.Tests
             // Dev Build
             o.Version = "0.0.1";
             Assert.IsFalse(o.FirmwareRequiresUpdate(), "Firmware version does NOT require update. Dev Build 0.0.1");
+        }
+
+        [TestMethod()]
+        public void Encoder_RaisesCorrectButtonEvent()
+        {
+            BoardDefinitions.LoadDefinitions();
+
+            var board = BoardDefinitions.GetBoardByMobiFlightType("MobiFlight Mega");
+
+            var module = new MobiFlightModule("COM1", board)
+            {
+                Serial = "SN-123-123",
+                Name = "TestBoard",
+                // These two fields make it a MobiFlight Board
+                // It will report the MobiFlight Type instead of the Arduino Type
+                CoreVersion = "1.0.0",
+                Version = "1.0.0"
+            };
+
+            InputEventArgs capturedArgs = null;
+            module.OnInputDeviceAction += (sender, e) => capturedArgs = e;
+
+            var command = new ReceivedCommand(new string[] {
+                "6", // EncoderChange
+                "Encoder",
+                "0"
+            });
+
+            var methodInfo = typeof(MobiFlightModule).GetMethod("OnEncoderChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            methodInfo.Invoke(module, new object[] { command });
+
+            // Assert
+            Assert.IsNotNull(capturedArgs, "OnInputDeviceAction was not raised.");
+            Assert.AreEqual(DeviceType.Encoder, capturedArgs.InputType, "Encoder should be reported as Encoder type");
+            Assert.AreEqual(DeviceType.Encoder, capturedArgs.Device.Type, "Encoder should be reported as Encoder events");
+            Assert.AreEqual("Encoder", capturedArgs.Device.Name, "Encoder have name");
+            Assert.AreEqual(0, capturedArgs.Value, "Encoder should report 0 (ON LEFT)");
+            Assert.AreEqual("SN-123-123", capturedArgs.Controller.Serial, "Controller serial should match");
+            Assert.AreEqual("TestBoard", capturedArgs.Controller.Name, "Controller name should match");
+        }
+
+        [TestMethod()]
+        public void InputMultiplexerChange_RaisesCorrectButtonEvent()
+        {
+            BoardDefinitions.LoadDefinitions();
+
+            var board = BoardDefinitions.GetBoardByMobiFlightType("MobiFlight Mega");
+
+            var module = new MobiFlightModule("COM1", board) {
+                Serial = "SN-123-123",
+                Name = "TestBoard",
+                // These two fields make it a MobiFlight Board
+                // It will report the MobiFlight Type instead of the Arduino Type
+                CoreVersion = "1.0.0",
+                Version = "1.0.0"
+            };
+
+            InputEventArgs capturedArgs = null;
+            module.OnInputDeviceAction += (sender, e) => capturedArgs = e;
+
+            var command = new ReceivedCommand(new string[] {
+                "30",
+                "InputMultiplexer",
+                "2",
+                "0"
+            });
+
+            var methodInfo = typeof(MobiFlightModule).GetMethod("OnInputMultiplexerChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            methodInfo.Invoke(module, new object[] { command });
+
+            // Assert
+            Assert.IsNotNull(capturedArgs, "OnInputDeviceAction was not raised.");
+            Assert.AreEqual(DeviceType.Button, capturedArgs.InputType, "Input Multiplexer should be reported as Button type");
+            Assert.AreEqual(DeviceType.Button, capturedArgs.Device.Type, "Input Multiplexer should be reported as Button events");
+            Assert.AreEqual("InputMultiplexer:2", capturedArgs.Device.Name, "Input Multiplexer have name and sub-pin combined");
+            Assert.AreEqual(0, capturedArgs.Value, "Input Multiplexer should report 0 (ON PRESS)");
+            Assert.AreEqual("SN-123-123", capturedArgs.Controller.Serial, "Controller serial should match");
+            Assert.AreEqual("TestBoard", capturedArgs.Controller.Name, "Controller name should match");
+        }
+
+        [TestMethod()]
+        public void InputShiftRegisterChange_RaisesCorrectButtonEvent()
+        {
+            BoardDefinitions.LoadDefinitions();
+
+            var board = BoardDefinitions.GetBoardByMobiFlightType("MobiFlight Mega");
+
+            var module = new MobiFlightModule("COM1", board)
+            {
+                Serial = "SN-123-123",
+                Name = "TestBoard",
+                // These two fields make it a MobiFlight Board
+                // It will report the MobiFlight Type instead of the Arduino Type
+                CoreVersion = "1.0.0",
+                Version = "1.0.0"
+            };
+
+            InputEventArgs capturedArgs = null;
+            module.OnInputDeviceAction += (sender, e) => capturedArgs = e;
+
+            var command = new ReceivedCommand(new string[] {
+                "29",
+                "InputShiftRegister",
+                "2",
+                "0"
+            });
+
+            var methodInfo = typeof(MobiFlightModule).GetMethod("OnInputShiftRegisterChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            methodInfo.Invoke(module, new object[] { command });
+
+            // Assert
+            Assert.IsNotNull(capturedArgs, "OnInputDeviceAction was not raised.");
+            Assert.AreEqual(DeviceType.Button, capturedArgs.InputType, "Input Shift Register should be reported as Button type");
+            Assert.AreEqual(DeviceType.Button, capturedArgs.Device.Type, "Input Shift Register should be reported as Button events");
+            Assert.AreEqual("InputShiftRegister:2", capturedArgs.Device.Name, "Input Shift Register have name and sub-pin combined");
+            Assert.AreEqual(0, capturedArgs.Value, "Input Shift Register should report 0 (ON PRESS)");
+            Assert.AreEqual("SN-123-123", capturedArgs.Controller.Serial, "Controller serial should match");
+            Assert.AreEqual("TestBoard", capturedArgs.Controller.Name, "Controller name should match");
+        }
+
+        [TestMethod()]
+        public void Button_RaisesCorrectButtonEvent()
+        {
+            BoardDefinitions.LoadDefinitions();
+
+            var board = BoardDefinitions.GetBoardByMobiFlightType("MobiFlight Mega");
+
+            var module = new MobiFlightModule("COM1", board)
+            {
+                Serial = "SN-123-123",
+                Name = "TestBoard",
+                // These two fields make it a MobiFlight Board
+                // It will report the MobiFlight Type instead of the Arduino Type
+                CoreVersion = "1.0.0",
+                Version = "1.0.0"
+            };
+
+            InputEventArgs capturedArgs = null;
+            module.OnInputDeviceAction += (sender, e) => capturedArgs = e;
+
+            var command = new ReceivedCommand(new string[] {
+                "7", // ButtonChange
+                "Button",
+                "0"
+            });
+
+            var methodInfo = typeof(MobiFlightModule).GetMethod("OnButtonChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            methodInfo.Invoke(module, new object[] { command });
+
+            // Assert
+            Assert.IsNotNull(capturedArgs, "OnInputDeviceAction was not raised.");
+            Assert.AreEqual(DeviceType.Button, capturedArgs.InputType, "Button should be reported as Button type");
+            Assert.AreEqual(DeviceType.Button, capturedArgs.Device.Type, "Button should be reported as Button events");
+            Assert.AreEqual("Button", capturedArgs.Device.Name, "Button have name");
+            Assert.AreEqual(0, capturedArgs.Value, "Button should report 0 (ON PRESS)");
+            Assert.AreEqual("SN-123-123", capturedArgs.Controller.Serial, "Controller serial should match");
+            Assert.AreEqual("TestBoard", capturedArgs.Controller.Name, "Controller name should match");
+        }
+
+        [TestMethod()]
+        public void AnalogInput_RaisesCorrectButtonEvent()
+        {
+            BoardDefinitions.LoadDefinitions();
+
+            var board = BoardDefinitions.GetBoardByMobiFlightType("MobiFlight Mega");
+
+            var module = new MobiFlightModule("COM1", board)
+            {
+                Serial = "SN-123-123",
+                Name = "TestBoard",
+                // These two fields make it a MobiFlight Board
+                // It will report the MobiFlight Type instead of the Arduino Type
+                CoreVersion = "1.0.0",
+                Version = "1.0.0"
+            };
+
+            InputEventArgs capturedArgs = null;
+            module.OnInputDeviceAction += (sender, e) => capturedArgs = e;
+
+            var command = new ReceivedCommand(new string[] {
+                "28", // AnalogChange
+                "AnalogInput",
+                "768"
+            });
+
+            var methodInfo = typeof(MobiFlightModule).GetMethod("OnAnalogChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            methodInfo.Invoke(module, new object[] { command });
+
+            // Assert
+            Assert.IsNotNull(capturedArgs, "OnInputDeviceAction was not raised.");
+            Assert.AreEqual(DeviceType.AnalogInput, capturedArgs.InputType, "AnalogInput should be reported as Analog type");
+            Assert.AreEqual(DeviceType.AnalogInput, capturedArgs.Device.Type, "AnalogInput should be reported as Analog events");
+            Assert.AreEqual("AnalogInput", capturedArgs.Device.Name, "AnalogInput have name");
+            Assert.AreEqual(768, capturedArgs.Value, "AnalogInput should report 768");
+            Assert.AreEqual("SN-123-123", capturedArgs.Controller.Serial, "Controller serial should match");
+            Assert.AreEqual("TestBoard", capturedArgs.Controller.Name, "Controller name should match");
         }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleTests.cs
@@ -363,7 +363,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void Encoder_RaisesCorrectButtonEvent()
+        public void Encoder_RaisesCorrectEncoderInputEvent()
         {
             BoardDefinitions.LoadDefinitions();
 
@@ -389,6 +389,7 @@ namespace MobiFlight.Tests
             });
 
             var methodInfo = typeof(MobiFlightModule).GetMethod("OnEncoderChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(methodInfo, "Expected private method OnEncoderChange to exist.");
             methodInfo.Invoke(module, new object[] { command });
 
             // Assert
@@ -402,7 +403,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void InputMultiplexerChange_RaisesCorrectButtonEvent()
+        public void InputMultiplexerChange_RaisesCorrectButtonInputEvent()
         {
             BoardDefinitions.LoadDefinitions();
 
@@ -428,6 +429,7 @@ namespace MobiFlight.Tests
             });
 
             var methodInfo = typeof(MobiFlightModule).GetMethod("OnInputMultiplexerChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(methodInfo, "Expected private method OnInputMultiplexerChange to exist.");
             methodInfo.Invoke(module, new object[] { command });
 
             // Assert
@@ -441,7 +443,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void InputShiftRegisterChange_RaisesCorrectButtonEvent()
+        public void InputShiftRegisterChange_RaisesCorrectButtonInputEvent()
         {
             BoardDefinitions.LoadDefinitions();
 
@@ -468,6 +470,7 @@ namespace MobiFlight.Tests
             });
 
             var methodInfo = typeof(MobiFlightModule).GetMethod("OnInputShiftRegisterChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(methodInfo, "Expected private method OnInputShiftRegisterChange to exist.");
             methodInfo.Invoke(module, new object[] { command });
 
             // Assert
@@ -481,7 +484,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void Button_RaisesCorrectButtonEvent()
+        public void Button_RaisesCorrectButtonInputEvent()
         {
             BoardDefinitions.LoadDefinitions();
 
@@ -507,6 +510,7 @@ namespace MobiFlight.Tests
             });
 
             var methodInfo = typeof(MobiFlightModule).GetMethod("OnButtonChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(methodInfo, "Expected private method OnButtonChange to exist.");
             methodInfo.Invoke(module, new object[] { command });
 
             // Assert
@@ -520,7 +524,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void AnalogInput_RaisesCorrectButtonEvent()
+        public void AnalogInput_RaisesCorrectAnalogInputEvent()
         {
             BoardDefinitions.LoadDefinitions();
 
@@ -546,6 +550,7 @@ namespace MobiFlight.Tests
             });
 
             var methodInfo = typeof(MobiFlightModule).GetMethod("OnAnalogChange", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(methodInfo, "Expected private method OnAnalogChange to exist.");
             methodInfo.Invoke(module, new object[] { command });
 
             // Assert


### PR DESCRIPTION
### Summary
During #3030 we forgot to use the correct Device Type for Input Multiplexer and Input Shift Register when using Scan for input

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Scan for input works correctly
  - [x] Input shift register
  - [x] Input multiplexer

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [x] ~~Frontend tests~~
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
related to #3030