### PR TITLE
Improve output shift register message format

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/BinaryMobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/BinaryMobiFlightShiftRegister.cs
@@ -6,7 +6,7 @@ namespace MobiFlight
 {
     public class BinaryMobiFlightShiftRegister : MobiFlightShiftRegister
     {
-        public override void Display(String outputPins, String value)
+        public override void InternalDisplay(String outputPins, String value)
         {
             if (!_initialized) Initialize();
 

--- a/src/MobiFlightConnector/MobiFlight/BinaryMobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/BinaryMobiFlightShiftRegister.cs
@@ -1,0 +1,52 @@
+﻿using CommandMessenger;
+using System;
+using System.Linq;
+
+namespace MobiFlight
+{
+    public class BinaryMobiFlightShiftRegister : MobiFlightShiftRegister
+    {
+        public override void Display(String outputPins, String value)
+        {
+            if (!_initialized) Initialize();
+
+            var command = new SendCommand((int)MobiFlightModule.Command.SetShiftRegisterPins);
+
+            // Let's strip the static label
+            String pinsOnly = outputPins.Replace(LABEL_PREFIX + " ", "");
+
+            // clamp and reverse the string
+            if (value.Length > 8) value = value.Substring(0, 8);
+
+            var byteMask = ConvertStringToByteArray(pinsOnly, NumberOfShifters).Reverse();
+
+            command.AddArgument(this.ModuleNumber);
+            command.AddArgument(NumberOfShifters);
+            command.AddArgument(value);
+            byteMask.ToList().ForEach(b => command.AddBinArgument(b));
+
+            Log.Instance.log($"Command: SetShiftRegisterPin <{(int)MobiFlightModule.Command.SetShiftRegisterPins},{this.ModuleNumber},{value},{NumberOfShifters},{string.Join(",", byteMask)} ;>.", LogSeverity.Debug);
+            // Send command
+            CmdMessenger.SendCommand(command);
+        }
+
+        // Convert string to byte array
+        // value is a string of 1|2|6|7|8
+        public static byte[] ConvertStringToByteArray(string value, int numberOfShifters)
+        {
+            var selectedPins = value.Split('|').Select(int.Parse).ToList();
+            var byteArray = new byte[numberOfShifters];
+
+            selectedPins.ForEach(pin =>
+            {
+                int shifterIndex = pin / 8;
+                int bitIndex = pin % 8;
+                if (shifterIndex < numberOfShifters)
+                {
+                    byteArray[shifterIndex] |= (byte)(1 << bitIndex);
+                }
+            });
+            return byteArray;
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlight/BinaryMobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/BinaryMobiFlightShiftRegister.cs
@@ -14,18 +14,17 @@ namespace MobiFlight
 
             // Let's strip the static label
             String pinsOnly = outputPins.Replace(LABEL_PREFIX + " ", "");
+            var byteMask = ConvertStringToByteArray(pinsOnly, NumberOfShifters);
+            Array.Reverse(byteMask);
 
-            // clamp and reverse the string
-            if (value.Length > 8) value = value.Substring(0, 8);
+            if (value != "0") value = "1";
 
-            var byteMask = ConvertStringToByteArray(pinsOnly, NumberOfShifters).Reverse();
-
-            command.AddArgument(this.ModuleNumber);
+            command.AddArgument(ModuleNumber);
             command.AddArgument(NumberOfShifters);
             command.AddArgument(value);
-            byteMask.ToList().ForEach(b => command.AddBinArgument(b));
+            byteMask.ToList().ForEach(b => command.AddArgument(b));
 
-            Log.Instance.log($"Command: SetShiftRegisterPin <{(int)MobiFlightModule.Command.SetShiftRegisterPins},{this.ModuleNumber},{value},{NumberOfShifters},{string.Join(",", byteMask)} ;>.", LogSeverity.Debug);
+            Log.Instance.log($"Command: SetShiftRegisterPin (Binary) <{(int)MobiFlightModule.Command.SetShiftRegisterPins},{ModuleNumber},{NumberOfShifters},{value},{string.Join(",", byteMask)};>.", LogSeverity.Debug);
             // Send command
             CmdMessenger.SendCommand(command);
         }

--- a/src/MobiFlightConnector/MobiFlight/FirmwareFeature.cs
+++ b/src/MobiFlightConnector/MobiFlight/FirmwareFeature.cs
@@ -7,6 +7,6 @@
         public const string LedModuleTypeTM1637 = "2.4.2";
         public const string CustomDevices = "2.4.2";
         public const string AccessOutputByDeviceIndex = "3.0.0";
-        public const string OutputShiftRegisterSetPinsBinary = "3.1.2";
+        public const string OutputShiftRegisterSetPinsBinary = "3.1.3";
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/FirmwareFeature.cs
+++ b/src/MobiFlightConnector/MobiFlight/FirmwareFeature.cs
@@ -7,5 +7,6 @@
         public const string LedModuleTypeTM1637 = "2.4.2";
         public const string CustomDevices = "2.4.2";
         public const string AccessOutputByDeviceIndex = "3.0.0";
+        public const string OutputShiftRegisterSetPinsBinary = "3.1.2";
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
@@ -560,7 +560,6 @@ namespace MobiFlight
                     result = connectedPorts2.Except(connectedPorts).Last();
                 }
             }
-            ;
 
             return result;
         }

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
@@ -863,6 +863,8 @@ namespace MobiFlight
             lastValue[key] = cachedValue;
 
             shiftRegisters[moduleID].Display(outputPin, value);
+
+            Thread.Sleep(20);
             return true;
         }
 

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModule.cs
@@ -445,7 +445,12 @@ namespace MobiFlight
                                     LogSeverity.Error);
                                 break;
                             }
-                            shiftRegisters.Add(device.Name, new MobiFlightShiftRegister() { CmdMessenger = _cmdMessenger, Name = device.Name, NumberOfShifters = submodules, ModuleNumber = shiftRegisters.Count });
+                            var shiftRegister = HasFirmwareFeature(FirmwareFeature.OutputShiftRegisterSetPinsBinary) ? new BinaryMobiFlightShiftRegister() : new MobiFlightShiftRegister();
+                            shiftRegister.CmdMessenger = _cmdMessenger;
+                            shiftRegister.Name = device.Name;
+                            shiftRegister.NumberOfShifters = submodules;
+                            shiftRegister.ModuleNumber = shiftRegisters.Count;
+                            shiftRegisters.Add(device.Name, shiftRegister);
                             break;
 
                         case DeviceType.InputShiftRegister:
