### PR TITLE
Improve StaticPageWebResourceRequestHandler logic to prevent error messages

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
+++ b/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
@@ -46,7 +46,6 @@ namespace MobiFlight.WebView
 
         internal void RegisterWithWebView(WebView2 webView)
         {
-            Log.Instance.log($"SPWRRHandler:{Name} - Registering filter for {BaseUrl}/*", LogSeverity.Debug);
             webView.CoreWebView2.AddWebResourceRequestedFilter($"{BaseUrl}/*", CoreWebView2WebResourceContext.All, CoreWebView2WebResourceRequestSourceKinds.Document);
             webView.CoreWebView2.WebResourceRequested += CoreWebView2_WebResourceRequested;
         }

--- a/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
+++ b/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
@@ -12,14 +12,15 @@ namespace MobiFlight.WebView
         private readonly string BaseUrl;
         private readonly string RootPath;
         private readonly string Name;
-
+        private readonly string[] Exclusions;
         public bool IndexFallback { get; set; } = true;
 
-        public StaticPageWebResourceRequestHandler(string name, string baseUrl, string rootPath)
+        public StaticPageWebResourceRequestHandler(string name, string baseUrl, string rootPath, string[] exclusions = null)
         {
             BaseUrl = baseUrl;
             RootPath = rootPath;
             Name = name;
+            Exclusions = exclusions ?? Array.Empty<string>();
 
             // Initialize MIME types for common web files
             MimeTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -45,7 +46,8 @@ namespace MobiFlight.WebView
 
         internal void RegisterWithWebView(WebView2 webView)
         {
-            webView.CoreWebView2.AddWebResourceRequestedFilter($"{BaseUrl}/*", CoreWebView2WebResourceContext.All);
+            Log.Instance.log($"SPWRRHandler:{Name} - Registering filter for {BaseUrl}/*", LogSeverity.Debug);
+            webView.CoreWebView2.AddWebResourceRequestedFilter($"{BaseUrl}/*", CoreWebView2WebResourceContext.All, CoreWebView2WebResourceRequestSourceKinds.Document);
             webView.CoreWebView2.WebResourceRequested += CoreWebView2_WebResourceRequested;
         }
 
@@ -69,11 +71,33 @@ namespace MobiFlight.WebView
             }
         }
 
+        internal bool UriIsExcluded(string requestUri)
+        {
+            return (Exclusions != null && 
+                    Exclusions.Length > 0 && 
+                    Array.Exists(Exclusions, exclusion => requestUri.Contains(exclusion)));
+        }
+
+        internal bool UriMatchesBaseUrl(string requestUri)
+        {
+            return (requestUri.StartsWith(BaseUrl));
+        }
+
         // Pure business logic - easily testable without WebView2
         internal FileResponse GetFileResponse(string requestUri)
         {
             var uri = new Uri(requestUri);
             var relativePath = uri.AbsolutePath.TrimStart('/');
+
+            if (!UriMatchesBaseUrl(requestUri))
+            {
+                return FileResponse.Ignore();
+            }
+
+            if (UriIsExcluded(requestUri))
+            {
+                return FileResponse.Ignore();
+            }
 
             // Default to index.html if path is empty
             if (string.IsNullOrEmpty(relativePath))
@@ -156,6 +180,7 @@ namespace MobiFlight.WebView
             ShouldServe = shouldServe;
         }
 
+        public static FileResponse Ignore() => new FileResponse(false);
         public static FileResponse Blocked() => new FileResponse(false);
         public static FileResponse NotFound() => new FileResponse(false);
     }

--- a/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
+++ b/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
@@ -9,13 +9,17 @@ namespace MobiFlight.WebView
     internal class StaticPageWebResourceRequestHandler
     {
         private Dictionary<string, string> MimeTypes;
-        private string BaseUrl;
-        private string RootPath;
+        private readonly string BaseUrl;
+        private readonly string RootPath;
+        private readonly string Name;
 
-        public StaticPageWebResourceRequestHandler(string baseUrl, string rootPath)
+        public bool IndexFallback { get; set; } = true;
+
+        public StaticPageWebResourceRequestHandler(string name, string baseUrl, string rootPath)
         {
             BaseUrl = baseUrl;
             RootPath = rootPath;
+            Name = name;
 
             // Initialize MIME types for common web files
             MimeTypes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -61,7 +65,7 @@ namespace MobiFlight.WebView
             }
             catch (Exception ex)
             {
-                Log.Instance.log($"Error handling web resource request: {ex.Message}", LogSeverity.Error);
+                Log.Instance.log($"SPWRRHandler:{Name} - Error handling web resource request: {ex.Message}", LogSeverity.Error);
             }
         }
 
