### PR TITLE
Fix Blink mutating input ConnectorValue

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Modifier/Blink.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Blink.cs
@@ -20,11 +20,11 @@ namespace MobiFlight.Modifier
             // read precondition settings if present
             if (reader["blinkValue"] != null)
                 BlinkValue = reader["blinkValue"] as String;
-            
+
             if (reader["onOffSequence"] != null)
             {
                 OnOffSequence.Clear();
-                foreach(string s in reader["onOffSequence"].Split(','))
+                foreach (string s in reader["onOffSequence"].Split(','))
                 {
                     OnOffSequence.Add(int.Parse(s));
                 }
@@ -34,9 +34,9 @@ namespace MobiFlight.Modifier
         public override void WriteXml(XmlWriter writer)
         {
             writer.WriteStartElement("blink");
-                writer.WriteAttributeString("active", Active.ToString());
-                writer.WriteAttributeString("blinkValue", BlinkValue);
-                writer.WriteAttributeString("onOffSequence", string.Join(",", OnOffSequence));
+            writer.WriteAttributeString("active", Active.ToString());
+            writer.WriteAttributeString("blinkValue", BlinkValue);
+            writer.WriteAttributeString("onOffSequence", string.Join(",", OnOffSequence));
             writer.WriteEndElement();
         }
 
@@ -52,7 +52,7 @@ namespace MobiFlight.Modifier
         public override bool Equals(object obj)
         {
             if (obj == null || !(obj is Blink)) return false;
-            
+
             var other = obj as Blink;
 
             return
@@ -63,7 +63,8 @@ namespace MobiFlight.Modifier
 
         public override ConnectorValue Apply(ConnectorValue value, List<ConfigRefValue> configRefs)
         {
-            ConnectorValue result = value;
+
+            var result = value.Clone() as ConnectorValue;
             if (FirstExecutionTime == 0) FirstExecutionTime = DateTime.Now.Ticks;
 
             var Now = DateTime.Now.Ticks - FirstExecutionTime;
@@ -73,9 +74,10 @@ namespace MobiFlight.Modifier
 
             bool IsOn = true;
 
-            foreach(var time in OnOffSequence)
+            foreach (var time in OnOffSequence)
             {
-                if (Now > time) {
+                if (Now > time)
+                {
                     Now -= time;
                     IsOn = !IsOn;
                     continue;
@@ -91,9 +93,9 @@ namespace MobiFlight.Modifier
                     case FSUIPCOffsetType.Float:
                     case FSUIPCOffsetType.Integer:
                         string tmpValue = BlinkValue;
-                        if (Double.TryParse(tmpValue, out value.Float64))
+                        if (Double.TryParse(tmpValue, out double blinkValue))
                         {
-                            result.Float64 = value.Float64;
+                            result.Float64 = blinkValue;
                         }
                         else
                         {
@@ -114,7 +116,7 @@ namespace MobiFlight.Modifier
 
         public override string ToSummaryLabel()
         {
-            return $"Blink value: \"{BlinkValue}\", ON-OFF-Sequence: {String.Join((", "), OnOffSequence.Select(s => s+" ms"))}";
+            return $"Blink value: \"{BlinkValue}\", ON-OFF-Sequence: {String.Join((", "), OnOffSequence.Select(s => s + " ms"))}";
         }
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Blink.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Blink.cs
@@ -93,11 +93,7 @@ namespace MobiFlight.Modifier
                     case FSUIPCOffsetType.Float:
                     case FSUIPCOffsetType.Integer:
                         string tmpValue = BlinkValue;
-                        if (Double.TryParse(tmpValue, out double blinkValue))
-                        {
-                            result.Float64 = blinkValue;
-                        }
-                        else
+                        if (!Double.TryParse(tmpValue, out result.Float64))
                         {
                             // Expression has now made this a string
                             result.type = FSUIPCOffsetType.String;

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Blink.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Blink.cs
@@ -63,6 +63,7 @@ namespace MobiFlight.Modifier
 
         public override ConnectorValue Apply(ConnectorValue value, List<ConfigRefValue> configRefs)
         {
+            if (!Active) return value;
 
             var result = value.Clone() as ConnectorValue;
             if (FirstExecutionTime == 0) FirstExecutionTime = DateTime.Now.Ticks;

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Comparison.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Comparison.cs
@@ -85,6 +85,8 @@ namespace MobiFlight.Modifier
         }
         public override ConnectorValue Apply(ConnectorValue connectorValue, List<ConfigRefValue> configRefs)
         {
+            if (!Active) return connectorValue;
+
             var cacheKey = $"{connectorValue}:{Value}:{Operand}:{IfValue}:{ElseValue}";
             if (evaluationCache.TryGetValue(cacheKey, out ConnectorValue cachedResult))
             {

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Interpolation.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Interpolation.cs
@@ -95,6 +95,8 @@ namespace MobiFlight.Modifier
 
         public override ConnectorValue Apply(ConnectorValue connectorValue, List<ConfigRefValue> configRefs)
         {
+            if (!Active) return connectorValue;
+
             ConnectorValue result = connectorValue.Clone() as ConnectorValue;
 
             if (Count == 0) return result;

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Padding.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Padding.cs
@@ -81,20 +81,20 @@ namespace MobiFlight.Modifier
         {
             if (!Active) return value;
 
-            ConnectorValue result = value;
+            var result = value.Clone() as ConnectorValue;
 
             switch (value.type)
             {
                 case FSUIPCOffsetType.Float:
                 case FSUIPCOffsetType.Integer:
-                    string tmpValue = Apply(value.Float64, configRefs);
+                    string tmpValue = Apply(result.Float64, configRefs);
                     // Expression has now made this a string
-                    value.type = FSUIPCOffsetType.String;
-                    value.String = tmpValue;
+                    result.type = FSUIPCOffsetType.String;
+                    result.String = tmpValue;
                     break;
 
                 case FSUIPCOffsetType.String:
-                    value.String = Apply(value.String);
+                    result.String = Apply(result.String);
                     break;
             }
 

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Padding.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Padding.cs
@@ -79,6 +79,8 @@ namespace MobiFlight.Modifier
 
         public override ConnectorValue Apply(ConnectorValue value, List<ConfigRefValue> configRefs)
         {
+            if (!Active) return value;
+
             ConnectorValue result = value;
 
             switch (value.type)

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Substring.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Substring.cs
@@ -71,6 +71,7 @@ namespace MobiFlight.Modifier
 
         protected string Apply(string value)
         {
+            if (!Active) return value;
             if (Start > value.Length) return "";
 
             int length = (End - Start);

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Substring.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Substring.cs
@@ -50,19 +50,21 @@ namespace MobiFlight.Modifier
         }
 
         public override ConnectorValue Apply(ConnectorValue value, List<ConfigRefValue> configRefs)
-        {
-            ConnectorValue result = value;
+        { 
+            if (!Active) return value;
+
+            var result = value.Clone() as ConnectorValue;
 
             switch (value.type)
             {
                 case FSUIPCOffsetType.Float:
                 case FSUIPCOffsetType.Integer:
-                    string tmpValue = Apply(value.Float64.ToString());
-                    value.String = tmpValue;
+                    string tmpValue = Apply(result.Float64.ToString());
+                    result.String = tmpValue;
                     break;
 
                 case FSUIPCOffsetType.String:
-                    value.String = Apply(value.String);
+                    result.String = Apply(result.String);
                     break;
             }
 
@@ -71,7 +73,7 @@ namespace MobiFlight.Modifier
 
         protected string Apply(string value)
         {
-            if (!Active) return value;
+           
             if (Start > value.Length) return "";
 
             int length = (End - Start);

--- a/src/MobiFlightConnector/MobiFlight/Modifier/Transformation.cs
+++ b/src/MobiFlightConnector/MobiFlight/Modifier/Transformation.cs
@@ -43,6 +43,8 @@ namespace MobiFlight.Modifier
 
         public override ConnectorValue Apply(ConnectorValue value, List<ConfigRefValue> configRefs)
         {
+            if (!Active) return value;
+
             var result = value.Clone() as ConnectorValue;
 
             string exp = Expression.Replace("$", value.Float64.ToString());

--- a/src/MobiFlightConnector/frontend/.devcontainer/devcontainer-lock.json
+++ b/src/MobiFlightConnector/frontend/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    }
+  }
+}

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
@@ -74,5 +74,41 @@ namespace MobiFlight.Modifier.Tests
             Assert.AreEqual("1", blink.BlinkValue);
             CollectionAssert.AreEqual(new List<int>() { 200, 500 }, blink.OnOffSequence);
         }
+        [TestMethod]
+        public void Blink_ReturnsClone()
+        {
+            var blink = new Blink()
+            {
+                Active = true,
+                BlinkValue = "1",
+                OnOffSequence = new List<int>() { 200, 500 }
+            };
+            var value = new ConnectorValue()
+            {
+                type = FSUIPCOffsetType.Float,
+                Float64 = 1
+            };
+            var result = blink.Apply(value, new List<ConfigRefValue>());
+            Assert.AreNotSame(value, result);
+
+        }
+        [TestMethod]
+        public void Blink_ApplyDoesNotChangeOriginalValue()
+        {
+            var blink = new Blink()
+            {
+                Active = true,
+                BlinkValue = "2",
+                OnOffSequence = new List<int>() { -1, 500 }
+            };
+            var value = new ConnectorValue()
+            {
+                type = FSUIPCOffsetType.Float,
+                Float64 = 1
+            };
+            var originalBlink = value.Clone() as ConnectorValue;
+            var result = blink.Apply(value, new List<ConfigRefValue>());
+            Assert.AreNotEqual(originalBlink.Float64, result.Float64);
+        }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
@@ -1,6 +1,8 @@
-﻿using MobiFlight.Modifier;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.Modifier;
+using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace MobiFlight.Modifier.Tests
 {
@@ -73,6 +75,101 @@ namespace MobiFlight.Modifier.Tests
             Assert.IsTrue(blink.Active);
             Assert.AreEqual("1", blink.BlinkValue);
             CollectionAssert.AreEqual(new List<int>() { 200, 500 }, blink.OnOffSequence);
+        }
+        [TestMethod]
+        public async Task Blink_Apply()
+        {
+            //Test if blink is (On)
+            var blinkOn = new Blink
+            {
+                Active = true,
+                BlinkValue = "0",
+                OnOffSequence = new List<int> { 500, 500 }
+            };
+            var valueOn = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 1
+            };
+
+            valueOn = blinkOn.Apply(valueOn, new List<ConfigRefValue>());
+            Assert.AreEqual(1, valueOn.Float64);
+
+            //Test if Blink is (Off)
+
+            var blinkOff = new Blink
+            {
+                Active = true,
+                BlinkValue = "1",
+                OnOffSequence = new List<int> { 500, 500 }
+            };
+            var valueOff = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 0
+            };
+
+            valueOff = blinkOff.Apply(valueOff, new List<ConfigRefValue>());
+            Assert.AreEqual(0, valueOff.Float64);
+
+            //Test blink (On/Off)
+
+            var blinkOnOff = new Blink
+            {
+                Active = true,
+                BlinkValue = "1",
+                OnOffSequence = new List<int> { 500, 500 }
+            };
+            var valueOnOff = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 0
+            };
+       
+            valueOnOff = blinkOnOff.Apply(valueOnOff, new List<ConfigRefValue>());
+            Assert.AreEqual(0, valueOnOff.Float64);
+            await Task.Delay(600);
+            valueOnOff = blinkOnOff.Apply(valueOnOff, new List<ConfigRefValue>());
+            Assert.AreEqual(1, valueOnOff.Float64);
+
+            //Test string input
+            var blinkString = new Blink
+            {
+                Active = true,
+                BlinkValue = "1",
+                OnOffSequence = new List<int> { 500, 500 }
+            };
+            var valueString = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.String,
+                String = "0"
+            };
+            valueString = blinkString.Apply(valueString, new List<ConfigRefValue>());
+            await Task.Delay(600);
+            valueString = blinkString.Apply(valueString, new List<ConfigRefValue>());
+            Assert.AreEqual("1", valueString.String);
+
+            // Test invalid BlinkValue (Double.TryParse returns false)
+
+            var blinkInvalid = new Blink
+            {
+                Active = true,
+                BlinkValue = "ABC",
+                OnOffSequence = new List<int> { 500, 500 }
+            };
+
+            var valueInvalid = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 0
+            };
+
+            valueInvalid = blinkInvalid.Apply(valueInvalid, new List<ConfigRefValue>());
+            await Task.Delay(600);
+            valueInvalid = blinkInvalid.Apply(valueInvalid, new List<ConfigRefValue>());
+
+            Assert.AreEqual(FSUIPCOffsetType.String, valueInvalid.type);
+            Assert.AreEqual("ABC", valueInvalid.String);
         }
         [TestMethod]
         public void Blink_ReturnsClone()

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
@@ -155,7 +155,7 @@ namespace MobiFlight.Modifier.Tests
             {
                 Active = true,
                 BlinkValue = "ABC",
-                OnOffSequence = new List<int> { 500, 500 }
+                OnOffSequence = new List<int> { -1, 500 }
             };
 
             var valueInvalid = new ConnectorValue
@@ -163,9 +163,6 @@ namespace MobiFlight.Modifier.Tests
                 type = FSUIPCOffsetType.Integer,
                 Float64 = 0
             };
-
-            valueInvalid = blinkInvalid.Apply(valueInvalid, new List<ConfigRefValue>());
-            await Task.Delay(600);
             valueInvalid = blinkInvalid.Apply(valueInvalid, new List<ConfigRefValue>());
 
             Assert.AreEqual(FSUIPCOffsetType.String, valueInvalid.type);

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
@@ -1,6 +1,4 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.Modifier;
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -80,6 +78,7 @@ namespace MobiFlight.Modifier.Tests
         public async Task Blink_Apply()
         {
             //Test if blink is (On)
+
             var blinkOn = new Blink
             {
                 Active = true,
@@ -111,7 +110,9 @@ namespace MobiFlight.Modifier.Tests
 
             valueOff = blinkOff.Apply(valueOff, new List<ConfigRefValue>());
             Assert.AreEqual(0, valueOff.Float64);
+
             //Test string input
+
             var blinkString = new Blink
             {
                 Active = true,
@@ -123,6 +124,7 @@ namespace MobiFlight.Modifier.Tests
                 type = FSUIPCOffsetType.String,
                 String = "0"
             };
+
             valueString = blinkString.Apply(valueString, new List<ConfigRefValue>());
             Assert.AreEqual("1", valueString.String);
 
@@ -134,16 +136,33 @@ namespace MobiFlight.Modifier.Tests
                 BlinkValue = "ABC",
                 OnOffSequence = new List<int> { -1, 500 }
             };
-
             var valueInvalid = new ConnectorValue
             {
                 type = FSUIPCOffsetType.Integer,
                 Float64 = 0
             };
-            valueInvalid = blinkInvalid.Apply(valueInvalid, new List<ConfigRefValue>());
 
+            valueInvalid = blinkInvalid.Apply(valueInvalid, new List<ConfigRefValue>());
             Assert.AreEqual(FSUIPCOffsetType.String, valueInvalid.type);
             Assert.AreEqual("ABC", valueInvalid.String);
+
+            //Test if Active = false
+
+            var blinkActive = new Blink
+            {
+                Active = false,
+                BlinkValue = "1",
+                OnOffSequence = new List<int> { 500, 500 }
+            };
+            var valueActive = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 0
+            };
+
+            valueActive = blinkActive.Apply(valueActive, new List<ConfigRefValue>());
+            Assert.AreEqual(0, valueActive.Float64);
+            Assert.AreEqual(FSUIPCOffsetType.Integer, valueActive.type);
         }
         [TestMethod]
         public void Blink_ReturnsClone()

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
@@ -157,11 +157,11 @@ namespace MobiFlight.Modifier.Tests
             var valueActive = new ConnectorValue
             {
                 type = FSUIPCOffsetType.Integer,
-                Float64 = 0
+                Float64 = 1
             };
 
             valueActive = blinkActive.Apply(valueActive, new List<ConfigRefValue>());
-            Assert.AreEqual(0, valueActive.Float64);
+            Assert.AreEqual(1, valueActive.Float64);
             Assert.AreEqual(FSUIPCOffsetType.Integer, valueActive.type);
         }
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
@@ -111,41 +111,18 @@ namespace MobiFlight.Modifier.Tests
 
             valueOff = blinkOff.Apply(valueOff, new List<ConfigRefValue>());
             Assert.AreEqual(0, valueOff.Float64);
-
-            //Test blink (On/Off)
-
-            var blinkOnOff = new Blink
-            {
-                Active = true,
-                BlinkValue = "1",
-                OnOffSequence = new List<int> { 500, 500 }
-            };
-            var valueOnOff = new ConnectorValue
-            {
-                type = FSUIPCOffsetType.Integer,
-                Float64 = 0
-            };
-       
-            valueOnOff = blinkOnOff.Apply(valueOnOff, new List<ConfigRefValue>());
-            Assert.AreEqual(0, valueOnOff.Float64);
-            await Task.Delay(600);
-            valueOnOff = blinkOnOff.Apply(valueOnOff, new List<ConfigRefValue>());
-            Assert.AreEqual(1, valueOnOff.Float64);
-
             //Test string input
             var blinkString = new Blink
             {
                 Active = true,
                 BlinkValue = "1",
-                OnOffSequence = new List<int> { 500, 500 }
+                OnOffSequence = new List<int> { -1, 500 }
             };
             var valueString = new ConnectorValue
             {
                 type = FSUIPCOffsetType.String,
                 String = "0"
             };
-            valueString = blinkString.Apply(valueString, new List<ConfigRefValue>());
-            await Task.Delay(600);
             valueString = blinkString.Apply(valueString, new List<ConfigRefValue>());
             Assert.AreEqual("1", valueString.String);
 

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
@@ -151,18 +151,17 @@ namespace MobiFlight.Modifier.Tests
             var blinkActive = new Blink
             {
                 Active = false,
-                BlinkValue = "1",
-                OnOffSequence = new List<int> { 500, 500 }
+                BlinkValue = "Abs",
+                OnOffSequence = new List<int> { -1, 500 }
             };
             var valueActive = new ConnectorValue
             {
                 type = FSUIPCOffsetType.Integer,
-                Float64 = 1
+                Float64 = 5
             };
 
-            valueActive = blinkActive.Apply(valueActive, new List<ConfigRefValue>());
-            Assert.AreEqual(1, valueActive.Float64);
-            Assert.AreEqual(FSUIPCOffsetType.Integer, valueActive.type);
+            var result = blinkActive.Apply(valueActive, new List<ConfigRefValue>());
+            Assert.AreSame(result, valueActive);
         }
         [TestMethod]
         public void Blink_ReturnsClone()

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/BlinkTests.cs
@@ -75,7 +75,7 @@ namespace MobiFlight.Modifier.Tests
             CollectionAssert.AreEqual(new List<int>() { 200, 500 }, blink.OnOffSequence);
         }
         [TestMethod]
-        public async Task Blink_Apply()
+        public void Blink_Apply()
         {
             //Test if blink is (On)
 

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
@@ -196,6 +196,19 @@ namespace MobiFlight.Modifier.Tests
 
             var result2 = c.Apply(value, new List<ConfigRefValue>());
             Assert.AreEqual(0, result2.Float64);
+
+            c.Active = false;
+            c.Operand = "=";
+            c.Value = "0";
+            c.IfValue = "1";
+            c.ElseValue = "2";
+
+            value.type = FSUIPCOffsetType.Integer;
+            value.Float64 = 7;
+
+            var resultActive = c.Apply(value, new List<ConfigRefValue>());
+            Assert.AreSame(value, resultActive);
+
         }
 
 

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
@@ -233,39 +233,5 @@ namespace MobiFlight.Modifier.Tests
 
             Assert.AreEqual(1, value.Float64);
         }
-        [TestMethod]
-        public void Blink_ApplyDontChanegOregenalValue()
-        {
-            var comparison = new Comparison
-            {
-                Active = true,
-                Operand = "=",
-                Value = "1",
-                IfValue = "0",
-                ElseValue = "1"
-            };
-            var blink = new Blink
-            {
-                Active = true,
-                BlinkValue = "0",
-                OnOffSequence = new List<int> { 500, 500 }
-            };
-            var value = new ConnectorValue
-            {
-                type = FSUIPCOffsetType.Integer,
-                Float64 = 0
-            };
-            var configRefs = new List<ConfigRefValue>();
-            value = comparison.Apply(value, configRefs);
-
-            Assert.AreEqual(1, value.Float64);
-            var original = value.Clone() as ConnectorValue;
-
-            var result = blink.Apply(value, configRefs);
-            Assert.AreEqual(1, result.Float64);
-
-            Assert.AreEqual(original.Float64, value.Float64);
-            Assert.AreEqual(original.type, value.type);
-        }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
@@ -101,7 +101,7 @@ namespace MobiFlight.Modifier.Tests
         {
             var value = new ConnectorValue();
             var c = new Comparison();
-            
+
             c.Active = true;
             c.Operand = "=";
             c.Value = "0";
@@ -172,7 +172,100 @@ namespace MobiFlight.Modifier.Tests
 
             Assert.AreEqual(FSUIPCOffsetType.String, c.Apply(value, new List<ConfigRefValue>()).type);
             Assert.AreEqual("Hello world!", c.Apply(value, new List<ConfigRefValue>()).String);
+            c.Active = true;
+            c.Operand = "=";
+            c.Value = "1";
+            c.IfValue = "0";
+            c.ElseValue = "1";
 
+
+            value.type = FSUIPCOffsetType.Integer;
+            value.Float64 = 0;
+            var result = c.Apply(value, new List<ConfigRefValue>());
+
+            Assert.AreEqual(1, result.Float64);
+
+            c.Active = true;
+            c.Operand = "=";
+            c.Value = "1";
+            c.IfValue = "0";
+            c.ElseValue = "1";
+
+
+            value.type = FSUIPCOffsetType.Integer;
+            value.Float64 = 1;
+            var result2 = c.Apply(value, new List<ConfigRefValue>());
+
+            Assert.AreEqual(0, result2.Float64);
+        }
+
+
+        [TestMethod]
+        public void ComparisonFollowedByBlink_ShouldKeepComparisonResult()
+        {
+            var comparison = new Comparison
+            {
+                Active = true,
+                Operand = "=",
+                Value = "1",
+                IfValue = "0",
+                ElseValue = "1"
+            };
+            var blink = new Blink
+            {
+                Active = true,
+                BlinkValue = "0",
+                OnOffSequence = new List<int> { 500, 500 }
+            };
+            var value = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 0
+            };
+            var configRefs = new List<ConfigRefValue>();
+            value = comparison.Apply(value, configRefs);
+
+            Assert.AreEqual(1, value.Float64);
+
+
+            value = blink.Apply(value, configRefs);
+
+
+            Assert.AreEqual(1, value.Float64);
+        }
+        [TestMethod]
+        public void Blink_ApplyDontChanegOregenalValue()
+        {
+            var comparison = new Comparison
+            {
+                Active = true,
+                Operand = "=",
+                Value = "1",
+                IfValue = "0",
+                ElseValue = "1"
+            };
+            var blink = new Blink
+            {
+                Active = true,
+                BlinkValue = "0",
+                OnOffSequence = new List<int> { 500, 500 }
+            };
+            var value = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 0
+            };
+            var configRefs = new List<ConfigRefValue>();
+            value = comparison.Apply(value, configRefs);
+
+            Assert.AreEqual(1, value.Float64);
+            var original = value.Clone() as ConnectorValue;
+
+            var result = blink.Apply(value, configRefs);
+            Assert.AreEqual(1, result.Float64);
+
+            Assert.AreEqual(original.Float64, value.Float64);
+            Assert.AreEqual(original.type, value.type);
         }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/ComparisonTests.cs
