### PR TITLE
Allow PR firmware versions during firmware update check

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModuleInfo.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModuleInfo.cs
@@ -49,10 +49,10 @@ namespace MobiFlight
                 return false;
             }
             // and update when version lower than latest
-            return true ;
-                
-                
-               
+            return currentVersion.CompareTo(latestVersion) < 0;
+
+
+
         }
 
     }

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModuleInfo.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModuleInfo.cs
@@ -40,18 +40,19 @@ namespace MobiFlight
             {
                 currentVersion = new Version("0.0.0");
             }
-            bool isSpecialFirmware =
+            bool isDevOrPrFirmware =
                 currentVersion.Major == 0 &&
                 currentVersion.Minor == 0;
             // PR firmware uses version 0.0.<PR_NUMBER>, so don't require an update.
-            if (isSpecialFirmware)
+            if (isDevOrPrFirmware)
             {
                 return false;
             }
-            return (
-                // and update when version lower than latest
-                currentVersion.CompareTo(latestVersion) < 0
-                );
+            // and update when version lower than latest
+            return true ;
+                
+                
+               
         }
 
     }

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModuleInfo.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModuleInfo.cs
@@ -31,6 +31,7 @@ namespace MobiFlight
         {
             Version latestVersion = new Version(Board.Info.LatestFirmwareVersion);
             Version currentVersion;
+
             try
             {
                 currentVersion = new Version(Version != null ? Version : "0.0.0");
@@ -38,6 +39,15 @@ namespace MobiFlight
             catch (Exception ex)
             {
                 currentVersion = new Version("0.0.0");
+            }
+            bool isPrFirmware =
+                currentVersion.Major == 0 &&
+                currentVersion.Minor == 0 &&
+                currentVersion.Build > 1;
+            // PR firmware uses version 0.0.<PR_NUMBER>, so don't require an update.
+            if (isPrFirmware)
+            {
+                return false;
             }
             return (
                 // ignore the developer board that has 0.0.1

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightModuleInfo.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightModuleInfo.cs
@@ -40,20 +40,18 @@ namespace MobiFlight
             {
                 currentVersion = new Version("0.0.0");
             }
-            bool isPrFirmware =
+            bool isSpecialFirmware =
                 currentVersion.Major == 0 &&
-                currentVersion.Minor == 0 &&
-                currentVersion.Build > 1;
+                currentVersion.Minor == 0;
             // PR firmware uses version 0.0.<PR_NUMBER>, so don't require an update.
-            if (isPrFirmware)
+            if (isSpecialFirmware)
             {
                 return false;
             }
             return (
-                // ignore the developer board that has 0.0.1
-                currentVersion.CompareTo(new Version("0.0.1")) != 0 &&
                 // and update when version lower than latest
-                currentVersion.CompareTo(latestVersion) < 0);
+                currentVersion.CompareTo(latestVersion) < 0
+                );
         }
 
     }

--- a/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleInfoTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleInfoTests.cs
@@ -93,5 +93,59 @@ namespace MobiFlight.Tests
 
             Assert.IsFalse(info.FirmwareRequiresUpdate());
         }
+
+        [TestMethod]
+        public void FirmwareRequiresUpdate_FalseForNewerVersion()
+        {
+            var info = new MobiFlightModuleInfo
+            {
+                Board = new Board
+                {
+                    Info = new Info
+                    {
+                        LatestFirmwareVersion = "11.1.0"
+                    }
+                },
+                Version = "12.0.0"
+            };
+
+            Assert.IsFalse(info.FirmwareRequiresUpdate());
+        }
+
+        [TestMethod]
+        public void FirmwareRequiresUpdate_FalseForInvalidVersion()
+        {
+            var info = new MobiFlightModuleInfo
+            {
+                Board = new Board
+                {
+                    Info = new Info
+                    {
+                        LatestFirmwareVersion = "11.1.0"
+                    }
+                },
+                Version = null
+            };
+
+            Assert.IsFalse(info.FirmwareRequiresUpdate());
+        }
+
+        [TestMethod]
+        public void FirmwareRequiresUpdate_FalseForMissingVersion()
+        {
+            var info = new MobiFlightModuleInfo
+            {
+                Board = new Board
+                {
+                    Info = new Info
+                    {
+                        LatestFirmwareVersion = "11.1.0"
+                    }
+                }
+            };
+
+            Assert.IsFalse(info.FirmwareRequiresUpdate());
+        }
+
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleInfoTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleInfoTests.cs
@@ -36,10 +36,11 @@ namespace MobiFlight.Tests
             info.Board = board;
             Assert.IsTrue(info.FirmwareInstallPossible());
         }
