### PR TITLE
Restore text input context menus

### DIFF
--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
@@ -1,7 +1,9 @@
 ﻿using MobiFlight.BrowserMessages;
 using MobiFlight.BrowserMessages.Publisher;
 using MobiFlight.WebView;
+using Microsoft.Web.WebView2.Core;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Windows.Forms;
 
@@ -9,6 +11,19 @@ namespace MobiFlight.UI.Panels
 {
     public partial class FrontendPanel : UserControl
     {
+        private static readonly HashSet<string> TextEditingContextMenuItemNames = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "undo",
+            "redo",
+            "cut",
+            "copy",
+            "paste",
+            "pasteAsPlainText",
+            "pasteAndMatchStyle",
+            "delete",
+            "selectAll"
+        };
+
         CompositePublisher compositePublisher = new CompositePublisher();
         private string _frontendBaseUrl = "http://localhost:5173";
         private string _frontendDistPath;
@@ -48,7 +63,7 @@ namespace MobiFlight.UI.Panels
             await FrontendWebView.EnsureCoreWebView2Async(null);
             await UserAuthenticationWebView.EnsureCoreWebView2Async(null);
 
-            InitializeWebView(FrontendWebView, "/start");
+            InitializeWebView(FrontendWebView, "/start", enableDefaultContextMenus: true);
             InitializeWebView(UserAuthenticationWebView);
 
             compositePublisher.AddPublisher("frontend", new PostMessagePublisher(FrontendWebView));
@@ -57,7 +72,7 @@ namespace MobiFlight.UI.Panels
             MessageExchange.Instance.SetPublisher(compositePublisher);
         }
 
-        private void InitializeWebView(ThreadSafeWebView2 webView, string route = "/")
+        private void InitializeWebView(ThreadSafeWebView2 webView, string route = "/", bool enableDefaultContextMenus = false)
         {
             if (IsRunningInProduction)
             {
@@ -74,8 +89,15 @@ namespace MobiFlight.UI.Panels
 
                 staticPageHandler.RegisterWithWebView(webView);
 
-                webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
+                // The frontend filters native menus to text controls. Authentication and other
+                // WebViews keep the existing blanket suppression.
+                webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = enableDefaultContextMenus;
                 webView.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
+            }
+
+            if (enableDefaultContextMenus)
+            {
+                webView.CoreWebView2.ContextMenuRequested += RestrictFrontendContextMenu;
             }
 
             var staticPresetsHandler = new StaticPageWebResourceRequestHandler(
@@ -101,6 +123,34 @@ namespace MobiFlight.UI.Panels
             {
                 webView.ZoomFactor = _desiredZoomFactor;
             }
+        }
+
+        private static void RestrictFrontendContextMenu(object sender, CoreWebView2ContextMenuRequestedEventArgs args)
+        {
+            for (var index = args.MenuItems.Count - 1; index >= 0; index--)
+            {
+                var item = args.MenuItems[index];
+                if (item.Kind != CoreWebView2ContextMenuItemKind.Separator &&
+                    !TextEditingContextMenuItemNames.Contains(item.Name))
+                {
+                    args.MenuItems.RemoveAt(index);
+                }
+            }
+
+            // Preserve separators between native command groups, but remove any left
+            // dangling after browser-only commands were filtered out.
+            for (var index = args.MenuItems.Count - 1; index >= 0; index--)
+            {
+                if (args.MenuItems[index].Kind == CoreWebView2ContextMenuItemKind.Separator &&
+                    (index == 0 ||
+                     index == args.MenuItems.Count - 1 ||
+                     args.MenuItems[index - 1].Kind == CoreWebView2ContextMenuItemKind.Separator))
+                {
+                    args.MenuItems.RemoveAt(index);
+                }
+            }
+
+            args.Handled = args.MenuItems.Count == 0;
         }
 
         public void SetZoomFactor(double zoomFactor)

--- a/src/MobiFlightConnector/frontend/src/components/ui/input.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/ui/input.tsx
@@ -1,22 +1,34 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { isNativeTextContextMenuTarget } from "@/lib/contextMenuPolicy"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, onContextMenu, ...props }, ref) => {
+    const handleContextMenu: React.MouseEventHandler<HTMLInputElement> = (
+      event,
+    ) => {
+      onContextMenu?.(event)
+
+      if (isNativeTextContextMenuTarget(event.currentTarget)) {
+        event.stopPropagation()
+      }
+    }
+
     return (
       <input
         type={type}
         autoComplete="off"
         className={cn(
-          "flex h-8 w-full rounded-md border border-input bg-background px-2 py-1 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          className
+          "border-input bg-background ring-offset-background file:text-foreground placeholder:text-muted-foreground focus-visible:ring-ring flex h-8 w-full rounded-md border px-2 py-1 text-base file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-hidden disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          className,
         )}
         ref={ref}
         {...props}
+        onContextMenu={handleContextMenu}
       />
     )
-  }
+  },
 )
 Input.displayName = "Input"
 

