### PR TITLE
Add quick help section for people testing a PR zip

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -37,4 +37,15 @@ fixes #ISSUE_NUMBER
 <!-- mention what is not covered by this PR -->
 
 ### Notes
-<!-- provide furhter information that might be of interest -->
+<!-- provide further information that might be of interest -->
+
+<!-- Leave this here in the end as a quick help for users wanting to test this PR later -->
+> [!tip] 
+> ### How to test a Pull Request build?
+> If you would like to provide feedback on a PR build like this one, here's how:
+> 1. Scroll down to the bottom of this page, to find the _last_ comment from _github-actions_
+> 2. Download the MobiFlightConnector.zip file link on that comment and open it from your browser downloads
+> 3. Navigate inside the zip with the Windows file manager and locate MFConnector.exe and double click it to open
+> 4. Choose "Extract all" and select the default suggested destination, it will save to your Documents/MobiFlightConnector-0.0.NNNN.XXXX where NNNN is the pull request number, so you can later know which is which, if you are testing many PR builds.
+>
+> Now you can open the MFConnector.exe from the created folder. The PR build will have its own settings, and profile history, so it does not mess up your default MobiFlight installation.


### PR DESCRIPTION
### Summary
An idea whether a short help chapter in the end of a PR template would be helpful for those who want to test PR builds. Just quick info for those unfamiliar with GH PR builds.

### Screenshots / recordings
See first comment below.