@@ -172,17 +172,17 @@ namespace MobiFlight.Modifier.Tests
 
             Assert.AreEqual(FSUIPCOffsetType.String, c.Apply(value, new List<ConfigRefValue>()).type);
             Assert.AreEqual("Hello world!", c.Apply(value, new List<ConfigRefValue>()).String);
+
             c.Active = true;
             c.Operand = "=";
             c.Value = "1";
             c.IfValue = "0";
             c.ElseValue = "1";
 
-
             value.type = FSUIPCOffsetType.Integer;
             value.Float64 = 0;
-            var result = c.Apply(value, new List<ConfigRefValue>());
 
+            var result = c.Apply(value, new List<ConfigRefValue>());
             Assert.AreEqual(1, result.Float64);
 
             c.Active = true;
@@ -191,11 +191,10 @@ namespace MobiFlight.Modifier.Tests
             c.IfValue = "0";
             c.ElseValue = "1";
 
-
             value.type = FSUIPCOffsetType.Integer;
             value.Float64 = 1;
-            var result2 = c.Apply(value, new List<ConfigRefValue>());
 
+            var result2 = c.Apply(value, new List<ConfigRefValue>());
             Assert.AreEqual(0, result2.Float64);
         }
 
@@ -224,13 +223,8 @@ namespace MobiFlight.Modifier.Tests
             };
             var configRefs = new List<ConfigRefValue>();
             value = comparison.Apply(value, configRefs);
