### PR TITLE
Support WinCtrl NWS device

### DIFF
--- a/src/MobiFlightConnector/Joysticks/winwing/winwing_tiller_left.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/winwing/winwing_tiller_left.joystick.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "WINCTRL 32 NWS L",
+  "VendorId": "0x4098",
+  "ProductId": "0xB961",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Pedal Disconnect"
+    }    
+  ]
+}

--- a/src/MobiFlightConnector/Joysticks/winwing/winwing_tiller_right.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/winwing/winwing_tiller_right.joystick.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "WINCTRL 32 NWS R",
+  "VendorId": "0x4098",
+  "ProductId": "0xB962",
+  "Inputs": [
+    {
+      "Id": 1,
+      "Type": "Button",
+      "Label": "Pedal Disconnect"
+    }    
+  ]
+}

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Winwing/WinwingConstants.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Winwing/WinwingConstants.cs
@@ -44,6 +44,9 @@
         internal const int PRODUCT_ID_RMP_R = 0xBB84;
         internal const int PRODUCT_ID_RMP_C = 0xBB85;
 
+        internal const int PRODUCT_ID_NWS_L = 0xB961;
+        internal const int PRODUCT_ID_NWS_R = 0xB962;
+
         internal const int PRODUCT_ID_PTO2 = 0xBF05;
 
         internal static readonly int[] FCU_PRODUCTIDS = { PRODUCT_ID_FCU_ONLY, PRODUCT_ID_FCU_EFISL, PRODUCT_ID_FCU_EFISR, PRODUCT_ID_FCU_EFISL_EFISR };
@@ -58,6 +61,7 @@
         internal static readonly int[] AIRBUS_STICK_PRODUCTIDS = { PRODUCT_ID_AIRBUS_STICK_L, PRODUCT_ID_AIRBUS_STICK_R };
         internal static readonly int[] PDC3_PRODUCTIDS = { PRODUCT_ID_3NPDCL, PRODUCT_ID_3NPDCR, PRODUCT_ID_3MPDCL, PRODUCT_ID_3MPDCR };
         internal static readonly int[] RMP_PRODUCTIDS = { PRODUCT_ID_RMP_L, PRODUCT_ID_RMP_R, PRODUCT_ID_RMP_C };
+        internal static readonly int[] NWS_PRODUCTIDS = { PRODUCT_ID_NWS_L, PRODUCT_ID_NWS_R };
 
         internal const string CDU_DATA = "Cdu Data";
         internal const string FONT_DATA = "Font Data";

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Winwing/WinwingControllerFactory.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Winwing/WinwingControllerFactory.cs
@@ -28,6 +28,7 @@ namespace MobiFlight.Joysticks.Winwing
                    WinwingConstants.AIRBUS_STICK_PRODUCTIDS.Contains(productId) ||
                    WinwingConstants.PDC3_PRODUCTIDS.Contains(productId) ||
                    WinwingConstants.RMP_PRODUCTIDS.Contains(productId) ||
+                   WinwingConstants.NWS_PRODUCTIDS.Contains(productId) ||
                    productId == WinwingConstants.PRODUCT_ID_ECAM ||
                    productId == WinwingConstants.PRODUCT_ID_AGP ||
                    productId == WinwingConstants.PRODUCT_ID_TCAS ||
