### PR TITLE
WingFlex DAP500 - Fix photo sensor value reading

### DIFF
--- a/src/MobiFlightConnector/Joysticks/wingflex/wingflex_dap500.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/wingflex/wingflex_dap500.joystick.json
@@ -103,6 +103,11 @@
       "Id": 20,
       "Type": "Button",
       "Label": "ALT"
+    },
+    {
+      "Id": 48,
+      "Type": "Axis",
+      "Label": "Light Sensor"
     }
   ],
   "Outputs": [

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/Dap500Report.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/Dap500Report.cs
@@ -72,8 +72,8 @@ namespace MobiFlight.Joysticks.WingFlex
             }
 
             // Axes
-            // Background Light Brightness
-            state.X = LastInputBufferState[3];  // Light sensor value
+            // Light sensor value
+            state.X = LastInputBufferState[4];
 
             return state;
         }

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/Dap500Report.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/WingFlex/Dap500Report.cs
@@ -5,7 +5,7 @@ namespace MobiFlight.Joysticks.WingFlex
 {
     internal class Dap500Report
     {
-        private byte[] LastInputBufferState = new byte[4];
+        private byte[] LastInputBufferState = new byte[5];
         
         public Dap500Report() {}
 

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/Dap500ReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/Dap500ReportTests.cs
@@ -15,7 +15,6 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         }
 
         #region Parse Tests
-
         [TestMethod]
         public void Parse_ValidInputBuffer_ReturnsNewReportInstance()
         {
@@ -59,6 +58,27 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
 
             // Act & Assert - Should throw exception
             Assert.ThrowsExactly<ArgumentException>(() => _report.Parse(inputBuffer));
+        }
+        #endregion
+
+        #region Dap Input Report Tests
+        [TestMethod]
+        public void DapInputReport_SensorValueReportedCorrectly()
+        {
+            // Arrange
+            var inputBuffer = CreateValidInputBuffer();
+            inputBuffer[4] = 128;
+
+            var result = _report.Parse(inputBuffer).ToJoystickState();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(128, result.X);
+
+            // Verify with another value to make sure
+            // we are looking at the correct byte in the buffer
+            inputBuffer[4] = 15;
+            result = _report.Parse(inputBuffer).ToJoystickState();
+            Assert.IsNotNull(result);
+            Assert.AreEqual(15, result.X);
         }
         #endregion
 

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/Dap500ReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/WingFlex/Dap500ReportTests.cs
@@ -69,6 +69,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             var inputBuffer = CreateValidInputBuffer();
             inputBuffer[4] = 128;
 
+            // Act
             var result = _report.Parse(inputBuffer).ToJoystickState();
             Assert.IsNotNull(result);
             Assert.AreEqual(128, result.X);
@@ -86,7 +87,7 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         [TestMethod]
         public void DapConfig_HasCorrectDefaultValues()
         {
-            // Act
+            // Arrange
             var config = new DapConfig();
             // Assert
             Assert.IsNotNull(config);
@@ -98,10 +99,13 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         [TestMethod]
         public void DapConfig_ToData_ReturnsExpectedValue_ForDefaultValues()
         {
-            // Act
+            // Arrange
             var config = new DapConfig();
+            
+            // Act
             var byteData = config.ToData;
             var expectedReportId = (byte)4;
+            
             // Assert
             Assert.IsNotNull(config);
             Assert.AreEqual(expectedReportId, DapConfig.ReportId);
@@ -117,14 +121,16 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         [TestMethod]
         public void DapConfig_ToData_ReturnsExpectedValue_ForAutoBackLightEnabled()
         {
-            // Act
+            // Arrange
             var config = new DapConfig()
             {
                 AutoBackLightEnabled = true
             };
 
+            // Act
             var byteData = config.ToData;
             var expectedReportId = (byte)4;
+            
             // Assert
             Assert.IsNotNull(config);
             Assert.AreEqual(expectedReportId, DapConfig.ReportId);
@@ -140,14 +146,16 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         [TestMethod]
         public void DapConfig_ToData_ReturnsExpectedValue_ForLightSensorEnabled()
         {
-            // Act
+            // Arrange
             var config = new DapConfig()
             {
                 LightSensorEnabled = true
             };
 
+            // Act
             var byteData = config.ToData;
             var expectedReportId = (byte)4;
+            
             // Assert
             Assert.IsNotNull(config);
             Assert.AreEqual(expectedReportId, DapConfig.ReportId);
@@ -163,13 +171,15 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
         [TestMethod]
         public void DapConfig_ToData_ReturnsExpectedValue_ForAutoStandByTimeout()
         {
-            // Act
+            // Arrange
             var config = new DapConfig()
             {
                 AutoStandByTimeout = ushort.MaxValue
             };
 
+            // Act
             var byteData = config.ToData;
+            
             // Assert
             Assert.IsNotNull(config);
             Assert.AreEqual(DapConfig.ReportId, byteData[0]);
@@ -178,9 +188,12 @@ namespace MobiFlight.Joysticks.WingFlex.Tests
             Assert.AreEqual(0xFF, byteData[3]);
             Assert.AreEqual(0xFF, byteData[4]);
 
+            // Arange
             config.AutoStandByTimeout = 511;
 
+            // Act
             byteData = config.ToData;
+            
             // Assert
             Assert.IsNotNull(config);
             Assert.AreEqual(DapConfig.ReportId, byteData[0]);


### PR DESCRIPTION
### Summary
Fixes the missing photo sensor reading

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Photo sensor reports value via Axis X

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3084