-
             Assert.AreEqual(1, value.Float64);
-
-
             value = blink.Apply(value, configRefs);
-
-
             Assert.AreEqual(1, value.Float64);
         }
     }

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/ExponentialAverageTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/ExponentialAverageTests.cs
@@ -144,6 +144,18 @@ namespace MobiFlight.Modifier.Tests
             Assert.AreEqual(75.0, result.Float64);
         }
 
+        [TestMethod]
+        public void ExponentialAverage_ApplyTest_ActiveFalse()
+        {
+            var modifier = new ExponentialAverage { Active = false, Alpha =0.5, Threshold = 0 };
+            modifier.Apply(CreateConnectorValue(100.0), new List<ConfigRefValue>());
+
+            var input = CreateConnectorValue(50);
+            var result = modifier.Apply(input, new List<ConfigRefValue>());
+
+            Assert.AreSame(input, result);
+        }
+
         [TestMethod()]
         public void ExponentialAverage_ToSummaryLabelTest()
         {

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/InterpolationTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/InterpolationTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Xml;
 
@@ -94,6 +95,28 @@ namespace MobiFlight.Modifier.Tests
             // value is between second and third 
             // and interpolation is negative
             Assert.AreEqual(1.5f, i.Value(0.75f), "Interpolation not done correctly");
+        }
+
+        [TestMethod]
+        public void Interpolation_Apply_ActiveFalse()
+        {
+            var interpolation = new Interpolation
+            {
+                Active = false
+            };
+
+            interpolation.Add(0, 0);
+            interpolation.Add(10, 20);
+
+            var value= new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 5
+            };
+
+            var result = interpolation.Apply(value, new List<ConfigRefValue>());
+
+            Assert.AreSame(value, result);
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/PaddingTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/PaddingTests.cs
@@ -162,5 +162,27 @@ namespace MobiFlight.Modifier.Tests
 
             Assert.AreEqual("123456", result.String);
         }
