### PR TITLE
Fix stale precondition status after deletion

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -1483,24 +1483,20 @@ namespace MobiFlight
 
                     var originalCfg = cfgItem.Clone() as InputConfigItem;
 
-                    // if there are preconditions check and skip if necessary
-                    if (cfg.Preconditions.Count > 0)
+                    ConnectorValue currentValue = new ConnectorValue();
+
+                    if (!PreconditionChecker.CheckPrecondition(cfg, currentValue, ConfigItems, arcazeCache, mobiFlightCache))
                     {
-                        ConnectorValue currentValue = new ConnectorValue();
+                        cfg.Status[ConfigItemStatusType.Precondition] = "not satisfied";
+                    }
+                    else
+                    {
+                        cfg.Status.Remove(ConfigItemStatusType.Precondition);
+                    }
 
-                        if (!PreconditionChecker.CheckPrecondition(cfg, currentValue, ConfigItems, arcazeCache, mobiFlightCache))
-                        {
-                            cfg.Status[ConfigItemStatusType.Precondition] = "not satisfied";
-                        }
-                        else
-                        {
-                            cfg.Status.Remove(ConfigItemStatusType.Precondition);
-                        }
-
-                        if (!cfg.Status.SequenceEqual(originalCfg.Status))
-                        {
-                            updatedValues[cfg.GUID] = cfg;
-                        }
+                    if (!cfg.Status.SequenceEqual(originalCfg.Status))
+                    {
+                        updatedValues[cfg.GUID] = cfg;
                     }
                 }
                 catch (Exception ex)

--- a/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -707,6 +707,32 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void UpdateInputPreconditions_RemovesStatus_WhenPreconditionsAreEmpty()
+        {
+            var configItem = new InputConfigItem
+            {
+                GUID = Guid.NewGuid().ToString(),
+                Active = true,
+                Name = "TestInput"
+            };
+            configItem.Status[ConfigItemStatusType.Precondition] = "not satisfied";
+            var project = new Project();
+            project.ConfigFiles.Add(new ConfigFile() { ConfigItems = { configItem } });
+            _executionManager.Project = project;
+
+            var updateInputPreconditions = typeof(ExecutionManager).GetMethod("UpdateInputPreconditions",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var updatedValuesField = typeof(ExecutionManager).GetField("updatedValues",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var updatedValues = (ConcurrentDictionary<string, IConfigItem>)updatedValuesField.GetValue(_executionManager);
+
+            updateInputPreconditions.Invoke(_executionManager, null);
+
+            Assert.IsFalse(configItem.Status.ContainsKey(ConfigItemStatusType.Precondition));
+            Assert.IsTrue(updatedValues.ContainsKey(configItem.GUID));
+        }
+
+        [TestMethod]
         public void FrontendUpdateTimer_Execute_ConcurrentDictionaryModification_ShouldNotThrowInvalidOperationException()
         {
             // Arrange


### PR DESCRIPTION
### Summary

Removing the last precondition now clears the stale precondition status and queues the config update, so the icon disappears without restarting MobiFlight.

### Acceptance criteria

- [x] Removing the last precondition clears the old status
- [x] The config update is sent to the frontend
- [x] Existing precondition behavior still passes the full test suite

### DoD Checklist

- [x] Unit tests available
  - [x] .NET backend
- [x] Frontend production build

## Related issues

fixes #3156

### Notes

1,057 tests passed and 31 existing tests were skipped.