+     
         [TestMethod()]
-        public void Firmware_AskForUpdate()
+        public void FirmwareRequiresUpdate_IgnoresDevAndPrBuilds()
         {
-            var info = new MobiFlightModuleInfo
+           var info = new MobiFlightModuleInfo
             {
                 Board = new Board
                 {
@@ -55,9 +56,42 @@ namespace MobiFlight.Tests
 
             info.Version = "0.0.333";
             Assert.IsFalse(info.FirmwareRequiresUpdate());
+        }
+
+        [TestMethod()]
+        public void FirmwareRequiresUpdate_TrueForOldVersion()
+        {
+            var info = new MobiFlightModuleInfo
+            {
+                Board = new Board
+                {
+                    Info = new Info
+                    {
+                        LatestFirmwareVersion = "11.1.0"
+                    }
+                }
+            };
 
             info.Version = "1.0.0";
+
             Assert.IsTrue(info.FirmwareRequiresUpdate());
+        }
+        [TestMethod]
+        public void FirmwareRequiresUpdate_FalseForLatestVersion()
+        {
+            var info = new MobiFlightModuleInfo
+            {
+                Board = new Board
+                {
+                    Info = new Info
+                    {
+                        LatestFirmwareVersion = "11.1.0"
+                    }
+                },
+                Version = "11.1.0"
+            };
+
+            Assert.IsFalse(info.FirmwareRequiresUpdate());
         }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleInfoTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleInfoTests.cs
@@ -36,5 +36,28 @@ namespace MobiFlight.Tests
             info.Board = board;
             Assert.IsTrue(info.FirmwareInstallPossible());
         }
+        [TestMethod()]
+        public void Firmware_AskForUpdate()
+        {
+            var info = new MobiFlightModuleInfo
+            {
+                Board = new Board
+                {
+                    Info = new Info
+                    {
+                        LatestFirmwareVersion = "11.1.0"
+                    }
+                }
+            };
+
+            info.Version = "0.0.1";
+            Assert.IsFalse(info.FirmwareRequiresUpdate());
+
+            info.Version = "0.0.333";
+            Assert.IsFalse(info.FirmwareRequiresUpdate());
+
+            info.Version = "1.0.0";
+            Assert.IsTrue(info.FirmwareRequiresUpdate());
+        }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleInfoTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/MobiFlightModuleInfoTests.cs
@@ -113,24 +113,6 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
-        public void FirmwareRequiresUpdate_FalseForInvalidVersion()
-        {
-            var info = new MobiFlightModuleInfo
-            {
-                Board = new Board
-                {
-                    Info = new Info
-                    {
-                        LatestFirmwareVersion = "11.1.0"
-                    }
-                },
-                Version = null
-            };
-
-            Assert.IsFalse(info.FirmwareRequiresUpdate());
-        }
-
-        [TestMethod]
         public void FirmwareRequiresUpdate_FalseForMissingVersion()
         {
             var info = new MobiFlightModuleInfo


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Allow PR firmware (`0.0.<PR_NUMBER>`) to bypass the outdated firmware check so configuration uploads work correctly for pull request firmware builds.
### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Unable to upload configs to devices with PR firmware.


### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
 - [x] .NET backend


     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3191 

