### PR TITLE
Show release notes before update inc Beta opt-out

### DIFF
--- a/src/MobiFlightConnector/Base/AutoUpdateChecker.cs
+++ b/src/MobiFlightConnector/Base/AutoUpdateChecker.cs
@@ -1,17 +1,72 @@
-﻿using System;
-using System.Windows.Forms;
-using System.Reflection;
+﻿using MobiFlight.UI.Dialogs;
+using System;
 using System.Diagnostics;
 using System.IO;
-
+using System.Reflection;
+using System.Threading.Tasks;
+using System.Windows.Forms;
 
 namespace MobiFlight.UpdateChecker
 {
     static class AutoUpdateChecker
     {
+        internal enum UpdatePath
+        {
+            StableToStable,
+            StableToBeta,
+            BetaToBeta,
+            BetaToStable
+        }
         static readonly string mobiFlightInstaller = "MobiFlight-Installer.exe";
         static readonly int UpdateCheckTimeoutInMs = 5000;
-        public static void CheckForUpdate(bool silent = false)
+
+        internal static bool VersionCheck(string output, out string newVersion, out string betaOrRelease)
+        {
+            newVersion = null;
+            betaOrRelease = null;
+
+            if (!output.Contains("##RESULT##|1"))
+                return false;
+            string[] outputArray = output.Split('|'); // Get the version number
+            newVersion = outputArray[2];
+            string[] versionArray = newVersion.Split('.'); // Split the version number to get the last number
+            int versionLastNumber = Int32.Parse(versionArray[3]);
+
+            betaOrRelease = (outputArray.Length == 4) && (versionLastNumber > 0)
+                ? "BETA"
+                : "RELEASE";
+            return true;
+        }
+
+        internal static string ReleaseVersion(string version)
+        {
+            if (!Version.TryParse(version, out var parsedVersion))
+                return version;
+
+            return parsedVersion.Revision > 0
+                ? parsedVersion.ToString(4)
+                : parsedVersion.ToString(3);
+        }
+
+        internal static bool IsBetaVersion(Version version)
+        {
+            return version.Revision > 0;
+        }
+
+        internal static UpdatePath GetUpdatePath(bool currentIsBeta, string targetChannel)
+        {
+            var targetIsBeta = targetChannel == "BETA";
+
+            if (!currentIsBeta && !targetIsBeta)
+                return UpdatePath.StableToStable;
+            if (!currentIsBeta)
+                return UpdatePath.StableToBeta;
+            if (targetIsBeta)
+                return UpdatePath.BetaToBeta;
+            return UpdatePath.BetaToStable;
+        }
+
+        public static async Task CheckForUpdate(bool silent = false)
         {
             String hash = (Environment.UserName + Environment.MachineName).GetHashCode().ToString();
             if (Properties.Settings.Default.CacheId == "0") Properties.Settings.Default.CacheId = Guid.NewGuid().ToString();
@@ -45,47 +100,62 @@ namespace MobiFlight.UpdateChecker
                 return;
             }
 
-            System.Diagnostics.Process p = new Process();
-            p.StartInfo.FileName = mobiFlightInstaller;
-            p.StartInfo.Arguments = CommandToSend;
-            p.StartInfo.UseShellExecute = false;
-            p.StartInfo.CreateNoWindow = true;
-            p.StartInfo.RedirectStandardOutput = true;
-            p.StartInfo.RedirectStandardError = true;
-            p.Start();
-            string output = p.StandardOutput.ReadToEnd();
-            string error = p.StandardError.ReadToEnd();
-            p.WaitForExit(UpdateCheckTimeoutInMs);
+            string output;
+            string error;
+            try
+            {
+                (output, error) = await Task.Run(() => RunInstallerCheck(CommandToSend));
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log("Unable to run MobiFlight-Installer.exe: " + ex.Message, LogSeverity.Error);
+                return;
+            }
 
             Console.WriteLine(output + error);
-            if (output.Contains("##RESULT##|1"))
+
+            // Get the new version and the channel (BETA or RELEASE) from the installer output
+            if (VersionCheck(output, out string newVersion, out string betaOrRelease))
             {
-                string[] OutputArray = output.Split('|'); // Get the version number
-                string newVersion = OutputArray[2];
-                string[] VersionArray = newVersion.Split('.'); // Split the version number to get the last number
-                int VersionLastnumber = Int32.Parse(VersionArray[3]);
-                string BetaOrRelease;
-                
-                if ((OutputArray.Length == 4) & (VersionLastnumber > 0)) // If the last number is > 0 is a beta version
-                    BetaOrRelease = "BETA";
-                else
-                    BetaOrRelease = "RELEASE";
+                Log.Instance.log($"Found a new version: {newVersion} {betaOrRelease}.", LogSeverity.Info);
+                var updatePath = GetUpdatePath(IsBetaVersion(CurVersion), betaOrRelease);
+                Log.Instance.log($"Update path: {updatePath}.", LogSeverity.Info);
 
-                Log.Instance.log($"Found a new version: {newVersion} {BetaOrRelease}.", LogSeverity.Info);
-
-                DialogResult dialogResult = MessageBox.Show(
-                    String.Format(i18n._tr("uiMessageNewUpdateAvailablePleaseUpdate"), newVersion),
-                    i18n._tr("uiMessageNewUpdateAvailable"),
-                    MessageBoxButtons.YesNo
-                );
-
-                if (dialogResult == DialogResult.Yes)
+                var releaseVersion = ReleaseVersion(newVersion);
+                var releaseUrl = $"https://github.com/MobiFlight/MobiFlight-Connector/releases/tag/{releaseVersion}";
+                var releaseLabel = betaOrRelease == "BETA" ? " (BETA)" : string.Empty;
+                using (var dialog = new WelcomeDialog())
                 {
-                    Process.Start(mobiFlightInstaller, "/install " + newVersion);
-                    Environment.Exit(0);
+                    dialog.Mode = WelcomeDialogMode.BeforeUpdate;
+                    dialog.WebsiteUrl = releaseUrl;
+                    dialog.StartPosition = FormStartPosition.CenterParent;
+                    dialog.ShowDisableBetaButton = updatePath == UpdatePath.StableToBeta //Show "DisableBetaButton" if update from stable to beta
+                        && Properties.Settings.Default.BetaUpdates;
+                    dialog.Text = $"{i18n._tr("uiMessageNewUpdateAvailable")} - MobiFlight {releaseVersion}{releaseLabel} - Release Notes";
+                    dialog.ReleaseNotesClicked += (sender, e) => Process.Start(releaseUrl);
+                    dialog.DisableBetaClicked += (sender, e) =>
+                    {
+                        Properties.Settings.Default.BetaUpdates = false;
+                        Properties.Settings.Default.Save();
+                    };
+
+                    if (dialog.ShowDialog() == DialogResult.Yes)
+                    {
+                        try
+                        {
+                            Process.Start(mobiFlightInstaller, "/install " + newVersion);
+                            Environment.Exit(0);
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Instance.log("Unable to start MobiFlight-Installer.exe: " + ex.Message, LogSeverity.Error);
+                            MessageBox.Show("The installer could not be started. Please update manually.", "Update", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        }
+                    }
                 }
                 return;
             }
+
             if (!silent)
                 MessageBox.Show(
                     String.Format(i18n._tr("uiMessageNoUpdateNecessary"), MobiFlight.UI.MainForm.DisplayVersion()),
@@ -93,6 +163,25 @@ namespace MobiFlight.UpdateChecker
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
             Log.Instance.log("MobiFlight is up to date.", LogSeverity.Info);
             return;
+        }
+
+        // Runs the installer to check for available updates
+        private static (string output, string error) RunInstallerCheck(string arguments)
+        {
+            using (var process = new Process())
+            {
+                process.StartInfo.FileName = mobiFlightInstaller;
+                process.StartInfo.Arguments = arguments;
+                process.StartInfo.UseShellExecute = false;
+                process.StartInfo.CreateNoWindow = true;
+                process.StartInfo.RedirectStandardOutput = true;
+                process.StartInfo.RedirectStandardError = true;
+                process.Start();
+                var output = process.StandardOutput.ReadToEnd();
+                var error = process.StandardError.ReadToEnd();
+                process.WaitForExit(UpdateCheckTimeoutInMs);
+                return (output, error);
+            }
         }
     }
 }

--- a/src/MobiFlightConnector/ProjectMessages/ProjectMessages.Designer.cs
+++ b/src/MobiFlightConnector/ProjectMessages/ProjectMessages.Designer.cs
@@ -19,7 +19,7 @@ namespace MobiFlight.ProjectMessages {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "18.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ProjectMessages {
@@ -448,6 +448,15 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MobiFlight - {0}.
+        /// </summary>
+        internal static string uiLabelTrayTooltipFormat {
+            get {
+                return ResourceManager.GetString("uiLabelTrayTooltipFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Application is now running in the background..
         /// </summary>
         internal static string uiMessageApplicationIsRunningInBackgroundMode {
@@ -816,15 +825,6 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The connection to ProSim got lost.
-        /// </summary>
-        internal static string uiMessageProSimConnectionLost {
-            get {
-                return ResourceManager.GetString("uiMessageProSimConnectionLost", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Your HubHop presets are older than 7 days.
         ///
         ///Would you like to update?.
@@ -950,7 +950,7 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to MobiFlight Update available!.
+        ///   Looks up a localized string similar to Update available!.
         /// </summary>
         internal static string uiMessageNewUpdateAvailable {
             get {
@@ -1180,6 +1180,15 @@ namespace MobiFlight.ProjectMessages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The connection to ProSim got lost.
+        /// </summary>
+        internal static string uiMessageProSimConnectionLost {
+            get {
+                return ResourceManager.GetString("uiMessageProSimConnectionLost", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Python environment not ready.
         /// </summary>
         internal static string uiMessagePythonHint {
@@ -1279,15 +1288,6 @@ namespace MobiFlight.ProjectMessages {
         internal static string uiMessageSimConnectConnectionLost {
             get {
                 return ResourceManager.GetString("uiMessageSimConnectConnectionLost", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The connection to X-Plane got lost.
-        /// </summary>
-        internal static string uiMessageXplaneConnectionLost {
-            get {
-                return ResourceManager.GetString("uiMessageXplaneConnectionLost", resourceCulture);
             }
         }
         
@@ -1518,6 +1518,15 @@ namespace MobiFlight.ProjectMessages {
         internal static string uiMessageWasmUpdater {
             get {
                 return ResourceManager.GetString("uiMessageWasmUpdater", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The connection to X-Plane got lost.
+        /// </summary>
+        internal static string uiMessageXplaneConnectionLost {
+            get {
+                return ResourceManager.GetString("uiMessageXplaneConnectionLost", resourceCulture);
             }
         }
         

--- a/src/MobiFlightConnector/ProjectMessages/ProjectMessages.resx
+++ b/src/MobiFlightConnector/ProjectMessages/ProjectMessages.resx
@@ -415,7 +415,7 @@ You can always enable it later again in the settings menu.</value>
     <value>Error during Test-Mode: Module not connected.</value>
   </data>
   <data name="uiMessageNewUpdateAvailable" xml:space="preserve">
-    <value>MobiFlight Update available!</value>
+    <value>Update available!</value>
   </data>
   <data name="uiMessageNewUpdateAvailablePleaseUpdate" xml:space="preserve">
     <value>YEAH! - New Version {0} is available! Please update now.</value>

--- a/src/MobiFlightConnector/UI/Dialogs/WelcomeDialog.Designer.cs
+++ b/src/MobiFlightConnector/UI/Dialogs/WelcomeDialog.Designer.cs
@@ -34,9 +34,14 @@ namespace MobiFlight.UI.Dialogs
             this.okButton = new System.Windows.Forms.Button();
             this.titleLabel = new System.Windows.Forms.Label();
             this.panel = new System.Windows.Forms.Panel();
+            this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.updateButton = new System.Windows.Forms.Button();
+            this.disableBetaButton = new System.Windows.Forms.Button();
+            this.dontUpdateNowLabel = new System.Windows.Forms.Label();
             this.openReleaseNotesinBrowserLabel = new System.Windows.Forms.Label();
             this.webView = new Microsoft.Web.WebView2.WinForms.WebView2();
             this.panel.SuspendLayout();
+            this.flowLayoutPanel1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.webView)).BeginInit();
             this.SuspendLayout();
             // 
@@ -54,15 +59,45 @@ namespace MobiFlight.UI.Dialogs
             // 
             // panel
             // 
+            this.panel.Controls.Add(this.flowLayoutPanel1);
             this.panel.Controls.Add(this.openReleaseNotesinBrowserLabel);
-            this.panel.Controls.Add(this.okButton);
             resources.ApplyResources(this.panel, "panel");
             this.panel.Name = "panel";
             // 
+            // flowLayoutPanel1
+            // 
+            this.flowLayoutPanel1.Controls.Add(this.okButton);
+            this.flowLayoutPanel1.Controls.Add(this.updateButton);
+            this.flowLayoutPanel1.Controls.Add(this.disableBetaButton);
+            this.flowLayoutPanel1.Controls.Add(this.dontUpdateNowLabel);
+            resources.ApplyResources(this.flowLayoutPanel1, "flowLayoutPanel1");
+            this.flowLayoutPanel1.Name = "flowLayoutPanel1";
+            // 
+            // updateButton
+            // 
+            resources.ApplyResources(this.updateButton, "updateButton");
+            this.updateButton.Name = "updateButton";
+            this.updateButton.UseVisualStyleBackColor = true;
+            this.updateButton.Click += new System.EventHandler(this.updateButton_Click);
+            // 
+            // disableBetaButton
+            // 
+            resources.ApplyResources(this.disableBetaButton, "disableBetaButton");
+            this.disableBetaButton.Name = "disableBetaButton";
+            this.disableBetaButton.UseVisualStyleBackColor = true;
+            this.disableBetaButton.Click += new System.EventHandler(this.disableBetaButton_Click);
+            // 
+            // dontUpdateNowLabel
+            // 
+            this.dontUpdateNowLabel.Cursor = System.Windows.Forms.Cursors.Hand;
+            resources.ApplyResources(this.dontUpdateNowLabel, "dontUpdateNowLabel");
+            this.dontUpdateNowLabel.Name = "dontUpdateNowLabel";
+            this.dontUpdateNowLabel.Click += new System.EventHandler(this.dontUpdateNowLabel_Click);
+            // 
             // openReleaseNotesinBrowserLabel
             // 
-            resources.ApplyResources(this.openReleaseNotesinBrowserLabel, "openReleaseNotesinBrowserLabel");
             this.openReleaseNotesinBrowserLabel.Cursor = System.Windows.Forms.Cursors.Hand;
+            resources.ApplyResources(this.openReleaseNotesinBrowserLabel, "openReleaseNotesinBrowserLabel");
             this.openReleaseNotesinBrowserLabel.Name = "openReleaseNotesinBrowserLabel";
             this.openReleaseNotesinBrowserLabel.Click += new System.EventHandler(this.transparentOverlay1_Click);
             // 
@@ -85,7 +120,7 @@ namespace MobiFlight.UI.Dialogs
             this.Name = "WelcomeDialog";
             this.Load += new System.EventHandler(this.WelcomeDialog_Load);
             this.panel.ResumeLayout(false);
-            this.panel.PerformLayout();
+            this.flowLayoutPanel1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.webView)).EndInit();
             this.ResumeLayout(false);
 
@@ -97,5 +132,9 @@ namespace MobiFlight.UI.Dialogs
         private System.Windows.Forms.Panel panel;
         private Microsoft.Web.WebView2.WinForms.WebView2 webView;
         private System.Windows.Forms.Label openReleaseNotesinBrowserLabel;
+        private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.Button updateButton;
+        private System.Windows.Forms.Label dontUpdateNowLabel;
+        private System.Windows.Forms.Button disableBetaButton;
     }
 }

--- a/src/MobiFlightConnector/UI/Dialogs/WelcomeDialog.cs
+++ b/src/MobiFlightConnector/UI/Dialogs/WelcomeDialog.cs
@@ -1,31 +1,54 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
-using System.Diagnostics;
-using System.Drawing;
-using System.Linq;
-using System.Text;
 using System.Windows.Forms;
-using static System.Net.WebRequestMethods;
 
 namespace MobiFlight.UI.Dialogs
 {
+    public enum WelcomeDialogMode
+    {
+        BeforeUpdate,
+        FirstStart
+    }
     public partial class WelcomeDialog : Form
     {
         public event EventHandler<EventArgs> ReleaseNotesClicked;
+        public event EventHandler<EventArgs> DisableBetaClicked;
 
-        public string WebsiteUrl {
+        public string WebsiteUrl
+        {
             get { return this.webView.Source.ToString(); }
-            set { 
+            set
+            {
                 this.webView.Source = new System.Uri(value, System.UriKind.Absolute);
-            } 
+            }
+        }
+
+        private WelcomeDialogMode _mode;
+        public WelcomeDialogMode Mode
+        {
+            get { return _mode; }
+            set
+            {
+                if (_mode == value) return;
+                _mode = value;
+                okButton.Visible = _mode == WelcomeDialogMode.FirstStart;
+                updateButton.Visible = _mode == WelcomeDialogMode.BeforeUpdate;
+                disableBetaButton.Visible = _mode == WelcomeDialogMode.BeforeUpdate;
+                dontUpdateNowLabel.Visible = _mode == WelcomeDialogMode.BeforeUpdate;
+            }
+        }
+
+        public bool ShowDisableBetaButton
+        {
+            get { return disableBetaButton.Visible; }
+            set { disableBetaButton.Visible = value; }
         }
 
         public WelcomeDialog()
         {
             InitializeComponent();
-            WebsiteUrl = "https://www.mobiflight.com/en/release-notes.html";
+
+            // Default Setting
+            Mode = WelcomeDialogMode.FirstStart;
             this.webView.NavigationCompleted += WebView21_NavigationCompleted;
         }
 
@@ -52,6 +75,22 @@ namespace MobiFlight.UI.Dialogs
         private void transparentOverlay1_Click(object sender, EventArgs e)
         {
             ReleaseNotesClicked?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void disableBetaButton_Click(object sender, EventArgs e)
+        {
+            DisableBetaClicked?.Invoke(this, EventArgs.Empty);
+            DialogResult = DialogResult.No;
+        }
+
+        private void updateButton_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Yes;
+        }
+
+        private void dontUpdateNowLabel_Click(object sender, EventArgs e)
+        {
+            DialogResult = DialogResult.Cancel;
         }
     }
 }

--- a/src/MobiFlightConnector/UI/Dialogs/WelcomeDialog.resx
+++ b/src/MobiFlightConnector/UI/Dialogs/WelcomeDialog.resx
@@ -117,13 +117,13 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="okButton.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
-  </data>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="okButton.Location" type="System.Drawing.Point, System.Drawing">
-    <value>321, 2</value>
+    <value>474, 3</value>
+  </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="okButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
   </data>
   <data name="okButton.Size" type="System.Drawing.Size, System.Drawing">
     <value>151, 35</value>
@@ -142,10 +142,10 @@
     <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;okButton.Parent" xml:space="preserve">
-    <value>panel</value>
+    <value>flowLayoutPanel1</value>
   </data>
   <data name="&gt;&gt;okButton.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>0</value>
   </data>
   <data name="titleLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
@@ -180,23 +180,143 @@
   <data name="&gt;&gt;titleLabel.ZOrder" xml:space="preserve">
     <value>1</value>
   </data>
-  <data name="openReleaseNotesinBrowserLabel.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Right</value>
+  <data name="updateButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
   </data>
-  <data name="openReleaseNotesinBrowserLabel.AutoSize" type="System.Boolean, mscorlib">
-    <value>True</value>
+  <data name="updateButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>320, 3</value>
+  </data>
+  <data name="updateButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="updateButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>151, 35</value>
+  </data>
+  <data name="updateButton.TabIndex" type="System.Int32, mscorlib">
+    <value>2</value>
+  </data>
+  <data name="updateButton.Text" xml:space="preserve">
+    <value>Update now</value>
+  </data>
+  <data name="&gt;&gt;updateButton.Name" xml:space="preserve">
+    <value>updateButton</value>
+  </data>
+  <data name="&gt;&gt;updateButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;updateButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;updateButton.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="disableBetaButton.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="disableBetaButton.Location" type="System.Drawing.Point, System.Drawing">
+    <value>166, 3</value>
+  </data>
+  <data name="disableBetaButton.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="disableBetaButton.Size" type="System.Drawing.Size, System.Drawing">
+    <value>151, 35</value>
+  </data>
+  <data name="disableBetaButton.TabIndex" type="System.Int32, mscorlib">
+    <value>4</value>
+  </data>
+  <data name="disableBetaButton.Text" xml:space="preserve">
+    <value>Disable BETA updates</value>
+  </data>
+  <data name="&gt;&gt;disableBetaButton.Name" xml:space="preserve">
+    <value>disableBetaButton</value>
+  </data>
+  <data name="&gt;&gt;disableBetaButton.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;disableBetaButton.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;disableBetaButton.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="dontUpdateNowLabel.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
+  <data name="dontUpdateNowLabel.Location" type="System.Drawing.Point, System.Drawing">
+    <value>57, 3</value>
+  </data>
+  <data name="dontUpdateNowLabel.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>3, 3, 0, 3</value>
+  </data>
+  <data name="dontUpdateNowLabel.Size" type="System.Drawing.Size, System.Drawing">
+    <value>106, 33</value>
+  </data>
+  <data name="dontUpdateNowLabel.TabIndex" type="System.Int32, mscorlib">
+    <value>3</value>
+  </data>
+  <data name="dontUpdateNowLabel.Text" xml:space="preserve">
+    <value>Don't update now</value>
+  </data>
+  <data name="dontUpdateNowLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
+  </data>
+  <data name="&gt;&gt;dontUpdateNowLabel.Name" xml:space="preserve">
+    <value>dontUpdateNowLabel</value>
+  </data>
+  <data name="&gt;&gt;dontUpdateNowLabel.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;dontUpdateNowLabel.Parent" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;dontUpdateNowLabel.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="flowLayoutPanel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Fill</value>
+  </data>
+  <data name="flowLayoutPanel1.FlowDirection" type="System.Windows.Forms.FlowDirection, System.Windows.Forms">
+    <value>RightToLeft</value>
+  </data>
+  <data name="flowLayoutPanel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>167, 0</value>
+  </data>
+  <data name="flowLayoutPanel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>625, 39</value>
+  </data>
+  <data name="flowLayoutPanel1.TabIndex" type="System.Int32, mscorlib">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Name" xml:space="preserve">
+    <value>flowLayoutPanel1</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.FlowLayoutPanel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.Parent" xml:space="preserve">
+    <value>panel</value>
+  </data>
+  <data name="&gt;&gt;flowLayoutPanel1.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="openReleaseNotesinBrowserLabel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Left</value>
   </data>
   <data name="openReleaseNotesinBrowserLabel.Location" type="System.Drawing.Point, System.Drawing">
-    <value>614, 13</value>
+    <value>0, 0</value>
   </data>
   <data name="openReleaseNotesinBrowserLabel.Size" type="System.Drawing.Size, System.Drawing">
-    <value>157, 13</value>
+    <value>167, 39</value>
   </data>
   <data name="openReleaseNotesinBrowserLabel.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
   </data>
   <data name="openReleaseNotesinBrowserLabel.Text" xml:space="preserve">
     <value>Open Release Notes in browser</value>
+  </data>
+  <data name="openReleaseNotesinBrowserLabel.TextAlign" type="System.Drawing.ContentAlignment, System.Drawing">
+    <value>MiddleCenter</value>
   </data>
   <data name="&gt;&gt;openReleaseNotesinBrowserLabel.Name" xml:space="preserve">
     <value>openReleaseNotesinBrowserLabel</value>
@@ -208,7 +328,7 @@
     <value>panel</value>
   </data>
   <data name="&gt;&gt;openReleaseNotesinBrowserLabel.ZOrder" xml:space="preserve">
-    <value>0</value>
+    <value>1</value>
   </data>
   <data name="panel.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Bottom</value>
@@ -250,7 +370,7 @@
     <value>webView</value>
   </data>
   <data name="&gt;&gt;webView.Type" xml:space="preserve">
-    <value>Microsoft.Web.WebView2.WinForms.WebView2, Microsoft.Web.WebView2.WinForms, Version=1.0.1370.28, Culture=neutral, PublicKeyToken=2a8ab48044d2601e</value>
+    <value>Microsoft.Web.WebView2.WinForms.WebView2, Microsoft.Web.WebView2.WinForms, Version=1.0.4022.49, Culture=neutral, PublicKeyToken=2a8ab48044d2601e</value>
   </data>
   <data name="&gt;&gt;webView.Parent" xml:space="preserve">
     <value>$this</value>

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -447,11 +447,11 @@ namespace MobiFlight.UI
             }
         }
 
-        private void MainForm_Shown(object sender, EventArgs e)
+        private async void MainForm_Shown(object sender, EventArgs e)
         {
             // Check for updates before loading anything else
 #if (!DEBUG)
-            AutoUpdateChecker.CheckForUpdate(true);
+            await AutoUpdateChecker.CheckForUpdate(true);
 #endif
         }
 
@@ -1165,9 +1165,9 @@ namespace MobiFlight.UI
             }
         }
 
-        public void checkForUpdateToolStripMenuItem_Click(object sender, EventArgs e)
+        public async void checkForUpdateToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            AutoUpdateChecker.CheckForUpdate();
+            await AutoUpdateChecker.CheckForUpdate();
         }
 
         void execManager_OnTestModeException(object sender, EventArgs e)

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -451,7 +451,12 @@ namespace MobiFlight.UI
         {
             // Check for updates before loading anything else
 #if (!DEBUG)
-            await AutoUpdateChecker.CheckForUpdate(true);
+            try
+            {
+                await AutoUpdateChecker.CheckForUpdate(true);
+            } catch (Exception ex) {
+                Log.Instance.log($"Error checking for updates: {ex.Message}", LogSeverity.Error);
+            }
 #endif
         }
 
@@ -1167,7 +1172,15 @@ namespace MobiFlight.UI
 
         public async void checkForUpdateToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            await AutoUpdateChecker.CheckForUpdate();
+            try
+            {
+
+                await AutoUpdateChecker.CheckForUpdate();
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log($"Error checking for updates: {ex.Message}", LogSeverity.Error);
+            }
         }
 
         void execManager_OnTestModeException(object sender, EventArgs e)

--- a/tests/MobiFlightUnitTests/Base/AutoUpdateCheckerTests.cs
+++ b/tests/MobiFlightUnitTests/Base/AutoUpdateCheckerTests.cs
@@ -1,0 +1,104 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.UpdateChecker;
+using System;
+
+namespace MobiFlight.Base.Tests
+{
+    [TestClass]
+    public class AutoUpdateCheckerTests
+    {
+        [TestMethod]
+        public void VersionCheck_StableVersion_ReturnsRelease()
+        {
+            var result = AutoUpdateChecker.VersionCheck(
+                "##RESULT##|1|11.0.1.0",
+                out var newVersion,
+                out var channel);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("11.0.1.0", newVersion);
+            Assert.AreEqual("RELEASE", channel);
+        }
+
+        [TestMethod]
+        public void VersionCheck_BetaVersion_ReturnsBeta()
+        {
+            var result = AutoUpdateChecker.VersionCheck(
+                "##RESULT##|1|11.0.1.2|BETA",
+                out var newVersion,
+                out var channel);
+
+            Assert.IsTrue(result);
+            Assert.AreEqual("11.0.1.2", newVersion);
+            Assert.AreEqual("BETA", channel);
+        }
+
+        [TestMethod]
+        public void VersionCheck_NoUpdate_ReturnsFalse()
+        {
+            var result = AutoUpdateChecker.VersionCheck(
+                "##RESULT##|0",
+                out var newVersion,
+                out var channel);
+
+            Assert.IsFalse(result);
+            Assert.IsNull(newVersion);
+            Assert.IsNull(channel);
+        }
+
+        [TestMethod]
+        public void ReleaseVersion_StableVersion_RemovesZeroRevision()
+        {
+            var result = AutoUpdateChecker.ReleaseVersion("11.0.1.0");
+
+            Assert.AreEqual("11.0.1", result);
+        }
+
+        [TestMethod]
+        public void ReleaseVersion_BetaVersion_KeepsRevision()
+        {
+            var result = AutoUpdateChecker.ReleaseVersion("11.0.1.2");
+
+            Assert.AreEqual("11.0.1.2", result);
+        }
+
+        [TestMethod]
+        public void ReleaseVersion_InvalidVersion_ReturnsOriginalValue()
+        {
+            var result = AutoUpdateChecker.ReleaseVersion("invalid");
+
+            Assert.AreEqual("invalid", result);
+        }
+
+        [TestMethod]
+        public void IsBetaVersion_RevisionZero_ReturnsFalse()
+        {
+            var result = AutoUpdateChecker.IsBetaVersion(new Version(11, 0, 1, 0));
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod]
+        public void IsBetaVersion_PositiveRevision_ReturnsTrue()
+        {
+            var result = AutoUpdateChecker.IsBetaVersion(new Version(11, 0, 1, 1));
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod]
+        [DataRow(false, "RELEASE", "StableToStable")]
+        [DataRow(false, "BETA", "StableToBeta")]
+        [DataRow(true, "BETA", "BetaToBeta")]
+        [DataRow(true, "RELEASE", "BetaToStable")]
+        public void GetUpdatePath_ReturnsExpectedPath(
+            bool currentIsBeta,
+            string targetChannel,
+            string expectedPath)
+        {
+            var result = AutoUpdateChecker.GetUpdatePath(currentIsBeta, targetChannel);
+
+            Assert.AreEqual(expectedPath, result.ToString());
+        }
+    }
+}

--- a/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -216,6 +216,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="AssemblyInitialize.cs" />
+    <Compile Include="Base\AutoUpdateCheckerTests.cs" />
     <Compile Include="Base\BooleanConverterConfigTests.cs" />
     <Compile Include="Base\CmdLineParamsTests.cs" />
     <Compile Include="Base\ComboBoxHelperTests.cs" />


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
The program can show the release notes before an update is installed.
Users can review the changes, open the full release notes in their browser, update now or postpone.
Version detection is improved. It adds an option to disable beta updates when STABLE ->BETA.
It keeps the existing installer-based update process as a fallback. The update check now runs asynchronously so the application remains responsive while checking for new versions.

The majority of the code changes was taken from https://github.com/MobiFlight/MobiFlight-Connector/pull/3116
Thanks to @DarkModest

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="1515" height="1149" alt="image" src="https://github.com/user-attachments/assets/b4b10f57-fc96-4a5a-9437-9f75e8d4f16c" />

<img width="1521" height="1150" alt="image" src="https://github.com/user-attachments/assets/9e5d15fa-3fa9-4f6e-83bb-70345d27f333" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] The application shows release notes before updating, using the existing WebView-based dialog or a shared implementation of it.
- [x] The system correctly distinguishes 4 update paths.
- For Stable -> Stable, Beta -> Beta and Beta -> Stable updates:
  - [x] All users on the stable channel see the update dialog.
  - [x] No beta opt-out action is available.
- For Stable -> Beta updates:
  - [x] Only users with beta updates enabled see the update dialog.
  - [x] A visible opt-out action is available in the dialog.
  - [x] Selecting the opt-out action disables beta updates in global settings.
  - [x] The changed setting persists across application restarts.
- [x] `Update now` and `Disable BETA Updates` are buttons, while `Don't update now` and `Open in browser` are links. 
- [x] The dialog continues to offer `Update now` and `Don't update now`.
- [x] There is no snooze, skip-version, or "don't remind me again" behavior.
- [x] If the user selects `Don't update now`, the dialog is shown again on the next application start.
- [x] `Update now` is set to default.

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [x] i18n - All user-facing strings are translated

## DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
  - [x] Frontend
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3093 and #2958

## Out-of-scope
<!-- mention what is not covered by this PR -->
1. i18n of texts of new buttons. It hasn't been covered before this PR.
2. In an older version comparing to latest, Release Notes Dialog will pop up before Update Dialog and be covered by it.