### PR TITLE
Show live modifier chain values in the input config editor.

### DIFF
--- a/src/MobiFlightConnector/Base/ConfigItem.cs
+++ b/src/MobiFlightConnector/Base/ConfigItem.cs
@@ -13,6 +13,10 @@ namespace MobiFlight.Base
         string GUID { get; set; }
         string RawValue { get; set; }
         string Value { get; set; }
+        // The live value entering each modifier in the chain, aligned 1:1 to Modifiers.Items
+        // by index. ModifierInputValues[i] is the value that enters Items[i]; index 0 is the
+        // numeric value entering the first modifier (distinct from the event-label RawValue).
+        List<string> ModifierInputValues { get; set; }
         Dictionary<ConfigItemStatusType, string> Status { get; set; }
     }
 
@@ -23,6 +27,8 @@ namespace MobiFlight.Base
         public string RawValue { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Value { get; set; }
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+        public List<string> ModifierInputValues { get; set; }
         public Dictionary<ConfigItemStatusType, string> Status { get; set; }
         public ConfigValueOnlyItem() { }
         public ConfigValueOnlyItem(IConfigValueOnlyItem item)
@@ -30,6 +36,7 @@ namespace MobiFlight.Base
             GUID = item.GUID.Clone() as string;
             RawValue = item.RawValue?.Clone() as string;
             Value = item.Value?.Clone() as string;
+            ModifierInputValues = item.ModifierInputValues != null ? new List<string>(item.ModifierInputValues) : null;
             Status = new Dictionary<ConfigItemStatusType, string>(item.Status);
         }
     }