+
+        [TestMethod]
+        public void Padding_Apply_ActiveFalse()
+        {
+            var padding = new Padding
+            {
+                Active = false,
+                Length = 5,
+                Character = '0',
+                Direction = Padding.PaddingDirection.Left
+            };
+
+            var value = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.String,
+                String = "12"
+            };
+
+            var result = padding.Apply(value, new List<ConfigRefValue>());
+
+            Assert.AreSame(value, result);
+        }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/QuantizeTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/QuantizeTests.cs
@@ -220,6 +220,26 @@ namespace MobiFlight.Modifier.Tests
             StringAssert.Contains(label, "16");
         }
 
+        [TestMethod]
+        public void Quantization_Apply_ActiveFalse()
+        {
+            var modifier = new Quantize
+            {
+                Active = false,
+                StepSize = 10
+            };
+
+            var value = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 17
+            };
+
+            var result = modifier.Apply(value, new List<ConfigRefValue>());
+
+            Assert.AreSame(value, result);
+
+        }
         #endregion
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/SimpleMovingAverageTest.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/SimpleMovingAverageTest.cs
@@ -261,6 +261,29 @@ namespace MobiFlight.Modifier.Tests
             StringAssert.Contains(label, "16");
         }
 
+        [TestMethod]
+        public void SimpleMovingAverage_Apply_ActiveFalse()
+        {
+            var modifier = new SimpleMovingAverage
+            {
+                Active = false,
+                WindowSize = 4,
+                Threshold = 0,
+                JumpResetThreshold = 64
+            };
+
+            var value = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 100
+            };
+
+            var result = modifier.Apply(value, new List<ConfigRefValue>());
+
+            Assert.AreSame(value, result);
+
+        }
+
         #endregion
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Modifier/TransformationTests.cs
@@ -23,6 +23,7 @@ namespace MobiFlight.Modifier.Tests
             // this is needed for correct conversion
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.DefaultThreadCurrentUICulture = CultureInfo.InvariantCulture;
+            t.Active=true;
 
             // Number type
             var ConnectValue = new ConnectorValue() { Float64 = 1 };
@@ -58,6 +59,22 @@ namespace MobiFlight.Modifier.Tests
             Assert.AreEqual("0.000", step1Result.String);
             t.Expression = "if('$'=1,2,'$')";
             Assert.AreEqual("0.000", t.Apply(step1Result, configRefs).String);
+
+            var transformation = new Transformation
+            {
+                Active = false,
+                Expression = "$ + 10"
+            };
+
+            var value = new ConnectorValue
+            {
+                type = FSUIPCOffsetType.Integer,
+                Float64 = 5
+            };
+
+            var result = transformation.Apply(value, new List<ConfigRefValue>());
+
+            Assert.AreSame(value, result);
         }
 
         [TestMethod()]


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Blink work after the compare.
The issue was caused by modifying the original ConnectorValue instead of working on a local copy
### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="1037" height="764" alt="image" src="https://github.com/user-attachments/assets/d79e8c2a-194b-4370-bee1-356e551b238c" />
<img width="1003" height="756" alt="image" src="https://github.com/user-attachments/assets/c378e59e-69b8-4d58-8abb-cc2aa5c80843" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Blink work after the Compare.


### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
  - [x] Frontend

     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #2995 

