### PR TITLE
Don`t persist Project runtime-only values

### DIFF
--- a/src/MobiFlightConnector/Base/ConfigFile.cs
+++ b/src/MobiFlightConnector/Base/ConfigFile.cs
@@ -1,4 +1,5 @@
-﻿using MobiFlight.InputConfig;
+﻿using MobiFlight.Base.Serialization.Json.Resolver;
+using MobiFlight.InputConfig;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -31,7 +32,9 @@ namespace MobiFlight.Base
             }
 
             var json = File.ReadAllText(FileName);
+
             var configFile = JsonConvert.DeserializeObject<ConfigFile>(json);
+            
             FileName = configFile.FileName ?? Path.GetFileName(FileName);
             ReferenceOnly = configFile.ReferenceOnly;
             EmbedContent = configFile.EmbedContent;
@@ -56,8 +59,10 @@ namespace MobiFlight.Base
 
         public string ToJson()
         {
+            // Use custom contract resolver to control serialization of properties correctly
             var settings = new JsonSerializerSettings
             {
+                ContractResolver = new CustomJsonIgnoreContractResolver(),
                 NullValueHandling = NullValueHandling.Ignore
             };
             return JsonConvert.SerializeObject(this, Formatting.Indented, settings);

--- a/src/MobiFlightConnector/Base/ConfigItem.cs
+++ b/src/MobiFlightConnector/Base/ConfigItem.cs
@@ -1,4 +1,5 @@
 ﻿using MobiFlight.Base.Serialization.Json;
+using MobiFlight.Base.Serialization.Json.Annotations;
 using MobiFlight.Modifier;
 using Newtonsoft.Json;
 using System;
@@ -19,6 +20,7 @@ namespace MobiFlight.Base
     public class ConfigValueOnlyItem : IConfigValueOnlyItem
     {
         public string GUID { get; set; }
+
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string RawValue { get; set; }
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -40,7 +42,7 @@ namespace MobiFlight.Base
         bool Active { get; set; }
         string Type { get; }
         string Name { get; set; }
-        Controller Controller{ get; set; }
+        Controller Controller { get; set; }
         PreconditionList Preconditions { get; set; }
         ModifierList Modifiers { get; set; }
         ConfigRefList ConfigRefs { get; set; }
@@ -59,14 +61,17 @@ namespace MobiFlight.Base
         public PreconditionList Preconditions { get; set; } = new PreconditionList();
         public ModifierList Modifiers { get; set; } = new ModifierList();
         public ConfigRefList ConfigRefs { get; set; } = new ConfigRefList();
+        [JsonIgnoreWhenPersistedToFile]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string RawValue { get; set; }
+        [JsonIgnoreWhenPersistedToFile]
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public string Value { get; set; }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public virtual IDeviceConfig Device { get { return GetDeviceConfig(); } set { new NotImplementedException(); } }
 
+        [JsonIgnoreWhenPersistedToFile]
         public Dictionary<ConfigItemStatusType, string> Status { get; set; } = new Dictionary<ConfigItemStatusType, string>();
 
         protected abstract IDeviceConfig GetDeviceConfig();
@@ -94,7 +99,7 @@ namespace MobiFlight.Base
             GUID = item.GUID.Clone() as string;
             Active = item.Active;
             Name = item.Name.Clone() as string;
-            Controller= item.Controller?.Clone() as Controller;
+            Controller = item.Controller?.Clone() as Controller;
             Preconditions = item.Preconditions.Clone() as PreconditionList;
             Modifiers = item.Modifiers.Clone() as ModifierList;
             ConfigRefs = item.ConfigRefs.Clone() as ConfigRefList;

--- a/src/MobiFlightConnector/Base/Project.cs
+++ b/src/MobiFlightConnector/Base/Project.cs
@@ -1,4 +1,5 @@
 ﻿using MobiFlight.Base.Migration;
+using MobiFlight.Base.Serialization.Json.Resolver;
 using MobiFlight.Controllers;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -553,8 +554,15 @@ namespace MobiFlight.Base
                 }
             }
 
+            // Use custom contract resolver to control serialization of Project properties correctly
+            var settings = new JsonSerializerSettings
+            {
+                ContractResolver = new PersistedProjectContractResolver(),
+                NullValueHandling = NullValueHandling.Ignore
+            };
+            var document = JObject.FromObject(new PersistedProject(this), JsonSerializer.Create(settings));
+
             // Add version when serializing
-            var document = JObject.FromObject(new PersistedProject(this));
             document["_version"] = SchemaVersion.ToString();
 
             // we don't want to serialize the FilePath

--- a/src/MobiFlightConnector/Base/Project.cs
+++ b/src/MobiFlightConnector/Base/Project.cs
@@ -557,7 +557,7 @@ namespace MobiFlight.Base
             // Use custom contract resolver to control serialization of Project properties correctly
             var settings = new JsonSerializerSettings
             {
-                ContractResolver = new PersistedProjectContractResolver(),
+                ContractResolver = new CustomJsonIgnoreContractResolver(),
                 NullValueHandling = NullValueHandling.Ignore
             };
             var document = JObject.FromObject(new PersistedProject(this), JsonSerializer.Create(settings));

--- a/src/MobiFlightConnector/Base/Serialization/Json/Annotations/JsonIgnoreWhenPersistedToFile.cs
+++ b/src/MobiFlightConnector/Base/Serialization/Json/Annotations/JsonIgnoreWhenPersistedToFile.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace MobiFlight.Base.Serialization.Json.Annotations
+{
+    // Attribute you can put on any DTO property
+    [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field)]
+    public class JsonIgnoreWhenPersistedToFileAttribute : Attribute { }
+}

--- a/src/MobiFlightConnector/Base/Serialization/Json/Resolver/CustomJsonIgnoreContractResolver.cs
+++ b/src/MobiFlightConnector/Base/Serialization/Json/Resolver/CustomJsonIgnoreContractResolver.cs
@@ -6,7 +6,7 @@
     using System;
     using System.Collections.Generic;
 
-    public class PersistedProjectContractResolver : DefaultContractResolver
+    public class CustomJsonIgnoreContractResolver : DefaultContractResolver
     {
         protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
         {

--- a/src/MobiFlightConnector/Base/Serialization/Json/Resolver/PersistedProjectContractResolver.cs
+++ b/src/MobiFlightConnector/Base/Serialization/Json/Resolver/PersistedProjectContractResolver.cs
@@ -1,0 +1,26 @@
+﻿namespace MobiFlight.Base.Serialization.Json.Resolver
+{
+    using MobiFlight.Base.Serialization.Json.Annotations;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
+    using System;
+    using System.Collections.Generic;
+
+    public class PersistedProjectContractResolver : DefaultContractResolver
+    {
+        protected override IList<JsonProperty> CreateProperties(Type type, MemberSerialization memberSerialization)
+        {
+            var properties = base.CreateProperties(type, memberSerialization);
+
+            foreach (var property in properties)
+            {
+                if (property.AttributeProvider?.GetAttributes(typeof(JsonIgnoreWhenPersistedToFileAttribute), true).Count > 0)
+                {
+                    property.Ignored = true;
+                }
+            }
+
+            return properties;
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightVariable.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightVariable.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using MobiFlight.Base.Serialization.Json.Annotations;
+using System;
 using System.Xml;
 
 namespace MobiFlight
@@ -8,11 +9,16 @@ namespace MobiFlight
         public const string TYPE_NUMBER = "number";
         public const string TYPE_STRING = "string";
 
-        public string TYPE = TYPE_NUMBER;
-        public string Name = "MyVar";
-        public double Number;
-        public string Text = "";
-        public string Expression = "$";
+        public string TYPE { get; set; } = TYPE_NUMBER;
+        public string Name { get; set; } = "MyVar";
+
+        [JsonIgnoreWhenPersistedToFile]
+        public double Number { get; set; }
+
+        [JsonIgnoreWhenPersistedToFile]
+        public string Text { get; set; } = String.Empty;
+
+        public string Expression { get; set; } = "$";
 
         public object Clone()
         {
@@ -26,11 +32,10 @@ namespace MobiFlight
             return clone;
         }
 
-
         public void ReadXml(System.Xml.XmlReader reader)
         {
             TYPE = reader["varType"];
-            Name =  reader["varName"];
+            Name = reader["varName"];
             Expression = reader["varExpression"];
         }
 

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -327,7 +327,7 @@
     <Compile Include="Base\Serialization\Json\ConfigValueOnlyItemConverter.cs" />
     <Compile Include="Base\Serialization\Json\KeyInputActionConverter.cs" />
     <Compile Include="Base\Serialization\Json\PreconditionConverter.cs" />
-    <Compile Include="Base\Serialization\Json\Resolver\PersistedProjectContractResolver.cs" />
+    <Compile Include="Base\Serialization\Json\Resolver\CustomJsonIgnoreContractResolver.cs" />
     <Compile Include="Base\Serialization\Json\SourceConverter.cs" />
     <Compile Include="Base\Settings.cs" />
     <Compile Include="Base\i18n.cs" />

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -322,10 +322,12 @@
     <Compile Include="Base\ObservableObject.cs" />
     <Compile Include="Base\Project.cs" />
     <Compile Include="Base\ProjectListManager.cs" />
+    <Compile Include="Base\Serialization\Json\Annotations\JsonIgnoreWhenPersistedToFile.cs" />
     <Compile Include="Base\Serialization\Json\DeviceConfigConverter.cs" />
     <Compile Include="Base\Serialization\Json\ConfigValueOnlyItemConverter.cs" />
     <Compile Include="Base\Serialization\Json\KeyInputActionConverter.cs" />
     <Compile Include="Base\Serialization\Json\PreconditionConverter.cs" />
+    <Compile Include="Base\Serialization\Json\Resolver\PersistedProjectContractResolver.cs" />
     <Compile Include="Base\Serialization\Json\SourceConverter.cs" />
     <Compile Include="Base\Settings.cs" />
     <Compile Include="Base\i18n.cs" />

--- a/tests/MobiFlightUnitTests/Base/ConfigFileTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ConfigFileTests.cs
@@ -3,6 +3,7 @@ using MobiFlight.OutputConfig;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace MobiFlight.Base.Tests
 {
@@ -143,6 +144,66 @@ namespace MobiFlight.Base.Tests
             Assert.AreEqual(configFile.ReferenceOnly, deserializedConfigFile.ReferenceOnly);
             Assert.AreEqual(configFile.EmbedContent, deserializedConfigFile.EmbedContent);
             Assert.HasCount(configFile.ConfigItems.Count, deserializedConfigFile.ConfigItems);
+        }
+
+        [TestMethod()]
+        public void ConfigFile_SaveFile_Should_Use_CustomJsonIgnoreContractResolver()
+        {
+            var configFile = new ConfigFile
+            {
+                FileName = TestFileName,
+                ReferenceOnly = false,
+                EmbedContent = false,
+                ConfigItems = new List<IConfigItem>()
+            };
+
+            configFile.ConfigItems.Add(new OutputConfigItem()
+            {
+                Source = new VariableSource()
+                {
+                    MobiFlightVariable = new MobiFlightVariable() { Number = 123.456f, Text = "Don't persist me!" }
+                },
+                RawValue = "Don't persist me!",
+                Value = "Don't persist me!",
+                Status = new System.Collections.Generic.Dictionary<ConfigItemStatusType, string> { {
+                       ConfigItemStatusType.Source, "Don't persist me!"
+                    } }
+            });
+
+            string outFile = @"assets\Base\ConfigFile\Json\SaveUse_CustomJsonIgnoreContractResolver_Test.mfproj";
+            configFile.FileName = outFile;
+            configFile.SaveFile();
+
+            string fileContent = File.ReadAllText(outFile);
+            Assert.DoesNotContain("\"Number\": 123.456", fileContent);
+            Assert.DoesNotContain("\"Text\": \"Don't persist me!\"", fileContent);
+            Assert.DoesNotContain("\"RawValue\": \"Don't persist me!\"", fileContent);
+            Assert.DoesNotContain("\"Value\": \"Don't persist me!\"", fileContent);
+            Assert.DoesNotContain("\"Status\": {", fileContent);
+            Assert.DoesNotContain("\"Source\": \"Don't persist me!\"", fileContent);
+
+            // to make sure we don't rely only on correct text formatting (whitespaces might break)
+            // we also deserialize the project and expect default values for the variable
+
+            // Arrange & act
+            var o2 = new ConfigFile()
+            {
+                FileName = outFile
+            };
+            o2.OpenFile();
+
+            var configItem = o2.ConfigItems[0] as OutputConfigItem;
+            var variableSource = configItem.Source as VariableSource;
+            var newVariable = new MobiFlightVariable();
+            var newConfigItem = new OutputConfigItem();
+
+            // Assert
+            Assert.IsNotNull(variableSource);
+            Assert.AreEqual(newVariable.Number, variableSource.MobiFlightVariable.Number);
+            Assert.AreEqual(newVariable.Text, variableSource.MobiFlightVariable.Text);
+            Assert.AreEqual(newConfigItem.RawValue, configItem.RawValue);
+            Assert.AreEqual(newConfigItem.Value, configItem.Value);
+            Assert.IsTrue(newConfigItem.Status.SequenceEqual(configItem.Status));
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -191,7 +191,9 @@ namespace MobiFlight.Base.Tests
                 Source = new VariableSource()
                 {
                     MobiFlightVariable = new MobiFlightVariable() { Number = 123.456f, Text = "Don't persist me!" }
-                }
+                },
+                RawValue = "Don't persist me!",
+                Value = "Don't persist me!"
             });
 
             string outFile = @"assets\Base\ConfigFile\Json\SaveUse_PersistedProjectContractResolver_Test.mfproj";
@@ -201,6 +203,8 @@ namespace MobiFlight.Base.Tests
             string fileContent = File.ReadAllText(outFile);
             Assert.DoesNotContain("\"Number\": 123.456", fileContent);
             Assert.DoesNotContain("\"Text\": \"Don't persist me!\"", fileContent);
+            Assert.DoesNotContain("\"RawValue\": \"Don't persist me!\"", fileContent);
+            Assert.DoesNotContain("\"Value\": \"Don't persist me!\"", fileContent);
 
             // to make sure we don't rely only on correct text formatting (whitespaces might break)
             // we also deserialize the project and expect default values for the variable
@@ -215,11 +219,14 @@ namespace MobiFlight.Base.Tests
             var configItem = o2.ConfigFiles[0].ConfigItems[0] as OutputConfigItem;
             var variableSource = configItem.Source as VariableSource;
             var newVariable = new MobiFlightVariable();
+            var newConfigItem = new OutputConfigItem();
 
             // Assert
             Assert.IsNotNull(variableSource);
             Assert.AreEqual(newVariable.Number, variableSource.MobiFlightVariable.Number);
             Assert.AreEqual(newVariable.Text, variableSource.MobiFlightVariable.Text);
+            Assert.AreEqual(newConfigItem.RawValue, configItem.RawValue);
+            Assert.AreEqual(newConfigItem.Value, configItem.Value);
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -181,9 +181,10 @@ namespace MobiFlight.Base.Tests
         public void SaveFileTest_Should_Use_PersistedProjectContractResolver()
         {
             var o = new Project();
-            
-            o.ConfigFiles.Add(new ConfigFile() { 
-                EmbedContent = true 
+
+            o.ConfigFiles.Add(new ConfigFile()
+            {
+                EmbedContent = true
             });
 
             o.ConfigFiles[0].ConfigItems.Add(new OutputConfigItem()
@@ -193,7 +194,10 @@ namespace MobiFlight.Base.Tests
                     MobiFlightVariable = new MobiFlightVariable() { Number = 123.456f, Text = "Don't persist me!" }
                 },
                 RawValue = "Don't persist me!",
-                Value = "Don't persist me!"
+                Value = "Don't persist me!",
+                Status = new System.Collections.Generic.Dictionary<ConfigItemStatusType, string> { {
+                       ConfigItemStatusType.Source, "Don't persist me!"
+                    } }
             });
 
             string outFile = @"assets\Base\ConfigFile\Json\SaveUse_PersistedProjectContractResolver_Test.mfproj";
@@ -205,6 +209,8 @@ namespace MobiFlight.Base.Tests
             Assert.DoesNotContain("\"Text\": \"Don't persist me!\"", fileContent);
             Assert.DoesNotContain("\"RawValue\": \"Don't persist me!\"", fileContent);
             Assert.DoesNotContain("\"Value\": \"Don't persist me!\"", fileContent);
+            Assert.DoesNotContain("\"Status\": {", fileContent);
+            Assert.DoesNotContain("\"Source\": \"Don't persist me!\"", fileContent);
 
             // to make sure we don't rely only on correct text formatting (whitespaces might break)
             // we also deserialize the project and expect default values for the variable
@@ -227,6 +233,7 @@ namespace MobiFlight.Base.Tests
             Assert.AreEqual(newVariable.Text, variableSource.MobiFlightVariable.Text);
             Assert.AreEqual(newConfigItem.RawValue, configItem.RawValue);
             Assert.AreEqual(newConfigItem.Value, configItem.Value);
+            Assert.IsTrue(newConfigItem.Status.SequenceEqual(configItem.Status));
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -178,7 +178,7 @@ namespace MobiFlight.Base.Tests
         }
 
         [TestMethod()]
-        public void SaveFileTest_Should_Use_PersistedProjectContractResolver()
+        public void SaveFileTest_Should_Use_CustomJsonIgnoreContractResolver()
         {
             var o = new Project();
 
@@ -200,7 +200,7 @@ namespace MobiFlight.Base.Tests
                     } }
             });
 
-            string outFile = @"assets\Base\ConfigFile\Json\SaveUse_PersistedProjectContractResolver_Test.mfproj";
+            string outFile = @"assets\Base\ConfigFile\Json\SaveUse_CustomJsonIgnoreContractResolver_Test.mfproj";
             o.FilePath = outFile;
             o.SaveFile();
 

--- a/tests/MobiFlightUnitTests/Base/ProjectTests.cs
+++ b/tests/MobiFlightUnitTests/Base/ProjectTests.cs
@@ -178,6 +178,51 @@ namespace MobiFlight.Base.Tests
         }
 
         [TestMethod()]
+        public void SaveFileTest_Should_Use_PersistedProjectContractResolver()
+        {
+            var o = new Project();
+            
+            o.ConfigFiles.Add(new ConfigFile() { 
+                EmbedContent = true 
+            });
+
+            o.ConfigFiles[0].ConfigItems.Add(new OutputConfigItem()
+            {
+                Source = new VariableSource()
+                {
+                    MobiFlightVariable = new MobiFlightVariable() { Number = 123.456f, Text = "Don't persist me!" }
+                }
+            });
+
+            string outFile = @"assets\Base\ConfigFile\Json\SaveUse_PersistedProjectContractResolver_Test.mfproj";
+            o.FilePath = outFile;
+            o.SaveFile();
+
+            string fileContent = File.ReadAllText(outFile);
+            Assert.DoesNotContain("\"Number\": 123.456", fileContent);
+            Assert.DoesNotContain("\"Text\": \"Don't persist me!\"", fileContent);
+
+            // to make sure we don't rely only on correct text formatting (whitespaces might break)
+            // we also deserialize the project and expect default values for the variable
+
+            // Arrange & act
+            var o2 = new Project()
+            {
+                FilePath = outFile
+            };
+            o2.OpenFile();
+
+            var configItem = o2.ConfigFiles[0].ConfigItems[0] as OutputConfigItem;
+            var variableSource = configItem.Source as VariableSource;
+            var newVariable = new MobiFlightVariable();
+
+            // Assert
+            Assert.IsNotNull(variableSource);
+            Assert.AreEqual(newVariable.Number, variableSource.MobiFlightVariable.Number);
+            Assert.AreEqual(newVariable.Text, variableSource.MobiFlightVariable.Text);
+        }
+
+        [TestMethod()]
         public void EqualsTest()
         {
             var o = new Project();

--- a/tests/MobiFlightUnitTests/MobiFlight/MobiFlightVariableTest.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/MobiFlightVariableTest.cs
@@ -1,0 +1,135 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MobiFlight.Tests
+{
+    [TestClass()]
+    public class MobiFlightVariableTest
+    {
+        [TestMethod]
+        public void MobiFlightVariable_HasCorrectDefaultValues()
+        {
+            // Arrange + Act
+            var variable = new MobiFlightVariable();
+            
+            // Assert
+            Assert.AreEqual(MobiFlightVariable.TYPE_NUMBER, variable.TYPE);
+            Assert.AreEqual("MyVar", variable.Name);
+            Assert.AreEqual(0.0, variable.Number);
+            Assert.AreEqual(string.Empty, variable.Text);
+            Assert.AreEqual("$", variable.Expression);
+        }
+
+        [TestMethod]
+        public void MobiFlightVariable_Clone_Test()
+        {
+            // Arrange
+            MobiFlightVariable original = new MobiFlightVariable()
+            {
+                TYPE = MobiFlightVariable.TYPE_NUMBER,
+                Name = "TestVar",
+                Number = 42.0,
+                Text = "TestText",
+                Expression = "$ + 1"
+            };
+
+            // Act
+            MobiFlightVariable clone = (MobiFlightVariable)original.Clone();
+
+            // Assert
+            Assert.AreEqual(original.TYPE, clone.TYPE);
+            Assert.AreEqual(original.Name, clone.Name);
+            Assert.AreEqual(original.Number, clone.Number);
+            Assert.AreEqual(original.Text, clone.Text);
+            Assert.AreEqual(original.Expression, clone.Expression);
+        }
+
+        [TestMethod]
+        public void MobiFlightVariable_Equals_IsTrueForEqualValues_Test()
+        {
+            // Arrange
+            MobiFlightVariable var1 = new MobiFlightVariable()
+            {
+                TYPE = MobiFlightVariable.TYPE_NUMBER,
+                Name = "TestVar",
+                Number = 42.0,
+                Text = "TestText",
+                Expression = "$ + 1"
+            };
+            MobiFlightVariable var2 = new MobiFlightVariable()
+            {
+                TYPE = MobiFlightVariable.TYPE_NUMBER,
+                Name = "TestVar",
+                Number = 42.0,
+                Text = "TestText",
+                Expression = "$ + 1"
+            };
+
+            // Act + Assert
+            Assert.IsTrue(var1.Equals(var2));
+        }
+        [TestMethod]
+        public void MobiFlightVariable_Equals_WorksCorrectlyForIndividualProps_Test()
+        {
+            // Arrange
+            MobiFlightVariable var1 = new MobiFlightVariable()
+            {
+                TYPE = MobiFlightVariable.TYPE_NUMBER,
+                Name = "TestVar",
+                Number = 42.0,
+                Text = "TestText",
+                Expression = "$ + 1"
+            };
+            MobiFlightVariable var2 = new MobiFlightVariable()
+            {
+                TYPE = MobiFlightVariable.TYPE_STRING,
+                Name = "TestVar",
+                Number = 42.0,
+                Text = "TestText",
+                Expression = "$ + 1"
+            };
+
+            // Act + Assert
+            Assert.IsFalse(var1.Equals(var2));
+            // Arrange 
+            var1.TYPE = MobiFlightVariable.TYPE_STRING;
+            // Act + Assert
+            Assert.IsTrue(var1.Equals(var2));
+
+            // Arrange
+            var2.Name = "DifferentName";
+            // Act + Assert
+            Assert.IsFalse(var1.Equals(var2));
+            // Arrange
+            var1.Name = "DifferentName";
+            // Act + Assert
+            Assert.IsTrue(var1.Equals(var2));
+
+            // Arrange
+            var2.Number = 999;
+            // Act + Assert
+            Assert.IsFalse(var1.Equals(var2));
+            // Arrange
+            var1.Number = 999;
+            // Act + Assert
+            Assert.IsTrue(var1.Equals(var2));
+
+            // Arrange
+            var2.Text = "DifferentText";
+            // Act + Assert
+            Assert.IsFalse(var1.Equals(var2));
+            // Arrange
+            var1.Text = "DifferentText";
+            // Act + Assert
+            Assert.IsTrue(var1.Equals(var2));
+
+            // Arrange
+            var2.Expression = "DifferentExpression";
+            // Act + Assert
+            Assert.IsFalse(var1.Equals(var2));
+            // Arrange
+            var1.Expression = "DifferentExpression";
+            // Act + Assert
+            Assert.IsTrue(var1.Equals(var2));
+        }
+    }
+}

--- a/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -265,6 +265,7 @@
     <Compile Include="MobiFlight\Joysticks\WingFlex\EfisCubeReportTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\OvhdCubeReportTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCubeReportTests.cs" />
+    <Compile Include="MobiFlight\MobiFlightVariableTest.cs" />
     <Compile Include="MobiFlight\Modifier\ExponentialAverageTests.cs" />
     <Compile Include="MobiFlight\InputEventArgsTests.cs" />
     <Compile Include="MobiFlight\Joysticks\Bodnar\BodnarReportTests.cs" />


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
We introduce a custom JSON annotation to mark properties in our Project that should not be persisted when saving it to file.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Don't persist dynamic runtime properties for `ConfigItem`:
  - [x] `ConfigItem.RawValue`
  - [x] `ConfigItem.Value`
  - [x] `ConfigItem.Status`
- [x] Don't persist dynamic runtime properties for `MobiFlightVariable`:
  - [x] `MobiFlightVariable.Text`
  - [x] `MobiFlightVariable.Number`

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [x] ~~Frontend tests~~
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3047 
