### PR TITLE
Auto-expand newly added modifiers in the editor

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierEditor.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierEditor.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Modifier, MODIFIER_TYPES, ModifierFactory } from "@/types/modifier"
 import {
@@ -23,11 +23,26 @@ const ModifierEditor = ({
 }: ModifierEditorProps) => {
   const { t } = useTranslation()
   const modifierTypes = MODIFIER_TYPES
-  const [newlyAddedIndex, setNewlyAddedIndex] = useState<number | null>(null)
+  const [newlyAddedId, setNewlyAddedId] = useState<string | null>(null)
+  const [fallbackIds] = useState(() => new WeakMap<Modifier, string>())
+
+  const modifiersWithIds = useMemo(
+    () =>
+      modifiers.map((modifier) => {
+        if (modifier.Id) return modifier
+        let id = fallbackIds.get(modifier)
+        if (!id) {
+          id = crypto.randomUUID()
+          fallbackIds.set(modifier, id)
+        }
+        return { ...modifier, Id: id }
+      }),
+    [modifiers, fallbackIds],
+  )
 
   const handleAdd = (type: string) => {
     const newModifier = ModifierFactory.createModifier(type)
-    setNewlyAddedIndex(modifiers.length)
+    setNewlyAddedId(newModifier.Id ?? null)
     onModifierChange([...modifiers, newModifier])
   }
   const handleDelete = (index: number) => {
@@ -102,9 +117,9 @@ const ModifierEditor = ({
       ) : (
         <ScrollArea className="grow">
           <div className="flex flex-col gap-2">
-            {modifiers.map((modifier, index) => (
+            {modifiersWithIds.map((modifier, index) => (
               <ModifierItem
-                key={index}
+                key={modifier.Id}
                 modifier={modifier}
                 onChange={(updated) => handleChange(index, updated)}
                 onDelete={() => handleDelete(index)}
@@ -112,7 +127,7 @@ const ModifierEditor = ({
                 onMoveDown={onMoveDown ? () => onMoveDown(index) : undefined}
                 isFirst={index === 0}
                 isLast={index === modifiers.length - 1}
-                defaultOpen={index === newlyAddedIndex}
+                defaultOpen={modifier.Id === newlyAddedId}
               />
             ))}
           </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierEditor.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierEditor.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Modifier, MODIFIER_TYPES, ModifierFactory } from "@/types/modifier"
 import {
@@ -22,9 +23,11 @@ const ModifierEditor = ({
 }: ModifierEditorProps) => {
   const { t } = useTranslation()
   const modifierTypes = MODIFIER_TYPES
+  const [newlyAddedIndex, setNewlyAddedIndex] = useState<number | null>(null)
 
   const handleAdd = (type: string) => {
     const newModifier = ModifierFactory.createModifier(type)
+    setNewlyAddedIndex(modifiers.length)
     onModifierChange([...modifiers, newModifier])
   }
   const handleDelete = (index: number) => {
@@ -109,6 +112,7 @@ const ModifierEditor = ({
                 onMoveDown={onMoveDown ? () => onMoveDown(index) : undefined}
                 isFirst={index === 0}
                 isLast={index === modifiers.length - 1}
+                defaultOpen={index === newlyAddedIndex}
               />
             ))}
           </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierItem.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierItem.tsx
@@ -42,6 +42,7 @@ type ModifierItemProps = {
   onMoveDown?: () => void
   isFirst?: boolean
   isLast?: boolean
+  defaultOpen?: boolean
 }
 
 export const ModifierItem = ({
@@ -52,9 +53,10 @@ export const ModifierItem = ({
   onMoveDown,
   isFirst,
   isLast,
+  defaultOpen,
 }: ModifierItemProps) => {
   const { t } = useTranslation()
-  const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(defaultOpen ?? false)
 
   const modifierContent =
     modifier.Type === "Transformation" ? (

--- a/src/MobiFlightConnector/frontend/src/types/modifier.ts
+++ b/src/MobiFlightConnector/frontend/src/types/modifier.ts
@@ -1,6 +1,7 @@
 export interface IModifier {
   Type: string
   Active: boolean
+  Id?: string
 }
 
 export type ModifierList = {
@@ -65,6 +66,7 @@ export class ModifierFactory {
           Type: "Transformation",
           Active: true,
           Expression: "$",
+          Id: crypto.randomUUID(),
         } as Transformation
       case "Substring":
         return {
@@ -72,6 +74,7 @@ export class ModifierFactory {
           Active: true,
           Start: 0,
           End: 1,
+          Id: crypto.randomUUID(),
         } as Substring
       case "Padding":
         return {
@@ -80,6 +83,7 @@ export class ModifierFactory {
           Length: 5,
           Character: "0",
           Direction: "Left",
+          Id: crypto.randomUUID(),
         } as Padding
       case "Interpolation":
         return {
@@ -89,6 +93,7 @@ export class ModifierFactory {
             0: 0,
             10: 1000,
           },
+          Id: crypto.randomUUID(),
         } as Interpolation
       case "Comparison":
         return {
@@ -98,6 +103,7 @@ export class ModifierFactory {
           Value: "0",
           IfValue: "1",
           ElseValue: "0",
+          Id: crypto.randomUUID(),
         } as Comparison
       case "Blink":
         return {
@@ -105,6 +111,7 @@ export class ModifierFactory {
           Active: true,
           BlinkValue: "0",
           OnOffSequence: [500, 500],
+          Id: crypto.randomUUID(),
         } as Blink
       default:
         throw new Error(`Unknown modifier type: ${type}`)

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -833,9 +833,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
       await expect(transformationOption).toBeVisible()
       await transformationOption.click()
 
-      const modifierHeader = modifierEditor.getByRole("button", {
-        name: modifierLabel,
-      })
+      const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
       await expect(modifierHeader).toBeVisible()
 
       const removeButton = modifierEditor.getByRole("button", {
@@ -1001,11 +999,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await expect(switchToggle).toBeVisible()
     await switchToggle.click()
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded and the input field is visible
     const inputField = modifierEditor.getByRole("textbox", {
@@ -1054,11 +1050,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await expect(switchToggle).toBeVisible()
     await switchToggle.click()
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded
     // Start input field is visible
@@ -1119,11 +1113,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await expect(switchToggle).toBeVisible()
     await switchToggle.click()
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded
     // Length input field is visible
@@ -1223,11 +1215,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await expect(switchToggle).toBeVisible()
     await switchToggle.click()
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded
     // Length input field is visible
@@ -1332,11 +1322,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
       page,
     )
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded
     // Length input field is visible
@@ -1426,11 +1414,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
       page,
     )
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded
     // Length input field is visible
@@ -1489,11 +1475,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await expect(switchToggle).toBeVisible()
     await switchToggle.click()
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded
     // Operator combobox
@@ -1587,11 +1571,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await expect(switchToggle).toBeVisible()
     await switchToggle.click()
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded
     // Alternate value input field is visible
@@ -1693,11 +1675,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
       page,
     )
 
-    const modifierHeader = modifierEditor.getByRole("button", {
-      name: modifierLabel,
-    })
+    const modifierHeader = getModifierHeader(modifierEditor, modifierLabel)
     await expect(modifierHeader).toBeVisible()
-    await modifierHeader.click()
+    await expandModifierIfCollapsed(modifierHeader)
 
     // The modifier is now expanded
     // Alternate value input field is visible
@@ -5240,6 +5220,19 @@ async function CreateNewInputConfigItemAndReturnActionEditor(
   await button.click()
   await expect(actionEditor).toBeVisible()
   return actionEditor
+}
+
+function getModifierHeader(modifierEditor: Locator, modifierLabel: string) {
+  return modifierEditor
+    .locator('[data-slot="collapsible-trigger"]')
+    .filter({ hasText: modifierLabel })
+}
+
+async function expandModifierIfCollapsed(modifierHeader: Locator) {
+  const expanded = await modifierHeader.getAttribute("aria-expanded")
+  if (expanded === "false") {
+    await modifierHeader.click()
+  }
 }
 
 async function addModifierItemAndReturnEditor(

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -930,6 +930,61 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await expect(lastMoveDownButton).toBeDisabled()
   })
 
+  test("New modifier is expanded by default when added", async ({
+    configListPage,
+    page,
+  }) => {
+    await CreateNewInputConfigItemAndWaitForDialog(configListPage, page)
+    const modifierEditor = await addModifierItemAndReturnEditor(
+      "Transformation",
+      page,
+    )
+
+    // Content should be visible without clicking the header
+    const expressionInput = modifierEditor.getByRole("textbox", {
+      name: "Expression",
+    })
+    await expect(expressionInput).toBeVisible()
+  })
+
+  test("Each new modifier expands by default without disturbing existing ones", async ({
+    configListPage,
+    page,
+  }) => {
+    await CreateNewInputConfigItemAndWaitForDialog(configListPage, page)
+    const modifierEditor = await addModifierItemAndReturnEditor(
+      "Transformation",
+      page,
+    )
+
+    // Collapse the first modifier manually
+    const transformationHeader = modifierEditor.getByRole("button", {
+      name: "Transformation",
+    })
+    await transformationHeader.click()
+    const expressionInput = modifierEditor.getByRole("textbox", {
+      name: "Expression",
+    })
+    await expect(expressionInput).not.toBeVisible()
+
+    // Add a second modifier
+    const addModifierButtonInEditor = modifierEditor.getByRole("button", {
+      name: "Add modifier",
+    })
+    await addModifierButtonInEditor.click()
+    const substringOption = page.getByRole("menuitem", { name: "Substring" })
+    await substringOption.click()
+
+    // Second modifier should open by default
+    const startInput = modifierEditor.getByRole("textbox", {
+      name: "Start position",
+    })
+    await expect(startInput).toBeVisible()
+
+    // First modifier should remain collapsed
+    await expect(expressionInput).not.toBeVisible()
+  })
+
   test("Transformation modifier works correctly", async ({
     configListPage,
     page,

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -1031,7 +1031,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     const commands = await configListPage.mobiFlightPage.getTrackedCommands()
     expect(commands).toBeDefined()
     const payload = commands?.pop()?.payload
-    expect(payload.item.Modifiers.Items[0]).toEqual({
+    expect(payload.item.Modifiers.Items[0]).toMatchObject({
       Type: "Transformation",
       Active: false,
       Expression: "$*2",
@@ -1098,7 +1098,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     const commands = await configListPage.mobiFlightPage.getTrackedCommands()
     expect(commands).toBeDefined()
     const payload = commands?.pop()?.payload
-    expect(payload.item.Modifiers.Items[0]).toEqual({
+    expect(payload.item.Modifiers.Items[0]).toMatchObject({
       Type: "Substring",
       Active: false,
       Start: 3,
@@ -1198,7 +1198,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     const commands = await configListPage.mobiFlightPage.getTrackedCommands()
     expect(commands).toBeDefined()
     const payload = commands?.pop()?.payload
-    expect(payload.item.Modifiers.Items[0]).toEqual({
+    expect(payload.item.Modifiers.Items[0]).toMatchObject({
       Type: "Padding",
       Active: false,
       Length: 3,
@@ -1310,7 +1310,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     const commands = await configListPage.mobiFlightPage.getTrackedCommands()
     expect(commands).toBeDefined()
     const payload = commands?.pop()?.payload
-    expect(payload.item.Modifiers.Items[0]).toEqual({
+    expect(payload.item.Modifiers.Items[0]).toMatchObject({
       Type: "Interpolation",
       Active: false,
       Values: {
@@ -1404,7 +1404,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     const commands = await configListPage.mobiFlightPage.getTrackedCommands()
     expect(commands).toBeDefined()
     const payload = commands?.pop()?.payload
-    expect(payload.item.Modifiers.Items[0]).toEqual({
+    expect(payload.item.Modifiers.Items[0]).toMatchObject({
       Type: "Interpolation",
       Active: true,
       Values: {
@@ -1564,7 +1564,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     const commands = await configListPage.mobiFlightPage.getTrackedCommands()
     expect(commands).toBeDefined()
     const payload = commands?.pop()?.payload
-    expect(payload.item.Modifiers.Items[0]).toEqual({
+    expect(payload.item.Modifiers.Items[0]).toMatchObject({
       Type: "Comparison",
       Active: false,
       Value: "3",
@@ -1674,7 +1674,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     const commands = await configListPage.mobiFlightPage.getTrackedCommands()
     expect(commands).toBeDefined()
     const payload = commands?.pop()?.payload
-    expect(payload.item.Modifiers.Items[0]).toEqual({
+    expect(payload.item.Modifiers.Items[0]).toMatchObject({
       Type: "Blink",
       Active: false,
       BlinkValue: "1",


### PR DESCRIPTION
ModifierEditor tracks the index of the most recently added item and passes defaultOpen={true} to it on its initial mount, less clicking for the user.

### Summary
When you add a new modifier, it is currently opened in the "collapsed" state, showing only the summary of the modifier contents. You always need to click it to edit it, and you need to edit a modifier parameters to make it fit your needs.

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->

Current Beta: modifiers open collapsed
https://github.com/user-attachments/assets/313d74e3-e46c-4977-b913-3d3d39c59ef6

PR: modifiers open expanded
https://github.com/user-attachments/assets/5c9bee15-6a4e-4ffd-b346-abee5cd22bec

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Modifiers can be added and deleted
- [x] Collapsing and expanding still works
- [x] New modifiers open by default

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] ~~.NET backend~~
  - [x] Frontend tests
- [x] Frontend tests
  - [x] Test new modifier opens expanded, and that existing ones are not affected by this.
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3129

### Out-of-scope
Does not try to create any complex heuristics as to for example close other modifiers, because the user might want to look up stuff from them, the panel still scrolls if it gets too long with a lot of modifiers.