@@ -63,6 +70,12 @@ namespace MobiFlight.Base
         public string RawValue { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Value { get; set; }
+
+        // Runtime-only live values (the value entering each active/inactive modifier by index).
+        // JsonIgnore keeps this out of the persisted project file; it is emitted to the frontend
+        // only via the ConfigValueOnlyItem projection / ConfigValueOnlyItemConverter.
+        [JsonIgnore]
+        public List<string> ModifierInputValues { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public virtual IDeviceConfig Device { get { return GetDeviceConfig(); } set { new NotImplementedException(); } }

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -113,20 +113,19 @@ namespace MobiFlight.Execution
                         Float64 = e.Value,
                     };
 
+                    // Capture the value entering each modifier (by Items index) so the
+                    // frontend can show the live value flowing through the chain. Inactive
+                    // modifiers pass the value through unchanged but still get an entry, so
+                    // the list stays aligned 1:1 with Modifiers.Items.
+                    var modifierInputValues = new List<string>();
                     try
                     {
-                        // Capture the value entering each modifier (by Items index) so the
-                        // frontend can show the live value flowing through the chain. Inactive
-                        // modifiers pass the value through unchanged but still get an entry, so
-                        // the list stays aligned 1:1 with Modifiers.Items.
-                        var modifierInputValues = new List<string>();
                         foreach (var modifier in cfg.Modifiers.Items)
                         {
                             modifierInputValues.Add(modifiableValue.ToString());
                             if (modifier.Active)
                                 modifiableValue = modifier.Apply(modifiableValue, references);
                         }
-                        cfg.ModifierInputValues = modifierInputValues;
 
                         cfg.Value = modifiableValue.ToString();
                         e.Value = modifiableValue.Float64;
@@ -136,6 +135,15 @@ namespace MobiFlight.Execution
                     {
                         Log.Instance.log($"Transform error ({cfg.Name}): {ex.Message}", LogSeverity.Error);
                         cfg.Status[ConfigItemStatusType.Modifier] = ex.Message;
+                    }
+                    finally
+                    {
+                        // Always publish this event's list so a failing modifier can't leave
+                        // stale values from a previous event visible. On error the list ends
+                        // at the failing modifier's input, which shows where the chain broke.
+                        // The list is never mutated after this point: the frontend update
+                        // timer snapshots it from another thread (ConfigValueOnlyItem ctor).
+                        cfg.ModifierInputValues = modifierInputValues;
                     }
 
                     cfg.execute(cacheCollection, e, references);

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -115,10 +115,18 @@ namespace MobiFlight.Execution
 
                     try
                     {
-                        foreach (var modifier in cfg.Modifiers.Items.Where(m => m.Active))
+                        // Capture the value entering each modifier (by Items index) so the
+                        // frontend can show the live value flowing through the chain. Inactive
+                        // modifiers pass the value through unchanged but still get an entry, so
+                        // the list stays aligned 1:1 with Modifiers.Items.
+                        var modifierInputValues = new List<string>();
+                        foreach (var modifier in cfg.Modifiers.Items)
                         {
-                            modifiableValue = modifier.Apply(modifiableValue, references);
+                            modifierInputValues.Add(modifiableValue.ToString());
+                            if (modifier.Active)
+                                modifiableValue = modifier.Apply(modifiableValue, references);
                         }
+                        cfg.ModifierInputValues = modifierInputValues;
 
                         cfg.Value = modifiableValue.ToString();
                         e.Value = modifiableValue.Float64;

--- a/src/MobiFlightConnector/Base/Serialization/Json/ConfigValueOnlyItemConverter.cs
+++ b/src/MobiFlightConnector/Base/Serialization/Json/ConfigValueOnlyItemConverter.cs
@@ -38,6 +38,11 @@ namespace MobiFlight.Base.Serialization.Json
                 obj.Add(nameof(IConfigValueOnlyItem.Value), JToken.FromObject(configValueOnlyItem.Value));
             }
 
+            if (configValueOnlyItem.ModifierInputValues != null && configValueOnlyItem.ModifierInputValues.Count > 0)
+            {
+                obj.Add(nameof(IConfigValueOnlyItem.ModifierInputValues), JToken.FromObject(configValueOnlyItem.ModifierInputValues));
+            }
+
             if (configValueOnlyItem.Status != null)
             {
                 obj.Add(nameof(IConfigValueOnlyItem.Status), JToken.FromObject(configValueOnlyItem.Status));

--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -1,5 +1,9 @@
 {
   "General": {
+    "Terms": {
+      "RawValue": "Rohwert",
+      "FinalValue": "Endwert"
+    },
     "Action": {
       "OpenMenu": "Menü öffnen"
     },
@@ -258,8 +262,6 @@
       "Device": "Steuerung",
       "Component": "Gerät",
       "Status": "Status",
-      "RawValue": "Rohwert",
-      "FinalValue": "Endwert",
       "Actions": "Aktionen"
     },
     "Cell": {

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -1,5 +1,9 @@
 {
   "General": {
+    "Terms": {
+      "RawValue": "Raw Value",
+      "FinalValue": "Final Value"
+    },
     "Action": {
       "OpenMenu": "Open menu"
     },
@@ -252,8 +256,6 @@
       "Device": "Controller",
       "Component": "Device",
       "Status": "Status",
-      "RawValue": "Raw Value",
-      "FinalValue": "Final Value",
       "Actions": "Actions"
     },
     "Cell": {

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -1,5 +1,9 @@
 {
   "General": {
+    "Terms": {
+      "RawValue": "Valor Original",
+      "FinalValue": "Valor Final"
+    },
     "Action": {
       "OpenMenu": "Abrir menú"
     },
@@ -258,8 +262,6 @@
       "Device": "Controlador",
       "Component": "Dispositivo",
       "Status": "Estado",
-      "RawValue": "Valor Original",
-      "FinalValue": "Valor Final",
       "Actions": "Acciones"
     },
     "Cell": {

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -1,5 +1,9 @@
 {
   "General": {
+    "Terms": {
+      "RawValue": "Tuloarvo",
+      "FinalValue": "Lähtöarvo"
+    },
     "Action": {
       "OpenMenu": "Avaa valikko"
     },
@@ -252,8 +256,6 @@
       "Device": "Ohjain",
       "Component": "Laite",
       "Status": "Tila",
-      "RawValue": "Tuloarvo",
-      "FinalValue": "Lähtöarvo",
       "Actions": "Toiminnot"
     },
     "Cell": {

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -1,5 +1,9 @@
 {
   "General": {
+    "Terms": {
+      "RawValue": "Valor bruto",
+      "FinalValue": "Valor final"
+    },
     "Action": {
       "OpenMenu": "Abrir menu"
     },
@@ -252,8 +256,6 @@
       "Device": "Controlador",
       "Component": "Dispositivo",
       "Status": "Status",
-      "RawValue": "Valor bruto",
-      "FinalValue": "Valor final",
       "Actions": "Ações"
     },
     "Cell": {

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/config-item-table-columns.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/config-item-table-columns.tsx
@@ -162,7 +162,7 @@ export const columns: ColumnDef<IConfigItem>[] = [
     header: () => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const { t } = useTranslation()
-      return <div className="text-center">{t("ConfigList.Header.RawValue")}</div>
+      return <div className="text-center">{t("General.Terms.RawValue")}</div>
     },
     cell: ConfigItemTableRawValueCell,
   },
@@ -175,7 +175,7 @@ export const columns: ColumnDef<IConfigItem>[] = [
     header: () => {
       // eslint-disable-next-line react-hooks/rules-of-hooks
       const { t } = useTranslation()
-      return <div className="text-center">{t("ConfigList.Header.FinalValue")}</div>
+      return <div className="text-center">{t("General.Terms.FinalValue")}</div>
     },
     cell: ConfigItemTableFinalValueCell,
   },

--- a/src/MobiFlightConnector/frontend/src/components/wizard/ConfigWizard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/ConfigWizard.tsx
@@ -32,6 +32,7 @@ export type ConfigWizardProps = {
   liveData: {
     rawValue: string | null | undefined
     finalValue: string | null | undefined
+    modifierValues: string[] | null | undefined
   }
 }
 
@@ -282,6 +283,7 @@ const ConfigWizard = ({
                   liveData={{
                     rawValue: liveData.rawValue,
                     finalValue: liveData.finalValue,
+                    modifierValues: liveData.modifierValues,
                   }}
                 />
               )}

--- a/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
@@ -108,7 +108,11 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
                     setCurrentConfigItem(item)
                   }}
                   drawerContainer={containerRef}
-                  liveData={{ rawValue: configItem?.RawValue, finalValue: configItem?.Value }}
+                  liveData={{
+                    rawValue: configItem?.RawValue,
+                    finalValue: configItem?.Value,
+                    modifierValues: configItem?.ModifierInputValues,
+                  }}
                 />
               )}
             </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierEditor.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierEditor.tsx
@@ -156,7 +156,7 @@ const ModifierEditor = ({
                   ) : (
                     <PipelineValue
                       value={liveData.modifierValues?.[index + 1]}
-                      testId="modifier-pipeline-value"
+                      testId={`modifier-pipeline-value-${index + 1}`}
                     />
                   )}
                 </Fragment>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierEditor.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifierEditor.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
 import { Modifier, MODIFIER_TYPES, ModifierFactory } from "@/types/modifier"
 import {
   DropdownMenu,
@@ -7,6 +8,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { IconPlus } from "@tabler/icons-react"
+import { Fragment } from "react"
 import { useTranslation } from "react-i18next"
 import { ModifierItem } from "@/components/wizard/Modifier/ModifierItem"
 import { ScrollArea } from "@/components/ui/scroll-area"
@@ -14,11 +16,39 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 type ModifierEditorProps = {
   modifiers: Modifier[]
   onModifierChange: (modifiers: Modifier[]) => void
+  liveData: {
+    rawValue: string | null | undefined
+    finalValue: string | null | undefined
+    modifierValues: string[] | null | undefined
+  }
 }
+
+// A single value "chip" in the live pipeline shown down the modifier stack. The optional
+// label anchors the Raw (top) and Final (bottom) chips; the in-between chips show the value
+// passed from one modifier to the next.
+const PipelineValue = ({
+  label,
+  value,
+  testId,
+}: {
+  label?: string
+  value: string | null | undefined
+  testId?: string
+}) => (
+  <div className="flex flex-row items-center justify-center gap-2">
+    {label && (
+      <span className="text-muted-foreground text-xs">{label}</span>
+    )}
+    <Badge variant="secondary" className="font-mono" data-testid={testId}>
+      {value ?? "?"}
+    </Badge>
+  </div>
+)
 
 const ModifierEditor = ({
   modifiers,
   onModifierChange,
+  liveData,
 }: ModifierEditorProps) => {
   const { t } = useTranslation()
   const modifierTypes = MODIFIER_TYPES
@@ -99,18 +129,39 @@ const ModifierEditor = ({
       ) : (
         <ScrollArea className="grow">
           <div className="flex flex-col gap-2">
-            {modifiers.map((modifier, index) => (
-              <ModifierItem
-                key={index}
-                modifier={modifier}
-                onChange={(updated) => handleChange(index, updated)}
-                onDelete={() => handleDelete(index)}
-                onMoveUp={onMoveUp ? () => onMoveUp(index) : undefined}
-                onMoveDown={onMoveDown ? () => onMoveDown(index) : undefined}
-                isFirst={index === 0}
-                isLast={index === modifiers.length - 1}
-              />
-            ))}
+            <PipelineValue
+              label={t("General.Terms.RawValue")}
+              value={liveData.modifierValues?.[0]}
+              testId="modifier-pipeline-raw"
+            />
+            {modifiers.map((modifier, index) => {
+              const isLast = index === modifiers.length - 1
+              return (
+                <Fragment key={index}>
+                  <ModifierItem
+                    modifier={modifier}
+                    onChange={(updated) => handleChange(index, updated)}
+                    onDelete={() => handleDelete(index)}
+                    onMoveUp={onMoveUp ? () => onMoveUp(index) : undefined}
+                    onMoveDown={onMoveDown ? () => onMoveDown(index) : undefined}
+                    isFirst={index === 0}
+                    isLast={isLast}
+                  />
+                  {isLast ? (
+                    <PipelineValue
+                      label={t("General.Terms.FinalValue")}
+                      value={liveData.finalValue}
+                      testId="modifier-pipeline-final"
+                    />
+                  ) : (
+                    <PipelineValue
+                      value={liveData.modifierValues?.[index + 1]}
+                      testId="modifier-pipeline-value"
+                    />
+                  )}
+                </Fragment>
+              )
+            })}
           </div>
         </ScrollArea>
       )}

--- a/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifiersPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/Modifier/ModifiersPanel.tsx
@@ -14,6 +14,7 @@ type ModifiersPanelProps = {
   liveData: {
     rawValue: string | null | undefined
     finalValue: string | null | undefined
+    modifierValues: string[] | null | undefined
   }
 }
 
@@ -69,6 +70,7 @@ const ModifiersPanel = ({
           Modifiers: { Items: updatedModifiers },
         })
       }
+      liveData={liveData}
     />
   )
 }

--- a/src/MobiFlightConnector/frontend/src/pages/ConfigList.tsx
+++ b/src/MobiFlightConnector/frontend/src/pages/ConfigList.tsx
@@ -54,6 +54,7 @@ const ConfigListPage = () => {
         ...item,
         RawValue: newItem.RawValue,
         Value: newItem.Value,
+        ModifierInputValues: newItem.ModifierInputValues,
         Status: newItem.Status,
       }
     }) as IConfigItem[]

--- a/src/MobiFlightConnector/frontend/src/types/config.d.ts
+++ b/src/MobiFlightConnector/frontend/src/types/config.d.ts
@@ -10,6 +10,10 @@ export interface IConfigValueOnlyItem {
   GUID: string
   RawValue?: string | null
   Value?: string | null
+  // Live value entering each modifier in the chain, aligned 1:1 to Modifiers.Items by index.
+  // ModifierInputValues[i] is the value entering Items[i]; index 0 is the numeric input to the
+  // first modifier. Only populated while the app is running (device events fire).
+  ModifierInputValues?: string[] | null
   Status: IDictionary<string, ConfigItemStatusType>
 }
 

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -1,6 +1,7 @@
 import { Locator, Page } from "@playwright/test"
 import {
   ConfigValueFullUpdate,
+  ConfigValueRawAndFinalUpdate,
   ScanForInputResult,
 } from "../src/types/messages"
 import { test, expect } from "./fixtures"
@@ -8,7 +9,7 @@ import { ConfigListPage } from "./fixtures/ConfigListPage"
 import msfsPresetsResponse from "./data/inputaction/msfspresets.testdata.json" with { type: "json" }
 import xplanePresetsResponse from "./data/inputaction/xplanepresets.testdata.json" with { type: "json" }
 import { ActionTypeOptions } from "../src/lib/configWizard"
-import { Project } from "../src/types"
+import { IConfigItem, Project } from "../src/types"
 import {
   EventIdInputAction,
   FsuipcOffsetInputAction,
@@ -1668,6 +1669,61 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     // Remove the first mapping row
     await firstRemoveButton.click()
     await expect(firstRemoveButton).toBeDisabled()
+  })
+
+  test("Live pipeline values are shown between modifiers", async ({
+    configListPage,
+    page,
+  }) => {
+    // Create the config with a known GUID so we can target it with a live update
+    const configGuid = "11111111-2222-3333-4444-555555555555"
+    await CreateNewInputConfigItemAndWaitForDialog(configListPage, page, undefined, {
+      GUID: configGuid,
+      Modifiers: {
+        Items: [
+          { Type: "Transformation", Active: true, Expression: "$*2" } as Transformation,
+          { Type: "Transformation", Active: true, Expression: "$+1" } as Transformation,
+        ],
+      },
+    })
+
+    const modifiersPanel = page.getByTestId("modifiers-panel")
+    await expect(modifiersPanel).toBeVisible()
+    await modifiersPanel
+      .getByRole("button", { name: "Edit modifiers" })
+      .click()
+
+    const modifierEditor = page.getByTestId("modifier-editor")
+    await expect(modifierEditor).toBeVisible()
+
+    const rawChip = modifierEditor.getByTestId("modifier-pipeline-raw")
+    const betweenChip = modifierEditor.getByTestId("modifier-pipeline-value-1")
+    const finalChip = modifierEditor.getByTestId("modifier-pipeline-final")
+
+    // no live data has arrived yet, all chips show the placeholder
+    await expect(rawChip).toHaveText("?")
+    await expect(betweenChip).toHaveText("?")
+    await expect(finalChip).toHaveText("?")
+
+    // backend publishes live values for this config while the drawer is open
+    await configListPage.mobiFlightPage.publishMessage({
+      key: "ConfigValueRawAndFinalUpdate",
+      payload: {
+        ConfigItems: [
+          {
+            GUID: configGuid,
+            RawValue: "Press",
+            Value: "5",
+            ModifierInputValues: ["2", "4"],
+            Status: {},
+          },
+        ],
+      } as ConfigValueRawAndFinalUpdate,
+    })
+
+    await expect(rawChip).toHaveText("2")
+    await expect(betweenChip).toHaveText("4")
+    await expect(finalChip).toHaveText("5")
   })
 })
 
@@ -5116,6 +5172,7 @@ async function CreateNewInputConfigItemAndWaitForDialog(
   configListPage: ConfigListPage,
   page: Page,
   projectOptions?: Partial<Project>,
+  configItemProps: Partial<IConfigItem> = {},
 ) {
   await configListPage.gotoPage()
   if (projectOptions) {
@@ -5131,7 +5188,12 @@ async function CreateNewInputConfigItemAndWaitForDialog(
     name: "Add Input Config",
   })
   await addInputConfigButton.click()
-  await configListPage.addNewConfigItem("InputConfigItem", 0, "inputaction")
+  await configListPage.addNewConfigItem(
+    "InputConfigItem",
+    0,
+    "inputaction",
+    configItemProps,
+  )
   await expect(page.getByText("Edit Input Configuration")).toBeVisible()
 }
 

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -2,6 +2,7 @@
 using MobiFlight.Base;
 using MobiFlight.FSUIPC;
 using MobiFlight.InputConfig;
+using MobiFlight.Modifier;
 using MobiFlight.ProSim;
 using MobiFlight.SimConnectMSFS;
 using MobiFlight.xplane;
@@ -855,6 +856,91 @@ namespace MobiFlight.Execution.Tests
             Assert.HasCount(1, result, "Only the matching device config should execute");
             Assert.IsTrue(result.ContainsKey(configItem2.GUID), "Should execute Button2Config");
             Assert.IsFalse(result.ContainsKey(configItem1.GUID), "Should not execute Button1Config");
+        }
+
+        #endregion
+
+        #region Modifier Chain Live Values
+
+        private InputConfigItem CreateInputConfigItemWithModifiers(params ModifierBase[] modifiers)
+        {
+            var configItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("TestModule / SN-mod001"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Button1"),
+                Name = "ModifierConfig",
+            };
+            configItem.Modifiers.Items.AddRange(modifiers);
+            _configItems.Add(configItem);
+            return configItem;
+        }
+
+        private InputEventArgs CreateButtonEventArgs(int value)
+        {
+            return new InputEventArgs
+            {
+                Controller = new Controller() { Serial = "SN-mod001" },
+                Device = new DeviceReference() { Name = "Button1", Type = DeviceType.Button },
+                InputType = DeviceType.Button,
+                Value = value
+            };
+        }
+
+        [TestMethod]
+        public void Execute_ConfigWithModifiers_PopulatesModifierInputValuesForEachModifier()
+        {
+            // Arrange - inactive modifier must still get an entry (pass-through),
+            // so the list stays aligned 1:1 with Modifiers.Items for the frontend.
+            var configItem = CreateInputConfigItemWithModifiers(
+                new Transformation() { Active = true, Expression = "$*2" },
+                new Transformation() { Active = false, Expression = "$+100" },
+                new Transformation() { Active = true, Expression = "$+1" }
+            );
+
+            // Act
+            var result = _executor.Execute(CreateButtonEventArgs(2), isStarted: true);
+
+            // Assert
+            Assert.IsTrue(result.ContainsKey(configItem.GUID));
+            CollectionAssert.AreEqual(
+                new List<string>() { "2", "4", "4" },
+                configItem.ModifierInputValues,
+                "Each modifier should get the value entering it; the inactive one passes it through unchanged"
+            );
+            Assert.AreEqual("5", configItem.Value);
+        }
+
+        [TestMethod]
+        public void Execute_ModifierThrows_ReplacesModifierInputValuesWithPartialChain()
+        {
+            // Arrange
+            var failingModifier = new Transformation() { Active = true, Expression = "$+1" };
+            var configItem = CreateInputConfigItemWithModifiers(
+                new Transformation() { Active = true, Expression = "$*2" },
+                failingModifier,
+                new Transformation() { Active = true, Expression = "$+10" }
+            );
+
+            // First event succeeds and populates all three entries
+            _executor.Execute(CreateButtonEventArgs(2), isStarted: true);
+            CollectionAssert.AreEqual(
+                new List<string>() { "2", "4", "5" },
+                configItem.ModifierInputValues
+            );
+
+            // Act - make the second modifier fail, values from the previous
+            // event must not survive (issue: stale live values after a transform error)
+            failingModifier.Expression = "$ +";
+            _executor.Execute(CreateButtonEventArgs(3), isStarted: true);
+
+            // Assert - the list ends at the failing modifier's input value
+            CollectionAssert.AreEqual(
+                new List<string>() { "3", "6" },
+                configItem.ModifierInputValues,
+                "Error path should publish the partial chain of this event, not stale values from the previous one"
+            );
+            Assert.IsTrue(configItem.Status.ContainsKey(ConfigItemStatusType.Modifier));
         }
 
         #endregion


### PR DESCRIPTION
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Show live modifier chain values in the input modifier editor.

This is work in progress on the UI part, just shows the values as simple "bubble" labels between modifiers that is not particularly pretty but works as a demonstration.

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="614" height="470" alt="image" src="https://github.com/user-attachments/assets/4fad6986-8091-4a41-9754-896304dcbbf0" />

Known limitations:
- needs you to save the config and then reopen the modifier editor again to see the values update, as we currently dont update configs live while editing.
- also needs MF running to get any updates at all.

The backend already evaluates the chain once per input event to compute the final value; so we capture the running value before each step of that same pass (no extra evaluation, no round trip) and ships it on the existing ConfigValueRawAndFinalUpdate message:
- ConfigItem: new ModifierInputValues, runtime-only ([JsonIgnore] so it is not persisted to the project file); carried on the value-only projection + copy ctor
- InputEventExecutor: record the value entering each Items index (active and inactive, keeping it 1:1 with Modifiers.Items) while applying only active ones
- ConfigValueOnlyItemConverter: serialize ModifierInputValues (omitted when empty)

Frontend threads the values through liveData into the modifier editor drawer and renders them as a vertical pipeline (Raw chip, between-row value chips, Final chip) in ModifierEditor; ModifierItem and ModifierSummary are unchanged.

Also consolidate the raw/final value translation strings into a generic General.Terms.*, now shared by the config table headers and the editor (old ConfigList.Header.RawValue/.FinalValue removed).

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [ ] X added
- [ ] Y still working
- [ ] Z changed

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [ ] Unit tests available
  - [ ] .NET backend
  - [ ] Frontend
- [ ] Frontend tests
- [ ] i18n - All user-facing strings are translated
  - [ ] core (en,de,es)
  - [ ] additional langs
- [ ] documentation
  - [ ] User docs (docs.mobiflight.com)
  - [ ] Developer docs (e.g., readme.md)
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #ISSUE_NUMBER

### Out-of-scope
<!-- mention what is not covered by this PR -->

### Notes
<!-- provide furhter information that might be of interest -->