--- a/src/MobiFlightConnector/frontend/src/components/ui/textarea.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/ui/textarea.tsx
@@ -1,16 +1,32 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { isNativeTextContextMenuTarget } from "@/lib/contextMenuPolicy"
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+function Textarea({
+  className,
+  onContextMenu,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  const handleContextMenu: React.MouseEventHandler<HTMLTextAreaElement> = (
+    event,
+  ) => {
+    onContextMenu?.(event)
+
+    if (isNativeTextContextMenuTarget(event.currentTarget)) {
+      event.stopPropagation()
+    }
+  }
+
   return (
     <textarea
       data-slot="textarea"
       className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
-        className
+        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
       )}
       {...props}
+      onContextMenu={handleContextMenu}
     />
   )
 }

--- a/src/MobiFlightConnector/frontend/src/lib/__tests__/contextMenuPolicy.test.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/__tests__/contextMenuPolicy.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest"
+import { allowsNativeTextContextMenu } from "../contextMenuPolicy"
+
+describe("allowsNativeTextContextMenu", () => {
+  it("allows editable and read-only text inputs", () => {
+    expect(
+      allowsNativeTextContextMenu({
+        kind: "input",
+        inputType: "text",
+        disabled: false,
+        readOnly: false,
+      }),
+    ).toBe(true)
+    expect(
+      allowsNativeTextContextMenu({
+        kind: "input",
+        inputType: "text",
+        disabled: false,
+        readOnly: true,
+      }),
+    ).toBe(true)
+  })
+
+  it("allows text-like input types", () => {
+    for (const inputType of [
+      "email",
+      "number",
+      "password",
+      "search",
+      "tel",
+      "url",
+    ]) {
+      expect(
+        allowsNativeTextContextMenu({
+          kind: "input",
+          inputType,
+          disabled: false,
+          readOnly: false,
+        }),
+      ).toBe(true)
+    }
+  })
+
+  it("rejects disabled and non-text inputs", () => {
+    expect(
+      allowsNativeTextContextMenu({
+        kind: "input",
+        inputType: "text",
+        disabled: true,
+        readOnly: false,
+      }),
+    ).toBe(false)
+    expect(
+      allowsNativeTextContextMenu({
+        kind: "input",
+        inputType: "checkbox",
+        disabled: false,
+        readOnly: false,
+      }),
+    ).toBe(false)
+  })
+
+  it("allows enabled and read-only textareas but rejects disabled textareas", () => {
+    expect(
+      allowsNativeTextContextMenu({
+        kind: "textarea",
+        disabled: false,
+        readOnly: false,
+      }),
+    ).toBe(true)
+    expect(
+      allowsNativeTextContextMenu({
+        kind: "textarea",
+        disabled: false,
+        readOnly: true,
+      }),
+    ).toBe(true)
+    expect(
+      allowsNativeTextContextMenu({
+        kind: "textarea",
+        disabled: true,
+        readOnly: false,
+      }),
+    ).toBe(false)
+  })
+
+  it("allows contenteditable targets and rejects other page content", () => {
+    expect(allowsNativeTextContextMenu({ kind: "contenteditable" })).toBe(true)
+    expect(allowsNativeTextContextMenu({ kind: "other" })).toBe(false)
+  })
+})

