### PR TITLE
Docs - adding a new UI language also requires backend registration

### DIFF
--- a/src/MobiFlightConnector/frontend/README.md
+++ b/src/MobiFlightConnector/frontend/README.md
@@ -65,6 +65,8 @@ npm run check:hardcoded-strings          # components with hardcoded strings
 npm run check:hardcoded-strings:verbose
 ```
 
+Adding a new locale folder under `public/locales/{lang}/` is enough for the React UI itself — i18next discovers and loads it automatically. However, language switching still happens in the legacy WinForms Settings dialog, not in the React UI. To make a new language selectable, add it to the list in `UI/Panels/Settings/GeneralPanel.cs` (repo root, not under `frontend/`).
+
 ## Testing
 
 See [tests/README.md](tests/README.md).

--- a/src/MobiFlightConnector/frontend/README.md
+++ b/src/MobiFlightConnector/frontend/README.md
@@ -65,7 +65,7 @@ npm run check:hardcoded-strings          # components with hardcoded strings
 npm run check:hardcoded-strings:verbose
 ```
 
-Adding a new locale folder under `public/locales/{lang}/` is enough for the React UI itself — i18next discovers and loads it automatically. However, language switching still happens in the legacy WinForms Settings dialog, not in the React UI. To make a new language selectable, add it to the list in `UI/Panels/Settings/GeneralPanel.cs` (repo root, not under `frontend/`).
+Adding a new locale folder under `public/locales/{lang}/` is enough for the React UI itself — i18next discovers and loads it automatically. However, language switching still happens in the legacy WinForms Settings dialog, not in the React UI. To make a new language selectable, add it to `InitializeLanguageComboBox()` in `src/MobiFlightConnector/UI/Panels/Settings/GeneralPanel.cs` (outside `frontend/`).
 
 ## Testing
 


### PR DESCRIPTION
### Summary
Adds a short note to the frontend README's Translations (i18n) section explaining that (`UI/Panels/Settings/GeneralPanel.cs`) also needs a new entry for the language to actually work. 

### Screenshots / recordings
~~Before/After for UI changes~~ — not applicable, docs-only change.

### Acceptance criteria
- [x] updated the README file 

### DoD Checklist
- ~~Unit tests available~~ — docs-only, no code changed
  - ~~.NET backend~~
  - ~~Frontend~~
- ~~Frontend tests~~
- ~~i18n - All user-facing strings are translated~~ — no translation strings changed
  - ~~core (en,de,es)~~
  - ~~additional langs~~
- [x] documentation
  - ~~User docs (docs.mobiflight.com)~~ — developer-facing only
  - [x] Developer docs (e.g., README.md)

## Related issues
fixes #3215
