### PR TITLE
Playwright test workflow runs only when frontend files are changed

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,6 +2,9 @@ name: Playwright Tests
 on:
   pull_request:
     branches: [ main, hotfix/* ]
+    paths:
+      # Trigger only when files in frontend folder change
+      - "src/MobiFlightConnector/frontend/**"
   workflow_dispatch:
 jobs:
   test:

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,8 +3,11 @@ on:
   pull_request:
     branches: [ main, hotfix/* ]
     paths:
-      # Trigger only when files in frontend folder change
+      # Trigger when workflow file or 
+      # files in frontend folder change
+      - ".github/workflows/playwright.yml"
       - "src/MobiFlightConnector/frontend/**"
+
   workflow_dispatch:
 jobs:
   test:

--- a/.github/workflows/translations.yml
+++ b/.github/workflows/translations.yml
@@ -3,7 +3,9 @@ on:
   pull_request:
     branches: [main, hotfix/*]
     paths:
-      # Trigger only when files in the public/locales folder change
+      # Trigger when workflow file or 
+      # files in the public/locales folder change
+      - ".github/workflows/translations.yml"
       - "src/MobiFlightConnector/frontend/public/locales/**"
 
   workflow_dispatch:


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
Execute playwright workflow only when files inside the frontend folder have been modified. This will save execution time.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Workflow has additional path condition
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3183 