### PR TITLE
Only show one default aircraft for MSFS

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
@@ -42,7 +42,6 @@ const ProjectForm = ({
 }: ProjectFormProps) => {
   const defaultAircraft = {
     msfs: [
-      { Vendor: "Asobo", Name: "Generic" },
       { Vendor: "Microsoft", Name: "Generic" },
     ],
     xplane: [{ Vendor: "Laminar Research", Name: "Generic" }],

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -305,7 +305,6 @@ test.describe("Project settings modal features", () => {
         fsuipc: { click: false, use: false },
         prosim: { click: false, use: false },
         aircraft: [
-          { Vendor: "Asobo", Name: "Generic" },
           { Vendor: "Microsoft", Name: "Generic" },
         ],
       },
@@ -316,7 +315,6 @@ test.describe("Project settings modal features", () => {
         fsuipc: { click: true, use: true },
         prosim: { click: false, use: false },
         aircraft: [
-          { Vendor: "Asobo", Name: "Generic" },
           { Vendor: "Microsoft", Name: "Generic" },
         ],
       },
@@ -351,7 +349,6 @@ test.describe("Project settings modal features", () => {
         fsuipc: { click: false, use: false },
         prosim: { click: true, use: true },
         aircraft: [
-          { Vendor: "Asobo", Name: "Generic" },
           { Vendor: "Microsoft", Name: "Generic" },
         ],
       },
@@ -591,9 +588,7 @@ test.describe("Project settings modal features", () => {
 
     // verify badges are showing
     const msGenericBadge = createProjectDialog.getByText("Microsoft - Generic")
-    const asoboGenericBadge = createProjectDialog.getByText("Asobo - Generic")
     await expect(msGenericBadge).toBeVisible()
-    await expect(asoboGenericBadge).toBeVisible()
 
     const editAircraftButton = createProjectDialog.getByRole("button", {
       name: "Edit aircraft list",
@@ -612,25 +607,43 @@ test.describe("Project settings modal features", () => {
     const selectedAircraftOptions = selectedAircraftList.getByRole("option")
     const availableAircraftOptions = availableAircraftList.getByRole("option")
 
-    
-    
+    // Verify initial state of aircraft lists
     await expect(selectedAircraftList).toBeVisible()
     await expect(availableAircraftList).toBeVisible()
-    await expect(selectedAircraftOptions).toHaveCount(2)
+    await expect(selectedAircraftOptions).toHaveCount(1)
     await expect(availableAircraftOptions).toHaveCount(1)
-    
-    await availableAircraftOptions.first().click()
-    await expect(selectedAircraftOptions).toHaveCount(3)
-    await expect(availableAircraftOptions).toHaveCount(0)
 
-    await selectedAircraftOptions.first().click()
+    // Verify clicking on an available aircraft option adds it to the selected list
+    await availableAircraftOptions.first().click()
     await expect(selectedAircraftOptions).toHaveCount(2)
-    await expect(availableAircraftOptions).toHaveCount(1)
-    
+    await expect(availableAircraftOptions).toHaveCount(0)
+    // and a message is displayed
+    await expect(
+      projectAircraftDialog.getByText("No aircraft available.", {
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    // Verify clicking on a selected aircraft option removes it from the selected list
     await selectedAircraftOptions.first().click()
     await expect(selectedAircraftOptions).toHaveCount(1)
+    await expect(availableAircraftOptions).toHaveCount(1)
+
+    await selectedAircraftOptions.first().click()
+    await expect(selectedAircraftOptions).toHaveCount(0)
     await expect(availableAircraftOptions).toHaveCount(2)
+    // and a message is displayed
+    await expect(
+      projectAircraftDialog.getByText("No aircraft selected. No filter will apply. All presets will be available.", {
+        exact: true,
+      }),
+    ).toBeVisible()
+
+    // Now re-add the first available aircraft
+    // so that we can verify that the badge shows correct value
+    await availableAircraftOptions.first().click()
     
+    // Close drawer
     const goBackButton = page.getByRole("button", {
       name: "Go back",
     })
@@ -639,7 +652,6 @@ test.describe("Project settings modal features", () => {
     await expect(projectAircraftDialog).not.toBeVisible()
 
     await expect(msGenericBadge).not.toBeVisible()
-    await expect(asoboGenericBadge).not.toBeVisible()
     const c172Badge = createProjectDialog.getByText("Microsoft - C172")
     await expect(c172Badge).toBeVisible()
 
@@ -647,7 +659,10 @@ test.describe("Project settings modal features", () => {
     // this is covered by the "Create new project in modal" test
   })
 
-  test("Clicking on aircraft list checkbox only adds one aircraft at a time", async ({ dashboardPage, page }) => {
+  test("Clicking on aircraft list checkbox only adds one aircraft at a time", async ({
+    dashboardPage,
+    page,
+  }) => {
     // this was a bug because of two event handlers firing
     // https://github.com/MobiFlight/MobiFlight-Connector/issues/3085
 
@@ -673,7 +688,7 @@ test.describe("Project settings modal features", () => {
       name: "Edit aircraft list",
     })
     const projectAircraftDialog = page.getByTestId("project-aircraft-drawer")
-    
+
     // create a new project with two aircraft selected
     await createProjectButton.click()
     await editAircraftButton.click()
@@ -687,27 +702,27 @@ test.describe("Project settings modal features", () => {
     })
     const selectedAircraftOptions = selectedAircraftList.getByRole("option")
     const availableAircraftOptions = availableAircraftList.getByRole("option")
-    
+
     // verify initial state
     await expect(selectedAircraftList).toBeVisible()
     await expect(availableAircraftList).toBeVisible()
-    await expect(selectedAircraftOptions).toHaveCount(2)
+    await expect(selectedAircraftOptions).toHaveCount(1)
     await expect(availableAircraftOptions).toHaveCount(1)
-    
+
     // explicitly click on the checkbox of the first available aircraft option
     await availableAircraftOptions.first().getByRole("checkbox").click()
 
-    // only one aircraft should be added to the selected list, and 
+    // only one aircraft should be added to the selected list, and
     // the available list should be empty
-    await expect(selectedAircraftOptions).toHaveCount(3)
+    await expect(selectedAircraftOptions).toHaveCount(2)
     await expect(availableAircraftOptions).toHaveCount(0)
 
     // explicitly click on the checkbox of the first selected aircraft option
     await selectedAircraftOptions.first().getByRole("checkbox").click()
 
-    // only one aircraft should be removed from the selected list, and 
+    // only one aircraft should be removed from the selected list, and
     // the available list should have one aircraft
-    await expect(selectedAircraftOptions).toHaveCount(2)
+    await expect(selectedAircraftOptions).toHaveCount(1)
     await expect(availableAircraftOptions).toHaveCount(1)
   })
 })

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -611,11 +611,14 @@ test.describe("Project settings modal features", () => {
     await expect(selectedAircraftList).toBeVisible()
     await expect(availableAircraftList).toBeVisible()
     await expect(selectedAircraftOptions).toHaveCount(1)
-    await expect(availableAircraftOptions).toHaveCount(1)
+    await expect(availableAircraftOptions).toHaveCount(2)
 
     // Verify clicking on an available aircraft option adds it to the selected list
     await availableAircraftOptions.first().click()
     await expect(selectedAircraftOptions).toHaveCount(2)
+    await expect(availableAircraftOptions).toHaveCount(1)
+    await availableAircraftOptions.first().click()
+    await expect(selectedAircraftOptions).toHaveCount(3)
     await expect(availableAircraftOptions).toHaveCount(0)
     // and a message is displayed
     await expect(
@@ -626,12 +629,13 @@ test.describe("Project settings modal features", () => {
 
     // Verify clicking on a selected aircraft option removes it from the selected list
     await selectedAircraftOptions.first().click()
-    await expect(selectedAircraftOptions).toHaveCount(1)
+    await expect(selectedAircraftOptions).toHaveCount(2)
     await expect(availableAircraftOptions).toHaveCount(1)
 
     await selectedAircraftOptions.first().click()
+    await selectedAircraftOptions.first().click()
     await expect(selectedAircraftOptions).toHaveCount(0)
-    await expect(availableAircraftOptions).toHaveCount(2)
+    await expect(availableAircraftOptions).toHaveCount(3)
     // and a message is displayed
     await expect(
       projectAircraftDialog.getByText("No aircraft selected. No filter will apply. All presets will be available.", {
@@ -707,23 +711,23 @@ test.describe("Project settings modal features", () => {
     await expect(selectedAircraftList).toBeVisible()
     await expect(availableAircraftList).toBeVisible()
     await expect(selectedAircraftOptions).toHaveCount(1)
-    await expect(availableAircraftOptions).toHaveCount(1)
+    await expect(availableAircraftOptions).toHaveCount(2)
 
     // explicitly click on the checkbox of the first available aircraft option
     await availableAircraftOptions.first().getByRole("checkbox").click()
 
     // only one aircraft should be added to the selected list, and
-    // the available list should be empty
+    // the available list should be showing one less aircraft
     await expect(selectedAircraftOptions).toHaveCount(2)
-    await expect(availableAircraftOptions).toHaveCount(0)
+    await expect(availableAircraftOptions).toHaveCount(1)
 
     // explicitly click on the checkbox of the first selected aircraft option
     await selectedAircraftOptions.first().getByRole("checkbox").click()
 
     // only one aircraft should be removed from the selected list, and
-    // the available list should have one aircraft
+    // the available list should have one more aircraft
     await expect(selectedAircraftOptions).toHaveCount(1)
-    await expect(availableAircraftOptions).toHaveCount(1)
+    await expect(availableAircraftOptions).toHaveCount(2)
   })
 })
 

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -633,6 +633,9 @@ test.describe("Project settings modal features", () => {
     await expect(availableAircraftOptions).toHaveCount(1)
 
     await selectedAircraftOptions.first().click()
+    await expect(selectedAircraftOptions).toHaveCount(1)
+    await expect(availableAircraftOptions).toHaveCount(2)
+    
     await selectedAircraftOptions.first().click()
     await expect(selectedAircraftOptions).toHaveCount(0)
     await expect(availableAircraftOptions).toHaveCount(3)
@@ -693,7 +696,7 @@ test.describe("Project settings modal features", () => {
     })
     const projectAircraftDialog = page.getByTestId("project-aircraft-drawer")
 
-    // create a new project with two aircraft selected
+    // create a new project with default aircraft selected
     await createProjectButton.click()
     await editAircraftButton.click()
     await expect(projectAircraftDialog).toBeVisible()

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -1966,7 +1966,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
       .filter({ hasText: "Filter by vendor" })
       .click()
     await expect(optionsList).toBeVisible()
-    const vendorOption = optionsList.getByRole("option", { name: "Microsoft" })
+    const vendorOption = optionsList.getByRole("option", { name: "Microsoft", exact: true })
     await expect(vendorOption).toBeVisible()
     await vendorOption.click()
     await expect(vendorOption).not.toBeVisible()

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
@@ -63,7 +63,7 @@
   },
   {
     "path": "Microsoft.Generic.Controls.Axis Elevator Set",
-    "vendor": "Microsoft",
+    "vendor": "Other than Microsoft",
     "aircraft": "Generic",
     "system": "Controls",
     "code": "@ 32.0293 * 16383 - -16383 max 16383 min (>K:AXIS_ELEVATOR_SET)",

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
@@ -45,8 +45,8 @@
     "description": "Garmin G1000"
   },
   {
-    "path": "Asobo.Generic.Autopilot.AP_PANEL_HEADING_HOLD",
-    "vendor": "Asobo",
+    "path": "Microsoft.Generic.Autopilot.AP_PANEL_HEADING_HOLD",
+    "vendor": "Microsoft",
     "aircraft": "Generic",
     "system": "Autopilot",
     "code": "(>K:AP_PANEL_HEADING_HOLD)",


### PR DESCRIPTION
### Summary
After consolidation of vendor and aircraft categories, we only have one default plane now for generic events in MSFS.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Only one aircraft is representing "generic" events

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Frontend tests
- [x] Documentation (@neilenns)
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3110