@@ -554,7 +559,8 @@ namespace MobiFlight
                 {
                     result = connectedPorts2.Except(connectedPorts).Last();
                 }
-            };
+            }
+            ;
 
             return result;
         }
@@ -614,7 +620,7 @@ namespace MobiFlight
                 OnInputDeviceAction(this, new InputEventArgs()
                 {
                     Controller = new Controller() { Serial = this.Serial, Name = this.Name },
-                    Device = new DeviceReference() {Type = DeviceType.Encoder, Name = enc, Label = enc},
+                    Device = new DeviceReference() { Type = DeviceType.Encoder, Name = enc, Label = enc },
                     InputType = DeviceType.Encoder,
                     Value = value
                 });
@@ -666,12 +672,12 @@ namespace MobiFlight
                 Log.Instance.log($"Unable to convert {strState} to an integer.", LogSeverity.Error);
                 return;
             }
-            
+
             if (OnInputDeviceAction != null)
                 OnInputDeviceAction(this, new InputEventArgs()
                 {
                     Controller = new Controller() { Serial = this.Serial, Name = Name },
-                    Device =  new DeviceReference() { Type = DeviceType.Button, Name = $"{deviceId}:{subId}", Label = $"{deviceId}:{subId}" },
+                    Device = new DeviceReference() { Type = DeviceType.Button, Name = $"{deviceId}:{subId}", Label = $"{deviceId}:{subId}" },
                     InputType = DeviceType.Button,
                     Value = state
                 });
@@ -709,7 +715,7 @@ namespace MobiFlight
                 Log.Instance.log($"Unable to convert {strValue} to an integer.", LogSeverity.Error);
                 return;
             }
-            
+
             OnInputDeviceAction?.Invoke(this, new InputEventArgs()
             {
                 Controller = new Controller() { Serial = this.Serial, Name = Name },
@@ -864,7 +870,6 @@ namespace MobiFlight
 
             shiftRegisters[moduleID].Display(outputPin, value);
 
-            Thread.Sleep(20);
             return true;
         }
 
@@ -1332,7 +1337,7 @@ namespace MobiFlight
                 // and will not be able to process them all
                 // which can lead to random behavior on the arduino side
                 // see #3117
-                Thread.Sleep(StopDelayInMs); 
+                Thread.Sleep(StopDelayInMs);
                 device.Stop();
             });
         }

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿using CommandMessenger;
+using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using CommandMessenger;
 
 namespace MobiFlight
 {
@@ -14,7 +12,7 @@ namespace MobiFlight
         public CmdMessenger CmdMessenger { get; set; }
 
         public int NumberOfShifters { get; set; }
-        
+
         public int ModuleNumber { get; set; }
 
         private String _name = "ShiftRegister";
@@ -45,7 +43,7 @@ namespace MobiFlight
             _initialized = true;
         }
 
