### PR TITLE
Fix overflow scrolling in project settings dialog

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
@@ -145,7 +145,7 @@ const ProjectForm = ({
                 >
                   {t("Project.Form.Name.Error.Required")}
                 </p>
-              )}{" "}
+              )}{""}
               {/* Show error */}
             </div>
             <ProjectSimAndFeatures

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
@@ -109,7 +109,7 @@ const ProjectForm = ({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className="flex h-[85vh] max-h-[675px] flex-col overflow-x-hidden sm:max-w-[675px]"
+        className=" flex h-[85vh] max-h-[675px] flex-col overflow-x-hidden sm:max-w-[675px]"
         onKeyDown={handleFormKeyDown}
         ref={containerRef}
       >

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectForm.tsx
@@ -21,6 +21,7 @@ import { useLocation } from "react-router"
 import { useTranslation } from "react-i18next"
 import ProjectAircraft from "@/components/project/Settings/ProjectAircraft"
 import ProjectSimAndFeatures from "@/components/project/Settings/ProjectSimAndFeatures"
+import { ScrollArea } from "../ui/scroll-area"
 
 type ProjectFormProps = {
   project: ProjectInfo
@@ -41,9 +42,7 @@ const ProjectForm = ({
   onSave,
 }: ProjectFormProps) => {
   const defaultAircraft = {
-    msfs: [
-      { Vendor: "Microsoft", Name: "Generic" },
-    ],
+    msfs: [{ Vendor: "Microsoft", Name: "Generic" }],
     xplane: [{ Vendor: "Laminar Research", Name: "Generic" }],
     p3d: [],
     fsx: [],
@@ -110,7 +109,7 @@ const ProjectForm = ({
   return (
     <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-h-[90vh] overflow-x-hidden overflow-y-auto sm:max-w-[600px]"
+        className="flex h-[85vh] max-h-[675px] flex-col overflow-x-hidden sm:max-w-[675px]"
         onKeyDown={handleFormKeyDown}
         ref={containerRef}
       >
@@ -120,68 +119,66 @@ const ProjectForm = ({
               ? t("Project.Form.Title.Edit")
               : t("Project.Form.Title.New")}
           </DialogTitle>
-          <DialogDescription>
-            {t("Project.Form.Description")}
-          </DialogDescription>
+          <DialogDescription>{t("Project.Form.Description")}</DialogDescription>
         </DialogHeader>
-
-        <div className="grid gap-6">
-          {/* Project Name */}
-          <div className="grid gap-2">
-            <Label htmlFor="project-name" className="text-base font-semibold">
-              {t("Project.Form.Name.Label")}
-            </Label>
-            <Input
-              id="project-name"
-              name="name"
-              value={name}
-              className={showErrorMessage ? "border-red-500" : ""}
-              onChange={(e) => setName(e.target.value)}
-              placeholder={t("Project.Form.Name.Placeholder")}
-              aria-invalid={showErrorMessage ? "true" : "false"}
-              required
+        <ScrollArea className="grow">
+          <div className="grid gap-6">
+            {/* Project Name */}
+            <div className="grid gap-2">
+              <Label htmlFor="project-name" className="text-base font-semibold">
+                {t("Project.Form.Name.Label")}
+              </Label>
+              <Input
+                id="project-name"
+                name="name"
+                value={name}
+                className={showErrorMessage ? "border-red-500" : ""}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t("Project.Form.Name.Placeholder")}
+                aria-invalid={showErrorMessage ? "true" : "false"}
+                required
+              />
+              {showErrorMessage && (
+                <p
+                  className="text-sm text-red-500"
+                  data-testid="form-project-name-error"
+                >
+                  {t("Project.Form.Name.Error.Required")}
+                </p>
+              )}{" "}
+              {/* Show error */}
+            </div>
+            <ProjectSimAndFeatures
+              simSettings={
+                {
+                  Sim: simulator,
+                  Features: {
+                    FSUIPC: useFsuipc,
+                    ProSim: useProsim,
+                  },
+                } as Partial<ProjectInfo>
+              }
+              onChange={(values) => {
+                console.log(values)
+                if (values.Sim) {
+                  setSimulator(values.Sim)
+                }
+                if (values.Features) {
+                  setUseFsuipc(values.Features.FSUIPC ?? false)
+                  setUseProsim(values.Features.ProSim ?? false)
+                }
+                // reset to default aircraft on switching simulator type
+                setAircraft(defaultAircraft[values.Sim ?? "none"])
+              }}
             />
-            {showErrorMessage && (
-              <p
-                className="text-sm text-red-500"
-                data-testid="form-project-name-error"
-              >
-                {t("Project.Form.Name.Error.Required")}
-              </p>
-            )}{" "}
-            {/* Show error */}
+            <ProjectAircraft
+              variant={simulator}
+              selectedAircraft={aircraft}
+              setSelectedAircraft={setAircraft}
+              drawerContainer={containerRef}
+            />
           </div>
-          <ProjectSimAndFeatures
-            simSettings={
-              {
-                Sim: simulator,
-                Features: {
-                  FSUIPC: useFsuipc,
-                  ProSim: useProsim,
-                },
-              } as Partial<ProjectInfo>
-            }
-            onChange={(values) => {
-              console.log(values)
-              if (values.Sim) {
-                setSimulator(values.Sim)
-              }
-              if (values.Features) {
-                setUseFsuipc(values.Features.FSUIPC ?? false)
-                setUseProsim(values.Features.ProSim ?? false)
-              }
-              // reset to default aircraft on switching simulator type
-              setAircraft(defaultAircraft[values.Sim ?? "none"])
-            }}
-          />
-          <ProjectAircraft
-            variant={simulator}
-            selectedAircraft={aircraft}
-            setSelectedAircraft={setAircraft}
-            drawerContainer={containerRef}
-          />
-        </div>
-
+        </ScrollArea>
         <DialogFooter>
           <DialogClose asChild>
             <Button variant="outline" type="button">

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -304,9 +304,7 @@ test.describe("Project settings modal features", () => {
         simLabel: "Microsoft Flight Simulator",
         fsuipc: { click: false, use: false },
         prosim: { click: false, use: false },
-        aircraft: [
-          { Vendor: "Microsoft", Name: "Generic" },
-        ],
+        aircraft: [{ Vendor: "Microsoft", Name: "Generic" }],
       },
       {
         name: "MSFS with FSUIPC",
@@ -314,9 +312,7 @@ test.describe("Project settings modal features", () => {
         simLabel: "Microsoft Flight Simulator",
         fsuipc: { click: true, use: true },
         prosim: { click: false, use: false },
-        aircraft: [
-          { Vendor: "Microsoft", Name: "Generic" },
-        ],
+        aircraft: [{ Vendor: "Microsoft", Name: "Generic" }],
       },
       {
         name: "X-Plane",
@@ -348,9 +344,7 @@ test.describe("Project settings modal features", () => {
         simLabel: "Microsoft Flight Simulator",
         fsuipc: { click: false, use: false },
         prosim: { click: true, use: true },
-        aircraft: [
-          { Vendor: "Microsoft", Name: "Generic" },
-        ],
+        aircraft: [{ Vendor: "Microsoft", Name: "Generic" }],
       },
     ]
 
@@ -635,21 +629,24 @@ test.describe("Project settings modal features", () => {
     await selectedAircraftOptions.first().click()
     await expect(selectedAircraftOptions).toHaveCount(1)
     await expect(availableAircraftOptions).toHaveCount(2)
-    
+
     await selectedAircraftOptions.first().click()
     await expect(selectedAircraftOptions).toHaveCount(0)
     await expect(availableAircraftOptions).toHaveCount(3)
     // and a message is displayed
     await expect(
-      projectAircraftDialog.getByText("No aircraft selected. No filter will apply. All presets will be available.", {
-        exact: true,
-      }),
+      projectAircraftDialog.getByText(
+        "No aircraft selected. No filter will apply. All presets will be available.",
+        {
+          exact: true,
+        },
+      ),
     ).toBeVisible()
 
     // Now re-add the first available aircraft
     // so that we can verify that the badge shows correct value
     await availableAircraftOptions.first().click()
-    
+
     // Close drawer
     const goBackButton = page.getByRole("button", {
       name: "Go back",
@@ -767,6 +764,30 @@ test.describe("Project settings modal features", () => {
     await goBackButton.click()
     await expect(goBackButton).not.toBeVisible()
     await expect(projectAircraftDialog).not.toBeVisible()
+  })
+  test("Is the Create button visible on the small screen without scrolling", async ({
+    dashboardPage,
+    page,
+  }) => {
+    await dashboardPage.gotoPage()
+    await page.setViewportSize({ width: 803, height: 533 })
+    await page
+      .getByTestId("project-main-card")
+      .getByRole("button", { name: "Project" })
+      .click()
+    const createProjectDialog = page.getByRole("dialog", {
+      name: "Create New Project",
+    })
+    await expect(createProjectDialog).toBeVisible()
+    const projectCreateButton = createProjectDialog.getByRole("button", {
+      name: "Create",
+    })
+    const projectCancelButton = createProjectDialog.getByRole("button", {
+      name: "Cancel",
+    })
+    // If overflow works correctly , the two buttons will be visible in the viewport.
+    await expect(projectCreateButton).toBeInViewport()
+    await expect(projectCancelButton).toBeInViewport()
   })
 })
 

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -765,7 +765,7 @@ test.describe("Project settings modal features", () => {
     await expect(goBackButton).not.toBeVisible()
     await expect(projectAircraftDialog).not.toBeVisible()
   })
-  test("Is the Create button visible on the small screen without scrolling", async ({
+  test("Create project dialog - Create and Cancel buttons are visible on small screens without scrolling", async ({
     dashboardPage,
     page,
   }) => {
@@ -785,7 +785,7 @@ test.describe("Project settings modal features", () => {
     const projectCancelButton = createProjectDialog.getByRole("button", {
       name: "Cancel",
     })
-    // If overflow works correctly , the two buttons will be visible in the viewport.
+    // If overflow works correctly, the two buttons will be visible in the viewport.
     await expect(projectCreateButton).toBeInViewport()
     await expect(projectCancelButton).toBeInViewport()
   })


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
The "Create" and "Cancel" buttons in the dialog are always clearly visible, and the scrollbar style has been adjusted for small screens.
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="804" height="585" alt="image" src="https://github.com/user-attachments/assets/0ef9f02b-b8cc-4f58-938f-7b99b228a069" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] The two buttons are always clearly visible, regardless of the screen size.
- [x] We use our scrollbar .


### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Frontend tests

     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3104 