--- a/src/MobiFlightConnector/frontend/src/lib/contextMenuPolicy.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/contextMenuPolicy.ts
@@ -1,0 +1,85 @@
+const textInputTypes = new Set([
+  "email",
+  "number",
+  "password",
+  "search",
+  "tel",
+  "text",
+  "url",
+])
+
+export type TextContextMenuTargetState =
+  | {
+      kind: "input"
+      inputType: string
+      disabled: boolean
+      readOnly: boolean
+    }
+  | { kind: "textarea"; disabled: boolean; readOnly: boolean }
+  | { kind: "contenteditable" }
+  | { kind: "other" }
+
+export function allowsNativeTextContextMenu(
+  target: TextContextMenuTargetState,
+): boolean {
+  switch (target.kind) {
+    case "input":
+      // Read-only text still needs native Copy and Select All. Chromium disables
+      // mutating commands such as Cut and Paste for us.
+      return !target.disabled && textInputTypes.has(target.inputType)
+    case "textarea":
+      return !target.disabled
+    case "contenteditable":
+      return true
+    default:
+      return false
+  }
+}
+
+function describeContextMenuTarget(
+  target: EventTarget | null,
+): TextContextMenuTargetState {
+  if (target instanceof HTMLInputElement) {
+    return {
+      kind: "input",
+      inputType: target.type,
+      disabled: target.disabled,
+      readOnly: target.readOnly,
+    }
+  }
+
+  if (target instanceof HTMLTextAreaElement) {
+    return {
+      kind: "textarea",
+      disabled: target.disabled,
+      readOnly: target.readOnly,
+    }
+  }
+
+  const element =
+    target instanceof HTMLElement
+      ? target
+      : target instanceof Element
+        ? target.parentElement
+        : null
+
+  if (element?.isContentEditable) {
+    return { kind: "contenteditable" }
+  }
+
+  return { kind: "other" }
+}
+
+export function isNativeTextContextMenuTarget(
+  target: EventTarget | null,
+): boolean {
+  return allowsNativeTextContextMenu(describeContextMenuTarget(target))
+}
+
+export function enforceTextContextMenuPolicy(event: MouseEvent) {
+  const target = event.composedPath()[0] ?? event.target
+
+  if (!isNativeTextContextMenuTarget(target)) {
+    event.preventDefault()
+  }
+}

--- a/src/MobiFlightConnector/frontend/src/main.tsx
+++ b/src/MobiFlightConnector/frontend/src/main.tsx
@@ -11,6 +11,7 @@ import { oidcConfig } from "@/lib/auth/config"
 import { BackendStateMessageHandler } from "@/components/BackendStateMessageHandler.tsx"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { UserProfileLoader } from "@/components/UserProfileLoader.tsx"
+import { enforceTextContextMenuPolicy } from "@/lib/contextMenuPolicy"
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -28,6 +29,8 @@ if (process.env.NODE_ENV !== "development") {
   console.info = () => {}
   console.debug = () => {}
 }
+
+window.addEventListener("contextmenu", enforceTextContextMenuPolicy)
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>