@@ -68,6 +69,7 @@ namespace MobiFlight.Joysticks.Winwing
             else if (WinwingConstants.AIRBUS_THROTTLE_PRODUCTIDS.Contains(productId) ||
                      WinwingConstants.AIRBUS_STICK_PRODUCTIDS.Contains(productId) ||
                      WinwingConstants.PDC3_PRODUCTIDS.Contains(productId) ||
+                     WinwingConstants.NWS_PRODUCTIDS.Contains(productId) ||
                      productId == WinwingConstants.PRODUCT_ID_ECAM ||
                      productId == WinwingConstants.PRODUCT_ID_AGP ||
                      productId == WinwingConstants.PRODUCT_ID_TCAS ||

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -1603,6 +1603,12 @@
     <None Include="Joysticks\winwing\winwing_tcas.joystick.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Joysticks\winwing\winwing_tiller_left.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Joysticks\winwing\winwing_tiller_right.joystick.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="MidiBoards\BoardEditorConfigs\intechf44\Mobiflight-SessionProfile.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/MobiFlightWwFcu/WinwingConstants.cs
+++ b/src/MobiFlightWwFcu/WinwingConstants.cs
@@ -34,6 +34,9 @@ namespace MobiFlightWwFcu
         // All three RMP variants (L/R/C) share one destination address.
         internal static readonly byte[] DEST_RMP = new byte[] { 0x82, 0xbb };
 
+        // Both NWS variants (L/R) share one destination address
+        internal static readonly byte[] DEST_NWS = new byte[] { 0x60, 0xb9 };
+
 
         internal const int PRODUCT_ID_FCU_ONLY = 0xBB10;
         internal const int PRODUCT_ID_FCU_EFISL = 0xBC1D;
@@ -79,6 +82,9 @@ namespace MobiFlightWwFcu
         internal const int PRODUCT_ID_RMP_R = 0xBB84;
         internal const int PRODUCT_ID_RMP_C = 0xBB85;
 
+        internal const int PRODUCT_ID_NWS_L = 0xB961;
+        internal const int PRODUCT_ID_NWS_R = 0xB962;
+
         internal static readonly int[] FCU_PRODUCTIDS = { PRODUCT_ID_FCU_ONLY, PRODUCT_ID_FCU_EFISL, PRODUCT_ID_FCU_EFISR, PRODUCT_ID_FCU_EFISL_EFISR };
         internal static readonly int[] CDU_PRODUCTIDS = { PRODUCT_ID_MCDU_CPT, PRODUCT_ID_MCDU_OBS, PRODUCT_ID_MCDU_FO,
                                                           PRODUCT_ID_PFP3N_CPT, PRODUCT_ID_PFP3N_OBS, PRODUCT_ID_PFP3N_FO,
@@ -108,6 +114,9 @@ namespace MobiFlightWwFcu
         internal const string RMP_L_NAME = "RMP Left";
         internal const string RMP_R_NAME = "RMP Right";
         internal const string RMP_C_NAME = "RMP Center";
+
+        internal const string NWS_L_NAME = "NWS Left";
+        internal const string NWS_R_NAME = "NWS Right";
 
         internal static Dictionary<string, byte[]> DisplayCmdHeaders = new Dictionary<string, byte[]>()
         {

--- a/src/MobiFlightWwFcu/WinwingDisplayControl.cs
+++ b/src/MobiFlightWwFcu/WinwingDisplayControl.cs
@@ -156,6 +156,12 @@ namespace MobiFlightWwFcu
                 case WinwingConstants.PRODUCT_ID_RMP_C:
                     AddToCoupledDevices(new WinwingRmpDevice(MessageSender, WinwingConstants.RMP_C_NAME));
                     break;
+                case WinwingConstants.PRODUCT_ID_NWS_L:
+                    AddToCoupledDevices(new WinwingNwsDevice(MessageSender, WinwingConstants.NWS_L_NAME));
+                    break;
+                case WinwingConstants.PRODUCT_ID_NWS_R:
+                    AddToCoupledDevices(new WinwingNwsDevice(MessageSender, WinwingConstants.NWS_R_NAME));
+                    break;
                 case WinwingConstants.PRODUCT_ID_MCDU_CPT:
                     AddCduDevice("/winwing/cdu-captain", WinwingCduType.MCDU);
                     break;

--- a/src/MobiFlightWwFcu/WinwingNwsDevice.cs
+++ b/src/MobiFlightWwFcu/WinwingNwsDevice.cs
@@ -1,0 +1,34 @@
+namespace MobiFlightWwFcu
+{
+    internal class WinwingNwsDevice : SimpleOutputDeviceBase
+    {
+        public override string Name => $"WinWing {VariantName}";
+
+        private readonly string VariantName;
+
+        public WinwingNwsDevice(IWinwingMessageSender sender, string variantName)
+            : base(sender, WinwingConstants.DEST_NWS)
+        {
+            VariantName = variantName;
+
+            OutputNameToActionMapping.Add(BACK_BRIGHTNESS, Brightness(0x00));
+
+            InitializeCaches();
+        }
+
+        protected override void OnConnect()
+        {
+            InvokeOutputBrightness(BACK_BRIGHTNESS, 50);
+        }
+
+        protected override void OnShutdown()
+        {
+            InvokeOutputBrightness(BACK_BRIGHTNESS, 0);
+        }
+
+        public override void Stop()
+        {
+            // NWS has no controllable LEDs — Stop is a no-op.
+        }
+    }
+}

--- a/tests/MobiFlightWwFcuUnitTests/WinwingNwsDeviceTests.cs
+++ b/tests/MobiFlightWwFcuUnitTests/WinwingNwsDeviceTests.cs
@@ -1,0 +1,164 @@
+using MobiFlightWwFcu;
+using MobiFlightWwFcuUnitTests.Mocks;
+
+namespace MobiFlightWwFcuUnitTests
+{
+    [TestClass]
+    public class WinwingNwsDeviceTests
+    {
+        private MockWinwingMessageSender mockMessageSender = null!;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            mockMessageSender = new MockWinwingMessageSender();
+        }
+
+        private WinwingNwsDevice CreateDevice(string variantName)
+        {
+            return new WinwingNwsDevice(mockMessageSender, variantName);
+        }
+
+        #region Basic Properties Tests
+
+        [TestMethod]
+        [DataRow("NWS Left",  "WinWing NWS Left")]
+        [DataRow("NWS Right", "WinWing NWS Right")]
+        public void Name_PrefixesWinWingToVariantName(string variantName, string expectedName)
+        {
+            var device = CreateDevice(variantName);
+            Assert.AreEqual(expectedName, device.Name);
+        }
+
+        [TestMethod]
+        public void GetDisplayNames_ReturnsEmptyList()
+        {
+            var device = CreateDevice("NWS Left");
+            Assert.IsEmpty(device.GetDisplayNames());
+        }
+
+        [TestMethod]
+        public void GetInternalDisplayNames_ReturnsEmptyList()
+        {
+            var device = CreateDevice("NWS Left");
+            Assert.IsEmpty(device.GetInternalDisplayNames());
+        }
+
+        [TestMethod]
+        public void GetLedNames_ContainsOnlyBacklightChannel()
+        {
+            var device = CreateDevice("NWS Left");
+            var ledNames = device.GetLedNames();
+
+            Assert.HasCount(1, ledNames);
+            Assert.Contains("Backlight Percentage", ledNames);
+        }
+
+        #endregion
+
+        #region Connect / Shutdown / Stop
+
+        [TestMethod]
+        public void Connect_SetsBacklightTo50()
+        {
+            var device = CreateDevice("NWS Left");
+            device.Connect();
+
+            Assert.HasCount(1, mockMessageSender.BrightnessCommands);
+            Assert.AreEqual(0x00, mockMessageSender.BrightnessCommands[0].Type);
+            Assert.AreEqual("50", mockMessageSender.BrightnessCommands[0].Brightness);
+            Assert.IsEmpty(mockMessageSender.DisplayCommandsSent);
+        }
+
+        [TestMethod]
+        public void Shutdown_SetsBacklightToZero()
+        {
+            var device = CreateDevice("NWS Right");
+            device.Connect();
+            mockMessageSender.Reset();
+
+            device.Shutdown();
+
+            Assert.HasCount(1, mockMessageSender.BrightnessCommands);
+            Assert.AreEqual(0x00, mockMessageSender.BrightnessCommands[0].Type);
+            Assert.AreEqual("0", mockMessageSender.BrightnessCommands[0].Brightness);
+        }
+
+        [TestMethod]
+        public void Stop_DoesNothing()
+        {
+            var device = CreateDevice("NWS Left");
+            device.Stop();
+
+            Assert.IsEmpty(mockMessageSender.LightControlCommands);
+            Assert.IsEmpty(mockMessageSender.BrightnessCommands);
+            Assert.IsEmpty(mockMessageSender.DisplayCommandsSent);
+        }
+
+        [TestMethod]
+        [DataRow("NWS Left")]
+        [DataRow("NWS Right")]
+        public void Connect_RoutesBrightnessToSharedDestination(string variantName)
+        {
+            // Both variants share {0x60, 0xb9} (confirmed via capture, 3PDC pattern).
+            var device = CreateDevice(variantName);
+            device.Connect();
+
+            var dest = mockMessageSender.BrightnessCommands[0].DestinationAddress;
+            Assert.HasCount(2, dest);
+            Assert.AreEqual((byte)0x60, dest[0]);
+            Assert.AreEqual((byte)0xb9, dest[1]);
+        }
+
+        #endregion
+
+        #region LED / Output Tests
+
+        [TestMethod]
+        public void SetLed_BacklightPercentage_SendsBrightnessMessage()
+        {
+            var device = CreateDevice("NWS Left");
+            device.Connect();
+            mockMessageSender.Reset();
+
+            device.SetLed("Backlight Percentage", 80);
+
+            Assert.HasCount(1, mockMessageSender.BrightnessCommands);
+            Assert.AreEqual(0x00, mockMessageSender.BrightnessCommands[0].Type);
+            Assert.AreEqual("80", mockMessageSender.BrightnessCommands[0].Brightness);
+        }
+
+        [TestMethod]
+        public void SetLed_SameBrightnessTwice_OnlySendsOnce()
+        {
+            var device = CreateDevice("NWS Left");
+            device.SetLed("Backlight Percentage", 80);
+            device.SetLed("Backlight Percentage", 80);
+
+            Assert.HasCount(1, mockMessageSender.BrightnessCommands);
+        }
+
+        [TestMethod]
+        public void SetLed_NullOrEmptyName_SendsNothing()
+        {
+            var device = CreateDevice("NWS Left");
+            device.SetLed(null, 1);
+            device.SetLed("", 1);
+
+            Assert.IsEmpty(mockMessageSender.LightControlCommands);
+            Assert.IsEmpty(mockMessageSender.BrightnessCommands);
+        }
+
+        [TestMethod]
+        public void SetLed_UnknownName_ThrowsKeyNotFoundException()
+        {
+            // SetLed indexes LedCurrentValuesCache before the dictionary lookup
+            // so unknown LED names raise KeyNotFoundException.
+            var device = CreateDevice("NWS Left");
+            Assert.ThrowsExactly<System.Collections.Generic.KeyNotFoundException>(
+                () => device.SetLed("DOES_NOT_EXIST", 1));
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Support the WinCtrl NWS device. Main focus is to support backlighting control.
- Control backlighting.
- Provide button text.

<img width="329" height="357" alt="image" src="https://github.com/user-attachments/assets/209b15ec-3686-4e8f-8f6b-9475921996b1" />


### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Backlight control
  - [x] Backlight Led Output available
  - [x] Backlight is set to 50% on connect
  - [x] Backlight is set to OFF on shutdown
- [x] Tested by discord users
- [x] Complete this description text

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
  - ~~[ ] Frontend~~
- ~~[ ] Frontend tests~~
- ~~[ ] i18n - All user-facing strings are translated~~
- [x] documentation
  - [x] User docs (docs.mobiflight.com)
  - ~~[ ] Developer docs (e.g., readme.md)~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3149 

