### PR TITLE
Show current filter for facted dropdown options when 0 results

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -101,14 +101,24 @@ const MsfsPresetPanel = ({
       filterPresetByText(p, filter.search),
   )
   const categories = [
-    ...new Set(filteredCategoryPresets.map((p) => p.system)),
+    ...new Set([
+      ...filteredCategoryPresets.map((p) => p.system),
+      ...(filter.system ? [filter.system] : []),
+    ]),
   ].sort()
   const aircraft = [
-    ...new Set(filteredAircraftPresets.map((p) => p.aircraft)),
+    ...new Set([
+      ...filteredAircraftPresets.map((p) => p.aircraft),
+      ...(filter.aircraft ? [filter.aircraft] : []),
+    ]),
   ].sort()
   const vendors = [
-    ...new Set(filteredVendorPresets.map((p) => p.vendor)),
+    ...new Set([
+      ...filteredVendorPresets.map((p) => p.vendor),
+      ...(filter.vendor ? [filter.vendor] : []),
+    ]),
   ].sort()
+
   useEffect(() => {
     if (!refActiveElement.current) return
     scrollActivePresetIntoView()
@@ -215,28 +225,28 @@ const MsfsPresetPanel = ({
               filter.vendor ||
               filter.system ||
               filter.search) && (
-                <Button
-                  size={"sm"}
-                  className="w-fit px-2 py-0"
-                  variant="ghost"
-                  onClick={() =>
-                    setFilter({
-                      vendor: "",
-                      aircraft: "",
-                      system: "",
-                      search: "",
-                    })
-                  }
-                >
-                  <IconX />
-                  <span className="py-0 text-sm">
-                    {t("Dialog.General.ResetFilters")}
-                  </span>
-                </Button>
-              )}
+              <Button
+                size={"sm"}
+                className="w-fit px-2 py-0"
+                variant="ghost"
+                onClick={() =>
+                  setFilter({
+                    vendor: "",
+                    aircraft: "",
+                    system: "",
+                    search: "",
+                  })
+                }
+              >
+                <IconX />
+                <span className="py-0 text-sm">
+                  {t("Dialog.General.ResetFilters")}
+                </span>
+              </Button>
+            )}
           </div>
         </div>
-        <div className="flex flex-col gap-2 -mt-3">
+        <div className="-mt-3 flex flex-col gap-2">
           <ScrollArea
             className="h-56"
             onMouseEnter={cancelScrollIntoView}

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
@@ -117,13 +117,22 @@ const XplanePresetPanel = ({
   )
 
   const categories = [
-    ...new Set(filteredCategoryPresets.map((p) => p.system)),
+    ...new Set([
+      ...filteredCategoryPresets.map((p) => p.system),
+      ...(filter.system ? [filter.system] : []),
+    ]),
   ].sort()
   const aircraft = [
-    ...new Set(filteredAircraftPresets.map((p) => p.aircraft)),
+    ...new Set([
+      ...filteredAircraftPresets.map((p) => p.aircraft),
+      ...(filter.aircraft ? [filter.aircraft] : []),
+    ]),
   ].sort()
   const vendors = [
-    ...new Set(filteredVendorPresets.map((p) => p.vendor)),
+    ...new Set([
+      ...filteredVendorPresets.map((p) => p.vendor),
+      ...(filter.vendor ? [filter.vendor] : []),
+    ]),
   ].sort()
 
   useEffect(() => {

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2723,36 +2723,61 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
       name: "Reset filters",
     })
 
+    const selectedAircraftOption = actionEditor.getByRole('combobox').filter({ hasText: /^Microsoft$/ })
+    const selectedVendorOption = actionEditor.getByRole('combobox').filter({ hasText: /^Generic$/ })
+    const selectedSystemOption = actionEditor.getByRole('combobox').filter({ hasText: /^Autopilot$/ })
+    
+    await expect(selectedAircraftOption).toBeVisible()
+    await expect(selectedVendorOption).toBeVisible()
+    await expect(selectedSystemOption).toBeVisible()
+
+    // Only one visible with all filters applied
     await expect(countLabel).toHaveText("1 preset(s) found")
+    
+    // fill text search filter with bogus text -> 0 presets found
+    const filterInput = actionEditor.getByPlaceholder("Filter presets")
+    await filterInput.fill("NonExistingPreset")
+    await expect(countLabel).toHaveText("0 preset(s) found")
+
+    // The filter options are still displayed
+    // even though technically there are no presets available
+    await expect(selectedVendorOption).toBeVisible()
+    await expect(selectedAircraftOption).toBeVisible()
+    await expect(selectedSystemOption).toBeVisible()
+    
+    // Now reset the filters and verify that all presets are available again
     await resetFiltersButton.click()
     await expect(countLabel).toHaveText("5 preset(s) found")
+    
 
-    const optionsList = page.getByRole("listbox")
-
-    // Select a vendor filter
+    // Click on the vendor combobox to open the list of options
     await actionEditor
       .getByRole("combobox")
       .filter({ hasText: "Filter by vendor" })
       .click()
+
+    const optionsList = page.getByRole("listbox")
     await expect(optionsList).toBeVisible()
     const vendorOption = optionsList.getByRole("option", {
       name: "Microsoft",
       exact: true,
     })
+    const aircraftOption = optionsList.getByRole("option", { name: "Generic" })
+    const systemOption = optionsList.getByRole("option", { name: "Avionics" })
+    
     await expect(vendorOption).toBeVisible()
     await vendorOption.click()
     await expect(vendorOption).not.toBeVisible()
-
+    
     await expect(countLabel).toHaveText("4 preset(s) found")
-
+    
     // Select an aircraft filter
     await actionEditor
-      .getByRole("combobox")
-      .filter({ hasText: "Filter by aircraft" })
-      .click()
-    await expect(optionsList).toBeVisible()
-    const aircraftOption = optionsList.getByRole("option", { name: "Generic" })
+    .getByRole("combobox")
+    .filter({ hasText: "Filter by aircraft" })
+    .click()
     await expect(aircraftOption).toBeVisible()
+    await expect(optionsList).toBeVisible()
     await aircraftOption.click()
     await expect(aircraftOption).not.toBeVisible() // Should be removed from options since it's already selected as a filter
 
@@ -2764,7 +2789,6 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
       .filter({ hasText: "Filter by system" })
       .click()
     await expect(optionsList).toBeVisible()
-    const systemOption = optionsList.getByRole("option", { name: "Avionics" })
     await expect(systemOption).toBeVisible()
     await systemOption.click()
     await expect(systemOption).not.toBeVisible()
@@ -3208,6 +3232,14 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     const actionEditor = page.getByTestId("action-editor")
 
+    const selectedAircraftOption = actionEditor.getByRole('combobox').filter({ hasText: /^Laminar Research$/ })
+    const selectedVendorOption = actionEditor.getByRole('combobox').filter({ hasText: /^Boeing 737-800$/ })
+    const selectedSystemOption = actionEditor.getByRole('combobox').filter({ hasText: /^Autopilot$/ })
+    
+    await expect(selectedAircraftOption).toBeVisible()
+    await expect(selectedVendorOption).toBeVisible()
+    await expect(selectedSystemOption).toBeVisible()
+
     const countLabel = actionEditor.getByRole("status")
     const resetFiltersButton = actionEditor.getByRole("button", {
       name: "Reset filters",
@@ -3216,6 +3248,17 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     // initially only 1 preset is available
     // because of current test data filtering
     await expect(countLabel).toHaveText("1 preset(s) found")
+
+    // fill text search filter with bogus text -> 0 presets found
+    const filterInput = actionEditor.getByPlaceholder("Filter presets")
+    await filterInput.fill("NonExistingPreset")
+    await expect(countLabel).toHaveText("0 preset(s) found")
+
+    // The filter options are still displayed
+    // even though technically there are no presets available
+    await expect(selectedAircraftOption).toBeVisible()
+    await expect(selectedVendorOption).toBeVisible()
+    await expect(selectedSystemOption).toBeVisible()
 
     // now reset all filters to show all options
     await resetFiltersButton.click()

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2723,17 +2723,23 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
       name: "Reset filters",
     })
 
-    const selectedAircraftOption = actionEditor.getByRole('combobox').filter({ hasText: /^Microsoft$/ })
-    const selectedVendorOption = actionEditor.getByRole('combobox').filter({ hasText: /^Generic$/ })
-    const selectedSystemOption = actionEditor.getByRole('combobox').filter({ hasText: /^Autopilot$/ })
-    
-    await expect(selectedAircraftOption).toBeVisible()
+    const selectedVendorOption = actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: /^Microsoft$/ })
+    const selectedAircraftOption = actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: /^Generic$/ })
+    const selectedSystemOption = actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: /^Autopilot$/ })
+
     await expect(selectedVendorOption).toBeVisible()