@@ -83,7 +87,7 @@ namespace MobiFlight.WebView
             var fullPath = Path.GetFullPath(filePath);
             if (!fullPath.StartsWith(RootPath, StringComparison.OrdinalIgnoreCase))
             {
-                Log.Instance.log($"Security: Blocked path traversal attempt - {fullPath}", LogSeverity.Warn);
+                Log.Instance.log($"SPWRRHandler:{Name} - Security: Blocked path traversal attempt - {fullPath}", LogSeverity.Warn);
                 return FileResponse.Blocked();
             }
 
@@ -94,16 +98,22 @@ namespace MobiFlight.WebView
             }
             else
             {
+                if (!IndexFallback)
+                {
+                    Log.Instance.log($"SPWRRHandler:{Name} - Error: {requestUri} not found", LogSeverity.Error);
+                    return FileResponse.NotFound();
+                }
+
                 // File doesn't exist - serve index.html for SPA routing
                 var indexPath = Path.Combine(RootPath, "index.html");
                 if (File.Exists(indexPath))
                 {
-                    Log.Instance.log($"SPA Route: {relativePath} -> serving index.html", LogSeverity.Debug);
+                    Log.Instance.log($"SPWRRHandler:{Name} - SPA Route: {relativePath} -> serving index.html", LogSeverity.Debug);
                     return CreateFileResponse(indexPath, "text/html");
                 }
                 else
                 {
-                    Log.Instance.log($"Error: index.html not found at {indexPath}", LogSeverity.Error);
+                    Log.Instance.log($"SPWRRHandler:{Name} - Error: index.html not found at {indexPath}", LogSeverity.Error);
                     return FileResponse.NotFound();
                 }
             }

--- a/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
+++ b/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
@@ -46,7 +46,11 @@ namespace MobiFlight.WebView
 
         internal void RegisterWithWebView(WebView2 webView)
         {
-            webView.CoreWebView2.AddWebResourceRequestedFilter($"{BaseUrl}/*", CoreWebView2WebResourceContext.All, CoreWebView2WebResourceRequestSourceKinds.Document);
+            webView.CoreWebView2.AddWebResourceRequestedFilter(
+                $"{BaseUrl}/*", 
+                CoreWebView2WebResourceContext.All, 
+                CoreWebView2WebResourceRequestSourceKinds.All
+            );
             webView.CoreWebView2.WebResourceRequested += CoreWebView2_WebResourceRequested;
         }
 

--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
@@ -68,7 +68,8 @@ namespace MobiFlight.UI.Panels
                 var staticPageHandler = new StaticPageWebResourceRequestHandler(
                     "frontend",
                     _frontendBaseUrl,
-                    _frontendDistPath
+                    _frontendDistPath,
+                    new string[] { _frontendBaseUrl + "/presets" }
                 );
 
                 staticPageHandler.RegisterWithWebView(webView);

--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
@@ -66,7 +66,8 @@ namespace MobiFlight.UI.Panels
 
                 // Add event handler
                 var staticPageHandler = new StaticPageWebResourceRequestHandler(
-                    _frontendBaseUrl, 
+                    "frontend",
+                    _frontendBaseUrl,
                     _frontendDistPath
                 );
 
@@ -76,13 +77,20 @@ namespace MobiFlight.UI.Panels
                 webView.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
             }
 
-            var staticPresetsHandler = new StaticPageWebResourceRequestHandler(_frontendBaseUrl + "/presets", _presetPath);
+            var staticPresetsHandler = new StaticPageWebResourceRequestHandler(
+                "presets",
+                _frontendBaseUrl + "/presets",
+                _presetPath
+            )
+            {
+                IndexFallback = false
+            };
             staticPresetsHandler.RegisterWithWebView(webView);
-            
+
             var addButtonHandler = new AddCloseButtonHandlerOnNavigationCompleted();
             addButtonHandler.AddExclusionFilter(_frontendBaseUrl);
             addButtonHandler.RegisterWithWebView(webView);
