### PR TITLE
Project feature settings are restored correctly

### DIFF
--- a/src/MobiFlightConnector/Base/Project.cs
+++ b/src/MobiFlightConnector/Base/Project.cs
@@ -290,8 +290,6 @@ namespace MobiFlight.Base
 
         public void DetermineProjectInfos()
         {
-            Features = new ProjectFeatures();
-
             foreach (var item in ConfigFiles)
             {
                 if (string.IsNullOrEmpty(Sim))

--- a/tests/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using Newtonsoft.Json;
 using System.IO;
 using System.Linq;
 
@@ -475,7 +476,6 @@ namespace MobiFlight.Base.Tests
 
         #endregion
 
-
         #region ProjectInfo Tests
         [TestMethod()]
         public void DetermineProjectInfos_WithEmptyProject_ShouldHaveCorrectDefaults()
@@ -730,6 +730,85 @@ namespace MobiFlight.Base.Tests
             // Assert
             Assert.AreEqual("xplane", project.Sim);
         }
+
+        [TestMethod()]
+        public void DetermineProjectInfos_WithoutInputConfigItems_ShouldStillMaintainProjectSettings()
+        {
+            // Arrange
+            var project = new Project();
+            project.Features.FSUIPC = true;
+            project.Features.ProSim = true;
+
+            var config = new ConfigFile();
+
+            // Act
+            project.DetermineProjectInfos();
+
+            // Assert
+            Assert.IsTrue(project.Features.FSUIPC);
+            Assert.IsTrue(project.Features.ProSim);
+        }
+
+        [TestMethod()]
+        public void ProjectInfos_WithFsuipcEnabled_ShouldSerializeCorrectly()
+        {
+            // Arrange
+            var project = new Project();
+            project.Features.FSUIPC = true;
+
+            // Act
+            var json = JsonConvert.SerializeObject(project);
+            var deserializedProject = JsonConvert.DeserializeObject<Project>(json);
+
+            // Assert
+            Assert.IsTrue(deserializedProject.Features.FSUIPC);
+        }
+
+        [TestMethod()]
+        public void ProjectInfos_WithFsuipcDisabled_ShouldSerializeCorrectly()
+        {
+            // Arrange
+            var project = new Project();
+            project.Features.FSUIPC = false;
+
+            // Act
+            var json = JsonConvert.SerializeObject(project);
+            var deserializedProject = JsonConvert.DeserializeObject<Project>(json);
+
+            // Assert
+            Assert.IsFalse(deserializedProject.Features.FSUIPC);
+        }
+
+        [TestMethod()]
+        public void ProjectInfos_WithProSimEnabled_ShouldSerializeCorrectly()
+        {
+            // Arrange
+            var project = new Project();
+            project.Features.ProSim = true;
+
+            // Act
+            var json = JsonConvert.SerializeObject(project);
+            var deserializedProject = JsonConvert.DeserializeObject<Project>(json);
+
+            // Assert
+            Assert.IsTrue(deserializedProject.Features.ProSim);
+        }
+
+        [TestMethod()]
+        public void ProjectInfos_WithProSimDisabled_ShouldSerializeCorrectly()
+        {
+            // Arrange
+            var project = new Project();
+            project.Features.ProSim = false;
+
+            // Act
+            var json = JsonConvert.SerializeObject(project);
+            var deserializedProject = JsonConvert.DeserializeObject<Project>(json);
+
+            // Assert
+            Assert.IsFalse(deserializedProject.Features.ProSim);
+        }
+
         #endregion
 
         [TestMethod()]
@@ -854,7 +933,6 @@ namespace MobiFlight.Base.Tests
         }
 
         #endregion
-
 
     }
 }

--- a/tests/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -739,8 +739,6 @@ namespace MobiFlight.Base.Tests
             project.Features.FSUIPC = true;
             project.Features.ProSim = true;
 
-            var config = new ConfigFile();
-
             // Act
             project.DetermineProjectInfos();
 


### PR DESCRIPTION
### Summary
Project feature settings are restored correctly even without any config items in the project yet.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Project feature settings are restored correctly on load
- [x] It works without any config items

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3123