--- a/src/MobiFlightConnector/frontend/tests/ConfigListView.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/ConfigListView.spec.ts
@@ -287,7 +287,7 @@ test.describe("Confirm content and basic functions are working", () => {
     await contextMenu.getByRole("menuitem", { name: "Duplicate" }).click()
 
     // Simulate the backend response after duplicating the item.
-    
+
     await configListPage.duplicateConfigItem(0, "inputaction")
     await page.mouse.move(0, 0)
     const duplicatedRow = await configListPage.getConfigItemRow(2)
@@ -1486,6 +1486,102 @@ test.describe("Confirm context menu actions are working", () => {
         await expect(inlineEdit).toBeVisible()
       }
     }
+  })
+
+  test("Right click on an inline input keeps the row menu closed", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData()
+
+    const firstRow = page.getByRole("row").nth(1)
+    const contextMenu = page.getByTestId("config-item-context-menu")
+
+    await firstRow.click({ button: "right" })
+    await contextMenu.getByRole("menuitem", { name: "Rename" }).click()
+
+    const inlineEdit = firstRow.getByRole("textbox")
+    await expect(inlineEdit).toBeVisible()
+    await inlineEdit.click({ button: "right" })
+
+    await expect(contextMenu).not.toBeVisible()
+    await expect(inlineEdit).toBeFocused()
+  })
+
+  test("Native menus remain limited to text editing targets", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+    await configListPage.mobiFlightPage.initWithTestData()
+
+    const prevented = await page.evaluate(() => {
+      const container = document.createElement("div")
+      const enabledText = document.createElement("input")
+      const readOnlyText = document.createElement("input")
+      const disabledText = document.createElement("input")
+      const textarea = document.createElement("textarea")
+      const contentEditable = document.createElement("div")
+      const checkbox = document.createElement("input")
+      const nonEditable = document.createElement("div")
+
+      enabledText.value = "selected text"
+      readOnlyText.value = "read-only text"
+      readOnlyText.readOnly = true
+      disabledText.disabled = true
+      textarea.value = "textarea text"
+      contentEditable.contentEditable = "true"
+      checkbox.type = "checkbox"
+
+      container.append(
+        enabledText,
+        readOnlyText,
+        disabledText,
+        textarea,
+        contentEditable,
+        checkbox,
+        nonEditable,
+      )
+      document.body.append(container)
+
+      enabledText.select()
+      readOnlyText.select()
+      textarea.select()
+
+      const dispatch = (target: HTMLElement) => {
+        const event = new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+        })
+        target.dispatchEvent(event)
+        return event.defaultPrevented
+      }
+
+      const result = {
+        enabledText: dispatch(enabledText),
+        readOnlyText: dispatch(readOnlyText),
+        disabledText: dispatch(disabledText),
+        textarea: dispatch(textarea),
+        contentEditable: dispatch(contentEditable),
+        checkbox: dispatch(checkbox),
+        nonEditable: dispatch(nonEditable),
+      }
+
+      container.remove()
+      return result
+    })
+
+    expect(prevented).toEqual({
+      enabledText: false,
+      readOnlyText: false,
+      disabledText: true,
+      textarea: false,
+      contentEditable: false,
+      checkbox: true,
+      nonEditable: true,
+    })
   })
 
   test("Confirm context menu shows on button click", async ({


### PR DESCRIPTION
### Summary

Restore native copy, paste, cut, undo, redo, delete, and select-all context-menu actions for editable text controls in the frontend.

The frontend now allows native menus only for enabled text inputs, textareas, and contenteditable elements. WebView2 filters the resulting native menu to text-editing commands, while authentication and non-text surfaces keep their existing suppression. Inline editors also stop the row context menu from opening on right-click.

### Screenshots / recordings

Not included. The visible surface is the native WebView2 context menu; the interaction is covered by focused Playwright tests.

### Acceptance criteria

- [x] Enabled and read-only text controls may open the native editing menu.
- [x] Disabled controls, non-text inputs, and ordinary page surfaces remain suppressed.
- [x] Right-clicking an inline editor keeps the row action menu closed.
- [x] Authentication WebViews retain blanket default-menu suppression.

### DoD Checklist

- [x] Unit tests available
  - [ ] .NET backend (the production WebView2 handler was API-compiled against the pinned package)
  - [x] Frontend
- [x] Frontend tests
- [x] ~~i18n - All user-facing strings are translated~~ (no user-facing strings added)
- [x] ~~documentation~~ (no documentation change needed)

## Related issues

Fixes #3209

### Out-of-scope

- Enabling browser/navigation commands on non-text surfaces.
- Replacing WebView2's native editing menu with a custom localized menu.

### Notes

Validation:

- Fresh `npm ci` and `npm ls --depth=0`
- ESLint and Prettier on all changed frontend files
- `vitest --run src/lib/__tests__/contextMenuPolicy.test.ts` (5 tests)
- Focused Chromium Playwright run (2 tests)
- `npm run build`
- WebView2 context-menu handler compiled against `Microsoft.Web.WebView2.Core` 1.0.4022.49
- `git diff --check`

The full legacy .NET project build was attempted, but NuGet/MSBuild hit the Windows 260-character path limit inside the coordinator-generated workspace before compilation.
