### PR TITLE
Support selecting multiple LED outputs in one config for Joysticks

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Joystick.cs
@@ -482,14 +482,16 @@ namespace MobiFlight
 
         public virtual void SetOutputDeviceState(string name, byte state)
         {
+            var names = name.Split('|');
+
             foreach (var light in Lights)
             {
-                if (light.Label != name) continue;
+                if (names.All(n => light.Label != n)) continue;
+
                 if (light.State == state) continue;
 
                 light.State = state;
                 RequiresOutputUpdate = true;
-                return;
             }
         }
 

--- a/src/MobiFlightConnector/UI/Panels/Output/DisplayPinPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/Output/DisplayPinPanel.cs
@@ -3,7 +3,6 @@ using MobiFlight.OutputConfig;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Windows.Forms;
 
 namespace MobiFlight.UI.Panels
@@ -22,6 +21,7 @@ namespace MobiFlight.UI.Panels
             MultiPinSelectPanel.SelectionChanged += MultiPinSelectPanel_SelectionChanged;
 
             MultiPinSelectPanel.Visible = false;
+            selectMultiplePinsCheckBox.Visible = false;
             singlePinSelectFlowLayoutPanel.Visible = true;
             displayPinBrightnessPanel.Visible = displayPinBrightnessPanel.Enabled = displayPortComboBox.Visible = displayPortComboBox.Enabled = false;
             PinSelectContainer.Height = singlePinSelectFlowLayoutPanel.Height;
@@ -36,7 +36,6 @@ namespace MobiFlight.UI.Panels
         {
             displayPinComboBox.SelectedValue = value;
         }
-
 
         internal void EnablePWMSelect(bool enable)
         {
@@ -68,9 +67,9 @@ namespace MobiFlight.UI.Panels
             displayPinComboBox.Enabled = pins.Count > 0;
             displayPinComboBox.Width = WideStyle ? displayPinComboBox.MaximumSize.Width : displayPinComboBox.MinimumSize.Width;
 
-            if (Module != null && pins.Count > 1)
+            if (pins.Count > 1)
             {
-                // this is MobiFlight Outputs
+                // allow for multi select
                 _MultiSelectOptions(true);
             }
             MultiPinSelectPanel?.SetPins(pins);
@@ -102,12 +101,24 @@ namespace MobiFlight.UI.Panels
             var cfg = config.Device as Output;
             string pin = cfg.Pin;
 
-            if (SerialNumber.IsJoystickSerial(serial) ||
-                SerialNumber.IsMidiBoardSerial(serial))                                   
+            if (SerialNumber.IsJoystickSerial(serial))
             {
                 // disable multi-select option
                 _MultiSelectOptions(false);
                 pin = cfg.Pin;
+            }
+            else if (SerialNumber.IsJoystickSerial(serial))                                   
+            {
+                // enable multi-select option
+                _MultiSelectOptions(true);
+
+                // initialize multi-select panel
+                MultiPinSelectPanel?.SetSelectedPinsFromString(cfg.Pin);
+
+                // get the first from the multi select
+                pin = cfg.Pin.Split(Panels.PinSelectPanel.POSITION_SEPERATOR)[0];
+
+                selectMultiplePinsCheckBox.Checked = cfg.Pin.Split(Panels.PinSelectPanel.POSITION_SEPERATOR).Length > 1;
             }
             else if (SerialNumber.IsArcazeSerial(serial))
             {


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
Support selecting multiple LED outputs in one config for Joysticks

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [ ] Joysticks with multiple LED outputs offer "select multiple" option
- [ ] Multiple LEDs can be controlled

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [ ] Unit tests available
  - [ ] .NET backend
  - [ ] Frontend
- [ ] Frontend tests
- [ ] i18n - All user-facing strings are translated
  - [ ] core (en,de,es)
  - [ ] additional langs
- [ ] documentation
  - [ ] User docs (docs.mobiflight.com)
  - [ ] Developer docs (e.g., readme.md)
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3164

### Out-of-scope
midi controller

### Notes
[Discord post](https://discord.com/channels/608690978081210392/1521869211037864007)