-        public void Display(String outputPins, String value)
+        public virtual void Display(String outputPins, String value)
         {
             if (!_initialized) Initialize();
 
@@ -69,7 +67,7 @@ namespace MobiFlight
         public void Stop()
         {
             List<String> pins = new List<string>();
-            for (int i = 0; i != NumberOfShifters*8; i++)
+            for (int i = 0; i != NumberOfShifters * 8; i++)
                 pins.Add(i.ToString());
 
             String pinString = string.Join("|", pins);

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
@@ -50,7 +50,7 @@ namespace MobiFlight
             AggregationTimer.Elapsed += ProcessAggregatedPins;
         }
 
-        private void ProcessAggregatedPins(object sender, ElapsedEventArgs e)
+        protected void ProcessAggregatedPins(object sender, ElapsedEventArgs e)
         {
             if (AggregationSet.Count == 0) return;
 

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
@@ -9,6 +9,7 @@ namespace MobiFlight
 {
     public class MobiFlightShiftRegister : IConnectedDevice
     {
+        public const int DEFAULT_AGGREGATION_WINDOW_IN_MS = 20;
         public const string TYPE = "ShiftRegister";
         public const string LABEL_PREFIX = "Output";
 
@@ -28,16 +29,15 @@ namespace MobiFlight
 
         protected bool _initialized = false;
 
-        private double _aggregationWindowInMs = 20;
         public double AggregationWindowInMs
         {
-            get { return _aggregationWindowInMs; }
+            get { return AggregationTimer.Interval; }
             set
             {
-                _aggregationWindowInMs = value;
                 AggregationTimer.Interval = value;
             }
         }
+
         public Timer AggregationTimer { get; set; } = new Timer();
 
         ConcurrentStack<string> AggregationOn = new ConcurrentStack<string>();
@@ -46,6 +46,7 @@ namespace MobiFlight
         public MobiFlightShiftRegister()
         {
             AggregationTimer.AutoReset = false;
+            AggregationTimer.Interval = DEFAULT_AGGREGATION_WINDOW_IN_MS;
             AggregationTimer.Elapsed += ProcessAggregatedPins;
         }
 

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
@@ -9,6 +9,7 @@ namespace MobiFlight
 {
     public class MobiFlightShiftRegister : IConnectedDevice
     {
+        private object _lock = new object();
         public const int DEFAULT_AGGREGATION_WINDOW_IN_MS = 50;
         public const string TYPE = "ShiftRegister";
         public const string LABEL_PREFIX = "Output";
@@ -53,10 +54,14 @@ namespace MobiFlight
         {
             if (AggregationSet.Count == 0) return;
 
-            var onKeys = AggregationSet.Keys.Where(k => AggregationSet[k] == "1").ToList();
-            var offKeys = AggregationSet.Keys.Where(k => AggregationSet[k] == "0").ToList();
-
-            AggregationSet.Clear();
+            List<string> onKeys;
+            List<string> offKeys;
+            lock (_lock)
+            {
+                onKeys = AggregationSet.Keys.Where(k => AggregationSet[k] == "1").ToList();
+                offKeys = AggregationSet.Keys.Where(k => AggregationSet[k] == "0").ToList();
+                AggregationSet.Clear();
+            }
 
             if (onKeys.Count > 0)
             {
@@ -92,15 +97,16 @@ namespace MobiFlight
                                  .Split('|')
                                  .Select(p => p.Trim())
                                  .ToList();
-
-            pins.ForEach(p =>
+            lock (_lock)
             {
-                AggregationSet.AddOrUpdate(p, v, (key, oldValue) => v);
-            });
+                pins.ForEach(p =>
+                {
+                    AggregationSet.AddOrUpdate(p, v, (key, oldValue) => v);
+                });
 
-            if (AggregationTimer.Enabled) return;
-
-            AggregationTimer.Start();
+                if (AggregationTimer.Enabled) return;
+                AggregationTimer.Start();
+            }
         }
 
         public virtual void InternalDisplay(String outputPins, String value)

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
@@ -1,6 +1,9 @@
 ﻿using CommandMessenger;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Timers;
 
 namespace MobiFlight
 {
@@ -25,8 +28,50 @@ namespace MobiFlight
 
         protected bool _initialized = false;
 
+        private double _aggregationWindowInMs = 20;
+        public double AggregationWindowInMs
+        {
+            get { return _aggregationWindowInMs; }
+            set
+            {
+                _aggregationWindowInMs = value;
+                AggregationTimer.Interval = value;
+            }
+        }
+        public Timer AggregationTimer { get; set; } = new Timer();
+
+        ConcurrentStack<string> AggregationOn = new ConcurrentStack<string>();
+        ConcurrentStack<string> AggregationOff = new ConcurrentStack<string>();
+
         public MobiFlightShiftRegister()
         {
+            AggregationTimer.AutoReset = false;
+            AggregationTimer.Elapsed += ProcessAggregatedPins;
+        }
+
+        private void ProcessAggregatedPins(object sender, ElapsedEventArgs e)
+        {
+            if (AggregationOn.Count > 0)
+            {
+                var onPins = AggregateFinalDisplayProps(AggregationOn);
+                InternalDisplay(onPins, "1");
+            }
+
+            if (AggregationOff.Count > 0)
+            {
+                var offPins = AggregateFinalDisplayProps(AggregationOff);
+                InternalDisplay(offPins, "0");
+            }
+        }
+
+        static public string AggregateFinalDisplayProps(ConcurrentStack<string> aggregation)
+        {
+            lock (aggregation)
+            {
+                var outputPins = string.Join("|", aggregation.Distinct());
+                aggregation.Clear();
+                return outputPins;
+            }
         }
 
         private DeviceType _type = DeviceType.ShiftRegister;
@@ -43,7 +88,27 @@ namespace MobiFlight
             _initialized = true;
         }
 
-        public virtual void Display(String outputPins, String value)
+        public void Display(String outputPins, String value)
+        {
+            var v = value == "0" ? "0" : "1";
+            var aggregation = v == "1" ? AggregationOn : AggregationOff;
+
+            var pins = outputPins.Replace(LABEL_PREFIX + " ", "")
+                                 .Split('|')
+                                 .Select(p => p.Trim())
+                                 .ToList();
+
+            pins.ForEach(p =>
+            {
+                aggregation.Push(p);
+            });
+
+            if (AggregationTimer.Enabled) return;
+
+            AggregationTimer.Start();
+        }
+
+        public virtual void InternalDisplay(String outputPins, String value)
         {
             if (!_initialized) Initialize();
 

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
@@ -9,7 +9,7 @@ namespace MobiFlight
 {
     public class MobiFlightShiftRegister : IConnectedDevice
     {
-        public const int DEFAULT_AGGREGATION_WINDOW_IN_MS = 20;
+        public const int DEFAULT_AGGREGATION_WINDOW_IN_MS = 50;
         public const string TYPE = "ShiftRegister";
         public const string LABEL_PREFIX = "Output";
 
@@ -40,8 +40,7 @@ namespace MobiFlight
 
         public Timer AggregationTimer { get; set; } = new Timer();
 
-        ConcurrentStack<string> AggregationOn = new ConcurrentStack<string>();
-        ConcurrentStack<string> AggregationOff = new ConcurrentStack<string>();
+        ConcurrentDictionary<string, string> AggregationSet = new ConcurrentDictionary<string, string>();
 
         public MobiFlightShiftRegister()
         {
@@ -52,26 +51,24 @@ namespace MobiFlight
 
         private void ProcessAggregatedPins(object sender, ElapsedEventArgs e)
         {
-            if (AggregationOn.Count > 0)
+            if (AggregationSet.Count == 0) return;
+
+            var onKeys = AggregationSet.Keys.Where(k => AggregationSet[k] == "1").ToList();
+            var offKeys = AggregationSet.Keys.Where(k => AggregationSet[k] == "0").ToList();
+
+            AggregationSet.Clear();
+
+            if (onKeys.Count > 0)
             {
-                var onPins = AggregateFinalDisplayProps(AggregationOn);
+                var onPins = string.Join("|", onKeys);
                 InternalDisplay(onPins, "1");
             }
 
-            if (AggregationOff.Count > 0)
+            if (offKeys.Count > 0)
             {
-                var offPins = AggregateFinalDisplayProps(AggregationOff);
+                var offPins = string.Join("|", offKeys);
+                if (onKeys.Count > 10) System.Threading.Thread.Sleep(10);
                 InternalDisplay(offPins, "0");
-            }
-        }
-
-        static public string AggregateFinalDisplayProps(ConcurrentStack<string> aggregation)
-        {
-            lock (aggregation)
-            {
-                var outputPins = string.Join("|", aggregation.Distinct());
-                aggregation.Clear();
-                return outputPins;
             }
         }
 
@@ -92,8 +89,6 @@ namespace MobiFlight
         public void Display(String outputPins, String value)
         {
             var v = value == "0" ? "0" : "1";
-            var aggregation = v == "1" ? AggregationOn : AggregationOff;
-
             var pins = outputPins.Replace(LABEL_PREFIX + " ", "")
                                  .Split('|')
                                  .Select(p => p.Trim())
@@ -101,7 +96,7 @@ namespace MobiFlight
 
             pins.ForEach(p =>
             {
-                aggregation.Push(p);
+                AggregationSet.AddOrUpdate(p, v, (key, oldValue) => v);
             });
 
             if (AggregationTimer.Enabled) return;

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
@@ -67,7 +67,6 @@ namespace MobiFlight
             if (offKeys.Count > 0)
             {
                 var offPins = string.Join("|", offKeys);
-                if (onKeys.Count > 10) System.Threading.Thread.Sleep(10);
                 InternalDisplay(offPins, "0");
             }
         }
@@ -110,17 +109,11 @@ namespace MobiFlight
 
             var command = new SendCommand((int)MobiFlightModule.Command.SetShiftRegisterPins);
 
-            // Let's strip the static label
-            String pinsOnly = outputPins.Replace(LABEL_PREFIX + " ", "");
-
-            // clamp and reverse the string
-            if (value.Length > 8) value = value.Substring(0, 8);
-
             command.AddArgument(this.ModuleNumber);
-            command.AddArgument(pinsOnly);
+            command.AddArgument(outputPins);
             command.AddArgument(value);
 
-            Log.Instance.log($"Command: SetShiftRegisterPin <{(int)MobiFlightModule.Command.SetShiftRegisterPins},{this.ModuleNumber},{pinsOnly},{value};>.", LogSeverity.Debug);
+            Log.Instance.log($"Command: SetShiftRegisterPin <{(int)MobiFlightModule.Command.SetShiftRegisterPins},{this.ModuleNumber},{outputPins},{value};>.", LogSeverity.Debug);
             // Send command
             CmdMessenger.SendCommand(command);
         }

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightShiftRegister.cs
@@ -9,7 +9,7 @@ namespace MobiFlight
 {
     public class MobiFlightShiftRegister : IConnectedDevice
     {
-        private object _lock = new object();
+        private readonly object _lock = new object();
         public const int DEFAULT_AGGREGATION_WINDOW_IN_MS = 50;
         public const string TYPE = "ShiftRegister";
         public const string LABEL_PREFIX = "Output";
@@ -41,7 +41,7 @@ namespace MobiFlight
 
         public Timer AggregationTimer { get; set; } = new Timer();
 
-        ConcurrentDictionary<string, string> AggregationSet = new ConcurrentDictionary<string, string>();
+        Dictionary<string, string> AggregationSet = new Dictionary<string, string>();
 
         public MobiFlightShiftRegister()
         {
@@ -52,12 +52,13 @@ namespace MobiFlight
 
         protected void ProcessAggregatedPins(object sender, ElapsedEventArgs e)
         {
-            if (AggregationSet.Count == 0) return;
-
             List<string> onKeys;
             List<string> offKeys;
+
             lock (_lock)
             {
+                if (AggregationSet.Count == 0) return;
+
                 onKeys = AggregationSet.Keys.Where(k => AggregationSet[k] == "1").ToList();
                 offKeys = AggregationSet.Keys.Where(k => AggregationSet[k] == "0").ToList();
                 AggregationSet.Clear();
@@ -101,7 +102,7 @@ namespace MobiFlight
             {
                 pins.ForEach(p =>
                 {
-                    AggregationSet.AddOrUpdate(p, v, (key, oldValue) => v);
+                    AggregationSet[p] = v;
                 });
 
                 if (AggregationTimer.Enabled) return;
@@ -126,6 +127,8 @@ namespace MobiFlight
 
         public void Stop()
         {
+            if (NumberOfShifters == 0) return;
+
             List<String> pins = new List<string>();
             for (int i = 0; i != NumberOfShifters * 8; i++)
                 pins.Add(i.ToString());

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -485,6 +485,7 @@
     <Compile Include="MobiFlight\MobiFlightCustomDevice.cs" />
     <Compile Include="MobiFlight\MobiFlightPin.cs" />
     <Compile Include="MobiFlight\MobiFlightInputShiftRegister.cs" />
+    <Compile Include="MobiFlight\BinaryMobiFlightShiftRegister.cs" />
     <Compile Include="MobiFlight\MobiFlightShiftRegister.cs" />
     <Compile Include="MobiFlight\MobiFlightButton.cs" />
     <Compile Include="MobiFlight\MobiFlightEncoder.cs" />

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -99,7 +99,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForCommandMessengerQueueIsProcessed(200);
+            await WaitForCommandMessengerQueueIsProcessed(100);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -127,7 +127,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForCommandMessengerQueueIsProcessed(200);
+            await WaitForCommandMessengerQueueIsProcessed(100);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -158,7 +158,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForCommandMessengerQueueIsProcessed(200);
+            await WaitForCommandMessengerQueueIsProcessed(100);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -179,13 +179,18 @@ namespace MobiFlight.Tests
             {
                 ModuleNumber = 0,
                 NumberOfShifters = 2,
-                CmdMessenger = new CmdMessenger(mockTransport.Object)
+                // CmdMessenger's send queue combines consecutive non-ack commands into a single
+                // Write() call as long as they fit within the send buffer (default 60 chars).
+                // Whether the "on" and "off" commands get combined depends on background-thread
+                // scheduling, which is racy between local runs and CI. Forcing a buffer of 1 char
+                // makes CmdMessenger flush after every single command deterministically.
+                CmdMessenger = new CmdMessenger(mockTransport.Object, 1)
             };
 
             module.CmdMessenger.Connect();
-            
+
             var commandId = (byte)MobiFlightModule.Command.SetShiftRegisterPins;
-            
+
             var outputPins = "0|6|14";
             var outputPinsOff = "1|7|15";
 
@@ -202,10 +207,9 @@ namespace MobiFlight.Tests
             // Act
             module.Display(outputPins, value);
             module.Display(outputPinsOff, valueOff);
-
             // We have to trigger the aggregation instead of using a timer
             module.TriggerAggregationInsteadOfTimer();
-            await WaitForCommandMessengerQueueIsProcessed(500);
+            await WaitForCommandMessengerQueueIsProcessed(100);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -226,7 +230,7 @@ namespace MobiFlight.Tests
             {
                 ModuleNumber = 0,
                 NumberOfShifters = 2,
-                CmdMessenger = new CmdMessenger(mockTransport.Object)
+                CmdMessenger = new CmdMessenger(mockTransport.Object),
             };
 
             module.CmdMessenger.Connect();
@@ -252,7 +256,7 @@ namespace MobiFlight.Tests
 
             // We have to trigger the aggregation instead of using a timer
             module.TriggerAggregationInsteadOfTimer();
-            await WaitForCommandMessengerQueueIsProcessed(500);
+            await WaitForCommandMessengerQueueIsProcessed(100);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -205,7 +205,7 @@ namespace MobiFlight.Tests
 
             // We have to trigger the aggregation instead of using a timer
             module.TriggerAggregationInsteadOfTimer();
-            await WaitForCommandMessengerQueueIsProcessed(100);
+            await WaitForCommandMessengerQueueIsProcessed(500);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -252,7 +252,7 @@ namespace MobiFlight.Tests
 
             // We have to trigger the aggregation instead of using a timer
             module.TriggerAggregationInsteadOfTimer();
-            await WaitForCommandMessengerQueueIsProcessed(100);
+            await WaitForCommandMessengerQueueIsProcessed(500);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -1,9 +1,8 @@
 ﻿using CommandMessenger;
+using CommandMessenger.Transport;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlightUnitTests.mock.CommandMessenger;
-using Newtonsoft.Json.Linq;
-using System.ComponentModel.Design;
-using System.Threading;
+using Moq;
 using System.Threading.Tasks;
 
 namespace MobiFlight.Tests
@@ -85,11 +84,11 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForQueueUpdate(200);
+            await WaitForAggregationWindow(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
-            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write after brigthness change should always send command.");
+            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write should have all output pins set.");
         }
 
         [TestMethod()]
@@ -113,11 +112,11 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForQueueUpdate(200);
+            await WaitForAggregationWindow(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
-            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write after brigthness change should always send command.");
+            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write should have some output pins set.");
         }
 
         [TestMethod()]
@@ -144,14 +143,104 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForQueueUpdate(200);
+            await WaitForAggregationWindow(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
-            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write after brigthness change should always send command.");
+            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write should have correct byte order.");
         }
 
-        private async Task WaitForQueueUpdate(int timeout = 100)
+        [TestMethod()]
+        public async Task SetDisplay_Aggregation_WorksCorrectly_ForMultiplePins()
+        {
+            var mockTransport = new Mock<ITransport>();
+
+            // Arrange
+            var module = new BinaryMobiFlightShiftRegister
+            {
+                ModuleNumber = 0,
+                NumberOfShifters = 2,
+                CmdMessenger = new CmdMessenger(mockTransport.Object)
+            };
+
+            module.CmdMessenger.Connect();
+            
+            var commandId = (byte)MobiFlightModule.Command.SetShiftRegisterPins;
+            
+            var outputPins = "0|6|14";
+            var outputPinsOff = "1|7|15";
+
+            var value = "1";
+            var valueOff = "0";
+            // the second shifter comes first
+            var firstByteValue = "64";
+            var firstByteValueOff = "128";
+
+            // and the first last
+            var secondByteValue = "65";
+            var secondByteValueOff = "130";
+
+            // Act
+            module.Display(outputPins, value);
+            module.Display(outputPinsOff, valueOff);
+
+            // We have to wait for the aggregation window to complete
+            await WaitForAggregationWindow(200);
+
+            // Assert
+            var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
+            var DataExpectedOff = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{valueOff},{firstByteValueOff},{secondByteValueOff};";
+
+            mockTransport.Verify(t => t.Write(It.Is<byte[]>(b => System.Text.Encoding.ASCII.GetString(b) == DataExpected)), Times.Once, "The on write should occur once.");
+            mockTransport.Verify(t => t.Write(It.Is<byte[]>(b => System.Text.Encoding.ASCII.GetString(b) == DataExpectedOff)), Times.Once, "The off write should occur once.");
+        }
+
+        [TestMethod()]
+        public async Task SetDisplay_Aggregation_WorksCorrectly_ForSamePins()
+        {
+            var mockTransport = new Mock<ITransport>();
+
+            // Arrange
+            var module = new BinaryMobiFlightShiftRegister
+            {
+                ModuleNumber = 0,
+                NumberOfShifters = 2,
+                CmdMessenger = new CmdMessenger(mockTransport.Object)
+            };
+
+            module.CmdMessenger.Connect();
+
+            var commandId = (byte)MobiFlightModule.Command.SetShiftRegisterPins;
+
+            var outputPins = "0|6|14";
+            var outputPinsOff = "0|6|14";
+
+            var value = "1";
+            var valueOff = "0";
+            // the second shifter comes first
+            var firstByteValue = "64";
+            var firstByteValueOff = "64";
+
+            // and the first last
+            var secondByteValue = "65";
+            var secondByteValueOff = "65";
+
+            // Act
+            module.Display(outputPins, value);
+            module.Display(outputPinsOff, valueOff);
+
+            // We have to wait for the aggregation window to complete
+            await WaitForAggregationWindow(200);
+
+            // Assert
+            var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
+            var DataExpectedOff = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{valueOff},{firstByteValueOff},{secondByteValueOff};";
+
+            mockTransport.Verify(t => t.Write(It.Is<byte[]>(b => System.Text.Encoding.ASCII.GetString(b) == DataExpected)), Times.Never, "The on write should never occur.");
+            mockTransport.Verify(t => t.Write(It.Is<byte[]>(b => System.Text.Encoding.ASCII.GetString(b) == DataExpectedOff)), Times.Once, "The off write should occur once.");
+        }
+
+        private async Task WaitForAggregationWindow(int timeout = 100)
         {
             await Task.Delay(timeout);
         }

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -10,6 +10,19 @@ namespace MobiFlight.Tests
     [TestClass()]
     public class BinaryMobiFlightShiftRegisterTests
     {
+        class TestableMobiFlightShiftRegister : BinaryMobiFlightShiftRegister
+        {
+            public void TriggerAggregationInsteadOfTimer()
+            {
+                // Stop the timer to prevent it from firing
+                AggregationTimer.Stop();
+
+                // Manually call the aggregation processing method
+                // this is deterministic for testing in CI pipeline
+                ProcessAggregatedPins(null, null);
+            }
+        }
+
         [TestMethod()]
         public void BinaryMobiFlightShiftRegister_HasCorrectDefaults()
         {
@@ -156,7 +169,7 @@ namespace MobiFlight.Tests
             var mockTransport = new Mock<ITransport>();
 
             // Arrange
-            var module = new BinaryMobiFlightShiftRegister
+            var module = new TestableMobiFlightShiftRegister
             {
                 ModuleNumber = 0,
                 NumberOfShifters = 2,
@@ -184,8 +197,8 @@ namespace MobiFlight.Tests
             module.Display(outputPins, value);
             module.Display(outputPinsOff, valueOff);
 
-            // We have to wait for the aggregation window to complete
-            await WaitForAggregationWindow(200);
+            // We have to trigger the aggregation instead of using a timer
+            module.TriggerAggregationInsteadOfTimer();
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -201,7 +214,7 @@ namespace MobiFlight.Tests
             var mockTransport = new Mock<ITransport>();
 
             // Arrange
-            var module = new BinaryMobiFlightShiftRegister
+            var module = new TestableMobiFlightShiftRegister
             {
                 ModuleNumber = 0,
                 NumberOfShifters = 2,
@@ -229,8 +242,8 @@ namespace MobiFlight.Tests
             module.Display(outputPins, value);
             module.Display(outputPinsOff, valueOff);
 
-            // We have to wait for the aggregation window to complete
-            await WaitForAggregationWindow(200);
+            // We have to trigger the aggregation instead of using a timer
+            module.TriggerAggregationInsteadOfTimer();
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -12,6 +12,16 @@ namespace MobiFlight.Tests
     public class BinaryMobiFlightShiftRegisterTests
     {
         [TestMethod()]
+        public void BinaryMobiFlightShiftRegister_HasCorrectDefaults()
+        {
+            // Arrange
+            var module = new BinaryMobiFlightShiftRegister();
+            Assert.AreEqual(0, module.NumberOfShifters, "Default number of shifters should be 0.");
+            Assert.AreEqual(0, module.ModuleNumber, "Default module number should be 0.");
+            Assert.AreEqual(20, module.AggregationWindowInMs, "Default aggregation window should be 20ms.");
+        }
+
+        [TestMethod()]
         public void ConvertStringToByteArray_ShouldReturnCorrectByteArray()
         {
             // Arrange
@@ -56,7 +66,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void SetDisplay_SendsCorrectCommand_WithAllPinsSet()
+        public async Task SetDisplay_SendsCorrectCommand_WithAllPinsSet()
         {
             // Arrange
             var module = new BinaryMobiFlightShiftRegister() {
@@ -75,7 +85,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            WaitForQueueUpdate(200);
+            await WaitForQueueUpdate(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -83,7 +93,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void SetDisplay_SendsCorrectCommand_WithSomePinsSet()
+        public async Task SetDisplay_SendsCorrectCommand_WithSomePinsSet()
         {
             // Arrange
             var module = new BinaryMobiFlightShiftRegister()
@@ -103,7 +113,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            WaitForQueueUpdate(200);
+            await WaitForQueueUpdate(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -111,7 +121,7 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void SetDisplay_SendsCorrectCommand_ByteOrderIsCorrect()
+        public async Task SetDisplay_SendsCorrectCommand_ByteOrderIsCorrect()
         {
             // Arrange
             var module = new BinaryMobiFlightShiftRegister()
@@ -134,20 +144,16 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            WaitForQueueUpdate(200);
+            await WaitForQueueUpdate(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
             Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write after brigthness change should always send command.");
         }
 
-        private void WaitForQueueUpdate(int timeout = 100)
+        private async Task WaitForQueueUpdate(int timeout = 100)
         {
-            var task = Task.Run(() =>
-            {
-                Thread.Sleep(timeout);
-            });
-            task.Wait();
+            await Task.Delay(timeout);
         }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -12,7 +12,7 @@ namespace MobiFlight.Tests
     [TestClass()]
     public class BinaryMobiFlightShiftRegisterTests
     {
-        class TestableMobiFlightShiftRegister : BinaryMobiFlightShiftRegister
+        internal class TestableMobiFlightShiftRegister : BinaryMobiFlightShiftRegister
         {
             public void TriggerAggregationInsteadOfTimer()
             {
@@ -83,7 +83,8 @@ namespace MobiFlight.Tests
         public async Task SetDisplay_SendsCorrectCommand_WithAllPinsSet()
         {
             // Arrange
-            var module = new BinaryMobiFlightShiftRegister() {
+            var module = new BinaryMobiFlightShiftRegister()
+            {
                 ModuleNumber = 0,
                 NumberOfShifters = 2
             };
@@ -216,8 +217,8 @@ namespace MobiFlight.Tests
             var DataExpectedOff = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{valueOff},{firstByteValueOff},{secondByteValueOff};";
 
             Assert.HasCount(2, writes, "There should be two writes.");
-            Assert.AreEqual(writes[0], DataExpected, "The on write should occur once.");
-            Assert.AreEqual(writes[1], DataExpectedOff, "The off write should occur once.");
+            Assert.AreEqual(DataExpected, writes[0], "The on write should occur once.");
+            Assert.AreEqual(DataExpectedOff, writes[1], "The off write should occur once.");
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -3,6 +3,8 @@ using CommandMessenger.Transport;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlightUnitTests.mock.CommandMessenger;
 using Moq;
+using System.Collections.Generic;
+using System.Text;
 using System.Threading.Tasks;
 
 namespace MobiFlight.Tests
@@ -97,7 +99,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForAggregationWindow(200);
+            await WaitForCommandMessengerQueueIsProcessed(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -125,7 +127,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForAggregationWindow(200);
+            await WaitForCommandMessengerQueueIsProcessed(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -156,7 +158,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            await WaitForAggregationWindow(200);
+            await WaitForCommandMessengerQueueIsProcessed(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -166,7 +168,11 @@ namespace MobiFlight.Tests
         [TestMethod()]
         public async Task SetDisplay_Aggregation_WorksCorrectly_ForMultiplePins()
         {
+            var writes = new List<string>();
             var mockTransport = new Mock<ITransport>();
+            mockTransport
+            .Setup(t => t.Write(It.IsAny<byte[]>()))
+            .Callback<byte[]>(b => writes.Add(Encoding.ASCII.GetString(b)));
 
             // Arrange
             var module = new TestableMobiFlightShiftRegister
@@ -199,13 +205,15 @@ namespace MobiFlight.Tests
 
             // We have to trigger the aggregation instead of using a timer
             module.TriggerAggregationInsteadOfTimer();
+            await WaitForCommandMessengerQueueIsProcessed(100);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
             var DataExpectedOff = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{valueOff},{firstByteValueOff},{secondByteValueOff};";
 
-            mockTransport.Verify(t => t.Write(It.Is<byte[]>(b => System.Text.Encoding.ASCII.GetString(b) == DataExpected)), Times.Once, "The on write should occur once.");
-            mockTransport.Verify(t => t.Write(It.Is<byte[]>(b => System.Text.Encoding.ASCII.GetString(b) == DataExpectedOff)), Times.Once, "The off write should occur once.");
+            Assert.HasCount(2, writes, "There should be two writes.");
+            Assert.AreEqual(writes[0], DataExpected, "The on write should occur once.");
+            Assert.AreEqual(writes[1], DataExpectedOff, "The off write should occur once.");
         }
 
         [TestMethod()]
@@ -244,6 +252,7 @@ namespace MobiFlight.Tests
 
             // We have to trigger the aggregation instead of using a timer
             module.TriggerAggregationInsteadOfTimer();
+            await WaitForCommandMessengerQueueIsProcessed(100);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -253,7 +262,7 @@ namespace MobiFlight.Tests
             mockTransport.Verify(t => t.Write(It.Is<byte[]>(b => System.Text.Encoding.ASCII.GetString(b) == DataExpectedOff)), Times.Once, "The off write should occur once.");
         }
 
-        private async Task WaitForAggregationWindow(int timeout = 100)
+        private async Task WaitForCommandMessengerQueueIsProcessed(int timeout = 100)
         {
             await Task.Delay(timeout);
         }

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -18,7 +18,7 @@ namespace MobiFlight.Tests
             var module = new BinaryMobiFlightShiftRegister();
             Assert.AreEqual(0, module.NumberOfShifters, "Default number of shifters should be 0.");
             Assert.AreEqual(0, module.ModuleNumber, "Default module number should be 0.");
-            Assert.AreEqual(20, module.AggregationWindowInMs, "Default aggregation window should be 20ms.");
+            Assert.AreEqual(50, module.AggregationWindowInMs, "Default aggregation window should be 50ms.");
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -1,0 +1,153 @@
+﻿using CommandMessenger;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlightUnitTests.mock.CommandMessenger;
+using Newtonsoft.Json.Linq;
+using System.ComponentModel.Design;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MobiFlight.Tests
+{
+    [TestClass()]
+    public class BinaryMobiFlightShiftRegisterTests
+    {
+        [TestMethod()]
+        public void ConvertStringToByteArray_ShouldReturnCorrectByteArray()
+        {
+            // Arrange
+            string input = "0|1|2|3|4|5|6|7";
+            int numberOfShifters = 2;
+            // Act
+            byte[] result = BinaryMobiFlightShiftRegister.ConvertStringToByteArray(input, numberOfShifters);
+            // Assert
+            Assert.HasCount(2, result);
+            Assert.AreEqual(0b11111111, result[0]); // all set
+            Assert.AreEqual(0b00000000, result[1]); // non set
+
+            input = "8|9|10|11|12|13|14|15";
+            // Act
+            result = BinaryMobiFlightShiftRegister.ConvertStringToByteArray(input, numberOfShifters);
+            // Assert
+            Assert.HasCount(2, result);
+            Assert.AreEqual(0b00000000, result[0]); // none set
+            Assert.AreEqual(0b11111111, result[1]); // all set
+
+            input = "0|8";
+            // Act
+            result = BinaryMobiFlightShiftRegister.ConvertStringToByteArray(input, numberOfShifters);
+            // Assert
+            Assert.HasCount(2, result);
+            Assert.AreEqual(0b00000001, result[0]); // none set
+            Assert.AreEqual(0b00000001, result[1]); // all set
+        }
+
+        [TestMethod()]
+        public void ConvertStringToByteArray_UseLsbEncoding()
+        {
+            // Arrange
+            string input = "0|1|14|15";
+            int numberOfShifters = 2;
+            // Act
+            byte[] result = BinaryMobiFlightShiftRegister.ConvertStringToByteArray(input, numberOfShifters);
+            // Assert
+            Assert.HasCount(2, result);
+            Assert.AreEqual(0b00000011, result[0]); // none set
+            Assert.AreEqual(0b11000000, result[1]); // all set
+        }
+
+        [TestMethod()]
+        public void SetDisplay_SendsCorrectCommand_WithAllPinsSet()
+        {
+            // Arrange
+            var module = new BinaryMobiFlightShiftRegister() {
+                ModuleNumber = 0,
+                NumberOfShifters = 2
+            };
+            var mockTransport = new MockTransport();
+            module.CmdMessenger = new CmdMessenger(mockTransport);
+            module.CmdMessenger.Connect();
+            var commandId = (byte)MobiFlightModule.Command.SetShiftRegisterPins;
+            var outputPins = "0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15";
+            var value = "1";
+            mockTransport.Clear();
+            var firstByteValue = "�/\0";
+            var secondByteValue = "�/\0";
+
+            // Act
+            module.Display(outputPins, value);
+            WaitForQueueUpdate();
+
+            // Assert
+            var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
+            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write after brigthness change should always send command.");
+        }
+
+        [TestMethod()]
+        public void SetDisplay_SendsCorrectCommand_WithSomePinsSet()
+        {
+            // Arrange
+            var module = new BinaryMobiFlightShiftRegister()
+            {
+                ModuleNumber = 0,
+                NumberOfShifters = 2
+            };
+            var mockTransport = new MockTransport();
+            module.CmdMessenger = new CmdMessenger(mockTransport);
+            module.CmdMessenger.Connect();
+            var commandId = (byte)MobiFlightModule.Command.SetShiftRegisterPins;
+            var outputPins = "4|5|14";
+            var value = "1";
+            mockTransport.Clear();
+            var firstByteValue = "0/\0";
+            var secondByteValue = "@/\0";
+
+            // Act
+            module.Display(outputPins, value);
+            WaitForQueueUpdate();
+
+            // Assert
+            var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
+            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write after brigthness change should always send command.");
+        }
+
+        [TestMethod()]
+        public void SetDisplay_SendsCorrectCommand_ByteOrderIsCorrect()
+        {
+            // Arrange
+            var module = new BinaryMobiFlightShiftRegister()
+            {
+                ModuleNumber = 0,
+                NumberOfShifters = 2
+            };
+            var mockTransport = new MockTransport();
+            module.CmdMessenger = new CmdMessenger(mockTransport);
+            module.CmdMessenger.Connect();
+            var commandId = (byte)MobiFlightModule.Command.SetShiftRegisterPins;
+            var outputPins = "0|6|14";
+            var value = "1";
+            mockTransport.Clear();
+            // the second shifter comes first
+            var firstByteValue = "@/\0";
+
+            // and the first last
+            var secondByteValue = "A/\0";
+
+            // Act
+            module.Display(outputPins, value);
+            WaitForQueueUpdate();
+
+            // Assert
+            var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
+            Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write after brigthness change should always send command.");
+        }
+
+        private void WaitForQueueUpdate()
+        {
+            var task = Task.Run(() =>
+            {
+                Thread.Sleep(100);
+            });
+            task.Wait();
+        }
+    }
+}

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -75,7 +75,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            WaitForQueueUpdate();
+            WaitForQueueUpdate(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -103,7 +103,7 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            WaitForQueueUpdate();
+            WaitForQueueUpdate(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
@@ -134,18 +134,18 @@ namespace MobiFlight.Tests
 
             // Act
             module.Display(outputPins, value);
-            WaitForQueueUpdate();
+            WaitForQueueUpdate(200);
 
             // Assert
             var DataExpected = $"{commandId},{module.ModuleNumber},{module.NumberOfShifters},{value},{firstByteValue},{secondByteValue};";
             Assert.AreEqual(DataExpected, mockTransport.DataWrite, "Write after brigthness change should always send command.");
         }
 
-        private void WaitForQueueUpdate()
+        private void WaitForQueueUpdate(int timeout = 100)
         {
             var task = Task.Run(() =>
             {
-                Thread.Sleep(100);
+                Thread.Sleep(timeout);
             });
             task.Wait();
         }

--- a/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BinaryMobiFlightShiftRegisterTests.cs
@@ -70,8 +70,8 @@ namespace MobiFlight.Tests
             var outputPins = "0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15";
             var value = "1";
             mockTransport.Clear();
-            var firstByteValue = "�/\0";
-            var secondByteValue = "�/\0";
+            var firstByteValue = "255";
+            var secondByteValue = "255";
 
             // Act
             module.Display(outputPins, value);
@@ -98,8 +98,8 @@ namespace MobiFlight.Tests
             var outputPins = "4|5|14";
             var value = "1";
             mockTransport.Clear();
-            var firstByteValue = "0/\0";
-            var secondByteValue = "@/\0";
+            var firstByteValue = "64";
+            var secondByteValue = "48";
 
             // Act
             module.Display(outputPins, value);
@@ -127,10 +127,10 @@ namespace MobiFlight.Tests
             var value = "1";
             mockTransport.Clear();
             // the second shifter comes first
-            var firstByteValue = "@/\0";
+            var firstByteValue = "64";
 
             // and the first last
-            var secondByteValue = "A/\0";
+            var secondByteValue = "65";
 
             // Act
             module.Display(outputPins, value);

--- a/tests/MobiFlightUnitTests/MobiFlight/MobiFlightShiftRegisterTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/MobiFlightShiftRegisterTests.cs
@@ -1,0 +1,89 @@
+﻿using CommandMessenger;
+using CommandMessenger.Transport;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System.Threading.Tasks;
+
+namespace MobiFlight.Tests
+{
+    [TestClass()]
+    public class MobiFlightShiftRegisterTests
+    {
+        internal class TestableMobiFlightShiftRegister : MobiFlightShiftRegister
+        {
+            public void TriggerAggregationInsteadOfTimer()
+            {
+                // Stop the timer to prevent it from firing
+                AggregationTimer.Stop();
+
+                // Manually call the aggregation processing method
+                // this is deterministic for testing in CI pipeline
+                ProcessAggregatedPins(null, null);
+            }
+        }
+
+        [TestMethod()]
+        public async Task Stop_WithMultipleShifters_CreatesCorrectMessage()
+        {
+            var mockTransport = new Mock<ITransport>();
+
+            // Arrange
+            var module = new TestableMobiFlightShiftRegister
+            {
+                ModuleNumber = 0,
+                NumberOfShifters = 2,
+                CmdMessenger = new CmdMessenger(mockTransport.Object),
+            };
+
+            module.CmdMessenger.Connect();
+
+            var commandId = (byte)MobiFlightModule.Command.SetShiftRegisterPins;
+
+            var outputPins = "0|1|2|3|4|5|6|7|8|9|10|11|12|13|14|15";
+            var valueOff = "0";
+
+            // Act
+            module.Stop();
+
+            // We have to trigger the aggregation instead of using a timer
+            module.TriggerAggregationInsteadOfTimer();
+            await WaitForCommandMessengerQueueIsProcessed(100);
+
+            // Assert
+            var DataExpected = $"{commandId},{module.ModuleNumber},{outputPins},{valueOff};";
+
+            mockTransport.Verify(t => t.Write(It.Is<byte[]>(b => System.Text.Encoding.ASCII.GetString(b) == DataExpected)), Times.Once, "The on write should occur once.");
+        }
+
+        [TestMethod()]
+        public async Task Stop_WithNoShifters_DoesNotCreateMessage()
+        {
+            var mockTransport = new Mock<ITransport>();
+
+            // Arrange
+            var module = new TestableMobiFlightShiftRegister
+            {
+                ModuleNumber = 0,
+                NumberOfShifters = 0,
+                CmdMessenger = new CmdMessenger(mockTransport.Object),
+            };
+
+            module.CmdMessenger.Connect();
+
+            // Act
+            module.Stop();
+
+            // We have to trigger the aggregation instead of using a timer
+            module.TriggerAggregationInsteadOfTimer();
+            await WaitForCommandMessengerQueueIsProcessed(100);
+
+            // Assert
+            mockTransport.Verify(t => t.Write(It.IsAny<byte[]>()), Times.Never, "No write should occur.");
+
+        }
+        private async Task WaitForCommandMessengerQueueIsProcessed(int timeout = 100)
+        {
+            await Task.Delay(timeout);
+        }
+    }
+}

--- a/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -266,6 +266,7 @@
     <Compile Include="MobiFlight\Joysticks\WingFlex\EfisCubeReportTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\OvhdCubeReportTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCubeReportTests.cs" />
+    <Compile Include="MobiFlight\BinaryMobiFlightShiftRegisterTests.cs" />
     <Compile Include="MobiFlight\MobiFlightVariableTest.cs" />
     <Compile Include="MobiFlight\Modifier\ExponentialAverageTests.cs" />
     <Compile Include="MobiFlight\InputEventArgsTests.cs" />

--- a/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
+++ b/tests/MobiFlightUnitTests/MobiFlightUnitTests.csproj
@@ -267,6 +267,7 @@
     <Compile Include="MobiFlight\Joysticks\WingFlex\OvhdCubeReportTests.cs" />
     <Compile Include="MobiFlight\Joysticks\WingFlex\RmpCubeReportTests.cs" />
     <Compile Include="MobiFlight\BinaryMobiFlightShiftRegisterTests.cs" />
+    <Compile Include="MobiFlight\MobiFlightShiftRegisterTests.cs" />
     <Compile Include="MobiFlight\MobiFlightVariableTest.cs" />
     <Compile Include="MobiFlight\Modifier\ExponentialAverageTests.cs" />
     <Compile Include="MobiFlight\InputEventArgsTests.cs" />


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
This PR reduces the message size significantly when updating output shift register. It is very effective when updating multiple LEDs at once or multiple LEDs with individual configs during a short period.

Use cases:
- Running light test mode, where multiple LEDs change their state from OFF to ON and back.
- Updating groups of LEDs

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->

https://github.com/user-attachments/assets/4eef32d1-770d-4b1c-9ebc-3dc5228cf7b0

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] MobiFlight reduces amount of messages
  - [x] Aggregation is applied
  - [x] Window is 50ms
- [x] MobiFlight reduces size of messages
  - [x] New message format - bits are encoded as bytes instead of list of bits separated by pipe character

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend

## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3173 
depends on #3182 

### Notes
[Discord post](https://discord.com/channels/608690978081210392/1524034151299289239)
