### PR TITLE
Fix the annunciator test lights for WinCtrl EFIS R.

### DIFF
--- a/src/MobiFlightWwFcu/WinCtrlEfisController.cs
+++ b/src/MobiFlightWwFcu/WinCtrlEfisController.cs
@@ -23,13 +23,7 @@ namespace MobiFlightWwFcu
         {
             EfisType = efisType;
 
-            DisplayTestCommands = new Dictionary<string, DisplaySegment>()
-            {
-                { "AllOn",   new DisplaySegment(new Bit[] { new Bit(0,0,true),  new Bit(0,1,true),  new Bit(0,2,false), new Bit(0,5,true) }, false) },
-                { "AllOff",  new DisplaySegment(new Bit[] { new Bit(0,0,false), new Bit(0,1,false), new Bit(0,2,true),  new Bit(0,5,true) }, false) },
-                { "Half1On", new DisplaySegment(new Bit[] { new Bit(0,0,true),  new Bit(0,1,false), new Bit(0,2,true),  new Bit(0,5,true) }, false) },
-                { "Half2On", new DisplaySegment(new Bit[] { new Bit(0,0,false), new Bit(0,1,true),  new Bit(0,2,true),  new Bit(0,5,true) }, false) },
-            };
+            DisplayTestCommands = ResolveDisplayTestCommands(efisType);
 
             // Bit positions are byte-numbers in the data section (header offset 17 is added when writing).
             // Iteration order matters: overlapping mode-presets resolve last-writer-wins, so the entry that
@@ -73,6 +67,19 @@ namespace MobiFlightWwFcu
             if (efisType == WinCtrlConstants.EFISL_NAME) return WinCtrlConstants.DEST_EFISL;
             if (efisType == WinCtrlConstants.EFISR_NAME) return WinCtrlConstants.DEST_EFISR;
             return WinCtrlConstants.DEST_EFISL;
+        }
+
+        private static Dictionary<string, DisplaySegment> ResolveDisplayTestCommands(string efisType)
+        {
+            // EFIS-L and EFIS-R use the same mode bits except for the final selector bit.
+            int modeBit = efisType == WinCtrlConstants.EFISR_NAME ? 6 : 5;
+            return new Dictionary<string, DisplaySegment>()
+            {
+                { "AllOn",   new DisplaySegment(new Bit[] { new Bit(0,0,true),  new Bit(0,1,true),  new Bit(0,2,false), new Bit(0, modeBit, true) }, false) },
+                { "AllOff",  new DisplaySegment(new Bit[] { new Bit(0,0,false), new Bit(0,1,false), new Bit(0,2,true),  new Bit(0, modeBit, true) }, false) },
+                { "Half1On", new DisplaySegment(new Bit[] { new Bit(0,0,true),  new Bit(0,1,false), new Bit(0,2,true),  new Bit(0, modeBit, true) }, false) },
+                { "Half2On", new DisplaySegment(new Bit[] { new Bit(0,0,false), new Bit(0,1,true),  new Bit(0,2,true),  new Bit(0, modeBit, true) }, false) },
+            };
         }
 
         // EFIS Baro digit: 7 segments packed into one byte (bits 0..6); bit 7 is the inHg decimal point.

--- a/tests/MobiFlightWwFcuUnitTests/WinCtrlEfisRightDeviceTests.cs
+++ b/tests/MobiFlightWwFcuUnitTests/WinCtrlEfisRightDeviceTests.cs
@@ -1,0 +1,83 @@
+﻿using MobiFlightWwFcu;
+using MobiFlightWwFcuUnitTests.Mocks;
+
+namespace MobiFlightWwFcuUnitTests
+{
+    [TestClass]
+    public class WinCtrlEfisRightControllerTests
+    {
+        private MockWinCtrlMessageSender mockMessageSender = null!;
+        private WinCtrlEfisController device = null!;
+
+        // The EFIS-Right destination (0x0E, 0xBF) is the prefix on every command frame.
+        // RefreshCommand is always identical (17 bytes, header only).
+        private static readonly byte[] RefreshCommand = new byte[]
+        {
+            0x0E, 0xBF, 0x00, 0x00, 0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+        };
+
+        [TestInitialize]
+        public void Setup()
+        {
+            mockMessageSender = new MockWinCtrlMessageSender();
+            // Use the "Right" EFIS variant for all tests (DEST_EFISR = 0x0E 0xBF).
+            device = new WinCtrlEfisController(mockMessageSender, "Right");
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            device?.Stop();
+        }
+
+        #region Annunciator Light Tests
+
+        [TestMethod]
+        public void SetDisplay_AnnunciatorLight_WithOne_ShouldTurnOnAllLights_Right()
+        {
+            device.SetDisplay("LCD Test On/Off", "1");
+            Assert.HasCount(1, mockMessageSender.DisplayCommandsSent);
+
+            // 18-byte LCD-test frame; byte 17 carries the AllOn mode (0x43).
+            List<byte[]> expectedCommands = new List<byte[]>()
+            {
+                new byte[] { 0x0E, 0xBF, 0x00, 0x00, 0x04, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x43 },
+                RefreshCommand
+            };
+
+            CompareDisplayCommands(mockMessageSender.DisplayCommandsSent[0].Commands, expectedCommands);
+        }
+
+        [TestMethod]
+        public void SetDisplay_AnnunciatorLight_WithZero_ShouldResendCurrentBuffer_Right()
+        {
+            device.SetDisplay("LCD Test On/Off", "0");
+            Assert.HasCount(1, mockMessageSender.DisplayCommandsSent);
+
+            // The "off" branch resends the current SetValuesCommand (post-init "1013 QNH").
+            List<byte[]> expectedCommands = new List<byte[]>()
+            {
+                new byte[] { 0x0E, 0xBF, 0x00, 0x00, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x60, 0x7D, 0x60, 0x7A, 0x02 },
+                RefreshCommand
+            };
+
+            CompareDisplayCommands(mockMessageSender.DisplayCommandsSent[0].Commands, expectedCommands);
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private void CompareDisplayCommands(List<byte[]> sentCommands, List<byte[]> expectedCommands)
+        {
+            Assert.HasCount(expectedCommands.Count, sentCommands);
+
+            for (int i = 0; i < expectedCommands.Count; i++)
+            {
+                CollectionAssert.AreEqual(expectedCommands[i], sentCommands[i]);
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
### Summary

Fixes the "LCD Test On/Off" for the Right WinCtrl EFIS so that it lights up all of the LCD segments when a non-zero value is passed.

### Acceptance criteria
- [ ] The "LCD Test On/Off" display works for the WinCtrl 32 EFIS R in the same way as it does for the WinCtrl 32 EFIS L.

### DoD Checklist
- [x] Unit tests available
  - [x] .NET backend
     
### Notes

I have both the right and the left EFIS connected to my FCU. I have not tested the right EFIS or the left EFIS in isolation, however, it defaults to the left EFIS logic if it can't tell which one it is.