+    await expect(selectedAircraftOption).toBeVisible()
     await expect(selectedSystemOption).toBeVisible()
 
     // Only one visible with all filters applied
     await expect(countLabel).toHaveText("1 preset(s) found")
-    
+
     // fill text search filter with bogus text -> 0 presets found
     const filterInput = actionEditor.getByPlaceholder("Filter presets")
     await filterInput.fill("NonExistingPreset")
@@ -2744,11 +2750,10 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await expect(selectedVendorOption).toBeVisible()
     await expect(selectedAircraftOption).toBeVisible()
     await expect(selectedSystemOption).toBeVisible()
-    
+
     // Now reset the filters and verify that all presets are available again
     await resetFiltersButton.click()
     await expect(countLabel).toHaveText("5 preset(s) found")
-    
 
     // Click on the vendor combobox to open the list of options
     await actionEditor
@@ -2764,18 +2769,18 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     })
     const aircraftOption = optionsList.getByRole("option", { name: "Generic" })
     const systemOption = optionsList.getByRole("option", { name: "Avionics" })
-    
+
     await expect(vendorOption).toBeVisible()
     await vendorOption.click()
     await expect(vendorOption).not.toBeVisible()
-    
+
     await expect(countLabel).toHaveText("4 preset(s) found")
-    
+
     // Select an aircraft filter
     await actionEditor
