### PR TITLE
add devcontainer-lock.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -490,3 +490,6 @@ FodyWeavers.xsd
 # Python directory - include only RuntimeAndPackages*.zip files
 Python/*
 !Python/RuntimeAndPackages*.zip
+
+# ignore devcontainer lock file
+devcontainer-lock.json


### PR DESCRIPTION
### Summary
Devcontainer lock file is local metadata that should not be in git. It was missing from gitignore.


### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- ~~[ ] Unit tests available~~
- ~~[ ] Frontend tests~~
- ~~[ ] i18n - All user-facing strings are translated~~
- ~~[ ] documentation~~
     
## Related issues
No issue, figured this is tooling, not part of the MF Connector code.

### Out-of-scope
<!-- mention what is not covered by this PR -->

### Notes
<!-- provide furhter information that might be of interest -->
