### PR TITLE
Virtualize the HubHop preset lists in the config wizard

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/ui/scroll-area.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/ui/scroll-area.tsx
@@ -5,14 +5,19 @@ import { cn } from "@/lib/utils"
 
 const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
->(({ className, children, ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
+    viewportRef?: React.Ref<HTMLDivElement>
+  }
+>(({ className, children, viewportRef, ...props }, ref) => (
   <ScrollAreaPrimitive.Root
     ref={ref}
     className={cn("relative overflow-hidden", className)}
     {...props}
   >
-    <ScrollAreaPrimitive.Viewport className="absolute inset-0 h-full w-full rounded-[inherit]">
+    <ScrollAreaPrimitive.Viewport
+      ref={viewportRef}
+      className="absolute inset-0 h-full w-full rounded-[inherit]"
+    >
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -12,13 +12,26 @@ import { Preset, XplanePreset } from "@/types/preset"
 import { AircraftInfo } from "@/types/project"
 import { IconX } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { useTranslation } from "react-i18next"
 export type MsfsPresetPanelProps = {
   variant: "input" | "output"
   selectedPresetId: string | null
   setSelectedPreset: (preset: Preset | XplanePreset | null) => void
 }
+
+// Outside the component so it isn't a fresh value on every render (it is a
+// dependency of scrollActivePresetIntoView below).
+const SCROLL_INTO_VIEW_TIMEOUT = 800
+
 const MsfsPresetPanel = ({
   variant,
   selectedPresetId,
@@ -27,8 +40,7 @@ const MsfsPresetPanel = ({
   const { t } = useTranslation()
   const { project } = useProjectStore()
   const [favoritesOnly, setFavoritesOnly] = useState(true)
-  const SCROLL_INTO_VIEW_TIMEOUT = 800
-  const refActiveElement = useRef<HTMLDivElement | null>(null)
+  const viewportRef = useRef<HTMLDivElement | null>(null)
   const scrollTimeoutRef = useRef<number | null>(null)
   const cancelScrollIntoView = () => {
     if (scrollTimeoutRef.current !== null) {
@@ -37,37 +49,44 @@ const MsfsPresetPanel = ({
     }
   }
 
-  const scrollActivePresetIntoView = useCallback(() => {
-    if (refActiveElement.current) {
-      cancelScrollIntoView()
-      scrollTimeoutRef.current = window.setTimeout(() => {
-        refActiveElement.current?.scrollIntoView({
-          behavior: "smooth",
-          block: "nearest",
-        })
-        scrollTimeoutRef.current = null
-      }, SCROLL_INTO_VIEW_TIMEOUT)
-    }
-  }, [refActiveElement, scrollTimeoutRef])
-  const validPresetTypes =
-    variant === "input" ? ["input", "input (potentiometer)"] : ["output"]
+  // Give PresetListItem a stable callback identity so React.memo on it is
+  // actually effective, without requiring callers to memoize setSelectedPreset.
+  const setSelectedPresetRef = useRef(setSelectedPreset)
+  useEffect(() => {
+    setSelectedPresetRef.current = setSelectedPreset
+  })
+  const handleSelectPreset = useCallback(
+    (preset: Preset | XplanePreset | null) =>
+      setSelectedPresetRef.current(preset),
+    [],
+  )
+
+  const validPresetTypes = useMemo(
+    () =>
+      variant === "input" ? ["input", "input (potentiometer)"] : ["output"],
+    [variant],
+  )
   const { data: presets = [] /*, isLoading */ } = useQuery({
     queryKey: ["msfs-presets"],
     queryFn: () => fetchHubHopPresets("msfs"),
     // presets don't change at runtime; HubHopState drives invalidation
     staleTime: Infinity,
   })
-  const projectAircraftFilter = (p: Preset) =>
-    (project?.Aircraft?.length ?? 0) > 0
-      ? project!.Aircraft!.some(
-          (a: AircraftInfo) => a.Name === p.aircraft && a.Vendor === p.vendor,
-        )
-      : true
-  const validPresets = presets.filter(
-    (p: Preset) =>
-      validPresetTypes.includes(p.presetType.toLowerCase()) &&
-      (favoritesOnly ? projectAircraftFilter(p) : true),
-  )
+  const validPresets = useMemo(() => {
+    const aircraftList = project?.Aircraft
+    const hasAircraft = (aircraftList?.length ?? 0) > 0
+    const projectAircraftFilter = (p: Preset) =>
+      hasAircraft
+        ? aircraftList!.some(
+            (a: AircraftInfo) => a.Name === p.aircraft && a.Vendor === p.vendor,
+          )
+        : true
+    return presets.filter(
+      (p: Preset) =>
+        validPresetTypes.includes(p.presetType.toLowerCase()) &&
+        (favoritesOnly ? projectAircraftFilter(p) : true),
+    )
+  }, [presets, validPresetTypes, favoritesOnly, project?.Aircraft])
   const selectedPreset = validPresets.find((p) => p.id === selectedPresetId)
   const [filter, setFilter] = useState({
     vendor: selectedPreset?.vendor || "",
@@ -75,54 +94,117 @@ const MsfsPresetPanel = ({
     system: selectedPreset?.system || "",
     search: "",
   })
-  const filteredPresets = validPresets.filter(
-    (p) =>
-      (filter.vendor ? p.vendor === filter.vendor : true) &&
-      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      (filter.system ? p.system === filter.system : true) &&
-      filterPresetByText(p, filter.search),
+  const deferredSearch = useDeferredValue(filter.search)
+  const filteredPresets = useMemo(
+    () =>
+      validPresets.filter(
+        (p) =>
+          (filter.vendor ? p.vendor === filter.vendor : true) &&
+          (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+          (filter.system ? p.system === filter.system : true) &&
+          filterPresetByText(p, deferredSearch),
+      ),
+    [validPresets, filter.vendor, filter.aircraft, filter.system, deferredSearch],
   )
-  const filteredCategoryPresets = validPresets.filter(
-    (p) =>
-      (filter.vendor ? p.vendor === filter.vendor : true) &&
-      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      filterPresetByText(p, filter.search),
+  const filteredCategoryPresets = useMemo(
+    () =>
+      validPresets.filter(
+        (p) =>
+          (filter.vendor ? p.vendor === filter.vendor : true) &&
+          (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+          filterPresetByText(p, deferredSearch),
+      ),
+    [validPresets, filter.vendor, filter.aircraft, deferredSearch],
   )
-  const filteredVendorPresets = validPresets.filter(
-    (p) =>
-      (filter.system ? p.system === filter.system : true) &&
-      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      filterPresetByText(p, filter.search),
+  const filteredVendorPresets = useMemo(
+    () =>
+      validPresets.filter(
+        (p) =>
+          (filter.system ? p.system === filter.system : true) &&
+          (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+          filterPresetByText(p, deferredSearch),
+      ),
+    [validPresets, filter.system, filter.aircraft, deferredSearch],
   )
-  const filteredAircraftPresets = validPresets.filter(
-    (p) =>
-      (filter.vendor ? p.vendor === filter.vendor : true) &&
-      (filter.system ? p.system === filter.system : true) &&
-      filterPresetByText(p, filter.search),
+  const filteredAircraftPresets = useMemo(
+    () =>
+      validPresets.filter(
+        (p) =>
+          (filter.vendor ? p.vendor === filter.vendor : true) &&
+          (filter.system ? p.system === filter.system : true) &&
+          filterPresetByText(p, deferredSearch),
+      ),
+    [validPresets, filter.vendor, filter.system, deferredSearch],
   )
-  const categories = [
-    ...new Set([
-      ...filteredCategoryPresets.map((p) => p.system),
-      ...(filter.system ? [filter.system] : []),
-    ]),
-  ].sort()
-  const aircraft = [
-    ...new Set([
-      ...filteredAircraftPresets.map((p) => p.aircraft),
-      ...(filter.aircraft ? [filter.aircraft] : []),
-    ]),
-  ].sort()
-  const vendors = [
-    ...new Set([
-      ...filteredVendorPresets.map((p) => p.vendor),
-      ...(filter.vendor ? [filter.vendor] : []),
-    ]),
-  ].sort()
+  const categories = useMemo(
+    () =>
+      [
+        ...new Set([
+          ...filteredCategoryPresets.map((p) => p.system),
+          ...(filter.system ? [filter.system] : []),
+        ]),
+      ].sort(),
+    [filteredCategoryPresets, filter.system],
+  )
+  const aircraft = useMemo(
+    () =>
+      [
+        ...new Set([
+          ...filteredAircraftPresets.map((p) => p.aircraft),
+          ...(filter.aircraft ? [filter.aircraft] : []),
+        ]),
+      ].sort(),
+    [filteredAircraftPresets, filter.aircraft],
+  )
+  const vendors = useMemo(
+    () =>
+      [
+        ...new Set([
+          ...filteredVendorPresets.map((p) => p.vendor),
+          ...(filter.vendor ? [filter.vendor] : []),
+        ]),
+      ].sort(),
+    [filteredVendorPresets, filter.vendor],
+  )
+
+  const selectedIndex = useMemo(
+    () => filteredPresets.findIndex((p) => p.id === selectedPresetId),
+    [filteredPresets, selectedPresetId],
+  )
+
+  // Must keep a stable identity: the virtualizer's measurement memo compares
+  // getItemKey by reference, and a changed identity makes it notify React
+  // during render. A fresh arrow on every render therefore loops until React
+  // bails out with "Too many re-renders".
+  const getPresetKey = useCallback(
+    (index: number) => filteredPresets[index].id,
+    [filteredPresets],
+  )
+
+  const rowVirtualizer = useVirtualizer({
+    count: filteredPresets.length,
+    getScrollElement: () => viewportRef.current,
+    // Initial estimate only; measureElement refines it once a row mounts.
+    // Matches a single-line row: 20px title, 12px description, 2px borders,
+    // 8px vertical padding and the 4px gap on the wrapper.
+    estimateSize: () => 48,
+    overscan: 8,
+    getItemKey: getPresetKey,
+  })
+
+  const scrollActivePresetIntoView = useCallback(() => {
+    if (selectedIndex < 0) return
+    cancelScrollIntoView()
+    scrollTimeoutRef.current = window.setTimeout(() => {
+      rowVirtualizer.scrollToIndex(selectedIndex, { align: "center" })
+      scrollTimeoutRef.current = null
+    }, SCROLL_INTO_VIEW_TIMEOUT)
+  }, [selectedIndex, rowVirtualizer])
 
   useEffect(() => {
-    if (!refActiveElement.current) return
     scrollActivePresetIntoView()
-  }, [refActiveElement, scrollActivePresetIntoView])
+    return cancelScrollIntoView
+  }, [scrollActivePresetIntoView])
   return (
     <Card className="grow">
       <CardContent className="flex flex-col gap-4 pt-4">
@@ -249,19 +331,33 @@ const MsfsPresetPanel = ({
         <div className="-mt-3 flex flex-col gap-2">
           <ScrollArea
             className="h-56"
+            viewportRef={viewportRef}
             onMouseEnter={cancelScrollIntoView}
             onMouseLeave={scrollActivePresetIntoView}
           >
-            <div className="flex flex-col gap-1" role="list">
-              {filteredPresets.map((preset) => (
-                <PresetListItem
-                  ref={preset.id === selectedPresetId ? refActiveElement : null}
-                  key={preset.id}
-                  preset={preset}
-                  isSelected={preset.id === selectedPresetId}
-                  setSelectedPreset={setSelectedPreset}
-                />
-              ))}
+            <div
+              role="list"
+              className="relative w-full"
+              style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                const preset = filteredPresets[virtualRow.index]
+                return (
+                  <div
+                    key={virtualRow.key}
+                    ref={rowVirtualizer.measureElement}
+                    data-index={virtualRow.index}
+                    className="absolute top-0 left-0 w-full pb-1"
+                    style={{ transform: `translateY(${virtualRow.start}px)` }}
+                  >
+                    <PresetListItem
+                      preset={preset}
+                      isSelected={preset.id === selectedPresetId}
+                      setSelectedPreset={handleSelectPreset}
+                    />
+                  </div>
+                )
+              })}
             </div>
           </ScrollArea>
         </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
@@ -12,7 +12,15 @@ import { Preset, XplanePreset } from "@/types/preset"
 import { AircraftInfo } from "@/types/project"
 import { IconX } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
-import { useCallback, useEffect, useRef, useState } from "react"
+import { useVirtualizer } from "@tanstack/react-virtual"
+import {
+  useCallback,
+  useDeferredValue,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { useTranslation } from "react-i18next"
 
 export type XplanePresetPanelProps = {
@@ -20,6 +28,10 @@ export type XplanePresetPanelProps = {
   selectedPath: string | null
   setSelectedPreset: (preset: XplanePreset | Preset | null) => void
 }
+
+// Outside the component so it isn't a fresh value on every render (it is a
+// dependency of scrollActiveProjectIntoView below).
+const SCROLL_INTO_VIEW_TIMEOUT = 800
 
 const XplanePresetPanel = ({
   variant,
@@ -30,8 +42,7 @@ const XplanePresetPanel = ({
   const { project } = useProjectStore()
   const [favoritesOnly, setFavoritesOnly] = useState(true)
 
-  const SCROLL_INTO_VIEW_TIMEOUT = 800
-  const refActiveElement = useRef<HTMLDivElement | null>(null)
+  const viewportRef = useRef<HTMLDivElement | null>(null)
   const scrollTimeoutRef = useRef<number | null>(null)
 
   const cancelScrollIntoView = () => {
@@ -41,23 +52,25 @@ const XplanePresetPanel = ({
     }
   }
 
-  const scrollActiveProjectIntoView = useCallback(() => {
-    if (refActiveElement.current) {
-      cancelScrollIntoView()
-      scrollTimeoutRef.current = window.setTimeout(() => {
-        refActiveElement.current?.scrollIntoView({
-          behavior: "smooth",
-          block: "nearest",
-        })
-        scrollTimeoutRef.current = null
-      }, SCROLL_INTO_VIEW_TIMEOUT)
-    }
-  }, [refActiveElement, scrollTimeoutRef])
+  // Give PresetListItem a stable callback identity so React.memo on it is
+  // actually effective, without requiring callers to memoize setSelectedPreset.
+  const setSelectedPresetRef = useRef(setSelectedPreset)
+  useEffect(() => {
+    setSelectedPresetRef.current = setSelectedPreset
+  })
+  const handleSelectPreset = useCallback(
+    (preset: Preset | XplanePreset | null) =>
+      setSelectedPresetRef.current(preset),
+    [],
+  )
 
-  const validPresetTypes =
-    variant === "input"
-      ? ["input", "inputoutput", "input (potentiometer)"]
-      : ["output", "inputoutput"]
+  const validPresetTypes = useMemo(
+    () =>
+      variant === "input"
+        ? ["input", "inputoutput", "input (potentiometer)"]
+        : ["output", "inputoutput"],
+    [variant],
+  )
 
   const { data: presets = [] } = useQuery({
     queryKey: ["xplane-presets"],
@@ -65,18 +78,21 @@ const XplanePresetPanel = ({
     staleTime: Infinity,
   })
 
-  const projectAircraftFilter = (p: XplanePreset) =>
-    (project?.Aircraft?.length ?? 0) > 0
-      ? project!.Aircraft!.some(
-          (a: AircraftInfo) => a.Name === p.aircraft && a.Vendor === p.vendor,
-        )
-      : true
-
-  const validPresets = presets.filter(
-    (p: XplanePreset) =>
-      validPresetTypes.includes(p.presetType.toLowerCase()) &&
-      (favoritesOnly ? projectAircraftFilter(p) : true),
-  )
+  const validPresets = useMemo(() => {
+    const aircraftList = project?.Aircraft
+    const hasAircraft = (aircraftList?.length ?? 0) > 0
+    const projectAircraftFilter = (p: XplanePreset) =>
+      hasAircraft
+        ? aircraftList!.some(
+            (a: AircraftInfo) => a.Name === p.aircraft && a.Vendor === p.vendor,
+          )
+        : true
+    return presets.filter(
+      (p: XplanePreset) =>
+        validPresetTypes.includes(p.presetType.toLowerCase()) &&
+        (favoritesOnly ? projectAircraftFilter(p) : true),
+    )
+  }, [presets, validPresetTypes, favoritesOnly, project?.Aircraft])
 
   const selectedPreset = validPresets.find((p) => p.code === selectedPath)
 
@@ -87,58 +103,118 @@ const XplanePresetPanel = ({
     search: "",
   })
 
-  const filteredPresets = validPresets.filter(
-    (p) =>
-      (filter.vendor ? p.vendor === filter.vendor : true) &&
-      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      (filter.system ? p.system === filter.system : true) &&
-      filterPresetByText(p, filter.search),
+  const deferredSearch = useDeferredValue(filter.search)
+
+  const filteredPresets = useMemo(
+    () =>
+      validPresets.filter(
+        (p) =>
+          (filter.vendor ? p.vendor === filter.vendor : true) &&
+          (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+          (filter.system ? p.system === filter.system : true) &&
+          filterPresetByText(p, deferredSearch),
+      ),
+    [validPresets, filter.vendor, filter.aircraft, filter.system, deferredSearch],
   )
 
-  const filteredCategoryPresets = validPresets.filter(
-    (p) =>
-      (filter.vendor ? p.vendor === filter.vendor : true) &&
-      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      filterPresetByText(p, filter.search),
+  const filteredCategoryPresets = useMemo(
+    () =>
+      validPresets.filter(
+        (p) =>
+          (filter.vendor ? p.vendor === filter.vendor : true) &&
+          (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+          filterPresetByText(p, deferredSearch),
+      ),
+    [validPresets, filter.vendor, filter.aircraft, deferredSearch],
   )
 
-  const filteredVendorPresets = validPresets.filter(
-    (p) =>
-      (filter.system ? p.system === filter.system : true) &&
-      (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
-      filterPresetByText(p, filter.search),
+  const filteredVendorPresets = useMemo(
+    () =>
+      validPresets.filter(
+        (p) =>
+          (filter.system ? p.system === filter.system : true) &&
+          (filter.aircraft ? p.aircraft === filter.aircraft : true) &&
+          filterPresetByText(p, deferredSearch),
+      ),
+    [validPresets, filter.system, filter.aircraft, deferredSearch],
   )
 
-  const filteredAircraftPresets = validPresets.filter(
-    (p) =>
-      (filter.vendor ? p.vendor === filter.vendor : true) &&
-      (filter.system ? p.system === filter.system : true) &&
-      filterPresetByText(p, filter.search),
+  const filteredAircraftPresets = useMemo(
+    () =>
+      validPresets.filter(
+        (p) =>
+          (filter.vendor ? p.vendor === filter.vendor : true) &&
+          (filter.system ? p.system === filter.system : true) &&
+          filterPresetByText(p, deferredSearch),
+      ),
+    [validPresets, filter.vendor, filter.system, deferredSearch],
   )
 
-  const categories = [
-    ...new Set([
-      ...filteredCategoryPresets.map((p) => p.system),
-      ...(filter.system ? [filter.system] : []),
-    ]),
-  ].sort()
-  const aircraft = [
-    ...new Set([
-      ...filteredAircraftPresets.map((p) => p.aircraft),
-      ...(filter.aircraft ? [filter.aircraft] : []),
-    ]),
-  ].sort()
-  const vendors = [
-    ...new Set([
-      ...filteredVendorPresets.map((p) => p.vendor),
-      ...(filter.vendor ? [filter.vendor] : []),
-    ]),
-  ].sort()
+  const categories = useMemo(
+    () =>
+      [
+        ...new Set([
+          ...filteredCategoryPresets.map((p) => p.system),
+          ...(filter.system ? [filter.system] : []),
+        ]),
+      ].sort(),
+    [filteredCategoryPresets, filter.system],
+  )
+  const aircraft = useMemo(
+    () =>
+      [
+        ...new Set([
+          ...filteredAircraftPresets.map((p) => p.aircraft),
+          ...(filter.aircraft ? [filter.aircraft] : []),
+        ]),
+      ].sort(),
+    [filteredAircraftPresets, filter.aircraft],
+  )
+  const vendors = useMemo(
+    () =>
+      [
+        ...new Set([
+          ...filteredVendorPresets.map((p) => p.vendor),
+          ...(filter.vendor ? [filter.vendor] : []),
+        ]),
+      ].sort(),
+    [filteredVendorPresets, filter.vendor],
+  )
+
+  const selectedIndex = useMemo(
+    () => filteredPresets.findIndex((p) => p.code === selectedPath),
+    [filteredPresets, selectedPath],
+  )
+
+  const getPresetKey = useCallback(
+    (index: number) => filteredPresets[index].id,
+    [filteredPresets],
+  )
+
+  const rowVirtualizer = useVirtualizer({
+    count: filteredPresets.length,
+    getScrollElement: () => viewportRef.current,
+    // Initial estimate only; measureElement refines it once a row mounts.
+    // Matches a single-line row: 20px title, 12px description, 2px borders,
+    // 8px vertical padding and the 4px gap on the wrapper.
+    estimateSize: () => 48,
+    overscan: 8,
+    getItemKey: getPresetKey,
+  })
+
+  const scrollActiveProjectIntoView = useCallback(() => {
+    if (selectedIndex < 0) return
+    cancelScrollIntoView()
+    scrollTimeoutRef.current = window.setTimeout(() => {
+      rowVirtualizer.scrollToIndex(selectedIndex, { align: "center" })
+      scrollTimeoutRef.current = null
+    }, SCROLL_INTO_VIEW_TIMEOUT)
+  }, [selectedIndex, rowVirtualizer])
 
   useEffect(() => {
-    if (!refActiveElement.current) return
     scrollActiveProjectIntoView()
-  }, [refActiveElement, scrollActiveProjectIntoView])
+    return cancelScrollIntoView
+  }, [scrollActiveProjectIntoView])
 
   return (
     <Card className="grow">
@@ -266,19 +342,33 @@ const XplanePresetPanel = ({
         <div className="-mt-3 flex flex-col gap-2">
           <ScrollArea
             className="h-56"
+            viewportRef={viewportRef}
             onMouseEnter={cancelScrollIntoView}
             onMouseLeave={scrollActiveProjectIntoView}
           >
-            <div className="flex flex-col gap-1" role="list">
-              {filteredPresets.map((preset) => (
-                <PresetListItem
-                  ref={preset.code === selectedPath ? refActiveElement : null}
-                  key={preset.code}
-                  preset={preset}
-                  isSelected={preset.code === selectedPath}
-                  setSelectedPreset={setSelectedPreset}
-                />
-              ))}
+            <div
+              role="list"
+              className="relative w-full"
+              style={{ height: `${rowVirtualizer.getTotalSize()}px` }}
+            >
+              {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                const preset = filteredPresets[virtualRow.index]
+                return (
+                  <div
+                    key={virtualRow.key}
+                    ref={rowVirtualizer.measureElement}
+                    data-index={virtualRow.index}
+                    className="absolute top-0 left-0 w-full pb-1"
+                    style={{ transform: `translateY(${virtualRow.start}px)` }}
+                  >
+                    <PresetListItem
+                      preset={preset}
+                      isSelected={preset.code === selectedPath}
+                      setSelectedPreset={handleSelectPreset}
+                    />
+                  </div>
+                )
+              })}
             </div>
           </ScrollArea>
         </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/PresetListItem.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/PresetListItem.tsx
@@ -1,6 +1,6 @@
 import { cn } from "@/lib/utils"
 import { Preset, XplanePreset } from "@/types/preset"
-import { forwardRef } from "react"
+import { forwardRef, memo } from "react"
 
 type PresetListItemProps = {
   preset: Preset | XplanePreset
@@ -8,33 +8,36 @@ type PresetListItemProps = {
   setSelectedPreset: (preset: Preset | XplanePreset | null) => void
 }
 
-export const PresetListItem = forwardRef<HTMLDivElement, PresetListItemProps>(
-  ({ preset, isSelected, setSelectedPreset }: PresetListItemProps, ref) => {
-    return (
-      <div
-        ref={ref}
-        role="listitem"
-        className={cn(
-          "bg-accent/25 hover:bg-accent/50 border-background flex cursor-pointer flex-row justify-between gap-2 rounded-md border-2 px-2 pt-0.5 pb-1.5",
-          isSelected && "bg-primary/20 border-primary border-2",
-        )}
-        onClick={() => setSelectedPreset(preset)}
-      >
-        <div className="flex flex-col">
-          <div className="text-sm font-semibold">{preset.label}</div>
-          <div className="text-muted-foreground text-xs/3">
-            {preset.description ?? "-"}
+export const PresetListItem = memo(
+  forwardRef<HTMLDivElement, PresetListItemProps>(
+    ({ preset, isSelected, setSelectedPreset }: PresetListItemProps, ref) => {
+      return (
+        <div
+          ref={ref}
+          role="listitem"
+          className={cn(
+            "bg-accent/25 hover:bg-accent/50 border-background flex cursor-pointer flex-row justify-between gap-2 rounded-md border-2 px-2 pt-0.5 pb-1.5",
+            isSelected && "bg-primary/20 border-primary border-2",
+          )}
+          onClick={() => setSelectedPreset(preset)}
+        >
+          <div className="flex flex-col">
+            <div className="text-sm font-semibold">{preset.label}</div>
+            <div className="text-muted-foreground text-xs/3">
+              {preset.description ?? "-"}
+            </div>
+          </div>
+          <div className="flex flex-col justify-items-end px-2">
+            <div className="text-right text-sm/5 font-semibold">
+              {preset.system}
+            </div>
+            <div className="text-muted-foreground text-right text-xs/3">
+              {preset.aircraft}
+            </div>
           </div>
         </div>
-        <div className="flex flex-col justify-items-end px-2">
-          <div className="text-right text-sm/5 font-semibold">
-            {preset.system}
-          </div>
-          <div className="text-muted-foreground text-right text-xs/3">
-            {preset.aircraft}
-          </div>
-        </div>
-      </div>
-    )
-  },
+      )
+    },
+  ),
 )
+PresetListItem.displayName = "PresetListItem"

--- a/src/MobiFlightConnector/frontend/src/lib/configWizard.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/configWizard.ts
@@ -76,9 +76,25 @@ export const fetchHubHopPresets = async (sim: "msfs" | "xplane") => {
   return fetch(presetFile).then((r) => r.json() as Promise<Preset[]>)
 }
 
+// Preset objects are stable references while their data doesn't change
+// (they're held by the TanStack Query cache with staleTime: Infinity), so a
+// WeakMap actually hits here and saves rebuilding the lowercased haystack
+// string on every filter pass across ~25k presets.
+const haystackCache = new WeakMap<object, string>()
+
+const presetHaystack = (preset: Preset) => {
+  let haystack = haystackCache.get(preset)
+  if (haystack === undefined) {
+    haystack =
+      `${preset.label} ${preset.description ?? ""} ${preset.code}`.toLowerCase()
+    haystackCache.set(preset, haystack)
+  }
+  return haystack
+}
+
 export const filterPresetByText = (preset: Preset, filter: string) => {
   const terms = filter.toLowerCase().trim().split(/\s+/).filter(Boolean)
-  const haystack =
-    `${preset.label} ${preset.description ?? ""} ${preset.code}`.toLowerCase()
+  if (terms.length === 0) return true
+  const haystack = presetHaystack(preset)
   return terms.every((t) => haystack.includes(t))
 }


### PR DESCRIPTION
### Summary
Opening an MSFS action editor took about nine seconds, and closing it about
two. The preset panel rendered the entire HubHop library into a 224px tall
scroll area — 25,152 rows for the input list, 6,977 for the output one — so
every open built tens of thousands of DOM nodes that were never visible. The
X-Plane panel does the same with 7,960 and 7,085 rows.

The lists are now virtualized with @tanstack/react-virtual, which is already
a dependency. At most 21 rows exist at a time: about five fit in the viewport,
plus eight rows of overscan on each side. Opening and closing the editor is
immediate, scrolling is smooth, and typing in the Code field no longer stalls
on each character.

Three smaller changes come along, each of which was also costing a full pass
over the library on every render:

- The passes that build the filtered lists and the vendor/aircraft/system
  dropdowns are memoized instead of re-running on every render.
- The text filter no longer rebuilds a lowercased concatenation per preset per
  call; it caches one per preset in a WeakMap and short-circuits when the
  filter is empty.
- PresetListItem is memoized, and the panel gives it a callback with a stable
  identity so the memo is effective without requiring changes in callers.

One detail worth flagging for review: getItemKey is deliberately wrapped in
useCallback. The virtualizer keeps it in a memo dependency list, compares it
by reference, and notifies React from that memo's onChange — and setOptions
runs during render. An inline arrow there schedules a render from inside a
render on every pass, which React ends with "Too many re-renders". The key is
derived from the preset id rather than the row index so cached row
measurements follow the preset when the filter changes; ids are unique across
both preset files, codes are not.

### Screenshots / recordings
No visual change is intended — same layout, same styled ScrollArea, same row
markup.

### Acceptance criteria
- [x] MSFS preset list renders only the visible rows
- [x] X-Plane preset list renders only the visible rows
- [x] Selecting a preset still fills in the code and the Step 3 details
- [x] Opening a config with a valid preset still scrolls to it and highlights it
- [x] Vendor / aircraft / system / text filters and "Reset filters" behave as before
- [x] "Project aircraft only" behaves as before
- [x] Rows with a two-line description are not clipped or overlapped

### DoD Checklist
- [ ] Unit tests available
  - [ ] .NET backend
  - [ ] Frontend
- [ ] Frontend tests
- [x] i18n - All user-facing strings are translated
  - [x] core (en,de,es)
  - [x] additional langs
- [ ] documentation
  - [ ] User docs (docs.mobiflight.com)
  - [ ] Developer docs (e.g., readme.md)

## Related issues
fixes #3223

### Out-of-scope
The report also suggests storing vendor/aircraft/system next to the PresetId,
and not showing the whole library when nothing is selected. Both change the
project format or the UX, and virtualization removes the performance reason
for them, so they are left out of this PR.

### Notes
Backend untouched; no new dependencies. Built against 11.2.0 and verified in a
real install with a 270 config item project before being rebased onto main.