-    .getByRole("combobox")
-    .filter({ hasText: "Filter by aircraft" })
-    .click()
+      .getByRole("combobox")
+      .filter({ hasText: "Filter by aircraft" })
+      .click()
     await expect(aircraftOption).toBeVisible()
     await expect(optionsList).toBeVisible()
     await aircraftOption.click()
@@ -3232,12 +3237,18 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     const actionEditor = page.getByTestId("action-editor")
 
-    const selectedAircraftOption = actionEditor.getByRole('combobox').filter({ hasText: /^Laminar Research$/ })
-    const selectedVendorOption = actionEditor.getByRole('combobox').filter({ hasText: /^Boeing 737-800$/ })
-    const selectedSystemOption = actionEditor.getByRole('combobox').filter({ hasText: /^Autopilot$/ })
-    
-    await expect(selectedAircraftOption).toBeVisible()
+    const selectedVendorOption = actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: /^Laminar Research$/ })
+    const selectedAircraftOption = actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: /^Boeing 737-800$/ })
+    const selectedSystemOption = actionEditor
+      .getByRole("combobox")
+      .filter({ hasText: /^Autopilot$/ })
+
     await expect(selectedVendorOption).toBeVisible()
+    await expect(selectedAircraftOption).toBeVisible()
     await expect(selectedSystemOption).toBeVisible()
 
     const countLabel = actionEditor.getByRole("status")
@@ -3256,8 +3267,8 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     // The filter options are still displayed
     // even though technically there are no presets available
-    await expect(selectedAircraftOption).toBeVisible()
     await expect(selectedVendorOption).toBeVisible()
+    await expect(selectedAircraftOption).toBeVisible()
     await expect(selectedSystemOption).toBeVisible()
 
     // now reset all filters to show all options


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
Show current filter for facted dropdown options when 0 results. Before, if current filter settings resulted in 0 search results, the comboboxes looked like they had no active filter.

### Screenshots / recordings
<img width="996" height="234" alt="image" src="https://github.com/user-attachments/assets/2eb690ed-fd4a-43f6-956e-a511c2e1fb59" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Filter comboboxes show current option even when 0 search results

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] ~~Unit tests available~~
- [x] Frontend tests
- [x] ~~i18n - All user-facing strings are translated~~
- [x] ~~documentation~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3120
