### PR TITLE
Only save the active trigger

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/wizard/ConfigWizard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/ConfigWizard.tsx
@@ -175,8 +175,6 @@ const ConfigWizard = ({
           onTriggerChange={(trigger) => {
             const updatedConfigItem = {
               ...configItem,
-              encoder: undefined,
-              analog: undefined,
               button: trigger as ButtonTrigger,
             }
             onConfigChange(updatedConfigItem)
@@ -200,8 +198,6 @@ const ConfigWizard = ({
           onTriggerChange={(trigger) => {
             onConfigChange({
               ...configItem,
-              button: undefined,
-              analog: undefined,
               encoder: trigger as EncoderTrigger,
             })
           }}
@@ -224,8 +220,6 @@ const ConfigWizard = ({
           onTriggerChange={(trigger) => {
             onConfigChange({
               ...configItem,
-              button: undefined,
-              encoder: undefined,
               analog: trigger as AnalogTrigger,
             })
           }}

--- a/src/MobiFlightConnector/frontend/src/components/wizard/ConfigWizard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/ConfigWizard.tsx
@@ -175,6 +175,8 @@ const ConfigWizard = ({
           onTriggerChange={(trigger) => {
             const updatedConfigItem = {
               ...configItem,
+              encoder: undefined,
+              analog: undefined,
               button: trigger as ButtonTrigger,
             }
             onConfigChange(updatedConfigItem)
@@ -198,6 +200,8 @@ const ConfigWizard = ({
           onTriggerChange={(trigger) => {
             onConfigChange({
               ...configItem,
+              button: undefined,
+              analog: undefined,
               encoder: trigger as EncoderTrigger,
             })
           }}
@@ -220,6 +224,8 @@ const ConfigWizard = ({
           onTriggerChange={(trigger) => {
             onConfigChange({
               ...configItem,
+              button: undefined,
+              encoder: undefined,
               analog: trigger as AnalogTrigger,
             })
           }}

--- a/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
@@ -12,6 +12,7 @@ import { ScrollArea } from "@/components/ui/scroll-area"
 import ConfigWizard from "@/components/wizard/ConfigWizard"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { useProjectStore } from "@/stores/projectStore"
+import { IConfigItem } from "@/types/config"
 import { IconChevronRight } from "@tabler/icons-react"
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -19,6 +20,21 @@ import { useNavigate } from "react-router"
 
 export type InputConfigDialogProps = {
   configId: string
+}
+
+const resetTriggersBasedOnDeviceType = (configItem: IConfigItem | undefined) => {
+  if (!configItem?.Device) return configItem
+
+  switch (configItem.Device.Type) {
+    case "Button":
+      return { ...configItem, analog: undefined, encoder: undefined }
+    case "Encoder":
+      return { ...configItem, analog: undefined, button: undefined }
+    case "AnalogInput":
+      return { ...configItem, encoder: undefined, button: undefined }
+    default:
+      return configItem
+  }
 }
 
 const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
@@ -29,7 +45,6 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
   const configItem = configFile?.ConfigItems?.find(
     (item) => item.GUID === configId,
   )
-
   
   const closeDialog = () => {
     navigate(-1)
@@ -37,10 +52,12 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
   
   const saveChanges = () => {
     const { publish } = publishOnMessageExchange()
+    
+    const finalConfigItem = resetTriggersBasedOnDeviceType(currentConfigItem)
     publish({
       key: "CommandUpdateConfigItem",
       payload: {
-        item: currentConfigItem,
+        item: finalConfigItem,
       },
     })
     closeDialog()

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -525,7 +525,7 @@ test.describe("Input Config Wizard - Trigger Panel", () => {
         name: "Apply changes",
       })
 
-      applyChangesButton.click()
+      await applyChangesButton.click()
       await expect(triggerPanel).not.toBeVisible()
 
       const commandsAfterClick =

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -32,6 +32,7 @@ import {
   Transformation,
 } from "../src/types/modifier"
 import { Preset } from "../src/types/preset"
+import { IConfigItem } from "../src/types/config"
 
 const jeehellPresetsContent = `FCU_KNOBS:GROUP
 FCU_HDGKNOB_PRESS:6:FCU Heading Knob Press
@@ -442,6 +443,120 @@ test.describe("Input Config Wizard - Trigger Panel", () => {
         .getByRole("combobox")
         .filter({ hasText: "Select device..." }),
     ).toBeDisabled()
+  })
+
+  test("Only save active trigger on closing config dialog", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData("inputaction")
+    await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
+    
+    const triggerOptions = [
+      { triggerType: "Encoder", actionType: "On Left" },
+      { triggerType: "AnalogInput", actionType: "On Change" },
+    ]
+    
+    for (const triggerOption of triggerOptions) {
+      await configListPage.clickEditButtonForRow(1)
+      await configListPage.mobiFlightPage.clearTrackedCommands()
+      const triggerPanel = page.getByTestId("trigger-panel")
+      const dialog = page.getByRole("dialog")
+      await expect(triggerPanel).toBeVisible()
+
+      const scanForInputButton = triggerPanel.getByRole("button", {
+        name: "Scan for Input",
+      })
+      await expect(scanForInputButton).toBeVisible()
+      await scanForInputButton.click()
+
+      const useAnyInputText = triggerPanel.getByText("Use any input")
+      await expect(useAnyInputText).toBeVisible()
+      await useAnyInputText.click()
+
+      await configListPage.mobiFlightPage.publishMessage({
+        key: "ScanForInputResult",
+        payload: {
+          Controller: {
+            Devices: [],
+            Name: "Bravo Throttle Quadrant",
+            Serial: "JS-87654321",
+          },
+          Device: {
+            Name: triggerOption.triggerType,
+            Label: triggerOption.triggerType,
+            Type: triggerOption.triggerType,
+          },
+        } as ScanForInputResult,
+      })
+
+      const addActionButton = dialog.getByRole("button", {
+        name: triggerOption.actionType,
+        exact: true,
+      })
+
+      await expect(addActionButton).toBeVisible()
+      await addActionButton.scrollIntoViewIfNeeded()
+      await addActionButton.click()
+      const actionEditor = page.getByTestId("action-editor")
+      await expect(actionEditor).toBeVisible()
+
+      const actionTypeComboBox = actionEditor.getByRole("combobox").filter({
+        hasText: "Select...",
+      })
+
+      await expect(actionTypeComboBox).toBeVisible()
+      await actionTypeComboBox.click()
+      const optionsPopup = page.getByRole("listbox")
+      await expect(optionsPopup).toBeVisible()
+      const options = optionsPopup.getByRole("option")
+      await expect(options.first()).toBeVisible()
+      await options.first().click()
+
+      const goBackButton = page.getByRole("button", {
+        name: "Go back",
+      })
+      await expect(goBackButton).toBeVisible()
+      await goBackButton.click()
+      await expect(actionEditor).not.toBeVisible()
+
+      const applyChangesButton = page.getByRole("button", {
+        name: "Apply changes",
+      })
+
+      applyChangesButton.click()
+      await expect(triggerPanel).not.toBeVisible()
+
+      const commandsAfterClick =
+        await configListPage.mobiFlightPage.getTrackedCommands()
+      expect(commandsAfterClick?.length).toBe(1)
+      expect(commandsAfterClick![0].key).toBe("CommandUpdateConfigItem")
+
+      if (triggerOption.triggerType === "Encoder") {
+        expect(
+          (commandsAfterClick![0].payload.item as IConfigItem).button,
+        ).toBeUndefined()
+        expect(
+          (commandsAfterClick![0].payload.item as IConfigItem).encoder,
+        ).toBeDefined()
+        expect(
+          (commandsAfterClick![0].payload.item as IConfigItem).analog,
+        ).toBeUndefined()
+      }
+
+      if (triggerOption.triggerType === "AnalogInput") {
+        expect(
+          (commandsAfterClick![0].payload.item as IConfigItem).button,
+        ).toBeUndefined()
+        expect(
+          (commandsAfterClick![0].payload.item as IConfigItem).encoder,
+        ).toBeUndefined()
+        expect(
+          (commandsAfterClick![0].payload.item as IConfigItem).analog,
+        ).toBeDefined()
+      }
+    }
   })
 
   test("Updating controller doesn't send Devices back to backend", async ({


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
This PR ensures that only the active trigger is persisted. While assigning different trigger and actions in the Input Config Wizard, temporary options will be maintained. But once you apply the changes, only one trigger and respective actions are stored in the config item.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Only one trigger and respective actions are stored for each config item
- [x] You can switch between different device types and temporary settings are restored
- [x] On applying the changes and closing the dialog, only the last selected trigger will persist, all others will be set to undefined

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] Frontend tests
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~

## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3138