-            
+
             webView.CoreWebView2.Settings.IsWebMessageEnabled = true;
             webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
             // Navigate to start the app

--- a/tests/MobiFlightUnitTests/WebView/StaticPageWebResourceRequestHandlerTests.cs
+++ b/tests/MobiFlightUnitTests/WebView/StaticPageWebResourceRequestHandlerTests.cs
@@ -98,10 +98,12 @@ namespace MobiFlightUnitTests.WebView
         {
             // Arrange
             var baseUrl = $"{BaseUrl}/test";
+            CreateFile("index.html", "<html>SPA</html>");
+
             _handler = new StaticPageWebResourceRequestHandler("test", baseUrl, _testRootPath);
 
             // Act
-            var response = _handler.GetFileResponse($"{BaseUrl}/test");
+            var response = _handler.GetFileResponse($"{baseUrl}");
 
             // Assert
             Assert.IsTrue(response.ShouldServe);

--- a/tests/MobiFlightUnitTests/WebView/StaticPageWebResourceRequestHandlerTests.cs
+++ b/tests/MobiFlightUnitTests/WebView/StaticPageWebResourceRequestHandlerTests.cs
@@ -17,7 +17,7 @@ namespace MobiFlightUnitTests.WebView
         {
             _testRootPath = Path.Combine(Path.GetTempPath(), "Test_" + Guid.NewGuid());
             Directory.CreateDirectory(_testRootPath);
-            _handler = new StaticPageWebResourceRequestHandler(BaseUrl, _testRootPath);
+            _handler = new StaticPageWebResourceRequestHandler("test", BaseUrl, _testRootPath);
         }
 
         [TestCleanup]
@@ -77,6 +77,62 @@ namespace MobiFlightUnitTests.WebView
             // Assert
             Assert.IsTrue(response.ShouldServe);
             Assert.AreEqual("text/html", response.ContentType);
+        }
+
+        [TestMethod()]
+        public void GetFileResponse_SpaRoute_DoesntFallBackToIndex_IfIndexFallbackDisabled()
+        {
+            // Arrange
+            CreateFile("index.html", "<html>SPA</html>");
+            _handler.IndexFallback = false;
+
+            // Act
+            var response = _handler.GetFileResponse($"{BaseUrl}/user/profile");
+
+            // Assert
+            Assert.IsFalse(response.ShouldServe);
+        }
+
+        [TestMethod()]
+        public void GetFileResponse_UriMatchesBaseUrl_IsNotIgnored()
+        {
+            // Arrange
+            var baseUrl = $"{BaseUrl}/test";
+            _handler = new StaticPageWebResourceRequestHandler("test", baseUrl, _testRootPath);
+
+            // Act
+            var response = _handler.GetFileResponse($"{BaseUrl}/test");
+
+            // Assert
+            Assert.IsTrue(response.ShouldServe);
+        }
+
+        [TestMethod()]
+        public void GetFileResponse_UriMatchesBaseUrlNot_IsIgnored()
+        {
+            // Arrange
+            var baseUrl = $"{BaseUrl}/test";
+            _handler = new StaticPageWebResourceRequestHandler("test", baseUrl, _testRootPath);
+
+            // Act
+            var response = _handler.GetFileResponse($"{BaseUrl}/foo");
+
+            // Assert
+            Assert.IsFalse(response.ShouldServe);
+        }
+
+        [TestMethod()]
+        public void GetFileResponse_UriMatchesBase_WithExclusionFilter_IsIgnored()
+        {
+            // Arrange
+            var baseUrl = $"{BaseUrl}";
+            _handler = new StaticPageWebResourceRequestHandler("test", baseUrl, _testRootPath, new string[] { $"{BaseUrl}/test" });
+
+            // Act
+            var response = _handler.GetFileResponse($"{BaseUrl}/test");
+
+            // Assert
+            Assert.IsFalse(response.ShouldServe);
         }
 
         [TestMethod()]


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
This fix prevents the error messages in the log.

### Screenshots / recordings
<img width="1334" height="485" alt="image" src="https://github.com/user-attachments/assets/93d649e2-78b1-41b6-bd8f-edf12bc757f0" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] No Error messages in Log anymore
- [x] StaticPageWebResourceRequestHandler only serve specific matches
- [x] StaticPageWebResourceRequestHandler support exclusion list, to ignore specific matches

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3096