### PR TITLE
Show only input devices in config trigger dropdown

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
@@ -161,6 +161,13 @@ namespace MobiFlight
         {
             String name = device.Name;
 
+            AddPovSwitchWithName(name);
+
+            LogInputAdded(device, name);
+        }
+
+        protected virtual void AddPovSwitchWithName(string name)
+        {
             POV.Add(new JoystickDevice() { Name = $"{PovPrefix} {name}U", Label = $"{name} (↑)", Type = DeviceType.Button, JoystickDeviceType = JoystickDeviceType.POV });
             POV.Add(new JoystickDevice() { Name = $"{PovPrefix} {name}UR", Label = $"{name} (↗)", Type = DeviceType.Button, JoystickDeviceType = JoystickDeviceType.POV });
             POV.Add(new JoystickDevice() { Name = $"{PovPrefix} {name}R", Label = $"{name} (→)", Type = DeviceType.Button, JoystickDeviceType = JoystickDeviceType.POV });
@@ -169,7 +176,6 @@ namespace MobiFlight
             POV.Add(new JoystickDevice() { Name = $"{PovPrefix} {name}DL", Label = $"{name} (↙)", Type = DeviceType.Button, JoystickDeviceType = JoystickDeviceType.POV });
             POV.Add(new JoystickDevice() { Name = $"{PovPrefix} {name}L", Label = $"{name} (←)", Type = DeviceType.Button, JoystickDeviceType = JoystickDeviceType.POV });
             POV.Add(new JoystickDevice() { Name = $"{PovPrefix} {name}UL", Label = $"{name} (↖)", Type = DeviceType.Button, JoystickDeviceType = JoystickDeviceType.POV });
-            LogInputAdded(device, name);
         }
 
         protected void LogInputAdded(DeviceObjectInstance device, string label)

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
@@ -60,7 +60,7 @@ const ConfigTrigger = ({ configItem, setConfigItem }: ConfigTriggerProps) => {
     return (InputDeviceTypes.includes(device.Type as InputDeviceType))
   }
   
-  const devices: BaseDevice[] = [...(connectedController?.Devices.filter(inputDeviceFilter) ?? [])]
+  const devices: BaseDevice[] = [...(connectedController?.Devices?.filter(inputDeviceFilter) ?? [])]
 
   const configuredDevice: BaseDevice | undefined =
     configItem.Device != null

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
@@ -6,8 +6,9 @@ import { publishOnMessageExchange, useAppMessage } from "@/lib/hooks/appMessage"
 import { useControllerStore } from "@/stores/controllerStore"
 import { CommandScanForInput } from "@/types/commands"
 import { IConfigItem } from "@/types/config"
-import { BaseDevice, Controller } from "@/types/controller"
+import { BaseDevice, Controller, InputDeviceType } from "@/types/controller"
 import { ScanForInputResult } from "@/types/messages"
+import { InputDeviceTypes } from "@/types/typesOptions"
 import { IconLoader2, IconTrash } from "@tabler/icons-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -55,7 +56,11 @@ const ConfigTrigger = ({ configItem, setConfigItem }: ConfigTriggerProps) => {
       (!selectedController.Serial &&
         selectedController.Name === configItem.Controller.Name))
 
-  const devices: BaseDevice[] = [...(connectedController?.Devices ?? [])]
+  const inputDeviceFilter = (device: BaseDevice) => {
+    return (InputDeviceTypes.includes(device.Type as InputDeviceType))
+  }
+  
+  const devices: BaseDevice[] = [...(connectedController?.Devices.filter(inputDeviceFilter) ?? [])]
 
   const configuredDevice: BaseDevice | undefined =
     configItem.Device != null

--- a/src/MobiFlightConnector/frontend/src/types/config.d.ts
+++ b/src/MobiFlightConnector/frontend/src/types/config.d.ts
@@ -52,7 +52,7 @@ export type ControllerType = "MobiFlight" | "Joystick" | "Midi" | "Unknown"
 export type ConfigItemType = "InputConfigItem" | "OutputConfigItem"
 
 export interface IDeviceConfig {
-  Type: string
+  Type: InputDeviceType | OutputDeviceType
   Name: string
 }
 

--- a/src/MobiFlightConnector/frontend/src/types/controller.d.ts
+++ b/src/MobiFlightConnector/frontend/src/types/controller.d.ts
@@ -1,9 +1,11 @@
 import { ControllerType } from "./config"
 
