### PR TITLE
Improved HubHop download process and toast notifications

### DIFF
--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -601,8 +601,9 @@ namespace MobiFlight.UI
 
             // Publish the updated list of available variables
             var availableVars = execManager.GetAvailableVariables();
-            MessageExchange.Instance.Publish(new MobiFlightVariablesUpdate() { 
-                Variables = availableVars.Values.ToList() 
+            MessageExchange.Instance.Publish(new MobiFlightVariablesUpdate()
+            {
+                Variables = availableVars.Values.ToList()
             });
 
             ProjectHasUnsavedChanges = true;
@@ -955,7 +956,11 @@ namespace MobiFlight.UI
 
             // delay the HubHop presets download 
             // so that we can display the toast correctly
-            Task.Run(() => Thread.Sleep(5000)).ContinueWith(_ => CheckForHubhopUpdate());
+            Task.Delay(5000).ContinueWith(_ =>
+            {
+                if (IsDisposed || Disposing) return;
+                CheckForHubhopUpdate();
+            }, TaskScheduler.FromCurrentSynchronizationContext());
         }
 
         private void CheckForHubhopUpdate()
@@ -2728,7 +2733,9 @@ namespace MobiFlight.UI
                     XplaneHubhopPresetListSingleton.Instance.Clear();
                     HubHopState.Result = "Success";
 
-                    UpdateHubHopTimestampInStatusBar(DateTime.Now);
+                    var lastModification = WasmModuleUpdater.HubHopPresetTimestamp();
+                    HubHopState.LastUpdate = lastModification;
+                    UpdateHubHopTimestampInStatusBar(lastModification);
                 }
                 else
                 {
@@ -2745,11 +2752,6 @@ namespace MobiFlight.UI
 
         private void UpdateHubHopTimestampInStatusBar(DateTime lastModification)
         {
-            if (this.InvokeRequired)
-            {
-                this.Invoke(new Action(() => UpdateHubHopTimestampInStatusBar(lastModification)));
-                return;
-            }
             toolStripStatusLabelHubHop.Text = lastModification.ToLocalTime().ToShortDateString();
             toolStripStatusLabelHubHop.ToolTipText = lastModification.ToLocalTime().ToString();
         }

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -29,6 +29,7 @@ using System.ComponentModel;
 using MobiFlight.Controllers;
 using MobiFlight.UI.StateBadge;
 using MobiFlight.Base.LogAppender;
+using System.Threading;
 
 namespace MobiFlight.UI
 {
@@ -938,7 +939,6 @@ namespace MobiFlight.UI
             MessageExchange.Instance.Publish(new StatusBarUpdate { Value = StartupProgressValue, Text = "Startup.Finished" });
 
             CheckForWasmModuleUpdate();
-            CheckForHubhopUpdate();
 
             UpdateAllConnectionIcons();
 
@@ -952,6 +952,10 @@ namespace MobiFlight.UI
             // Now we are done with all initialization stuff
             // and now we are ready to look for sims
             execManager.AutoConnectStart();
+
+            // delay the HubHop presets download 
+            // so that we can display the toast correctly
+            Task.Run(() => Thread.Sleep(5000)).ContinueWith(_ => CheckForHubhopUpdate());
         }
 
         private void CheckForHubhopUpdate()
@@ -2723,6 +2727,8 @@ namespace MobiFlight.UI
                     Msfs2020HubhopPresetListSingleton.Instance.Clear();
                     XplaneHubhopPresetListSingleton.Instance.Clear();
                     HubHopState.Result = "Success";
+
+                    UpdateHubHopTimestampInStatusBar(DateTime.Now);
                 }
                 else
                 {
@@ -2739,6 +2745,11 @@ namespace MobiFlight.UI
 
         private void UpdateHubHopTimestampInStatusBar(DateTime lastModification)
         {
+            if (this.InvokeRequired)
+            {
+                this.Invoke(new Action(() => UpdateHubHopTimestampInStatusBar(lastModification)));
+                return;
+            }
             toolStripStatusLabelHubHop.Text = lastModification.ToLocalTime().ToShortDateString();
             toolStripStatusLabelHubHop.ToolTipText = lastModification.ToLocalTime().ToString();
         }

--- a/src/MobiFlightConnector/frontend/src/components/notifications/HubHopUpdateToast.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/HubHopUpdateToast.tsx
@@ -3,7 +3,7 @@ import { Progress } from "../ui/progress"
 import {
   IconCircleCheckFilled,
   IconCircleXFilled,
-  IconCloudDownload
+  IconCloudDownload,
 } from "@tabler/icons-react"
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"

--- a/src/MobiFlightConnector/frontend/src/components/notifications/HubHopUpdateToast.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/HubHopUpdateToast.tsx
@@ -3,7 +3,7 @@ import { Progress } from "../ui/progress"
 import {
   IconCircleCheckFilled,
   IconCircleXFilled,
-  IconLoader2,
+  IconCloudDownload
 } from "@tabler/icons-react"
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
@@ -30,7 +30,7 @@ const HubHopUpdateToast = ({ timeout = 2000 }: HubHopUpdateToastProps) => {
 
   return HubHopState?.Result === "InProgress" ? (
     <div className="flex flex-row items-center gap-2">
-      <IconLoader2 className="animate-spin" />
+      <IconCloudDownload className="animate-low-bounce text-primary" />
       <Progress value={HubHopState?.UpdateProgress} className="h-6 w-full" />
     </div>
   ) : HubHopState?.Result === "Success" ? (

--- a/src/MobiFlightConnector/frontend/src/components/notifications/HubHopUpdateToast.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/HubHopUpdateToast.tsx
@@ -1,6 +1,10 @@
 import { useHubHopState } from "@/stores/stateStore"
 import { Progress } from "../ui/progress"
-import { IconCircleCheckFilled, IconCircleXFilled } from "@tabler/icons-react"
+import {
+  IconCircleCheckFilled,
+  IconCircleXFilled,
+  IconLoader2,
+} from "@tabler/icons-react"
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 import { useToastContext } from "@/lib/hooks/useToastContext"
@@ -25,16 +29,19 @@ const HubHopUpdateToast = ({ timeout = 2000 }: HubHopUpdateToastProps) => {
   }, [HubHopState, dismiss, timeout])
 
   return HubHopState?.Result === "InProgress" ? (
-    <Progress value={HubHopState?.UpdateProgress} className="h-6 w-full" />
+    <div className="flex flex-row items-center gap-2">
+      <IconLoader2 className="animate-spin" />
+      <Progress value={HubHopState?.UpdateProgress} className="h-6 w-full" />
+    </div>
   ) : HubHopState?.Result === "Success" ? (
     <div className="flex flex-row items-center gap-2">
       <IconCircleCheckFilled className="fill-green-700" />
-      { t("General.HubHopUpdate.Success") }
+      {t("General.HubHopUpdate.Success")}
     </div>
   ) : (
     <div className="flex flex-row items-center gap-2">
       <IconCircleXFilled className="fill-red-700" />
-      <div>{ t("General.HubHopUpdate.Error") }</div>
+      <div>{t("General.HubHopUpdate.Error")}</div>
     </div>
   )
 }

--- a/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -99,7 +99,7 @@ export const ToastNotificationHandler = () => {
 
   useAppMessage("HubHopState", (message) => {
     const status = message.payload
-    if (status.ShouldUpdate && status.Result === "Pending") {
+    if (status.ShouldUpdate && status.Result === "Pending" && status.UpdateProgress === 0) {
       toast({
         id: "hubhop-auto-update",
         title: t("General.HubHopUpdate.Title"),
@@ -117,7 +117,6 @@ export const ToastNotificationHandler = () => {
     }
 
     if (
-      status.ShouldUpdate &&
       status.Result === "InProgress" &&
       status.UpdateProgress === 0
     ) {

--- a/src/MobiFlightConnector/frontend/src/lib/hooks/useBackendStateAppMessages.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/hooks/useBackendStateAppMessages.ts
@@ -35,11 +35,13 @@ import { Controller } from "@/types/controller"
 import { useVariableStore } from "@/stores/variableStore"
 import { useProSimDataRefStore } from "@/stores/prosimDataRefStore"
 import { useLogsStore } from "@/stores/logsStore"
+import { useQueryClient } from "@tanstack/react-query"
 
 export const useBackendStateAppMessages = () => {
   const [queryParameters] = useSearchParams()
 
-  const { project, setProject, setProjectStatus, setControllerBindings } = useProjectStore()
+  const { project, setProject, setProjectStatus, setControllerBindings } =
+    useProjectStore()
   const { setRecentProjects } = useRecentProjects()
   const { setSettings } = useSettingsStore()
   const { setControllers } = useControllerStore()
@@ -55,6 +57,8 @@ export const useBackendStateAppMessages = () => {
   const setHubHopState = useHubHopStateActions()
   const auth = useAuth()
   const { addLog } = useLogsStore()
+
+  const queryClient = useQueryClient()
 
   useAppMessage("Project", (message) => {
     const project = message.payload as Project
@@ -110,10 +114,20 @@ export const useBackendStateAppMessages = () => {
     console.log("ProjectStatus message received", projectStatus)
     setProjectStatus(projectStatus)
   })
-
+  
   useAppMessage("HubHopState", (message) => {
     const state = message.payload as HubHopState
+    console.log("HubHopState message received", state)
     setHubHopState(state)
+    
+    if (state.Result === "Success") {
+      queryClient.invalidateQueries({
+        queryKey: ["msfs-presets"],
+      })
+      queryClient.invalidateQueries({
+        queryKey: ["xplane-presets"],
+      })
+    }
   })
 
   useAppMessage("ConnectedControllers", (message) => {
@@ -147,7 +161,10 @@ export const useBackendStateAppMessages = () => {
 
   useAppMessage("ControllerBindingsUpdate", (message) => {
     const controllerBindings = message.payload as ControllerBindingsUpdate
-    console.log("ControllerBindingsUpdate message received", controllerBindings.Bindings)
+    console.log(
+      "ControllerBindingsUpdate message received",
+      controllerBindings.Bindings,
+    )
     setControllerBindings(controllerBindings.Bindings)
   })
 


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
HubHop toast notifications with download progress show correctly. HubHop 7-day-update option also is presented to the user.

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="1097" height="322" alt="image" src="https://github.com/user-attachments/assets/b51a25c0-10a5-4289-a373-4e790412367a" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Toast notification displays update progress
- [x] Toast notification when hubhop database older than 7 days
- [x] Auto-update on first start shows update progress

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Frontend tests
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3119 
fixes #3088 
relates to #1710 