### PR TITLE
Don't filter preset list by project aircraft for legacy Config Wizard

### DIFF
--- a/src/MobiFlightConnector/UI/Panels/Config/HubHopPresetPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/Config/HubHopPresetPanel.cs
@@ -166,7 +166,12 @@ namespace MobiFlight.UI.Panels.Config
 
         public void LoadPresets(ProjectInfo projectInfo)
         {
-            PresetList.ProjectInfo = projectInfo;
+            // We disable passing in the the project info
+            // because we don't want to filter by project aircraft.
+            // Compared to the new input config wizards,
+            // a user cannot deselect the filter and it might be confusing
+            // if they don't have access to the entire preset list.
+            // PresetList.ProjectInfo = projectInfo;
             _loadPresets();
         }
 


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
We have introduced the Aircraft in Project Settings - which filters the preset list using the selected aircraft as default filter.
The new Input Config Wizard also supports removing the filtering in case the user would like to see all presets.

The existing Config Wizard (old UI) does not provide an option to remove the aircraft filter, so with this PR we are reverting back to showing the full list. There are no plans to spend effort on old UI components.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] All presets are displayed no matter what aircraft is defined in Project Settings.
     
## Related issues
<!-- fixes, relates to existing #issues -->
part of #3078 
part of #2819 