### PR TITLE
Fix iniBuilds A300 MCDU display mapping

### DIFF
--- a/src/MobiFlightConnector/Scripts/ScriptMappings.json
+++ b/src/MobiFlightConnector/Scripts/ScriptMappings.json
@@ -135,7 +135,7 @@
     {
       "VendorId": "0x4098",
       "ProductIds": [ "WinwingCDUs" ],
-      "AircraftMatchPattern": "A300",
+      "AircraftMatchPattern": "[aA]300",
       "ScriptName": "ini_a300_winwing_cdu.py"
     },
     {


### PR DESCRIPTION
### Summary

The match pattern for the iniBuilds A300 uses a capital `A`, but the aircraft reports a lowercase `a`.

### Screenshots / recordings
n/a

### Acceptance criteria
- [x] Verified this fix works with Discord users

### DoD Checklist
n/a
     
## Related issues
fixes #2917

### Out-of-scope
n/a

### Notes

Used a regex of `[aA]` to match both cases just in case.