+export type OutputDeviceType = "Output" | "LedModule" | "LcdDisplay" | "Servo" | "Stepper" | "ShiftRegister" | "CustomDevice"
+export type InputDeviceType = "Button" | "Encoder" | "AnalogInput"
 export type BaseDevice = {
   Name: string
   Label: string
-  Type: string
+  Type: InputDeviceType | OutputDeviceType
 }
 
 export type Controller = {
@@ -29,7 +31,7 @@ export type ControllerBinding = {
 export type DeviceReference = {
   Name: string
   Label: string
-  Type: string
+  Type: InputDeviceType | OutputDeviceType
 }
 
 export type ControllerBindingStatus = "Match" | "AutoBind" | "Missing" | "RequiresManualBind"

--- a/src/MobiFlightConnector/frontend/src/types/typesOptions.ts
+++ b/src/MobiFlightConnector/frontend/src/types/typesOptions.ts
@@ -1,4 +1,16 @@
-import { InputDeviceType, OutputDeviceType } from "@/types/controller";
+import { InputDeviceType, OutputDeviceType } from "@/types/controller"
 
-export const InputDeviceTypes: InputDeviceType[] = ["Button", "Encoder", "AnalogInput"]
-export const OutputDeviceTypes: OutputDeviceType[] = ["Output", "LedModule", "LcdDisplay", "Servo", "Stepper", "ShiftRegister", "CustomDevice"]
+export const InputDeviceTypes: InputDeviceType[] = [
+  "Button",
+  "Encoder",
+  "AnalogInput",
+]
+export const OutputDeviceTypes: OutputDeviceType[] = [
+  "Output",
+  "LedModule",
+  "LcdDisplay",
+  "Servo",
+  "Stepper",
+  "ShiftRegister",
+  "CustomDevice",
+]

--- a/src/MobiFlightConnector/frontend/src/types/typesOptions.ts
+++ b/src/MobiFlightConnector/frontend/src/types/typesOptions.ts
@@ -1,0 +1,4 @@
+import { InputDeviceType, OutputDeviceType } from "@/types/controller";
+
+export const InputDeviceTypes: InputDeviceType[] = ["Button", "Encoder", "AnalogInput"]
+export const OutputDeviceTypes: OutputDeviceType[] = ["Output", "LedModule", "LcdDisplay", "Servo", "Stepper", "ShiftRegister", "CustomDevice"]

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -502,12 +502,12 @@ test.describe("Input Config Wizard - Trigger Panel", () => {
 
     const triggerPanel = page.getByTestId("trigger-panel")
     const controllerComboBox = triggerPanel
-    .getByRole("combobox")
-    .filter({ hasText: "Select controller..." })
+      .getByRole("combobox")
+      .filter({ hasText: "Select controller..." })
     const deviceComboBox = triggerPanel
-    .getByRole("combobox")
-    .filter({ hasText: "Select device..." })
-    
+      .getByRole("combobox")
+      .filter({ hasText: "Select device..." })
+
     await expect(triggerPanel).toBeVisible()
     await expect(controllerComboBox).toBeVisible()
     await expect(deviceComboBox).toBeVisible()
@@ -518,7 +518,9 @@ test.describe("Input Config Wizard - Trigger Panel", () => {
     await expect(optionsPopup).toBeVisible()
 
     // click on the Bravo Throttle Quadrant option
-    await optionsPopup.getByRole("option", { name: "Bravo Throttle Quadrant" }).click()
+    await optionsPopup
+      .getByRole("option", { name: "Bravo Throttle Quadrant" })
+      .click()
     // options overlay should close after selection
     await expect(optionsPopup).not.toBeVisible()
 
@@ -527,10 +529,7 @@ test.describe("Input Config Wizard - Trigger Panel", () => {
     await expect(optionsPopup).toBeVisible()
 
     // verify that we don't see any output devices in the list of options
-    const outputDeviceNames = [
-      "AP Mode - HDG",
-      "AP Display - HDG"
-    ]
+    const outputDeviceNames = ["AP Mode - HDG", "AP Display - HDG"]
 
     for (const outputDeviceName of outputDeviceNames) {
       await expect(
@@ -539,10 +538,7 @@ test.describe("Input Config Wizard - Trigger Panel", () => {
     }
 
     // verify that we do see input devices in the list of options
-    const inputDeviceNames = [
-      "Button 1",
-      "Mode - ALT",
-    ]
+    const inputDeviceNames = ["Button 1", "Mode - ALT"]
 
     for (const inputDeviceName of inputDeviceNames) {
       await expect(

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -178,7 +178,9 @@ test.describe("General Input Config Wizard Tests", () => {
     await configListPage.mobiFlightPage.initWithTestData("inputaction")
 
     await configListPage.clickEditButtonForRow(1)
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -226,7 +228,9 @@ test.describe("Input Config Wizard - Edit name", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -488,6 +492,63 @@ test.describe("Input Config Wizard - Trigger Panel", () => {
     const updatedController = commandsAfterClick![0].payload.item.Controller
 
     expect(updatedController?.Devices).toBeUndefined()
+  })
+
+  test("Trigger panel shows only input devices", async ({
+    configListPage,
+    page,
+  }) => {
+    await CreateNewInputConfigItemAndWaitForDialog(configListPage, page)
+
+    const triggerPanel = page.getByTestId("trigger-panel")
+    const controllerComboBox = triggerPanel
+    .getByRole("combobox")
+    .filter({ hasText: "Select controller..." })
+    const deviceComboBox = triggerPanel
+    .getByRole("combobox")
+    .filter({ hasText: "Select device..." })
+    
+    await expect(triggerPanel).toBeVisible()
+    await expect(controllerComboBox).toBeVisible()
+    await expect(deviceComboBox).toBeVisible()
+
+    // Bring up the options overlay
+    await controllerComboBox.click()
+    const optionsPopup = page.getByRole("listbox")
+    await expect(optionsPopup).toBeVisible()
+
+    // click on the Bravo Throttle Quadrant option
+    await optionsPopup.getByRole("option", { name: "Bravo Throttle Quadrant" }).click()
+    // options overlay should close after selection
+    await expect(optionsPopup).not.toBeVisible()
+
+    // bring up the device options overlay
+    await deviceComboBox.click()
+    await expect(optionsPopup).toBeVisible()
+
+    // verify that we don't see any output devices in the list of options
+    const outputDeviceNames = [
+      "AP Mode - HDG",
+      "AP Display - HDG"
+    ]
+
+    for (const outputDeviceName of outputDeviceNames) {
+      await expect(
+        optionsPopup.getByRole("option", { name: outputDeviceName }),
+      ).not.toBeVisible()
+    }
+
+    // verify that we do see input devices in the list of options
+    const inputDeviceNames = [
+      "Button 1",
+      "Mode - ALT",
+    ]
+
+    for (const inputDeviceName of inputDeviceNames) {
+      await expect(
+        optionsPopup.getByRole("option", { name: inputDeviceName }),
+      ).toBeVisible()
+    }
   })
 })
 
@@ -1023,7 +1084,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await goBackButton.click()
 
     configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -1087,7 +1150,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
 
     // Save the config
     configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -1185,7 +1250,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
 
     // Save the config
     configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -1295,7 +1362,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
 
     // Save the config
     configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -1386,7 +1455,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
 
     // Save the config
     configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -1543,7 +1614,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
 
     // Save the config
     configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -1651,7 +1724,9 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
 
     // Save the config
     configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -2264,7 +2339,9 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -2761,7 +2838,9 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
     // Save the config
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -2821,7 +2900,9 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -2965,7 +3046,9 @@ test.describe("Input Config Wizard - Variable Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -3035,7 +3118,9 @@ test.describe("Input Config Wizard - Variable Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -3127,7 +3212,9 @@ test.describe("Input Config Wizard - Retrigger Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -3371,7 +3458,9 @@ test.describe("Input Config Wizard - Keyboard Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -3628,7 +3717,9 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -3701,7 +3792,9 @@ test.describe("Input Config Wizard - vJoy Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -3929,7 +4022,9 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -4006,7 +4101,9 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -4072,7 +4169,9 @@ test.describe("Input Config Wizard - FSUIPC Offset Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -4215,7 +4314,9 @@ test.describe("Input Config Wizard - FSUIPC EventID Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -4376,7 +4477,9 @@ test.describe("Input Config Wizard - FSUIPC PMDG EventID Input Action Panel", ()
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -4536,7 +4639,9 @@ test.describe("Input Config Wizard - FSUIPC Jeehell Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -4676,7 +4781,9 @@ test.describe("Input Config Wizard - FSUIPC Lua Macro Input Action Panel", () =>
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -4867,7 +4974,9 @@ test.describe("Input Config Wizard - ProSim Input Action Panel", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -4998,7 +5107,9 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -5040,7 +5151,9 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
 
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
 
-    const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+    const applyChangesButton = page.getByRole("button", {
+      name: "Apply changes",
+    })
     await expect(applyChangesButton).toBeVisible()
     await applyChangesButton.click()
 
@@ -5084,7 +5197,9 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
         "CommandUpdateConfigItem",
       )
 
-      const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+      const applyChangesButton = page.getByRole("button", {
+        name: "Apply changes",
+      })
       await expect(applyChangesButton).toBeVisible()
       await applyChangesButton.click()
 
@@ -5173,7 +5288,9 @@ test.describe("Input Config Wizard - Action Binding Panels", () => {
         "CommandUpdateConfigItem",
       )
 
-      const applyChangesButton = page.getByRole("button", { name: "Apply changes" })
+      const applyChangesButton = page.getByRole("button", {
+        name: "Apply changes",
+      })
       await expect(applyChangesButton).toBeVisible()
       await applyChangesButton.click()
 

--- a/src/MobiFlightConnector/frontend/tests/data/connectedControllers.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/connectedControllers.testdata.json
@@ -55,6 +55,20 @@
         "Name": "Button 21",
         "Label": "Mode - ALT",
         "Type": "Button"
+      },
+      {
+        "Label": "AP Mode - HDG",
+        "Id": "AP.hdg",
+        "Byte": 1,
+        "Bit": 0,
+        "Type": "Output"
+      },
+      {
+        "Label": "AP Display - HDG",
+        "Id": "AP.display.hdg",
+        "Byte": 1,
+        "Bit": 1,
+        "Type": "LcdDisplay"
       }
     ]
   },

--- a/src/MobiFlightConnector/frontend/tests/fixtures/ConfigListPage.ts
+++ b/src/MobiFlightConnector/frontend/tests/fixtures/ConfigListPage.ts
@@ -102,8 +102,8 @@ export class ConfigListPage {
     const configItems = testdataProject.ConfigFiles[configIndex].ConfigItems
     const templateInputConfig = {
       Active: true,
-      Controller: {},
-      Device: {},
+      Controller: null,
+      Device: undefined,
       GUID: "b2c3d4e5-f6a7-8901-bcde-f12345678902",
       Name: "Empty Input Config Item",
       Type: "InputConfigItem",

--- a/src/MobiFlightConnector/frontend/tests/fixtures/MobiFlightPage.ts
+++ b/src/MobiFlightConnector/frontend/tests/fixtures/MobiFlightPage.ts
@@ -250,6 +250,7 @@ export class MobiFlightPage {
       payload: testProjectWithProps,
     }
     await this.publishMessage(message)
+    await this.initWithConnectedControllers()
     await this.initWithRecentProjects()
   }
 

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickTests.cs
@@ -159,7 +159,7 @@ namespace MobiFlight.Joysticks.Tests
                     new JoystickOutput { Id="2", Label = "LCD01", Type = "LcdDisplay", Cols = 16, Lines = 1 }
                 }
             };
-            var joystick = new TestableJoystick(dxJoystick, definition); // Assuming a constructor exists that takes a definition
+            var joystick = new TestableJoystick(dxJoystick, definition);
             // Connect is required so that devices will be enumerated
             joystick.Connect(IntPtr.Zero);
 
@@ -187,7 +187,7 @@ namespace MobiFlight.Joysticks.Tests
                     new JoystickOutput { Id="2", Label = "LCD01", Type = "LcdDisplay", Cols = 16, Lines = 1 }
                 }
             };
-            var joystick = new TestableJoystick(dxJoystick, definition); // Assuming a constructor exists that takes a definition
+            var joystick = new TestableJoystick(dxJoystick, definition);
             // Connect is required so that devices will be enumerated
             joystick.Connect(IntPtr.Zero);
 

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickTests.cs
@@ -2,11 +2,90 @@
 using System;
 using System.Collections.Generic;
 
-namespace MobiFlight.Tests
+namespace MobiFlight.Joysticks.Tests
 {
     [TestClass()]
     public class JoystickTests
     {
+        class TestableJoystick : Joystick
+        {
+            public bool HasPovButtons { get; set; } = false;
+            public TestableJoystick(SharpDX.DirectInput.Joystick joystick, JoystickDefinition definition) : base(joystick, definition)
+            {
+            }
+
+            protected override void EnumerateDevices()
+            {
+                if (HasPovButtons)
+                {
+                    AddPovSwitchWithName("POV Switch");
+                }
+
+                if (Definition?.Inputs == null) return;
+
+                Definition.Inputs.ForEach(d =>
+                {
+                    if (d.Type == JoystickDeviceType.Axis)
+                    {
+                        var OffsetAxisName = GetAxisNameForUsage(d.Id);
+                        var axisName = $"{AxisPrefix} {OffsetAxisName}";
+
+                        Axes.Add(new JoystickDevice()
+                        {
+                            JoystickDeviceType = JoystickDeviceType.Axis,
+                            Name = axisName,
+                            Label = d.Label,
+                            Type = DeviceType.AnalogInput
+                        });
+                        return;
+                    }
+
+                    if (d.Type == JoystickDeviceType.Button)
+                    {
+                        var buttonName = $"{ButtonPrefix} {d.Id}";
+                        Buttons.Add(new JoystickDevice()
+                        {
+                            JoystickDeviceType = JoystickDeviceType.Button,
+                            Name = buttonName,
+                            Label = d.Label,
+                            Type = DeviceType.Button
+                        });
+                    }
+                });
+            }
+
+            protected override void EnumerateOutputDevices()
+            {
+                if (Definition?.Outputs == null) return;
+
+                Definition.Outputs?.ForEach(d =>
+                {
+                    if (d.Type == DeviceType.LcdDisplay.ToString())
+                    {
+
+                        Lights.Add(new JoystickOutputDisplay()
+                        {
+                            Name = d.Id,
+                            Label = d.Label,
+                            Type = DeviceType.LcdDisplay,
+                            Cols = d.Cols,
+                            Lines = d.Lines
+                        });
+                        return;
+                    }
+
+                    Lights.Add(new JoystickOutputDevice()
+                    {
+                        Name = d.Id,
+                        Label = d.Label,
+                        Type = DeviceType.Output,
+                        Byte = d.Byte,
+                        Bit = d.Bit
+                    });
+                });
+            }
+        }
+
         [TestMethod()]
         public void GetAxisNameForUsage_ShouldReturnNamesForValidIds()
         {
@@ -62,6 +141,64 @@ namespace MobiFlight.Tests
             Assert.AreEqual("RotationZ", Joystick.GetAxisNameForUsage(53));
             Assert.AreEqual("Slider1", Joystick.GetAxisNameForUsage(54));
             Assert.AreEqual("Slider2", Joystick.GetAxisNameForUsage(55));
+        }
+
+        [TestMethod()]
+        public void GetAvailableLcdDevices_ReturnsValidDevice()
+        {
+            // Arrange
+            SharpDX.DirectInput.Joystick dxJoystick = null;
+            var definition = new JoystickDefinition
+            {
+                InstanceName = "Test Joystick",
+                ProductId = 0x1234,
+                VendorId = 0x5678,
+                Outputs = new List<JoystickOutput>
+                {
+                    new JoystickOutput { Id="1", Label = "LED01", Type = "Output", Byte = 2, Bit = 0 },
+                    new JoystickOutput { Id="2", Label = "LCD01", Type = "LcdDisplay", Cols = 16, Lines = 1 }
+                }
+            };
+            var joystick = new TestableJoystick(dxJoystick, definition); // Assuming a constructor exists that takes a definition
+            // Connect is required so that devices will be enumerated
+            joystick.Connect(IntPtr.Zero);
+
+            // Act
+            var lcdDevices = joystick.GetAvailableLcdDevices();
+            // Assert
+            Assert.IsNotNull(lcdDevices, "GetAvailableLcdDevices should not return null.");
+            Assert.HasCount(1, lcdDevices, "There should be at least one available LCD device.");
+            Assert.IsInstanceOfType(lcdDevices[0], typeof(Firmware.LcdDisplay), "The available device should be of type JoystickOutputDisplay.");
+        }
+
+        [TestMethod()]
+        public void GetAvailableOutputDevices_ReturnsValidDevices()
+        {
+            // Arrange
+            SharpDX.DirectInput.Joystick dxJoystick = null;
+            var definition = new JoystickDefinition
+            {
+                InstanceName = "Test Joystick",
+                ProductId = 0x1234,
+                VendorId = 0x5678,
+                Outputs = new List<JoystickOutput>
+                {
+                    new JoystickOutput { Id="1", Label = "LED01", Type = "Output", Byte = 2, Bit = 0 },
+                    new JoystickOutput { Id="2", Label = "LCD01", Type = "LcdDisplay", Cols = 16, Lines = 1 }
+                }
+            };
+            var joystick = new TestableJoystick(dxJoystick, definition); // Assuming a constructor exists that takes a definition
+            // Connect is required so that devices will be enumerated
+            joystick.Connect(IntPtr.Zero);
+
+            // Act
+            var outputDevices = joystick.GetAvailableOutputDevices();
+            // Assert
+            Assert.IsNotNull(outputDevices, "GetAvailableOutputDevices should not return null.");
+            Assert.HasCount(2, outputDevices, "There should be at least one available output device.");
+
+            Assert.IsInstanceOfType(outputDevices[0], typeof(JoystickOutputDevice), "The available device should be of type JoystickOutputDevice.");
+            Assert.IsInstanceOfType(outputDevices[1], typeof(JoystickOutputDisplay), "The available device should be of type JoystickOutputDisplay.");
         }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickTests.cs
@@ -27,8 +27,8 @@ namespace MobiFlight.Joysticks.Tests
                 {
                     if (d.Type == JoystickDeviceType.Axis)
                     {
-                        var OffsetAxisName = GetAxisNameForUsage(d.Id);
-                        var axisName = $"{AxisPrefix} {OffsetAxisName}";
+                        var offsetAxisName = GetAxisNameForUsage(d.Id);
+                        var axisName = $"{AxisPrefix} {offsetAxisName}";
 
                         Axes.Add(new JoystickDevice()
                         {
@@ -164,11 +164,11 @@ namespace MobiFlight.Joysticks.Tests
             joystick.Connect(IntPtr.Zero);
 
             // Act
-            var lcdDevices = joystick.GetAvailableLcdDevices();
+            var devices = joystick.GetAvailableLcdDevices();
             // Assert
-            Assert.IsNotNull(lcdDevices, "GetAvailableLcdDevices should not return null.");
-            Assert.HasCount(1, lcdDevices, "There should be at least one available LCD device.");
-            Assert.IsInstanceOfType(lcdDevices[0], typeof(Firmware.LcdDisplay), "The available device should be of type JoystickOutputDisplay.");
+            Assert.IsNotNull(devices, "GetAvailableLcdDevices should not return null.");
+            Assert.HasCount(1, devices, "There should be at least one available LCD device.");
+            Assert.IsInstanceOfType(devices[0], typeof(Firmware.LcdDisplay), "The available device should be of type LcdDisplay.");
         }
 
         [TestMethod()]
@@ -192,13 +192,13 @@ namespace MobiFlight.Joysticks.Tests
             joystick.Connect(IntPtr.Zero);
 
             // Act
-            var outputDevices = joystick.GetAvailableOutputDevices();
+            var devices = joystick.GetAvailableOutputDevices();
             // Assert
-            Assert.IsNotNull(outputDevices, "GetAvailableOutputDevices should not return null.");
-            Assert.HasCount(2, outputDevices, "There should be at least one available output device.");
+            Assert.IsNotNull(devices, "GetAvailableOutputDevices should not return null.");
+            Assert.HasCount(2, devices, "There should be at least one available output device.");
 
-            Assert.IsInstanceOfType(outputDevices[0], typeof(JoystickOutputDevice), "The available device should be of type JoystickOutputDevice.");
-            Assert.IsInstanceOfType(outputDevices[1], typeof(JoystickOutputDisplay), "The available device should be of type JoystickOutputDisplay.");
+            Assert.IsInstanceOfType(devices[0], typeof(JoystickOutputDevice), "The available device should be of type JoystickOutputDevice.");
+            Assert.IsInstanceOfType(devices[1], typeof(JoystickOutputDisplay), "The available device should be of type JoystickOutputDisplay.");
         }
     }
 }


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
The config trigger drop down will only show input devices in the combo box.

### Screenshots / recordings
https://github.com/user-attachments/assets/62429c8d-1bd3-42ca-8210-c9b71dad41ac

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] only input devices show in the dropdown box

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [x] Frontend tests
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3083