### PR TITLE
Smarter preset search

### DIFF
--- a/src/MobiFlightConnector/frontend/.claude/settings.local.json
+++ b/src/MobiFlightConnector/frontend/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx tsc *)",
+      "Bash(npx eslint *)"
+    ]
+  }
+}

--- a/src/MobiFlightConnector/frontend/.claude/settings.local.json
+++ b/src/MobiFlightConnector/frontend/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(npx tsc *)",
-      "Bash(npx eslint *)"
-    ]
-  }
-}

--- a/src/MobiFlightConnector/frontend/.gitignore
+++ b/src/MobiFlightConnector/frontend/.gitignore
@@ -38,3 +38,6 @@ dist-ssr
 
 # Playwright local storage and auth state
 tests/.auth/*
+
+# Ignore copilot & co temp folder
+.claude

--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -655,7 +655,7 @@
         "DeletePrecondition": "Vorbedingung löschen",
         "SelectPort": "Port auswählen...",
         "SelectPin": "Pin auswählen...",
-        "Types" : {
+        "Types": {
           "config": "Konfiguration",
           "variable": "Variable",
           "pin": "Arcaze-Pin"
@@ -716,11 +716,16 @@
           "Preset": {
             "Title": "Schritt 2 - Preset auswählen",
             "Description": "Wähle ein Preset aus unserer Preset-Bibliothek. Verwende Filter, um deine Suche einzugrenzen.",
-            "ProjectAircraftOnly": "Nur Projektflugzeuge"
+            "ProjectAircraftOnly": "Nur Projektflugzeuge",
+            "Vendor": "Hersteller",
+            "Aircraft": "Flugzeug",
+            "System": "System"
           },
           "Code": {
             "Title": "Schritt 3 - Code anpassen (optional)",
-            "Description": "Dieser Code wird vom Simulator verwendet. Du kannst ihn manuell bearbeiten oder ein Preset aus der obigen Liste auswählen."
+            "Description": "Dieser Code wird vom Simulator verwendet. Du kannst ihn manuell bearbeiten oder ein Preset aus der obigen Liste auswählen.",
+            "None": "Keiner",
+            "Customized": "Du hast dieses Preset angepasst oder es ist nicht mehr verfügbar."
           },
           "InputTypeLabel": "Eingabetyp",
           "SelectInputTypePlaceholder": "Eingabetyp auswählen",

--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -690,51 +690,34 @@
           "SearchPresets": "Presets suchen...",
           "PresetsFound": "{{count}} Preset(s) gefunden",
           "SupportedPlaceholders": "Unterstützt Eingabewert (@) und Platzhalter ($, #, etc.)",
-          "PresetLabel": "Preset",
           "ActionLabel": "Aktion",
-          "NameLabel": "Name"
-        },
-        "Msfs": {
+          "NameLabel": "Name",
           "Preset": {
+            "Label": "Preset",
             "Title": "Schritt 2 - Preset auswählen",
             "Description": "Wähle ein Preset aus unserer Preset-Bibliothek. Verwende Filter, um deine Suche einzugrenzen.",
             "ProjectAircraftOnly": "Nur Projektflugzeuge",
             "Vendor": "Hersteller",
             "Aircraft": "Flugzeug",
-            "System": "System"
-          },
-          "Code": {
-            "Title": "Schritt 3 - Code anpassen (optional)",
-            "Description": "Dieser Preset-Code wird für den Simulator verwendet. Du kannst den Code manuell bearbeiten oder ein Preset aus der obigen Liste auswählen.",
-            "None": "Keiner",
-            "Placeholder": "RPN-Code eingeben",
-            "Customized": "Du hast dieses Preset angepasst oder es ist nicht mehr verfügbar."
-          },
-          "CustomPreset": "Eigenes Preset"
+            "System": "System",
+            "Custom": "Eigenes Preset",
+            "Code": {
+              "Title": "Schritt 3 - Code anpassen (optional)",
+              "Description": "Dieser Preset-Code wird für den Simulator verwendet. Du kannst den Code manuell bearbeiten oder ein Preset aus der obigen Liste auswählen.",
+              "None": "Keiner",
+              "Placeholder": "RPN-Code eingeben",
+              "Customized": "Du hast dieses Preset angepasst oder es ist nicht mehr verfügbar."
+            }
+          }
         },
         "Xplane": {
-          "Preset": {
-            "Title": "Schritt 2 - Preset auswählen",
-            "Description": "Wähle ein Preset aus unserer Preset-Bibliothek. Verwende Filter, um deine Suche einzugrenzen.",
-            "ProjectAircraftOnly": "Nur Projektflugzeuge",
-            "Vendor": "Hersteller",
-            "Aircraft": "Flugzeug",
-            "System": "System"
-          },
-          "Code": {
-            "Title": "Schritt 3 - Code anpassen (optional)",
-            "Description": "Dieser Code wird vom Simulator verwendet. Du kannst ihn manuell bearbeiten oder ein Preset aus der obigen Liste auswählen.",
-            "None": "Keiner",
-            "Customized": "Du hast dieses Preset angepasst oder es ist nicht mehr verfügbar."
-          },
           "InputTypeLabel": "Eingabetyp",
           "SelectInputTypePlaceholder": "Eingabetyp auswählen",
           "PathLabel": "Pfad",
           "PathPlaceholder": "Pfad für DataRef oder Befehl eingeben, oder oben ein Preset auswählen",
           "PathDescription": "Hinweis: Verwende die Indexnotation, um auf Arrays zuzugreifen, z. B. sim/cockpit2/annunciators/fuel_pressure_low[0] für das 1. Triebwerk.",
           "ValueLabel": "Wert",
-          "ValuePlaceholder": "Wert eingeben",
-          "CustomPreset": "Eigenes Preset"
+          "ValuePlaceholder": "Wert eingeben"
         },
         "ProSim": {
           "Preset": {

--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -676,9 +676,9 @@
       },
       "InputActions": {
         "Common": {
-          "CodeLabel": "Code:",
+          "CodeLabel": "Code",
           "NoDescriptionAvailable": "Keine Beschreibung verfügbar",
-          "DescriptionLabel": "Beschreibung:",
+          "DescriptionLabel": "Beschreibung",
           "FilterPresets": "Presets filtern",
           "FilterByVendor": "Nach Hersteller filtern",
           "SearchVendors": "Hersteller suchen...",
@@ -691,19 +691,24 @@
           "PresetsFound": "{{count}} Preset(s) gefunden",
           "SupportedPlaceholders": "Unterstützt Eingabewert (@) und Platzhalter ($, #, etc.)",
           "PresetLabel": "Preset",
-          "ActionLabel": "Aktion"
+          "ActionLabel": "Aktion",
+          "NameLabel": "Name"
         },
         "Msfs": {
           "Preset": {
             "Title": "Schritt 2 - Preset auswählen",
             "Description": "Wähle ein Preset aus unserer Preset-Bibliothek. Verwende Filter, um deine Suche einzugrenzen.",
-            "ProjectAircraftOnly": "Nur Projektflugzeuge"
+            "ProjectAircraftOnly": "Nur Projektflugzeuge",
+            "Vendor": "Hersteller",
+            "Aircraft": "Flugzeug",
+            "System": "System"
           },
           "Code": {
             "Title": "Schritt 3 - Code anpassen (optional)",
-            "Description": "Dieser Code wird vom Simulator verwendet. Du kannst ihn manuell bearbeiten oder ein Preset aus der obigen Liste auswählen.",
+            "Description": "Dieser Preset-Code wird für den Simulator verwendet. Du kannst den Code manuell bearbeiten oder ein Preset aus der obigen Liste auswählen.",
             "None": "Keiner",
-            "Placeholder": "RPN-Code eingeben"
+            "Placeholder": "RPN-Code eingeben",
+            "Customized": "Du hast dieses Preset angepasst oder es ist nicht mehr verfügbar."
           },
           "CustomPreset": "Eigenes Preset"
         },

--- a/src/MobiFlightConnector/frontend/public/locales/de/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/de/translation.json
@@ -701,6 +701,8 @@
             "Aircraft": "Flugzeug",
             "System": "System",
             "Custom": "Eigenes Preset",
+            "Author": "Autor",
+            "Date": "Datum",
             "Code": {
               "Title": "Schritt 3 - Code anpassen (optional)",
               "Description": "Dieser Preset-Code wird für den Simulator verwendet. Du kannst den Code manuell bearbeiten oder ein Preset aus der obigen Liste auswählen.",

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -684,51 +684,34 @@
           "SearchPresets": "Search presets...",
           "PresetsFound": "{{count}} preset(s) found",
           "SupportedPlaceholders": "Supports input value (@) and placeholders ($, #, etc.)",
-          "PresetLabel": "Preset",
           "ActionLabel": "Action",
-          "NameLabel": "Name"
-        },
-        "Msfs": {
+          "NameLabel": "Name",
           "Preset": {
+            "Label": "Preset",
             "Title": "Step 2 - Select preset",
             "Description": "Choose a preset from our preset library. Use filters to narrow down your search.",
             "ProjectAircraftOnly": "Project aircraft only",
             "Vendor": "Vendor",
             "Aircraft": "Aircraft",
-            "System": "System"
-          },
-          "Code": {
-            "Title": "Step 3 - Customize preset (optional)",
-            "Description": "This preset code is used with your simulator. You can edit it manually or choose a preset from the list above.",
-            "None": "None",
-            "Placeholder": "Enter RPN code",
-            "Customized": "You customized this preset or it is no longer available."
-          },
-          "CustomPreset": "Custom Preset"
+            "System": "System",
+            "Custom": "Custom Preset",
+            "Code": {
+              "Title": "Step 3 - Customize preset (optional)",
+              "Description": "This preset code is used with your simulator. You can edit it manually or choose a preset from the list above.",
+              "None": "None",
+              "Placeholder": "Enter RPN code",
+              "Customized": "You customized this preset or it is no longer available."
+            }
+          }
         },
         "Xplane": {
-          "Preset": {
-            "Title": "Step 2 - Select preset",
-            "Description": "Choose a preset from our preset library. Use filters to narrow down your search.",
-            "ProjectAircraftOnly": "Project aircraft only",
-            "Vendor": "Vendor",
-            "Aircraft": "Aircraft",
-            "System": "System"
-          },
-          "Code": {
-            "Title": "Step 3 - Customize preset (optional)",
-            "Description": "This code is used by the simulator. You can edit it manually or select a preset from the list above.",
-            "None": "None",
-            "Customized": "You customized this preset or it is no longer available."
-          },
           "InputTypeLabel": "Input Type",
           "SelectInputTypePlaceholder": "Select input type",
           "PathLabel": "Path",
           "PathPlaceholder": "Enter path for DataRef or Command, or select a preset above",
           "PathDescription": "Hint: Use index notation for access of Arrays, e.g. sim/cockpit2/annunciators/fuel_pressure_low[0] for 1st engine.",
           "ValueLabel": "Value",
-          "ValuePlaceholder": "Enter value",
-          "CustomPreset": "Custom Preset"
+          "ValuePlaceholder": "Enter value"
         },
         "ProSim": {
           "Preset": {

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -670,9 +670,9 @@
       },
       "InputActions": {
         "Common": {
-          "CodeLabel": "Code:",
+          "CodeLabel": "Code",
           "NoDescriptionAvailable": "No description available",
-          "DescriptionLabel": "Description:",
+          "DescriptionLabel": "Description",
           "FilterPresets": "Filter presets by text",
           "FilterByVendor": "Filter by vendor",
           "SearchVendors": "Search vendors...",
@@ -685,19 +685,24 @@
           "PresetsFound": "{{count}} preset(s) found",
           "SupportedPlaceholders": "Supports input value (@) and placeholders ($, #, etc.)",
           "PresetLabel": "Preset",
-          "ActionLabel": "Action"
+          "ActionLabel": "Action",
+          "NameLabel": "Name"
         },
         "Msfs": {
           "Preset": {
             "Title": "Step 2 - Select preset",
             "Description": "Choose a preset from our preset library. Use filters to narrow down your search.",
-            "ProjectAircraftOnly": "Project aircraft only"
+            "ProjectAircraftOnly": "Project aircraft only",
+            "Vendor": "Vendor",
+            "Aircraft": "Aircraft",
+            "System": "System"
           },
           "Code": {
-            "Title": "Step 3 - Refine code (optional)",
-            "Description": "This code is used by the simulator. You can edit it manually or select a preset from the list above.",
+            "Title": "Step 3 - Customize preset (optional)",
+            "Description": "This preset code is used with your simulator. You can edit it manually or choose a preset from the list above.",
             "None": "None",
-            "Placeholder": "Enter RPN code"
+            "Placeholder": "Enter RPN code",
+            "Customized": "You customized this preset or it is no longer available."
           },
           "CustomPreset": "Custom Preset"
         },

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -695,6 +695,8 @@
             "Aircraft": "Aircraft",
             "System": "System",
             "Custom": "Custom Preset",
+            "Author": "Author",
+            "Date": "Date",
             "Code": {
               "Title": "Step 3 - Customize preset (optional)",
               "Description": "This preset code is used with your simulator. You can edit it manually or choose a preset from the list above.",

--- a/src/MobiFlightConnector/frontend/public/locales/en/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/en/translation.json
@@ -710,11 +710,16 @@
           "Preset": {
             "Title": "Step 2 - Select preset",
             "Description": "Choose a preset from our preset library. Use filters to narrow down your search.",
-            "ProjectAircraftOnly": "Project aircraft only"
+            "ProjectAircraftOnly": "Project aircraft only",
+            "Vendor": "Vendor",
+            "Aircraft": "Aircraft",
+            "System": "System"
           },
           "Code": {
-            "Title": "Step 3 - Refine code (optional)",
-            "Description": "This code is used by the simulator. You can edit it manually or select a preset from the list above."
+            "Title": "Step 3 - Customize preset (optional)",
+            "Description": "This code is used by the simulator. You can edit it manually or select a preset from the list above.",
+            "None": "None",
+            "Customized": "You customized this preset or it is no longer available."
           },
           "InputTypeLabel": "Input Type",
           "SelectInputTypePlaceholder": "Select input type",

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -676,9 +676,9 @@
       },
       "InputActions": {
         "Common": {
-          "CodeLabel": "Código:",
+          "CodeLabel": "Código",
           "NoDescriptionAvailable": "No hay descripción disponible",
-          "DescriptionLabel": "Descripción:",
+          "DescriptionLabel": "Descripción",
           "FilterPresets": "Filtrar presets",
           "FilterByVendor": "Filtrar por fabricante",
           "SearchVendors": "Buscar fabricantes...",
@@ -691,7 +691,8 @@
           "PresetsFound": "{{count}} preset(s) encontrado(s)",
           "SupportedPlaceholders": "Admite valor de entrada (@) y marcadores de posición ($, #, etc.)",
           "PresetLabel": "Preset",
-          "ActionLabel": "Acción"
+          "ActionLabel": "Acción",
+          "NameLabel": "Name"
         },
         "Msfs": {
           "Preset": {
@@ -700,10 +701,13 @@
             "ProjectAircraftOnly": "Solo aviones del proyecto"
           },
           "Code": {
-            "Title": "Paso 3 - Refinar código (opcional)",
+            "Title": "Paso 3 - Modificar código (opcional)",
             "Description": "Este código es utilizado por el simulador. Puedes editarlo manualmente o seleccionar un preset de la lista anterior.",
             "None": "Ninguno",
-            "Placeholder": "Ingresar código RPN"
+            "Placeholder": "Ingresar código RPN",
+            "Vendor": "Fabricante",
+            "Aircraft": "Aeronave",
+            "System": "Sistema"
           },
           "CustomPreset": "Preset personalizado"
         },

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -690,51 +690,34 @@
           "SearchPresets": "Buscar presets...",
           "PresetsFound": "{{count}} preset(s) encontrado(s)",
           "SupportedPlaceholders": "Admite valor de entrada (@) y marcadores de posición ($, #, etc.)",
-          "PresetLabel": "Preset",
           "ActionLabel": "Acción",
-          "NameLabel": "Nombre"
-        },
-        "Msfs": {
+          "NameLabel": "Nombre",
           "Preset": {
+            "Label": "Preset",
             "Title": "Paso 2 - Seleccionar preset",
             "Description": "Elige un preset de nuestra biblioteca de presets. Usa los filtros para acotar tu búsqueda.",
             "ProjectAircraftOnly": "Solo aviones del proyecto",
             "Vendor": "Fabricante",
             "Aircraft": "Aeronave",
-            "System": "Sistema"
-          },
-          "Code": {
-            "Title": "Paso 3 - Modificar código (opcional)",
-            "Description": "Este código es utilizado por el simulador. Puedes editarlo manualmente o seleccionar un preset de la lista anterior.",
-            "None": "Ninguno",
-            "Placeholder": "Ingresar código RPN",
-            "Customized": "Personalizaste este preset o ya no está disponible."
-          },
-          "CustomPreset": "Preset personalizado"
+            "System": "Sistema",
+            "Custom": "Preset personalizado",
+            "Code": {
+              "Title": "Paso 3 - Modificar código (opcional)",
+              "Description": "Este código es utilizado por el simulador. Puedes editarlo manualmente o seleccionar un preset de la lista anterior.",
+              "None": "Ninguno",
+              "Placeholder": "Ingresar código RPN",
+              "Customized": "Personalizaste este preset o ya no está disponible."
+            }
+          }
         },
         "Xplane": {
-          "Preset": {
-            "Title": "Paso 2 - Seleccionar preset",
-            "Description": "Elige un preset de nuestra biblioteca de presets. Usa los filtros para acotar tu búsqueda.",
-            "ProjectAircraftOnly": "Solo aviones del proyecto",
-            "Vendor": "Fabricante",
-            "Aircraft": "Aeronave",
-            "System": "Sistema"
-          },
-          "Code": {
-            "Title": "Paso 3 - Modificar código (opcional)",
-            "Description": "Este código es utilizado por el simulador. Puedes editarlo manualmente o seleccionar un preset de la lista anterior.",
-            "None": "Ninguno",
-            "Customized": "Personalizaste este preset o ya no está disponible."
-          },
           "InputTypeLabel": "Tipo de entrada",
           "SelectInputTypePlaceholder": "Seleccionar tipo de entrada",
           "PathLabel": "Ruta",
           "PathPlaceholder": "Ingresa la ruta para DataRef o Comando, o selecciona un preset arriba",
           "PathDescription": "Nota: Usa la notación de índice para acceder a los arrays, p. ej., sim/cockpit2/annunciators/fuel_pressure_low[0] para el 1er motor.",
           "ValueLabel": "Valor",
-          "ValuePlaceholder": "Ingresa el valor",
-          "CustomPreset": "Preset personalizado"
+          "ValuePlaceholder": "Ingresa el valor"
         },
         "ProSim": {
           "Preset": {

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -655,7 +655,7 @@
         "DeletePrecondition": "Eliminar precondición",
         "SelectPort": "Seleccionar puerto...",
         "SelectPin": "Seleccionar pin...",
-        "Types" : {
+        "Types": {
           "config": "Configuración",
           "variable": "Variable",
           "pin": "Pin Arcaze"
@@ -692,22 +692,23 @@
           "SupportedPlaceholders": "Admite valor de entrada (@) y marcadores de posición ($, #, etc.)",
           "PresetLabel": "Preset",
           "ActionLabel": "Acción",
-          "NameLabel": "Name"
+          "NameLabel": "Nombre"
         },
         "Msfs": {
           "Preset": {
             "Title": "Paso 2 - Seleccionar preset",
             "Description": "Elige un preset de nuestra biblioteca de presets. Usa los filtros para acotar tu búsqueda.",
-            "ProjectAircraftOnly": "Solo aviones del proyecto"
+            "ProjectAircraftOnly": "Solo aviones del proyecto",
+            "Vendor": "Fabricante",
+            "Aircraft": "Aeronave",
+            "System": "Sistema"
           },
           "Code": {
             "Title": "Paso 3 - Modificar código (opcional)",
             "Description": "Este código es utilizado por el simulador. Puedes editarlo manualmente o seleccionar un preset de la lista anterior.",
             "None": "Ninguno",
             "Placeholder": "Ingresar código RPN",
-            "Vendor": "Fabricante",
-            "Aircraft": "Aeronave",
-            "System": "Sistema"
+            "Customized": "Personalizaste este preset o ya no está disponible."
           },
           "CustomPreset": "Preset personalizado"
         },
@@ -715,11 +716,16 @@
           "Preset": {
             "Title": "Paso 2 - Seleccionar preset",
             "Description": "Elige un preset de nuestra biblioteca de presets. Usa los filtros para acotar tu búsqueda.",
-            "ProjectAircraftOnly": "Solo aviones del proyecto"
+            "ProjectAircraftOnly": "Solo aviones del proyecto",
+            "Vendor": "Fabricante",
+            "Aircraft": "Aeronave",
+            "System": "Sistema"
           },
           "Code": {
-            "Title": "Paso 3 - Refinar código (opcional)",
-            "Description": "Este código es utilizado por el simulador. Puedes editarlo manualmente o seleccionar un preset de la lista anterior."
+            "Title": "Paso 3 - Modificar código (opcional)",
+            "Description": "Este código es utilizado por el simulador. Puedes editarlo manualmente o seleccionar un preset de la lista anterior.",
+            "None": "Ninguno",
+            "Customized": "Personalizaste este preset o ya no está disponible."
           },
           "InputTypeLabel": "Tipo de entrada",
           "SelectInputTypePlaceholder": "Seleccionar tipo de entrada",

--- a/src/MobiFlightConnector/frontend/public/locales/es/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/es/translation.json
@@ -701,6 +701,8 @@
             "Aircraft": "Aeronave",
             "System": "Sistema",
             "Custom": "Preset personalizado",
+            "Author": "Autor",
+            "Date": "Fecha",
             "Code": {
               "Title": "Paso 3 - Modificar código (opcional)",
               "Description": "Este código es utilizado por el simulador. Puedes editarlo manualmente o seleccionar un preset de la lista anterior.",

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -670,9 +670,9 @@
       },
       "InputActions": {
         "Common": {
-          "CodeLabel": "Koodi:",
+          "CodeLabel": "Koodi",
           "NoDescriptionAvailable": "Ei kuvausta saatavilla",
-          "DescriptionLabel": "Kuvaus:",
+          "DescriptionLabel": "Kuvaus",
           "FilterPresets": "Suodata esiasetuksia",
           "FilterByVendor": "Suodata valmistajan mukaan",
           "SearchVendors": "Etsi valmistajia...",
@@ -685,19 +685,24 @@
           "PresetsFound": "{{count}} esiasetus(ta) löytyi",
           "SupportedPlaceholders": "Tukee syötearvoa (@) ja paikkamerkkejä ($, #, jne.)",
           "PresetLabel": "Esiasetus",
-          "ActionLabel": "Toiminto"
+          "ActionLabel": "Toiminto",
+          "NameLabel": "Nimi"
         },
         "Msfs": {
           "Preset": {
             "Title": "Vaihe 2 - Valitse esiasetus",
             "Description": "Valitse esiasetus esiasetuskirjastostamme. Käytä suodattimia rajataksesi hakua.",
-            "ProjectAircraftOnly": "Vain projektin lentokoneet"
+            "ProjectAircraftOnly": "Vain projektin lentokoneet",
+            "Vendor": "Valmistaja",
+            "Aircraft": "Lentokone",
+            "System": "Järjestelmä"
           },
           "Code": {
-            "Title": "Vaihe 3 - Hienosäädä koodi (valinnainen)",
+            "Title": "Vaihe 3 - Muokkaa koodia tarvittaessa",
             "Description": "Tätä koodia käyttää simulaattori. Voit muokata sitä manuaalisesti tai valita esiasetuksen yllä olevasta listasta.",
             "None": "Ei mitään",
-            "Placeholder": "Syötä RPN-koodi"
+            "Placeholder": "Syötä RPN-koodi",
+            "Customized": "Mukautit tämän esiasetuksen tai se ei ole enää saatavilla."
           },
           "CustomPreset": "Mukautettu esiasetus"
         },

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -695,6 +695,8 @@
             "Aircraft": "Lentokone",
             "System": "Järjestelmä",
             "Custom": "Mukautettu esiasetus",
+            "Author": "Tekijä",
+            "Date": "Päivämäärä",
             "Code": {
               "Title": "Vaihe 3 - Muokkaa koodia tarvittaessa",
               "Description": "Tätä koodia käyttää simulaattori. Voit muokata sitä manuaalisesti tai valita esiasetuksen yllä olevasta listasta.",

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -684,51 +684,34 @@
           "SearchPresets": "Etsi esiasetuksia...",
           "PresetsFound": "{{count}} esiasetus(ta) löytyi",
           "SupportedPlaceholders": "Tukee syötearvoa (@) ja paikkamerkkejä ($, #, jne.)",
-          "PresetLabel": "Esiasetus",
           "ActionLabel": "Toiminto",
-          "NameLabel": "Nimi"
-        },
-        "Msfs": {
+          "NameLabel": "Nimi",
           "Preset": {
+            "Label": "Esiasetus",
             "Title": "Vaihe 2 - Valitse esiasetus",
             "Description": "Valitse esiasetus esiasetuskirjastostamme. Käytä suodattimia rajataksesi hakua.",
             "ProjectAircraftOnly": "Vain projektin lentokoneet",
             "Vendor": "Valmistaja",
             "Aircraft": "Lentokone",
-            "System": "Järjestelmä"
-          },
-          "Code": {
-            "Title": "Vaihe 3 - Muokkaa koodia tarvittaessa",
-            "Description": "Tätä koodia käyttää simulaattori. Voit muokata sitä manuaalisesti tai valita esiasetuksen yllä olevasta listasta.",
-            "None": "Ei mitään",
-            "Placeholder": "Syötä RPN-koodi",
-            "Customized": "Mukautit tämän esiasetuksen tai se ei ole enää saatavilla."
-          },
-          "CustomPreset": "Mukautettu esiasetus"
+            "System": "Järjestelmä",
+            "Custom": "Mukautettu esiasetus",
+            "Code": {
+              "Title": "Vaihe 3 - Muokkaa koodia tarvittaessa",
+              "Description": "Tätä koodia käyttää simulaattori. Voit muokata sitä manuaalisesti tai valita esiasetuksen yllä olevasta listasta.",
+              "None": "Ei mitään",
+              "Placeholder": "Syötä RPN-koodi",
+              "Customized": "Mukautit tämän esiasetuksen tai se ei ole enää saatavilla."
+            }
+          }
         },
         "Xplane": {
-          "Preset": {
-            "Title": "Vaihe 2 - Valitse esiasetus",
-            "Description": "Valitse esiasetus esiasetuskirjastostamme. Käytä suodattimia rajataksesi hakua.",
-            "ProjectAircraftOnly": "Vain projektin lentokoneet",
-            "Vendor": "Valmistaja",
-            "Aircraft": "Lentokone",
-            "System": "Järjestelmä"
-          },
-          "Code": {
-            "Title": "Vaihe 3 - Muokkaa koodia tarvittaessa",
-            "Description": "Tätä koodia käyttää simulaattori. Voit muokata sitä manuaalisesti tai valita esiasetuksen yllä olevasta listasta.",
-            "None": "Ei mitään",
-            "Customized": "Mukautit tämän esiasetuksen tai se ei ole enää saatavilla."
-          },
           "InputTypeLabel": "Syötetyyppi",
           "SelectInputTypePlaceholder": "Valitse syötetyyppi",
           "PathLabel": "Polku",
           "PathPlaceholder": "Syötä polku DataRefille tai komennolle, tai valitse esiasetus yltä",
           "PathDescription": "Vihje: Käytä indeksi-notaatiota taulukoiden käsittelyyn, esim. sim/cockpit2/annunciators/fuel_pressure_low[0] ensimmäiselle moottorille.",
           "ValueLabel": "Arvo",
-          "ValuePlaceholder": "Syötä arvo",
-          "CustomPreset": "Mukautettu esiasetus"
+          "ValuePlaceholder": "Syötä arvo"
         },
         "ProSim": {
           "Preset": {

--- a/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/fi/translation.json
@@ -710,11 +710,16 @@
           "Preset": {
             "Title": "Vaihe 2 - Valitse esiasetus",
             "Description": "Valitse esiasetus esiasetuskirjastostamme. Käytä suodattimia rajataksesi hakua.",
-            "ProjectAircraftOnly": "Vain projektin lentokoneet"
+            "ProjectAircraftOnly": "Vain projektin lentokoneet",
+            "Vendor": "Valmistaja",
+            "Aircraft": "Lentokone",
+            "System": "Järjestelmä"
           },
           "Code": {
-            "Title": "Vaihe 3 - Hienosäädä koodi (valinnainen)",
-            "Description": "Tätä koodia käyttää simulaattori. Voit muokata sitä manuaalisesti tai valita esiasetuksen yllä olevasta listasta."
+            "Title": "Vaihe 3 - Muokkaa koodia tarvittaessa",
+            "Description": "Tätä koodia käyttää simulaattori. Voit muokata sitä manuaalisesti tai valita esiasetuksen yllä olevasta listasta.",
+            "None": "Ei mitään",
+            "Customized": "Mukautit tämän esiasetuksen tai se ei ole enää saatavilla."
           },
           "InputTypeLabel": "Syötetyyppi",
           "SelectInputTypePlaceholder": "Valitse syötetyyppi",

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -695,6 +695,8 @@
             "Aircraft": "Aeronave",
             "System": "Sistema",
             "Custom": "Predefinição personalizada",
+            "Author": "Autor",
+            "Date": "Data",
             "Code": {
               "Title": "Passo 3 - Refinar código (opcional)",
               "Description": "Este código é usado pelo simulador. Você pode editá-lo manualmente ou selecionar uma predefinição da lista acima.",

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -684,51 +684,34 @@
           "SearchPresets": "Pesquisar predefinições...",
           "PresetsFound": "{{count}} predefinição(ões) encontrada(s)",
           "SupportedPlaceholders": "Suporta valor de entrada (@) e espaços reservados ($, #, etc.)",
-          "PresetLabel": "Preset",
           "ActionLabel": "Ação",
-          "NameLabel": "Nome"
-        },
-        "Msfs": {
+          "NameLabel": "Nome",
           "Preset": {
+            "Label": "Preset",
             "Title": "Passo 2 - Selecionar predefinição",
             "Description": "Escolha uma predefinição da nossa biblioteca de predefinições. Use filtros para restringir sua pesquisa.",
             "ProjectAircraftOnly": "Apenas aeronaves do projeto",
             "Vendor": "Fornecedor",
             "Aircraft": "Aeronave",
-            "System": "Sistema"
-          },
-          "Code": {
-            "Title": "Passo 3 - Refinar código (opcional)",
-            "Description": "Este código é usado pelo simulador. Você pode editá-lo manualmente ou selecionar uma predefinição da lista acima.",
-            "None": "Nenhum",
-            "Placeholder": "Digite o código RPN",
-            "Customized": "Você personalizou esta predefinição ou ela não está mais disponível."
-          },
-          "CustomPreset": "Predefinição personalizada"
+            "System": "Sistema",
+            "Custom": "Predefinição personalizada",
+            "Code": {
+              "Title": "Passo 3 - Refinar código (opcional)",
+              "Description": "Este código é usado pelo simulador. Você pode editá-lo manualmente ou selecionar uma predefinição da lista acima.",
+              "None": "Nenhum",
+              "Placeholder": "Digite o código RPN",
+              "Customized": "Você personalizou esta predefinição ou ela não está mais disponível."
+            }
+          }
         },
         "Xplane": {
-          "Preset": {
-            "Title": "Passo 2 - Selecionar predefinição",
-            "Description": "Escolha uma predefinição da nossa biblioteca de predefinições. Use filtros para restringir sua pesquisa.",
-            "ProjectAircraftOnly": "Apenas aeronaves do projeto",
-            "Vendor": "Fornecedor",
-            "Aircraft": "Aeronave",
-            "System": "Sistema"
-          },
-          "Code": {
-            "Title": "Passo 3 - Refinar código (opcional)",
-            "Description": "Este código é usado pelo simulador. Você pode editá-lo manualmente ou selecionar uma predefinição da lista acima.",
-            "None": "Nenhum",
-            "Customized": "Você personalizou esta predefinição ou ela não está mais disponível."
-          },
           "InputTypeLabel": "Tipo de Entrada",
           "SelectInputTypePlaceholder": "Selecionar tipo de entrada",
           "PathLabel": "Caminho",
           "PathPlaceholder": "Digite o caminho para DataRef ou Comando, ou selecione uma predefinição acima",
           "PathDescription": "Dica: Use a notação de índice para acessar Arrays, por exemplo, sim/cockpit2/annunciators/fuel_pressure_low[0] para o 1º motor.",
           "ValueLabel": "Valor",
-          "ValuePlaceholder": "Digite o valor",
-          "CustomPreset": "Predefinição personalizada"
+          "ValuePlaceholder": "Digite o valor"
         },
         "ProSim": {
           "Preset": {

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -670,9 +670,9 @@
       },
       "InputActions": {
         "Common": {
-          "CodeLabel": "Código:",
+          "CodeLabel": "Código",
           "NoDescriptionAvailable": "Nenhuma descrição disponível",
-          "DescriptionLabel": "Descrição:",
+          "DescriptionLabel": "Descrição",
           "FilterPresets": "Filtrar predefinições",
           "FilterByVendor": "Filtrar por fornecedor",
           "SearchVendors": "Pesquisar fornecedores...",
@@ -685,19 +685,24 @@
           "PresetsFound": "{{count}} predefinição(ões) encontrada(s)",
           "SupportedPlaceholders": "Suporta valor de entrada (@) e espaços reservados ($, #, etc.)",
           "PresetLabel": "Preset",
-          "ActionLabel": "Ação"
+          "ActionLabel": "Ação",
+          "NameLabel": "Nome"
         },
         "Msfs": {
           "Preset": {
             "Title": "Passo 2 - Selecionar predefinição",
             "Description": "Escolha uma predefinição da nossa biblioteca de predefinições. Use filtros para restringir sua pesquisa.",
-            "ProjectAircraftOnly": "Apenas aeronaves do projeto"
+            "ProjectAircraftOnly": "Apenas aeronaves do projeto",
+            "Vendor": "Fornecedor",
+            "Aircraft": "Aeronave",
+            "System": "Sistema"
           },
           "Code": {
             "Title": "Passo 3 - Refinar código (opcional)",
             "Description": "Este código é usado pelo simulador. Você pode editá-lo manualmente ou selecionar uma predefinição da lista acima.",
             "None": "Nenhum",
-            "Placeholder": "Digite o código RPN"
+            "Placeholder": "Digite o código RPN",
+            "Customized": "Você personalizou esta predefinição ou ela não está mais disponível."
           },
           "CustomPreset": "Predefinição personalizada"
         },

--- a/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
+++ b/src/MobiFlightConnector/frontend/public/locales/pt/translation.json
@@ -649,7 +649,7 @@
         "DeletePrecondition": "Excluir precondição",
         "SelectPort": "Selecionar porta...",
         "SelectPin": "Selecionar pino...",
-        "Types" : {
+        "Types": {
           "config": "Configuração",
           "variable": "Variável",
           "pin": "Pino Arcaze"
@@ -710,11 +710,16 @@
           "Preset": {
             "Title": "Passo 2 - Selecionar predefinição",
             "Description": "Escolha uma predefinição da nossa biblioteca de predefinições. Use filtros para restringir sua pesquisa.",
-            "ProjectAircraftOnly": "Apenas aeronaves do projeto"
+            "ProjectAircraftOnly": "Apenas aeronaves do projeto",
+            "Vendor": "Fornecedor",
+            "Aircraft": "Aeronave",
+            "System": "Sistema"
           },
           "Code": {
             "Title": "Passo 3 - Refinar código (opcional)",
-            "Description": "Este código é usado pelo simulador. Você pode editá-lo manualmente ou selecionar uma predefinição da lista acima."
+            "Description": "Este código é usado pelo simulador. Você pode editá-lo manualmente ou selecionar uma predefinição da lista acima.",
+            "None": "Nenhum",
+            "Customized": "Você personalizou esta predefinição ou ela não está mais disponível."
           },
           "InputTypeLabel": "Tipo de Entrada",
           "SelectInputTypePlaceholder": "Selecionar tipo de entrada",

--- a/src/MobiFlightConnector/frontend/src/components/community/CommunityFeedItem.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/community/CommunityFeedItem.tsx
@@ -1,6 +1,6 @@
 import { CommunityPost } from "@/types/feed"
 import { Button } from "@/components/ui/button"
-import useMessageExchange from "@/lib/hooks/useMessageExchange"
+import useOpenUrl from "@/lib/hooks/useOpenUrl"
 import { cn } from "@/lib/utils"
 import Markdown, { Components } from "react-markdown"
 
@@ -10,14 +10,7 @@ export type CommunityFeedItemProps = {
 
 const CommunityFeedItem = (props: CommunityFeedItemProps) => {
   const post = props.post
-  const { publish } = useMessageExchange()
-
-  const openUrl = (url: string) => {
-    publish({
-      key: "CommandOpenLinkInBrowser",
-      payload: { url: url },
-    })
-  }
+  const openUrl = useOpenUrl()
 
   const handleLinkClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
     e.preventDefault()

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -10,6 +10,7 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import IconBrandHubHopLogo from "@/components/icons/IconBrandHubHopLogo"
 import { IconExclamationCircle } from "@tabler/icons-react"
+import useOpenUrl from "@/lib/hooks/useOpenUrl"
 
 export type MsfsInputActionPanelProps = {
   variant: "summary" | "details"
@@ -23,6 +24,8 @@ const MsfsInputActionPanel = ({
   onConfigChange,
 }: MsfsInputActionPanelProps) => {
   const { t } = useTranslation()
+  const openUrl = useOpenUrl()
+
   const { data: presets = [] /*, isLoading */ } = useQuery({
     queryKey: ["msfs-presets"],
     queryFn: () => fetchHubHopPresets("msfs"),
@@ -60,6 +63,11 @@ const MsfsInputActionPanel = ({
     vendor: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.Vendor"),
     aircraft: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.Aircraft"),
     system: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.System"),
+  }
+
+  const openHubHopDetails = () => {
+    const hubHopUrl = `https://hubhop.mobiflight.com/preset/?simType=msfs2020&id=${preset?.id}`
+    openUrl(hubHopUrl)
   }
 
   return (
@@ -134,6 +142,7 @@ const MsfsInputActionPanel = ({
                       <Button
                         className="h-8 gap-1 rounded-full px-4 py-1 [&_svg]:size-6"
                         variant={"ghost"}
+                        onClick={openHubHopDetails}
                       >
                         <IconBrandHubHopLogo className="fill-orange-400 stroke-orange-400" />
                         HubHop

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -39,11 +39,11 @@ const MsfsInputActionPanel = ({
       <div className="flex grow flex-row items-center gap-2">
         <div className="flex w-1/3 flex-col gap-1">
           <Label htmlFor="preset">
-            {t("Dialog.InputConfigWizard.InputActions.Common.PresetLabel")}:
+            {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Label")}:
           </Label>
           <div className="text-sm">
             {preset?.label ??
-              t("Dialog.InputConfigWizard.InputActions.Msfs.CustomPreset")}
+              t("Dialog.InputConfigWizard.InputActions.Common.Preset.Custom")}
           </div>
         </div>
         <div className="flex grow flex-col gap-1">
@@ -52,7 +52,7 @@ const MsfsInputActionPanel = ({
           </Label>
           <CodeValueLabel id="code" className="max-w-50 lg:max-w-100">
             {config?.Command ??
-              t("Dialog.InputConfigWizard.InputActions.Msfs.Code.None")}
+              t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.None")}
           </CodeValueLabel>
         </div>
       </div>
@@ -60,9 +60,9 @@ const MsfsInputActionPanel = ({
   }
 
   const labels = {
-    vendor: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.Vendor"),
-    aircraft: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.Aircraft"),
-    system: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.System"),
+    vendor: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Vendor"),
+    aircraft: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Aircraft"),
+    system: t("Dialog.InputConfigWizard.InputActions.Common.Preset.System"),
   }
 
   const openHubHopDetails = () => {
@@ -87,10 +87,10 @@ const MsfsInputActionPanel = ({
         <CardContent className="flex flex-col gap-4 pt-4">
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
-              {t("Dialog.InputConfigWizard.InputActions.Msfs.Code.Title")}
+              {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Title")}
             </div>
             <div className="text-muted-foreground text-sm">
-              {t("Dialog.InputConfigWizard.InputActions.Msfs.Code.Description")}
+              {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Description")}
             </div>
           </div>
           <div className="flex flex-col gap-4">
@@ -157,7 +157,7 @@ const MsfsInputActionPanel = ({
                   <IconExclamationCircle className="text-primary fill-background" />
                   <div className="text-primary text-sm">
                     {t(
-                      "Dialog.InputConfigWizard.InputActions.Msfs.Code.Customized",
+                      "Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Customized",
                     )}
                   </div>
                 </div>
@@ -172,7 +172,7 @@ const MsfsInputActionPanel = ({
                 name="code"
                 className="dark:focus:bg-input/20 font-mono text-sm whitespace-nowrap dark:bg-transparent"
                 placeholder={t(
-                  "Dialog.InputConfigWizard.InputActions.Msfs.Code.Placeholder",
+                  "Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Placeholder",
                 )}
                 value={config?.Command ?? ""}
                 onChange={(e) => {

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -52,7 +52,9 @@ const MsfsInputActionPanel = ({
           </Label>
           <CodeValueLabel id="code" className="max-w-50 lg:max-w-100">
             {config?.Command ??
-              t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.None")}
+              t(
+                "Dialog.InputConfigWizard.InputActions.Common.Preset.Code.None",
+              )}
           </CodeValueLabel>
         </div>
       </div>
@@ -63,6 +65,8 @@ const MsfsInputActionPanel = ({
     vendor: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Vendor"),
     aircraft: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Aircraft"),
     system: t("Dialog.InputConfigWizard.InputActions.Common.Preset.System"),
+    author: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Author"),
+    date: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Date"),
   }
 
   const openHubHopDetails = () => {
@@ -84,13 +88,20 @@ const MsfsInputActionPanel = ({
         }
       />
       <Card>
-        <CardContent className="flex flex-col gap-4 pt-4" data-testid="preset-code-panel">
+        <CardContent
+          className="flex flex-col gap-4 pt-4"
+          data-testid="preset-code-panel"
+        >
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
-              {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Title")}
+              {t(
+                "Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Title",
+              )}
             </div>
             <div className="text-muted-foreground text-sm">
-              {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Description")}
+              {t(
+                "Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Description",
+              )}
             </div>
           </div>
           <div className="flex flex-col gap-4">
@@ -99,7 +110,9 @@ const MsfsInputActionPanel = ({
                 <div className="flex flex-row gap-4">
                   <div className="flex flex-1 flex-col gap-1">
                     <Label htmlFor="code">
-                      {t("Dialog.InputConfigWizard.InputActions.Common.NameLabel")}
+                      {t(
+                        "Dialog.InputConfigWizard.InputActions.Common.NameLabel",
+                      )}
                     </Label>
                     <div className="text-sm font-semibold">{preset?.label}</div>
                   </div>
@@ -125,7 +138,9 @@ const MsfsInputActionPanel = ({
                   {preset?.author && preset?.createdDate && (
                     <div className="flex flex-1 flex-row items-center gap-1">
                       <div className="flex flex-1 flex-col gap-1">
-                        <Label htmlFor="code">Author / Date</Label>
+                        <Label htmlFor="code">
+                          {labels.author} / {labels.date}
+                        </Label>
                         <div className="text-sm">
                           {preset?.author}
                           {preset?.createdDate && (
@@ -152,7 +167,7 @@ const MsfsInputActionPanel = ({
                 </div>
               </>
             ) : (
-              config?.Command !== "" && (
+              (config?.Command ?? "") !== "" && (
                 <div className="flex flex-row items-center gap-2 rounded-md">
                   <IconExclamationCircle className="text-primary fill-background" />
                   <div className="text-primary text-sm">

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -84,7 +84,7 @@ const MsfsInputActionPanel = ({
         }
       />
       <Card>
-        <CardContent className="flex flex-col gap-4 pt-4">
+        <CardContent className="flex flex-col gap-4 pt-4" data-testid="preset-code-panel">
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
               {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Title")}

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -56,6 +56,12 @@ const MsfsInputActionPanel = ({
     )
   }
 
+  const labels = {
+    vendor: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.Vendor"),
+    aircraft: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.Aircraft"),
+    system: t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.System"),
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <MsfsPresetPanel
@@ -84,12 +90,16 @@ const MsfsInputActionPanel = ({
               <>
                 <div className="flex flex-row gap-4">
                   <div className="flex flex-1 flex-col gap-1">
-                    <Label htmlFor="code">Name</Label>
+                    <Label htmlFor="code">
+                      {t("Dialog.InputConfigWizard.InputActions.Common.NameLabel")}
+                    </Label>
                     <div className="text-sm font-semibold">{preset?.label}</div>
                   </div>
 
                   <div className="flex flex-1 flex-col gap-1">
-                    <Label htmlFor="code">Vendor / Aircraft / System</Label>
+                    <Label htmlFor="code">
+                      {labels.vendor} / {labels.aircraft} / {labels.system}
+                    </Label>
                     <div className="text-sm">
                       {preset?.vendor} / {preset?.aircraft} / {preset?.system}
                     </div>
@@ -97,7 +107,11 @@ const MsfsInputActionPanel = ({
                 </div>
                 <div className="flex flex-row gap-4">
                   <div className="flex flex-1 flex-col gap-1">
-                    <Label htmlFor="code">Description</Label>
+                    <Label htmlFor="code">
+                      {t(
+                        "Dialog.InputConfigWizard.InputActions.Common.DescriptionLabel",
+                      )}
+                    </Label>
                     <div className="text-sm">{preset?.description ?? "-"}</div>
                   </div>
                   {preset?.author && preset?.createdDate && (
@@ -107,7 +121,13 @@ const MsfsInputActionPanel = ({
                         <div className="text-sm">
                           {preset?.author}
                           {preset?.createdDate && (
-                            <> / {new Date(preset.createdDate).toLocaleDateString()} </>
+                            <>
+                              {" "}
+                              /{" "}
+                              {new Date(
+                                preset.createdDate,
+                              ).toLocaleDateString()}{" "}
+                            </>
                           )}
                         </div>
                       </div>
@@ -124,12 +144,14 @@ const MsfsInputActionPanel = ({
               </>
             ) : (
               config?.Command !== "" && (
-              <div className="flex flex-row gap-2 items-center rounded-md">
-                <IconExclamationCircle className="text-primary fill-background" />
-                <div className="text-primary text-sm">
-                  You customized this preset or it is no longer available.
+                <div className="flex flex-row items-center gap-2 rounded-md">
+                  <IconExclamationCircle className="text-primary fill-background" />
+                  <div className="text-primary text-sm">
+                    {t(
+                      "Dialog.InputConfigWizard.InputActions.Msfs.Code.Customized",
+                    )}
+                  </div>
                 </div>
-              </div>
               )
             )}
 

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -7,6 +7,9 @@ import CodeValueLabel from "@/components/wizard/components/CodeValueLabel"
 import { fetchHubHopPresets } from "@/lib/configWizard"
 import { useQuery } from "@tanstack/react-query"
 import { Card, CardContent } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import IconBrandHubHopLogo from "@/components/icons/IconBrandHubHopLogo"
+import { IconExclamationCircle } from "@tabler/icons-react"
 
 export type MsfsInputActionPanelProps = {
   variant: "summary" | "details"
@@ -26,8 +29,7 @@ const MsfsInputActionPanel = ({
     // presets don't change at runtime; HubHopState drives invalidation
     staleTime: Infinity,
   })
-  const presetLabel =
-    presets.find((p) => p.id === config?.PresetId)?.label ?? null
+  const preset = presets.find((p) => p.id === config?.PresetId) ?? null
 
   if (variant === "summary") {
     return (
@@ -37,7 +39,7 @@ const MsfsInputActionPanel = ({
             {t("Dialog.InputConfigWizard.InputActions.Common.PresetLabel")}:
           </Label>
           <div className="text-sm">
-            {presetLabel ??
+            {preset?.label ??
               t("Dialog.InputConfigWizard.InputActions.Msfs.CustomPreset")}
           </div>
         </div>
@@ -77,29 +79,84 @@ const MsfsInputActionPanel = ({
               {t("Dialog.InputConfigWizard.InputActions.Msfs.Code.Description")}
             </div>
           </div>
-          <div className="flex flex-col gap-1">
-            <Label htmlFor="code">
-              {t("Dialog.InputConfigWizard.InputActions.Common.CodeLabel")}
-            </Label>
-            <Textarea
-              name="code"
-              className="dark:focus:bg-input/20 font-mono text-sm whitespace-nowrap dark:bg-transparent"
-              placeholder={t(
-                "Dialog.InputConfigWizard.InputActions.Msfs.Code.Placeholder",
-              )}
-              value={config?.Command ?? ""}
-              onChange={(e) => {
-                onConfigChange({
-                  ...(config as MsfsInputAction),
-                  Command: e.target.value,
-                  PresetId: "", // Clear preset if user manually edits command
-                } as MsfsInputAction)
-              }}
-            />
-            <div className="text-muted-foreground text-sm">
-              {t(
-                "Dialog.InputConfigWizard.InputActions.Common.SupportedPlaceholders",
-              )}
+          <div className="flex flex-col gap-4">
+            {preset ? (
+              <>
+                <div className="flex flex-row gap-4">
+                  <div className="flex flex-1 flex-col gap-1">
+                    <Label htmlFor="code">Name</Label>
+                    <div className="text-sm font-semibold">{preset?.label}</div>
+                  </div>
+
+                  <div className="flex flex-1 flex-col gap-1">
+                    <Label htmlFor="code">Vendor / Aircraft / System</Label>
+                    <div className="text-sm">
+                      {preset?.vendor} / {preset?.aircraft} / {preset?.system}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex flex-row gap-4">
+                  <div className="flex flex-1 flex-col gap-1">
+                    <Label htmlFor="code">Description</Label>
+                    <div className="text-sm">{preset?.description ?? "-"}</div>
+                  </div>
+                  {preset?.author && preset?.createdDate && (
+                    <div className="flex flex-1 flex-row items-center gap-1">
+                      <div className="flex flex-1 flex-col gap-1">
+                        <Label htmlFor="code">Author / Date</Label>
+                        <div className="text-sm">
+                          {preset?.author}
+                          {preset?.createdDate && (
+                            <> / {new Date(preset.createdDate).toLocaleDateString()} </>
+                          )}
+                        </div>
+                      </div>
+                      <Button
+                        className="h-8 gap-1 rounded-full px-4 py-1 [&_svg]:size-6"
+                        variant={"ghost"}
+                      >
+                        <IconBrandHubHopLogo className="fill-orange-400 stroke-orange-400" />
+                        HubHop
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </>
+            ) : (
+              config?.Command !== "" && (
+              <div className="flex flex-row gap-2 items-center rounded-md">
+                <IconExclamationCircle className="text-primary fill-background" />
+                <div className="text-primary text-sm">
+                  You customized this preset or it is no longer available.
+                </div>
+              </div>
+              )
+            )}
+
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="code">
+                {t("Dialog.InputConfigWizard.InputActions.Common.CodeLabel")}
+              </Label>
+              <Textarea
+                name="code"
+                className="dark:focus:bg-input/20 font-mono text-sm whitespace-nowrap dark:bg-transparent"
+                placeholder={t(
+                  "Dialog.InputConfigWizard.InputActions.Msfs.Code.Placeholder",
+                )}
+                value={config?.Command ?? ""}
+                onChange={(e) => {
+                  onConfigChange({
+                    ...(config as MsfsInputAction),
+                    Command: e.target.value,
+                    PresetId: "", // Clear preset if user manually edits command
+                  } as MsfsInputAction)
+                }}
+              />
+              <div className="text-muted-foreground text-sm">
+                {t(
+                  "Dialog.InputConfigWizard.InputActions.Common.SupportedPlaceholders",
+                )}
+              </div>
             </div>
           </div>
         </CardContent>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -94,9 +94,32 @@ const MsfsPresetPanel = ({
       p.label.toLowerCase().includes(filter.search.toLowerCase()),
   )
 
-  const categories = [...new Set(filteredPresets.map((p) => p.system))].sort()
-  const aircraft = [...new Set(filteredPresets.map((p) => p.aircraft))].sort()
-  const vendors = [...new Set(filteredPresets.map((p) => p.vendor))].sort()
+  const filteredCategoryPresets = validPresets.filter(
+    (p) =>
+      (filter.vendor ? p.vendor === filter.vendor : true) &&
+      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+  )
+
+  const filteredVendorPresets = validPresets.filter(
+    (p) =>
+      (filter.system ? p.system === filter.system : true) &&
+      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+  )
+
+  const filteredAircraftPresets = validPresets.filter(
+    (p) =>
+      (filter.vendor ? p.vendor === filter.vendor : true) &&
+      (filter.system ? p.system === filter.system : true) &&
+      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+  )
+
+  const categories = [
+    ...new Set(filteredCategoryPresets.map((p) => p.system)),
+  ].sort()
+  const aircraft = [...new Set(filteredAircraftPresets.map((p) => p.aircraft))].sort()
+  const vendors = [...new Set(filteredVendorPresets.map((p) => p.vendor))].sort()
 
   useEffect(() => {
     if (!refActiveElement.current) return

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -136,11 +136,11 @@ const MsfsPresetPanel = ({
         <div className="flex flex-row items-end justify-between">
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
-              {t("Dialog.InputConfigWizard.InputActions.Msfs.Preset.Title")}
+              {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Title")}
             </div>
             <div className="text-muted-foreground text-sm">
               {t(
-                "Dialog.InputConfigWizard.InputActions.Msfs.Preset.Description",
+                "Dialog.InputConfigWizard.InputActions.Common.Preset.Description",
               )}
             </div>
           </div>
@@ -151,7 +151,7 @@ const MsfsPresetPanel = ({
             ></Switch>
             <Label>
               {t(
-                "Dialog.InputConfigWizard.InputActions.Msfs.Preset.ProjectAircraftOnly",
+                "Dialog.InputConfigWizard.InputActions.Common.Preset.ProjectAircraftOnly",
               )}
             </Label>
           </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -14,13 +14,11 @@ import { IconX } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
-
 export type MsfsPresetPanelProps = {
   variant: "input" | "output"
   selectedPresetId: string | null
   setSelectedPreset: (preset: Preset | XplanePreset | null) => void
 }
-
 const MsfsPresetPanel = ({
   variant,
   selectedPresetId,
@@ -29,19 +27,23 @@ const MsfsPresetPanel = ({
   const { t } = useTranslation()
   const { project } = useProjectStore()
   const [favoritesOnly, setFavoritesOnly] = useState(true)
-
   const SCROLL_INTO_VIEW_TIMEOUT = 800
   const refActiveElement = useRef<HTMLDivElement | null>(null)
   const scrollTimeoutRef = useRef<number | null>(null)
-
   const cancelScrollIntoView = () => {
     if (scrollTimeoutRef.current !== null) {
       window.clearTimeout(scrollTimeoutRef.current)
       scrollTimeoutRef.current = null
     }
   }
-
-  const scrollActiveProjectIntoView = useCallback(() => {
+  const filterByText = (preset: Preset, filter: string) => {
+    return (
+      preset.label.toLowerCase().includes(filter.toLowerCase()) ||
+      preset.code.toLowerCase().includes(filter.toLowerCase()) ||
+      (preset.description?.toLowerCase().includes(filter.toLowerCase()) ?? false)
+    )
+  }
+  const scrollActivePresetIntoView = useCallback(() => {
     if (refActiveElement.current) {
       cancelScrollIntoView()
       scrollTimeoutRef.current = window.setTimeout(() => {
@@ -53,68 +55,57 @@ const MsfsPresetPanel = ({
       }, SCROLL_INTO_VIEW_TIMEOUT)
     }
   }, [refActiveElement, scrollTimeoutRef])
-
   const validPresetTypes =
     variant === "input" ? ["input", "input (potentiometer)"] : ["output"]
-
   const { data: presets = [] /*, isLoading */ } = useQuery({
     queryKey: ["msfs-presets"],
     queryFn: () => fetchHubHopPresets("msfs"),
     // presets don't change at runtime; HubHopState drives invalidation
     staleTime: Infinity,
   })
-
   const projectAircraftFilter = (p: Preset) =>
     (project?.Aircraft?.length ?? 0) > 0
       ? project!.Aircraft!.some(
           (a: AircraftInfo) => a.Name === p.aircraft && a.Vendor === p.vendor,
         )
       : true
-
   const validPresets = presets.filter(
     (p: Preset) =>
       validPresetTypes.includes(p.presetType.toLowerCase()) &&
       (favoritesOnly ? projectAircraftFilter(p) : true),
   )
-
   const selectedPreset = validPresets.find((p) => p.id === selectedPresetId)
-
   const [filter, setFilter] = useState({
     vendor: selectedPreset?.vendor || "",
     aircraft: selectedPreset?.aircraft || "",
     system: selectedPreset?.system || "",
     search: "",
   })
-
   const filteredPresets = validPresets.filter(
     (p) =>
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
       (filter.system ? p.system === filter.system : true) &&
-      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+      filterByText(p, filter.search),
   )
-
   const filteredCategoryPresets = validPresets.filter(
     (p) =>
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+      filterByText(p, filter.search),
   )
-
   const filteredVendorPresets = validPresets.filter(
     (p) =>
       (filter.system ? p.system === filter.system : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+      filterByText(p, filter.search),
   )
-
   const filteredAircraftPresets = validPresets.filter(
     (p) =>
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.system ? p.system === filter.system : true) &&
-      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+      filterByText(p, filter.search),
   )
-
   const categories = [
     ...new Set(filteredCategoryPresets.map((p) => p.system)),
   ].sort()
@@ -124,12 +115,10 @@ const MsfsPresetPanel = ({
   const vendors = [
     ...new Set(filteredVendorPresets.map((p) => p.vendor)),
   ].sort()
-
   useEffect(() => {
     if (!refActiveElement.current) return
-    scrollActiveProjectIntoView()
-  }, [refActiveElement, scrollActiveProjectIntoView])
-
+    scrollActivePresetIntoView()
+  }, [refActiveElement, scrollActivePresetIntoView])
   return (
     <Card className="grow">
       <CardContent className="flex flex-col gap-4 pt-4">
@@ -257,7 +246,7 @@ const MsfsPresetPanel = ({
           <ScrollArea
             className="h-56"
             onMouseEnter={cancelScrollIntoView}
-            onMouseLeave={scrollActiveProjectIntoView}
+            onMouseLeave={scrollActivePresetIntoView}
           >
             <div className="flex flex-col gap-1" role="list">
               {filteredPresets.map((preset) => (

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Switch } from "@/components/ui/switch"
 import { PresetListItem } from "@/components/wizard/components/PresetListItem"
-import { fetchHubHopPresets } from "@/lib/configWizard"
+import { fetchHubHopPresets, filterPresetByText } from "@/lib/configWizard"
 import { useProjectStore } from "@/stores/projectStore"
 import { Preset, XplanePreset } from "@/types/preset"
 import { AircraftInfo } from "@/types/project"
@@ -36,13 +36,7 @@ const MsfsPresetPanel = ({
       scrollTimeoutRef.current = null
     }
   }
-  const filterByText = (preset: Preset, filter: string) => {
-    return (
-      preset.label.toLowerCase().includes(filter.toLowerCase()) ||
-      preset.code.toLowerCase().includes(filter.toLowerCase()) ||
-      (preset.description?.toLowerCase().includes(filter.toLowerCase()) ?? false)
-    )
-  }
+
   const scrollActivePresetIntoView = useCallback(() => {
     if (refActiveElement.current) {
       cancelScrollIntoView()
@@ -86,25 +80,25 @@ const MsfsPresetPanel = ({
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
       (filter.system ? p.system === filter.system : true) &&
-      filterByText(p, filter.search),
+      filterPresetByText(p, filter.search),
   )
   const filteredCategoryPresets = validPresets.filter(
     (p) =>
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      filterByText(p, filter.search),
+      filterPresetByText(p, filter.search),
   )
   const filteredVendorPresets = validPresets.filter(
     (p) =>
       (filter.system ? p.system === filter.system : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      filterByText(p, filter.search),
+      filterPresetByText(p, filter.search),
   )
   const filteredAircraftPresets = validPresets.filter(
     (p) =>
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.system ? p.system === filter.system : true) &&
-      filterByText(p, filter.search),
+      filterPresetByText(p, filter.search),
   )
   const categories = [
     ...new Set(filteredCategoryPresets.map((p) => p.system)),

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -118,8 +118,12 @@ const MsfsPresetPanel = ({
   const categories = [
     ...new Set(filteredCategoryPresets.map((p) => p.system)),
   ].sort()
-  const aircraft = [...new Set(filteredAircraftPresets.map((p) => p.aircraft))].sort()
-  const vendors = [...new Set(filteredVendorPresets.map((p) => p.vendor))].sort()
+  const aircraft = [
+    ...new Set(filteredAircraftPresets.map((p) => p.aircraft)),
+  ].sort()
+  const vendors = [
+    ...new Set(filteredVendorPresets.map((p) => p.vendor)),
+  ].sort()
 
   useEffect(() => {
     if (!refActiveElement.current) return
@@ -127,7 +131,7 @@ const MsfsPresetPanel = ({
   }, [refActiveElement, scrollActiveProjectIntoView])
 
   return (
-    <Card>
+    <Card className="grow">
       <CardContent className="flex flex-col gap-4 pt-4">
         <div className="flex flex-row items-end justify-between">
           <div className="flex flex-col">
@@ -218,8 +222,38 @@ const MsfsPresetPanel = ({
               )}
             />
           </div>
+          <div className="flex flex-row items-center justify-between">
+            <div role="status" className="px-2 py-2 text-sm">
+              {t("Dialog.InputConfigWizard.InputActions.Common.PresetsFound", {
+                count: filteredPresets.length,
+              })}
+            </div>
+            {(filter.aircraft ||
+              filter.vendor ||
+              filter.system ||
+              filter.search) && (
+                <Button
+                  size={"sm"}
+                  className="w-fit px-2 py-0"
+                  variant="ghost"
+                  onClick={() =>
+                    setFilter({
+                      vendor: "",
+                      aircraft: "",
+                      system: "",
+                      search: "",
+                    })
+                  }
+                >
+                  <IconX />
+                  <span className="py-0 text-sm">
+                    {t("Dialog.General.ResetFilters")}
+                  </span>
+                </Button>
+              )}
+          </div>
         </div>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 -mt-3">
           <ScrollArea
             className="h-56"
             onMouseEnter={cancelScrollIntoView}
@@ -237,26 +271,6 @@ const MsfsPresetPanel = ({
               ))}
             </div>
           </ScrollArea>
-          <div className="flex flex-row items-center justify-between">
-            <div role="status" className="px-2 text-sm">
-              {t("Dialog.InputConfigWizard.InputActions.Common.PresetsFound", {
-                count: filteredPresets.length,
-              })}
-            </div>
-            <Button
-              size={"sm"}
-              className="w-fit px-2 py-1"
-              variant="ghost"
-              onClick={() =>
-                setFilter({ vendor: "", aircraft: "", system: "", search: "" })
-              }
-            >
-              <IconX />
-              <span className="text-sm">
-                {t("Dialog.General.ResetFilters")}
-              </span>
-            </Button>
-          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -88,7 +88,7 @@ const XplaneInputActionPanel = ({
         }
       />
       <Card>
-        <CardContent className="flex flex-col gap-4 pt-4">
+        <CardContent className="flex flex-col gap-4 pt-4" data-testid="preset-code-panel">
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
               {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Title")}

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -43,11 +43,11 @@ const XplaneInputActionPanel = ({
       <div className="flex grow flex-row items-center gap-2">
         <div className="flex w-1/3 flex-col gap-1">
           <Label htmlFor="preset">
-            {t("Dialog.InputConfigWizard.InputActions.Common.PresetLabel")}:
+            {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Label")}:
           </Label>
           <div className="text-sm">
             {preset?.label ??
-              t("Dialog.InputConfigWizard.InputActions.Xplane.CustomPreset")}
+              t("Dialog.InputConfigWizard.InputActions.Common.Preset.Custom")}
           </div>
         </div>
         <div className="flex grow flex-col gap-1">
@@ -56,7 +56,7 @@ const XplaneInputActionPanel = ({
           </Label>
           <CodeValueLabel id="code" className="max-w-100">
             {config?.Path ??
-              t("Dialog.InputConfigWizard.InputActions.Xplane.Code.None")}
+              t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.None")}
           </CodeValueLabel>
         </div>
       </div>
@@ -64,9 +64,9 @@ const XplaneInputActionPanel = ({
   }
 
   const labels = {
-    vendor: t("Dialog.InputConfigWizard.InputActions.Xplane.Preset.Vendor"),
-    aircraft: t("Dialog.InputConfigWizard.InputActions.Xplane.Preset.Aircraft"),
-    system: t("Dialog.InputConfigWizard.InputActions.Xplane.Preset.System"),
+    vendor: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Vendor"),
+    aircraft: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Aircraft"),
+    system: t("Dialog.InputConfigWizard.InputActions.Common.Preset.System"),
   }
 
   const openHubHopDetails = () => {
@@ -91,11 +91,11 @@ const XplaneInputActionPanel = ({
         <CardContent className="flex flex-col gap-4 pt-4">
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
-              {t("Dialog.InputConfigWizard.InputActions.Xplane.Code.Title")}
+              {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Title")}
             </div>
             <div className="text-muted-foreground text-sm">
               {t(
-                "Dialog.InputConfigWizard.InputActions.Xplane.Code.Description",
+                "Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Description",
               )}
             </div>
           </div>
@@ -165,7 +165,7 @@ const XplaneInputActionPanel = ({
                   <IconExclamationCircle className="text-primary fill-background" />
                   <div className="text-primary text-sm">
                     {t(
-                      "Dialog.InputConfigWizard.InputActions.Xplane.Code.Customized",
+                      "Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Customized",
                     )}
                   </div>
                 </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -67,6 +67,8 @@ const XplaneInputActionPanel = ({
     vendor: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Vendor"),
     aircraft: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Aircraft"),
     system: t("Dialog.InputConfigWizard.InputActions.Common.Preset.System"),
+    author: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Author"),
+    date: t("Dialog.InputConfigWizard.InputActions.Common.Preset.Date"),
   }
 
   const openHubHopDetails = () => {

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -1,12 +1,16 @@
 import ComboBox from "@/components/ComboBox"
+import IconBrandHubHopLogo from "@/components/icons/IconBrandHubHopLogo"
+import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import CodeValueLabel from "@/components/wizard/components/CodeValueLabel"
 import XplanePresetPanel from "@/components/wizard/components/InputActions/XplanePresetPanel"
 import { fetchHubHopPresets } from "@/lib/configWizard"
+import useOpenUrl from "@/lib/hooks/useOpenUrl"
 import { XplaneInputAction } from "@/types/config"
 import { XplanePreset } from "@/types/preset"
+import { IconExclamationCircle } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
 
@@ -24,6 +28,7 @@ const XplaneInputActionPanel = ({
   onConfigChange,
 }: XplaneInputActionPanelProps) => {
   const { t } = useTranslation()
+  const openUrl = useOpenUrl()
 
   const { data: presets = [] } = useQuery({
     queryKey: ["xplane-presets"],
@@ -31,8 +36,7 @@ const XplaneInputActionPanel = ({
     staleTime: Infinity,
   })
 
-  const presetLabel =
-    presets.find((p) => p.code === config?.Path)?.label ?? null
+  const preset = presets.find((p) => p.code === config?.Path) ?? null
 
   if (variant === "summary") {
     return (
@@ -42,7 +46,7 @@ const XplaneInputActionPanel = ({
             {t("Dialog.InputConfigWizard.InputActions.Common.PresetLabel")}:
           </Label>
           <div className="text-sm">
-            {presetLabel ??
+            {preset?.label ??
               t("Dialog.InputConfigWizard.InputActions.Xplane.CustomPreset")}
           </div>
         </div>
@@ -52,12 +56,24 @@ const XplaneInputActionPanel = ({
           </Label>
           <CodeValueLabel id="code" className="max-w-100">
             {config?.Path ??
-              t("Dialog.InputConfigWizard.InputActions.Xplane.NonePath")}
+              t("Dialog.InputConfigWizard.InputActions.Xplane.Code.None")}
           </CodeValueLabel>
         </div>
       </div>
     )
   }
+
+  const labels = {
+    vendor: t("Dialog.InputConfigWizard.InputActions.Xplane.Preset.Vendor"),
+    aircraft: t("Dialog.InputConfigWizard.InputActions.Xplane.Preset.Aircraft"),
+    system: t("Dialog.InputConfigWizard.InputActions.Xplane.Preset.System"),
+  }
+
+  const openHubHopDetails = () => {
+    const hubHopUrl = `https://hubhop.mobiflight.com/preset/?simType=xplane&id=${preset?.id}`
+    openUrl(hubHopUrl)
+  }
+
   return (
     <div className="flex flex-col gap-4">
       <XplanePresetPanel
@@ -83,86 +99,159 @@ const XplaneInputActionPanel = ({
               )}
             </div>
           </div>
-          <div className="flex flex-row gap-2">
-            <div className="flex flex-col gap-1">
-              <Label>
-                {t(
-                  "Dialog.InputConfigWizard.InputActions.Xplane.InputTypeLabel",
-                )}
-              </Label>
-              <ComboBox
-                items={CODE_TYPE_OPTIONS}
-                selected={
-                  (config?.InputType as "DataRef" | "Command") ?? undefined
-                }
-                placeholder={t(
-                  "Dialog.InputConfigWizard.InputActions.Xplane.SelectInputTypePlaceholder",
-                )}
-                getLabel={(item) => item}
-                getValue={(item) => item}
-                isSelected={(item) => item === config?.InputType}
-                setSelected={(item) => {
-                  if (!item) return
-                  onConfigChange({
-                    ...(config as XplaneInputAction),
-                    InputType: item,
-                  })
-                }}
-                variant="nofilter"
-                widthClass="w-32"
-              />
-            </div>
-            <div className="flex flex-col gap-1">
-              <Label htmlFor="path">
-                {t("Dialog.InputConfigWizard.InputActions.Xplane.PathLabel")}
-              </Label>
-              <Input
-                id="path"
-                className="font-mono text-sm whitespace-nowrap"
-                value={config?.Path ?? ""}
-                onChange={(e) =>
-                  onConfigChange({
-                    ...(config as XplaneInputAction),
-                    Path: e.target.value,
-                  })
-                }
-                placeholder={t(
-                  "Dialog.InputConfigWizard.InputActions.Xplane.PathPlaceholder",
-                )}
-              />
-              <div className="text-muted-foreground text-sm">
-                {t(
-                  "Dialog.InputConfigWizard.InputActions.Xplane.PathDescription",
-                )}
+          <div className="flex flex-col gap-4">
+            {preset ? (
+              <>
+                <div className="flex flex-row gap-4">
+                  <div className="flex flex-1 flex-col gap-1">
+                    <Label htmlFor="code">
+                      {t(
+                        "Dialog.InputConfigWizard.InputActions.Common.NameLabel",
+                      )}
+                    </Label>
+                    <div className="text-sm font-semibold">{preset?.label}</div>
+                  </div>
+
+                  <div className="flex flex-1 flex-col gap-1">
+                    <Label htmlFor="code">
+                      {labels.vendor} / {labels.aircraft} / {labels.system}
+                    </Label>
+                    <div className="text-sm">
+                      {preset?.vendor} / {preset?.aircraft} / {preset?.system}
+                    </div>
+                  </div>
+                </div>
+                <div className="flex flex-row gap-4">
+                  <div className="flex flex-1 flex-col gap-1">
+                    <Label htmlFor="code">
+                      {t(
+                        "Dialog.InputConfigWizard.InputActions.Common.DescriptionLabel",
+                      )}
+                    </Label>
+                    <div className="text-sm">{preset?.description ?? "-"}</div>
+                  </div>
+                  {preset?.author && (
+                    <div className="flex flex-1 flex-row items-center gap-1">
+                      <div className="flex flex-1 flex-col gap-1">
+                        <Label htmlFor="code">Author / Date</Label>
+                        <div className="text-sm">
+                          {preset?.author}
+                          {preset?.createdDate && (
+                            <>
+                              {" "}
+                              /{" "}
+                              {new Date(
+                                preset.createdDate,
+                              ).toLocaleDateString()}{" "}
+                            </>
+                          )}
+                        </div>
+                      </div>
+                      <Button
+                        className="h-8 gap-1 rounded-full px-4 py-1 [&_svg]:size-6"
+                        variant={"ghost"}
+                        onClick={openHubHopDetails}
+                      >
+                        <IconBrandHubHopLogo className="fill-orange-400 stroke-orange-400" />
+                        HubHop
+                      </Button>
+                    </div>
+                  )}
+                </div>
+              </>
+            ) : (
+              (config?.Path ?? "") !== "" && (
+                <div className="flex flex-row items-center gap-2 rounded-md">
+                  <IconExclamationCircle className="text-primary fill-background" />
+                  <div className="text-primary text-sm">
+                    {t(
+                      "Dialog.InputConfigWizard.InputActions.Xplane.Code.Customized",
+                    )}
+                  </div>
+                </div>
+              )
+            )}
+            <div className="flex flex-row gap-2">
+              <div className="flex flex-col gap-1">
+                <Label>
+                  {t(
+                    "Dialog.InputConfigWizard.InputActions.Xplane.InputTypeLabel",
+                  )}
+                </Label>
+                <ComboBox
+                  items={CODE_TYPE_OPTIONS}
+                  selected={
+                    (config?.InputType as "DataRef" | "Command") ?? undefined
+                  }
+                  placeholder={t(
+                    "Dialog.InputConfigWizard.InputActions.Xplane.SelectInputTypePlaceholder",
+                  )}
+                  getLabel={(item) => item}
+                  getValue={(item) => item}
+                  isSelected={(item) => item === config?.InputType}
+                  setSelected={(item) => {
+                    if (!item) return
+                    onConfigChange({
+                      ...(config as XplaneInputAction),
+                      InputType: item,
+                    })
+                  }}
+                  variant="nofilter"
+                  widthClass="w-32"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="path">
+                  {t("Dialog.InputConfigWizard.InputActions.Xplane.PathLabel")}
+                </Label>
+                <Input
+                  id="path"
+                  className="font-mono text-sm whitespace-nowrap"
+                  value={config?.Path ?? ""}
+                  onChange={(e) =>
+                    onConfigChange({
+                      ...(config as XplaneInputAction),
+                      Path: e.target.value,
+                    })
+                  }
+                  placeholder={t(
+                    "Dialog.InputConfigWizard.InputActions.Xplane.PathPlaceholder",
+                  )}
+                />
+                <div className="text-muted-foreground text-sm">
+                  {t(
+                    "Dialog.InputConfigWizard.InputActions.Xplane.PathDescription",
+                  )}
+                </div>
               </div>
             </div>
+            {config?.InputType === "DataRef" && (
+              <div className="flex flex-col gap-1">
+                <Label htmlFor="value">
+                  {t("Dialog.InputConfigWizard.InputActions.Xplane.ValueLabel")}
+                </Label>
+                <Input
+                  className="font-mono text-sm whitespace-nowrap"
+                  id="value"
+                  value={config?.Expression ?? ""}
+                  onChange={(e) =>
+                    onConfigChange({
+                      ...(config as XplaneInputAction),
+                      Expression: e.target.value,
+                    })
+                  }
+                  placeholder={t(
+                    "Dialog.InputConfigWizard.InputActions.Xplane.ValuePlaceholder",
+                  )}
+                />
+                <div className="text-muted-foreground text-sm">
+                  {t(
+                    "Dialog.InputConfigWizard.InputActions.Common.SupportedPlaceholders",
+                  )}
+                </div>
+              </div>
+            )}
           </div>
-          {config?.InputType === "DataRef" && (
-            <div className="flex flex-col gap-1">
-              <Label htmlFor="value">
-                {t("Dialog.InputConfigWizard.InputActions.Xplane.ValueLabel")}
-              </Label>
-              <Input
-                className="font-mono text-sm whitespace-nowrap"
-                id="value"
-                value={config?.Expression ?? ""}
-                onChange={(e) =>
-                  onConfigChange({
-                    ...(config as XplaneInputAction),
-                    Expression: e.target.value,
-                  })
-                }
-                placeholder={t(
-                  "Dialog.InputConfigWizard.InputActions.Xplane.ValuePlaceholder",
-                )}
-              />
-              <div className="text-muted-foreground text-sm">
-                {t(
-                  "Dialog.InputConfigWizard.InputActions.Common.SupportedPlaceholders",
-                )}
-              </div>
-            </div>
-          )}
         </CardContent>
       </Card>
     </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Switch } from "@/components/ui/switch"
 import { PresetListItem } from "@/components/wizard/components/PresetListItem"
-import { fetchHubHopPresets } from "@/lib/configWizard"
+import { fetchHubHopPresets, filterPresetByText } from "@/lib/configWizard"
 import { useProjectStore } from "@/stores/projectStore"
 import { Preset, XplanePreset } from "@/types/preset"
 import { AircraftInfo } from "@/types/project"
@@ -92,28 +92,28 @@ const XplanePresetPanel = ({
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
       (filter.system ? p.system === filter.system : true) &&
-      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+      filterPresetByText(p, filter.search),
   )
 
   const filteredCategoryPresets = validPresets.filter(
     (p) =>
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+      filterPresetByText(p, filter.search),
   )
 
   const filteredVendorPresets = validPresets.filter(
     (p) =>
       (filter.system ? p.system === filter.system : true) &&
       (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+      filterPresetByText(p, filter.search),
   )
 
   const filteredAircraftPresets = validPresets.filter(
     (p) =>
       (filter.vendor ? p.vendor === filter.vendor : true) &&
       (filter.system ? p.system === filter.system : true) &&
-      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+      filterPresetByText(p, filter.search),
   )
 
   const categories = [

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
@@ -95,9 +95,36 @@ const XplanePresetPanel = ({
       p.label.toLowerCase().includes(filter.search.toLowerCase()),
   )
 
-  const categories = [...new Set(filteredPresets.map((p) => p.system))].sort()
-  const aircraft = [...new Set(filteredPresets.map((p) => p.aircraft))].sort()
-  const vendors = [...new Set(filteredPresets.map((p) => p.vendor))].sort()
+  const filteredCategoryPresets = validPresets.filter(
+    (p) =>
+      (filter.vendor ? p.vendor === filter.vendor : true) &&
+      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+  )
+
+  const filteredVendorPresets = validPresets.filter(
+    (p) =>
+      (filter.system ? p.system === filter.system : true) &&
+      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+  )
+
+  const filteredAircraftPresets = validPresets.filter(
+    (p) =>
+      (filter.vendor ? p.vendor === filter.vendor : true) &&
+      (filter.system ? p.system === filter.system : true) &&
+      p.label.toLowerCase().includes(filter.search.toLowerCase()),
+  )
+
+  const categories = [
+    ...new Set(filteredCategoryPresets.map((p) => p.system)),
+  ].sort()
+  const aircraft = [
+    ...new Set(filteredAircraftPresets.map((p) => p.aircraft)),
+  ].sort()
+  const vendors = [
+    ...new Set(filteredVendorPresets.map((p) => p.vendor)),
+  ].sort()
 
   useEffect(() => {
     if (!refActiveElement.current) return
@@ -105,7 +132,7 @@ const XplanePresetPanel = ({
   }, [refActiveElement, scrollActiveProjectIntoView])
 
   return (
-    <Card>
+    <Card className="grow">
       <CardContent className="flex flex-col gap-4 pt-4">
         <div className="flex flex-row items-end justify-between">
           <div className="flex flex-col">
@@ -196,8 +223,38 @@ const XplanePresetPanel = ({
               )}
             />
           </div>
+          <div className="flex flex-row items-center justify-between">
+            <div role="status" className="px-2 py-2 text-sm">
+              {t("Dialog.InputConfigWizard.InputActions.Common.PresetsFound", {
+                count: filteredPresets.length,
+              })}
+            </div>
+            {(filter.aircraft ||
+              filter.vendor ||
+              filter.system ||
+              filter.search) && (
+              <Button
+                size={"sm"}
+                className="w-fit px-2 py-0"
+                variant="ghost"
+                onClick={() =>
+                  setFilter({
+                    vendor: "",
+                    aircraft: "",
+                    system: "",
+                    search: "",
+                  })
+                }
+              >
+                <IconX />
+                <span className="py-0 text-sm">
+                  {t("Dialog.General.ResetFilters")}
+                </span>
+              </Button>
+            )}
+          </div>
         </div>
-        <div className="flex flex-col gap-2">
+        <div className="-mt-3 flex flex-col gap-2">
           <ScrollArea
             className="h-56"
             onMouseEnter={cancelScrollIntoView}
@@ -215,26 +272,6 @@ const XplanePresetPanel = ({
               ))}
             </div>
           </ScrollArea>
-          <div className="flex flex-row items-center justify-between">
-            <div role="status" className="px-2 text-sm">
-              {t("Dialog.InputConfigWizard.InputActions.Common.PresetsFound", {
-                count: filteredPresets.length,
-              })}
-            </div>
-            <Button
-              size={"sm"}
-              className="w-fit px-2 py-1"
-              variant="ghost"
-              onClick={() =>
-                setFilter({ vendor: "", aircraft: "", system: "", search: "" })
-              }
-            >
-              <IconX />
-              <span className="text-sm">
-                {t("Dialog.General.ResetFilters")}
-              </span>
-            </Button>
-          </div>
         </div>
       </CardContent>
     </Card>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
@@ -137,11 +137,11 @@ const XplanePresetPanel = ({
         <div className="flex flex-row items-end justify-between">
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
-              {t("Dialog.InputConfigWizard.InputActions.Xplane.Preset.Title")}
+              {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Title")}
             </div>
             <div className="text-muted-foreground text-sm">
               {t(
-                "Dialog.InputConfigWizard.InputActions.Xplane.Preset.Description",
+                "Dialog.InputConfigWizard.InputActions.Common.Preset.Description",
               )}
             </div>
           </div>
@@ -152,7 +152,7 @@ const XplanePresetPanel = ({
             ></Switch>
             <Label>
               {t(
-                "Dialog.InputConfigWizard.InputActions.Xplane.Preset.ProjectAircraftOnly",
+                "Dialog.InputConfigWizard.InputActions.Common.Preset.ProjectAircraftOnly",
               )}
             </Label>
           </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/PresetListItem.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/PresetListItem.tsx
@@ -15,7 +15,7 @@ export const PresetListItem = forwardRef<HTMLDivElement, PresetListItemProps>(
         ref={ref}
         role="listitem"
         className={cn(
-          "bg-background hover:bg-accent/50 border-background flex cursor-pointer flex-row justify-between gap-2 rounded-md border-2 px-2 pt-0.5 pb-1.5",
+          "bg-accent/25 hover:bg-accent/50 border-background flex cursor-pointer flex-row justify-between gap-2 rounded-md border-2 px-2 pt-0.5 pb-1.5",
           isSelected && "bg-primary/20 border-primary border-2",
         )}
         onClick={() => setSelectedPreset(preset)}

--- a/src/MobiFlightConnector/frontend/src/lib/configWizard.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/configWizard.ts
@@ -75,3 +75,11 @@ export const fetchHubHopPresets = async (sim: "msfs" | "xplane") => {
       : "/presets/xplane_hubhop_presets.json"
   return fetch(presetFile).then((r) => r.json() as Promise<Preset[]>)
 }
+
+export const filterPresetByText = (preset: Preset, filter: string) => {
+  return (
+    preset.label.toLowerCase().includes(filter.toLowerCase()) ||
+    preset.code.toLowerCase().includes(filter.toLowerCase()) ||
+    (preset.description?.toLowerCase().includes(filter.toLowerCase()) ?? false)
+  )
+}

--- a/src/MobiFlightConnector/frontend/src/lib/configWizard.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/configWizard.ts
@@ -77,9 +77,8 @@ export const fetchHubHopPresets = async (sim: "msfs" | "xplane") => {
 }
 
 export const filterPresetByText = (preset: Preset, filter: string) => {
-  return (
-    preset.label.toLowerCase().includes(filter.toLowerCase()) ||
-    preset.code.toLowerCase().includes(filter.toLowerCase()) ||
-    (preset.description?.toLowerCase().includes(filter.toLowerCase()) ?? false)
-  )
+  const terms = filter.toLowerCase().trim().split(/\s+/).filter(Boolean)
+  const haystack =
+    `${preset.label} ${preset.description ?? ""} ${preset.code}`.toLowerCase()
+  return terms.every((t) => haystack.includes(t))
 }

--- a/src/MobiFlightConnector/frontend/src/lib/hooks/useOpenUrl.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/hooks/useOpenUrl.ts
@@ -1,0 +1,16 @@
+import useMessageExchange from "@/lib/hooks/useMessageExchange"
+
+const useOpenUrl = () => {
+  const { publish } = useMessageExchange()
+
+  const openUrl = (url: string) => {
+    publish({
+      key: "CommandOpenLinkInBrowser",
+      payload: { url: url },
+    })
+  }
+
+  return openUrl
+}
+
+export default useOpenUrl

--- a/src/MobiFlightConnector/frontend/src/types/preset.d.ts
+++ b/src/MobiFlightConnector/frontend/src/types/preset.d.ts
@@ -12,7 +12,8 @@ export type Preset = {
   updatedBy?: string
   reported?: number
   score?: number
-  presetType: "Input" | "Output" | "Input (Potentiometer)"
+  presetType: "Input" | "Output" | "Input (Potentiometer)",
+  author?: string
 }
 
 export type XplanePreset = Preset & {

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -191,7 +191,7 @@ test.describe("General Input Config Wizard Tests", () => {
       name: "Apply changes",
     })
     await configListPage.mobiFlightPage.trackCommand("CommandUpdateConfigItem")
-    
+
     await expect(applyChangesButton).toBeEnabled()
     await applyChangesButton.click()
 
@@ -247,7 +247,7 @@ test.describe("General Input Config Wizard Tests", () => {
     await configListPage.mobiFlightPage.initWithTestData("inputaction")
 
     await configListPage.clickEditButtonForRow(1)
-    const dialog = page.getByTestId('inputconfigwizard-dialog')
+    const dialog = page.getByTestId("inputconfigwizard-dialog")
     await expect(dialog).toBeVisible()
 
     // Click outside the dialog to close it
@@ -1427,7 +1427,7 @@ test.describe("Input Config Wizard - Modifier Panel", () => {
     await backButton.click()
     await expect(modifierEditor).not.toBeVisible()
 
-    // double click on the summary panel 
+    // double click on the summary panel
     // to open the editor again
     await expect(panel).toBeVisible()
     await panel.dblclick()
@@ -2531,16 +2531,68 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
         .getByRole("combobox")
         .filter({ hasText: "Microsoft Flight Simulator (all versions)" }),
     ).toBeVisible()
-    // Pre-selected preset label is shown
+
+    // List item shows all the important data
+    // label
     await expect(
       actionEditor
         .getByRole("listitem")
         .getByText("AP_PANEL_HEADING_HOLD_TEST"),
     ).toBeVisible()
+    // description
+    await expect(
+      actionEditor
+        .getByRole("listitem")
+        .getByText("Heading Hold Test Description Text"),
+    ).toBeVisible()
+    // system
+    await expect(
+      actionEditor.getByRole("listitem").getByText("Autopilot"),
+    ).toBeVisible()
+    // aircraft
+    await expect(
+      actionEditor.getByRole("listitem").getByText("Generic"),
+    ).toBeVisible()
+
+    // Preset code panel
+    const presetCodePanel = actionEditor.getByTestId("preset-code-panel")
+    await expect(presetCodePanel).toBeVisible()
+
+    const presetName = presetCodePanel.getByText("AP_PANEL_HEADING_HOLD_TEST")
+    await expect(presetName).toBeVisible()
+
+    const presetVendorAircraftSystem = presetCodePanel.getByText(
+      "Microsoft / Generic / Autopilot",
+    )
+    await expect(presetVendorAircraftSystem).toBeVisible()
+
+    const presetDescription = presetCodePanel.getByText(
+      "Heading Hold Test Description Text",
+    )
+    await expect(presetDescription).toBeVisible()
+
+    const presetAuthorData = presetCodePanel.getByText(
+      "MobiFlight Community / 8/16/2021",
+    )
+    await expect(presetAuthorData).toBeVisible()
+
+    const hubHopButton = presetCodePanel.getByRole("button", {
+      name: "HubHop",
+    })
+    await expect(hubHopButton).toBeVisible()
+
+    await configListPage.mobiFlightPage.trackCommand("CommandOpenLinkInBrowser")
+    await hubHopButton.click()
+    const commands = await configListPage.mobiFlightPage.getTrackedCommands()
+    expect(commands).toBeDefined()
+    const payload = commands?.pop()?.payload
+    expect(payload.url).toBe(
+      "https://hubhop.mobiflight.com/preset/?simType=msfs2020&id=cf0526c0-da69-404f-a570-9f9d54d2803c",
+    )
 
     // Code field reflects the preset command
     await expect(
-      actionEditor.getByRole("textbox", { name: "Enter RPN code" }),
+      presetCodePanel.getByRole("textbox", { name: "Enter RPN code" }),
     ).toHaveValue("(>K:AP_PANEL_HEADING_HOLD)")
   })
 
@@ -2948,24 +3000,74 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     const actionEditor = page.getByTestId("action-editor")
 
+    // Action type panel shows the correct type
     await expect(
       actionEditor
         .getByRole("combobox")
         .filter({ hasText: "X-Plane (all versions)" }),
     ).toBeVisible()
-    // Input type from test data
+
+    // List item shows all the important data
+    // label
     await expect(
-      actionEditor.getByRole("combobox").filter({ hasText: "Command" }),
+      actionEditor.getByRole("listitem").getByText("land_alt_press_dn"),
     ).toBeVisible()
-    // Pre-selected preset label is shown (code matches the preset in mock data)
+    // description
     await expect(
       actionEditor
         .getByRole("listitem")
-        .filter({ hasText: "land_alt_press_dn" }),
+        .getByText("Landing Altitude Pressure Down"),
     ).toBeVisible()
+    // system
     await expect(
-      actionEditor.getByText("Landing Altitude Pressure Down"),
+      actionEditor.getByRole("listitem").getByText("Autopilot"),
     ).toBeVisible()
+    // aircraft
+    await expect(
+      actionEditor.getByRole("listitem").getByText("Boeing 737-800"),
+    ).toBeVisible()
+
+    // Preset code panel
+    const presetCodePanel = actionEditor.getByTestId("preset-code-panel")
+    await expect(presetCodePanel).toBeVisible()
+
+    const presetName = presetCodePanel.getByText("land_alt_press_dn")
+    await expect(presetName).toBeVisible()
+
+    const presetVendorAircraftSystem = presetCodePanel.getByText(
+      "Laminar Research / Boeing 737-800 / Autopilot",
+    )
+    await expect(presetVendorAircraftSystem).toBeVisible()
+
+    const presetDescription = presetCodePanel.getByText(
+      "Landing Altitude Pressure Down",
+    )
+    await expect(presetDescription).toBeVisible()
+
+        const presetAuthorData = presetCodePanel.getByText(
+      "MobiFlight Community / 8/1/2021",
+    )
+    await expect(presetAuthorData).toBeVisible()
+
+    const hubHopButton = presetCodePanel.getByRole("button", {
+      name: "HubHop",
+    })
+    await expect(hubHopButton).toBeVisible()
+
+    await configListPage.mobiFlightPage.trackCommand("CommandOpenLinkInBrowser")
+    await hubHopButton.click()
+    const commands = await configListPage.mobiFlightPage.getTrackedCommands()
+    expect(commands).toBeDefined()
+    const payload = commands?.pop()?.payload
+    expect(payload.url).toBe(
+      "https://hubhop.mobiflight.com/preset/?simType=xplane&id=xp-001",
+    )
+
+    // Input codeType from test data
+    await expect(
+      presetCodePanel.getByRole("combobox").filter({ hasText: "Command" }),
+    ).toBeVisible()
+
     // Code field reflects the path
     await expect(
       actionEditor.getByPlaceholder(

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2572,7 +2572,7 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await expect(presetDescription).toBeVisible()
 
     const presetAuthorData = presetCodePanel.getByText(
-      "MobiFlight Community / 8/16/2021",
+      "Mobiflight Community / 8/16/2021",
     )
     await expect(presetAuthorData).toBeVisible()
 
@@ -3044,8 +3044,8 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     )
     await expect(presetDescription).toBeVisible()
 
-        const presetAuthorData = presetCodePanel.getByText(
-      "MobiFlight Community / 8/1/2021",
+    const presetAuthorData = presetCodePanel.getByText(
+      "Mobiflight Community / 8/1/2021",
     )
     await expect(presetAuthorData).toBeVisible()
 

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/msfspresets.testdata.json
@@ -51,6 +51,7 @@
     "system": "Autopilot",
     "code": "(>K:AP_PANEL_HEADING_HOLD)",
     "label": "AP_PANEL_HEADING_HOLD_TEST",
+    "description": "Heading Hold Test Description Text",
     "presetType": "Input",
     "version": 2,
     "status": "Updated",

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/xplanepresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/xplanepresets.testdata.json
@@ -9,6 +9,7 @@
     "code": "laminar/B738/knob/land_alt_press_dn",
     "version": 1,
     "status": "Submitted",
+    "author": "MobiFlight Community",
     "createdDate": "2021-08-01T00:00:00.000Z",
     "presetType": "input",
     "codeType": "Command"

--- a/src/MobiFlightConnector/frontend/tests/data/inputaction/xplanepresets.testdata.json
+++ b/src/MobiFlightConnector/frontend/tests/data/inputaction/xplanepresets.testdata.json
@@ -9,7 +9,7 @@
     "code": "laminar/B738/knob/land_alt_press_dn",
     "version": 1,
     "status": "Submitted",
-    "author": "MobiFlight Community",
+    "author": "Mobiflight Community",
     "createdDate": "2021-08-01T00:00:00.000Z",
     "presetType": "input",
     "codeType": "Command"


### PR DESCRIPTION
### Summary
This PR improves search for MSFS and Xplane presets.

### Screenshots / recordings
<img width="1578" height="1629" alt="image" src="https://github.com/user-attachments/assets/41049186-5152-4fae-849c-117aad54e6d2" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Text search uses preset
  - [x] Name
  - [x] Description
  - [x] Code 
  - [x] use all words indivudally
- [x] Extended preset information is displayed for selected preset
- [x] HubHop button opens preset details in web browser
- [x] All changes work for xplane and msfs
- [x] Show note when user modified preset code

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [x] Frontend tests
- [x] i18n - All user-facing strings are translated
  - [x] core (en,de,es)
  - [x] additional langs
- [x] documentation
  - [x] User docs (docs.mobiflight.com) @neilenns 
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3120