### PR TITLE
Add loading state for HubHop presets

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -11,7 +11,6 @@ import { Button } from "@/components/ui/button"
 import IconBrandHubHopLogo from "@/components/icons/IconBrandHubHopLogo"
 import { IconExclamationCircle } from "@tabler/icons-react"
 import useOpenUrl from "@/lib/hooks/useOpenUrl"
-import LoadingSpinner from "../LoadingSpinner"
 
 export type MsfsInputActionPanelProps = {
   variant: "summary" | "details"
@@ -33,9 +32,7 @@ const MsfsInputActionPanel = ({
     // presets don't change at runtime; HubHopState drives invalidation
     staleTime: Infinity,
   })
-
-
-
+  
   const preset = presets.find((p) => p.id === config?.PresetId) ?? null
 
   if (variant === "summary") {
@@ -82,6 +79,7 @@ const MsfsInputActionPanel = ({
     <div className="flex flex-col gap-4">
       <MsfsPresetPanel
         variant="input"
+        isLoading={isLoading}
         selectedPresetId={config?.PresetId ?? null}
         setSelectedPreset={(preset) =>
           onConfigChange({
@@ -96,10 +94,7 @@ const MsfsInputActionPanel = ({
           className="flex flex-col gap-4 pt-4"
           data-testid="preset-code-panel"
         >
-          {isLoading ? (
-            <LoadingSpinner />
-          ) : (
-            <>
+        
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
               {t(
@@ -213,8 +208,6 @@ const MsfsInputActionPanel = ({
               </div>
             </div>
           </div>
-        </>
-        )}
         </CardContent>
       </Card>
     </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsInputActionPanel.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import IconBrandHubHopLogo from "@/components/icons/IconBrandHubHopLogo"
 import { IconExclamationCircle } from "@tabler/icons-react"
 import useOpenUrl from "@/lib/hooks/useOpenUrl"
+import LoadingSpinner from "../LoadingSpinner"
 
 export type MsfsInputActionPanelProps = {
   variant: "summary" | "details"
@@ -26,12 +27,15 @@ const MsfsInputActionPanel = ({
   const { t } = useTranslation()
   const openUrl = useOpenUrl()
 
-  const { data: presets = [] /*, isLoading */ } = useQuery({
+  const { data: presets = [], isLoading } = useQuery({
     queryKey: ["msfs-presets"],
     queryFn: () => fetchHubHopPresets("msfs"),
     // presets don't change at runtime; HubHopState drives invalidation
     staleTime: Infinity,
   })
+
+
+
   const preset = presets.find((p) => p.id === config?.PresetId) ?? null
 
   if (variant === "summary") {
@@ -92,6 +96,10 @@ const MsfsInputActionPanel = ({
           className="flex flex-col gap-4 pt-4"
           data-testid="preset-code-panel"
         >
+          {isLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <>
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
               {t(
@@ -205,6 +213,8 @@ const MsfsInputActionPanel = ({
               </div>
             </div>
           </div>
+        </>
+        )}
         </CardContent>
       </Card>
     </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/MsfsPresetPanel.tsx
@@ -14,13 +14,16 @@ import { IconX } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import LoadingSpinner from "../LoadingSpinner"
 export type MsfsPresetPanelProps = {
   variant: "input" | "output"
+  isLoading: boolean
   selectedPresetId: string | null
   setSelectedPreset: (preset: Preset | XplanePreset | null) => void
 }
 const MsfsPresetPanel = ({
   variant,
+  isLoading,
   selectedPresetId,
   setSelectedPreset,
 }: MsfsPresetPanelProps) => {
@@ -149,6 +152,7 @@ const MsfsPresetPanel = ({
             </Label>
           </div>
         </div>
+
         <div className="flex flex-col gap-1">
           <div className="grid grid-cols-4 gap-2">
             <Input
@@ -247,6 +251,7 @@ const MsfsPresetPanel = ({
           </div>
         </div>
         <div className="-mt-3 flex flex-col gap-2">
+          {isLoading ? <LoadingSpinner /> :(
           <ScrollArea
             className="h-56"
             onMouseEnter={cancelScrollIntoView}
@@ -264,6 +269,7 @@ const MsfsPresetPanel = ({
               ))}
             </div>
           </ScrollArea>
+        )}
         </div>
       </CardContent>
     </Card>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -13,7 +13,6 @@ import { XplanePreset } from "@/types/preset"
 import { IconExclamationCircle } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
-import LoadingSpinner from "../LoadingSpinner"
 
 const CODE_TYPE_OPTIONS: ("DataRef" | "Command")[] = ["DataRef", "Command"]
 
@@ -31,9 +30,10 @@ const XplaneInputActionPanel = ({
   const { t } = useTranslation()
   const openUrl = useOpenUrl()
 
-  const { data: presets = [],isLoading } = useQuery({
+  const { data: presets = [], isLoading } = useQuery({
     queryKey: ["xplane-presets"],
-    queryFn: () => fetchHubHopPresets("xplane") as Promise<XplanePreset[]>,
+    queryFn: () => fetchHubHopPresets("xplane") as Promise<XplanePreset[]>, 
+    // presets don't change at runtime; HubHopState drives invalidation
     staleTime: Infinity,
   })
   const preset = presets.find((p) => p.code === config?.Path) ?? null
@@ -61,6 +61,7 @@ const XplaneInputActionPanel = ({
         </div>
       </div>
     )
+  
   }
 
   const labels = {
@@ -80,6 +81,7 @@ const XplaneInputActionPanel = ({
     <div className="flex flex-col gap-4">
       <XplanePresetPanel
         variant="input"
+        isLoading={isLoading}
         selectedPath={config?.Path ?? null}
         setSelectedPreset={(preset) =>
           onConfigChange({
@@ -90,12 +92,8 @@ const XplaneInputActionPanel = ({
         }
       />
       <Card>
-        
+
         <CardContent className="flex flex-col gap-4 pt-4" data-testid="preset-code-panel">
-          {isLoading ? (
-            <LoadingSpinner />
-          ) : (
-            <>
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
               {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Title")}
@@ -259,8 +257,6 @@ const XplaneInputActionPanel = ({
               </div>
             )}
           </div>
-          </>
-          )}
         </CardContent>
       </Card>
     </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplaneInputActionPanel.tsx
@@ -13,6 +13,7 @@ import { XplanePreset } from "@/types/preset"
 import { IconExclamationCircle } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useTranslation } from "react-i18next"
+import LoadingSpinner from "../LoadingSpinner"
 
 const CODE_TYPE_OPTIONS: ("DataRef" | "Command")[] = ["DataRef", "Command"]
 
@@ -30,12 +31,11 @@ const XplaneInputActionPanel = ({
   const { t } = useTranslation()
   const openUrl = useOpenUrl()
 
-  const { data: presets = [] } = useQuery({
+  const { data: presets = [],isLoading } = useQuery({
     queryKey: ["xplane-presets"],
     queryFn: () => fetchHubHopPresets("xplane") as Promise<XplanePreset[]>,
     staleTime: Infinity,
   })
-
   const preset = presets.find((p) => p.code === config?.Path) ?? null
 
   if (variant === "summary") {
@@ -90,7 +90,12 @@ const XplaneInputActionPanel = ({
         }
       />
       <Card>
+        
         <CardContent className="flex flex-col gap-4 pt-4" data-testid="preset-code-panel">
+          {isLoading ? (
+            <LoadingSpinner />
+          ) : (
+            <>
           <div className="flex flex-col">
             <div className="text-lg font-semibold">
               {t("Dialog.InputConfigWizard.InputActions.Common.Preset.Code.Title")}
@@ -254,6 +259,8 @@ const XplaneInputActionPanel = ({
               </div>
             )}
           </div>
+          </>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/XplanePresetPanel.tsx
@@ -14,15 +14,17 @@ import { IconX } from "@tabler/icons-react"
 import { useQuery } from "@tanstack/react-query"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
+import LoadingSpinner from "../LoadingSpinner"
 
 export type XplanePresetPanelProps = {
   variant: "input" | "output"
+  isLoading: boolean
   selectedPath: string | null
   setSelectedPreset: (preset: XplanePreset | Preset | null) => void
 }
-
 const XplanePresetPanel = ({
   variant,
+  isLoading,
   selectedPath,
   setSelectedPreset,
 }: XplanePresetPanelProps) => {
@@ -264,6 +266,7 @@ const XplanePresetPanel = ({
           </div>
         </div>
         <div className="-mt-3 flex flex-col gap-2">
+          {isLoading ? <LoadingSpinner /> : (
           <ScrollArea
             className="h-56"
             onMouseEnter={cancelScrollIntoView}
@@ -281,6 +284,7 @@ const XplanePresetPanel = ({
               ))}
             </div>
           </ScrollArea>
+        )}
         </div>
       </CardContent>
     </Card>

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/LoadingSpinner.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/LoadingSpinner.tsx
@@ -1,0 +1,12 @@
+import { IconLoader2 } from "@tabler/icons-react"
+
+//loading spinner component to be used in the wizard when fetching presets
+const LoadingSpinner = () => {
+  return (
+    <div className="flex items-center justify-center p-6" data-testid="loading-spinner">
+      <IconLoader2 className="text-primary h-8 w-8 animate-spin" />
+    </div>
+  )
+}
+
+export default LoadingSpinner

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2979,6 +2979,12 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await expect(actionInputOption).toBeVisible()
     await actionInputOption.click()
 
+    //loading spinner may be visible while the preset list is being fetched
+    const loadingSpinner = page.getByTestId("loading-spinner")
+    if (await loadingSpinner.isVisible().catch(() => false)) {
+      await expect(loadingSpinner).toBeHidden()
+    }
+
     const codeInput = actionEditor.getByPlaceholder("Enter RPN code")
 
     await expect(codeInput).toBeVisible()
@@ -3540,6 +3546,12 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await expect(actionInputOption).toBeVisible()
     await actionInputOption.click()
 
+      //loading spinner may be visible while the preset list is being fetched
+    const loadingSpinner = page.getByTestId("loading-spinner")
+    if (await loadingSpinner.isVisible().catch(() => false)) {
+      await expect(loadingSpinner).toBeHidden()
+    }
+    
     // Open the input type combo box to get access to the options
     const inputTypeComboBox = actionEditor
       .getByRole("combobox")

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -3011,19 +3011,26 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    await page.route("**/*", async (route) => {
-      const request = route.request()
+    let resolvePresetsLoading!: () => void
 
-      if (request.url().includes("hubhop")) {
-        await new Promise((resolve) => setTimeout(resolve, 2000))
-      }
-
-      await route.continue()
+    const presetsLoadingPromise = new Promise<void>((resolve) => {
+      resolvePresetsLoading = resolve
     })
+
+    await page.route(
+      "**/presets/msfs2020_hubhop_presets.json",
+      async (route) => {
+        await presetsLoadingPromise
+        await route.continue()
+      },
+    )
 
     const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
+      "Button",
+      "On Press",
+      { Sim: "msfs" },
     )
 
     const actionTypeComboBox = actionEditor.getByTestId("action-type-combobox")
@@ -3041,6 +3048,9 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     const loadingSpinner = page.getByTestId("loading-spinner")
 
     await expect(loadingSpinner).toBeVisible()
+
+    resolvePresetsLoading()
+
     await expect(loadingSpinner).toBeHidden()
   })
 })
@@ -3685,20 +3695,23 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     configListPage,
     page,
   }) => {
-    let continueLoading!: () => void
+    let resolvePresetsLoading!: () => void
 
-    const loadingPromise = new Promise<void>((resolve) => {
-      continueLoading = resolve
+    const presetsLoadingPromise = new Promise<void>((resolve) => {
+      resolvePresetsLoading = resolve
     })
 
     await page.route("**/presets/xplane_hubhop_presets.json", async (route) => {
-      await loadingPromise
+      await presetsLoadingPromise
       await route.continue()
     })
 
     const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
       configListPage,
       page,
+      "Button",
+      "On Press",
+      { Sim: "xplane" },
     )
 
     const actionTypeComboBox = actionEditor.getByTestId("action-type-combobox")
@@ -3707,7 +3720,7 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await actionTypeComboBox.click()
 
     const actionInputOption = page.getByRole("option", {
-      name: "Microsoft Flight Simulator (all versions)",
+      name: "X-Plane (all versions)",
     })
 
     await expect(actionInputOption).toBeVisible()
@@ -3715,13 +3728,10 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
 
     const loadingSpinner = page.getByTestId("loading-spinner")
 
-    // Verify that the loading state is displayed
     await expect(loadingSpinner).toBeVisible()
 
-    // Allow the presets request to complete
-    continueLoading()
+    resolvePresetsLoading()
 
-    // Verify that the loading state disappears
     await expect(loadingSpinner).toBeHidden()
   })
 })

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2979,11 +2979,11 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await expect(actionInputOption).toBeVisible()
     await actionInputOption.click()
 
-    //loading spinner may be visible while the preset list is being fetched
     const loadingSpinner = page.getByTestId("loading-spinner")
-    if (await loadingSpinner.isVisible().catch(() => false)) {
-      await expect(loadingSpinner).toBeHidden()
-    }
+
+    await loadingSpinner.waitFor({ state: "hidden" }).catch(() => {
+    // Spinner never appeared, continue.
+    })
 
     const codeInput = actionEditor.getByPlaceholder("Enter RPN code")
 
@@ -3546,12 +3546,12 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await expect(actionInputOption).toBeVisible()
     await actionInputOption.click()
 
-      //loading spinner may be visible while the preset list is being fetched
-    const loadingSpinner = page.getByTestId("loading-spinner")
-    if (await loadingSpinner.isVisible().catch(() => false)) {
-      await expect(loadingSpinner).toBeHidden()
-    }
-    
+  const loadingSpinner = page.getByTestId("loading-spinner")
+
+await loadingSpinner.waitFor({ state: "hidden" }).catch(() => {
+  // Spinner never appeared, continue.
+})
+
     // Open the input type combo box to get access to the options
     const inputTypeComboBox = actionEditor
       .getByRole("combobox")

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2980,10 +2980,9 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await actionInputOption.click()
 
     const loadingSpinner = page.getByTestId("loading-spinner")
+    await expect(loadingSpinner).toBeVisible()
+    await expect(loadingSpinner).toBeHidden()
 
-    await loadingSpinner.waitFor({ state: "hidden" }).catch(() => {
-    // Spinner never appeared, continue.
-    })
 
     const codeInput = actionEditor.getByPlaceholder("Enter RPN code")
 
@@ -3546,11 +3545,10 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await expect(actionInputOption).toBeVisible()
     await actionInputOption.click()
 
-  const loadingSpinner = page.getByTestId("loading-spinner")
 
-await loadingSpinner.waitFor({ state: "hidden" }).catch(() => {
-  // Spinner never appeared, continue.
-})
+    const loadingSpinner = page.getByTestId("loading-spinner")
+    await expect(loadingSpinner).toBeVisible()
+    await expect(loadingSpinner).toBeHidden()
 
     // Open the input type combo box to get access to the options
     const inputTypeComboBox = actionEditor

--- a/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/InputConfigWizard.spec.ts
@@ -2979,11 +2979,6 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
     await expect(actionInputOption).toBeVisible()
     await actionInputOption.click()
 
-    const loadingSpinner = page.getByTestId("loading-spinner")
-    await expect(loadingSpinner).toBeVisible()
-    await expect(loadingSpinner).toBeHidden()
-
-
     const codeInput = actionEditor.getByPlaceholder("Enter RPN code")
 
     await expect(codeInput).toBeVisible()
@@ -3010,6 +3005,43 @@ test.describe("Input Config Wizard - MSFS Input Action Panel", () => {
       Command: "Test Code Input",
       PresetId: "",
     } as MsfsInputAction)
+  })
+
+  test("Shows loading spinner while MSFS presets are loading", async ({
+    configListPage,
+    page,
+  }) => {
+    await page.route("**/*", async (route) => {
+      const request = route.request()
+
+      if (request.url().includes("hubhop")) {
+        await new Promise((resolve) => setTimeout(resolve, 2000))
+      }
+
+      await route.continue()
+    })
+
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
+      configListPage,
+      page,
+    )
+
+    const actionTypeComboBox = actionEditor.getByTestId("action-type-combobox")
+
+    await expect(actionTypeComboBox).toBeVisible()
+    await actionTypeComboBox.click()
+
+    const actionInputOption = page.getByRole("option", {
+      name: "Microsoft Flight Simulator (all versions)",
+    })
+
+    await expect(actionInputOption).toBeVisible()
+    await actionInputOption.click()
+
+    const loadingSpinner = page.getByTestId("loading-spinner")
+
+    await expect(loadingSpinner).toBeVisible()
+    await expect(loadingSpinner).toBeHidden()
   })
 })
 
@@ -3545,11 +3577,6 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
     await expect(actionInputOption).toBeVisible()
     await actionInputOption.click()
 
-
-    const loadingSpinner = page.getByTestId("loading-spinner")
-    await expect(loadingSpinner).toBeVisible()
-    await expect(loadingSpinner).toBeHidden()
-
     // Open the input type combo box to get access to the options
     const inputTypeComboBox = actionEditor
       .getByRole("combobox")
@@ -3652,6 +3679,50 @@ test.describe("Input Config Wizard - X-Plane Input Action Panel", () => {
       Path: "Test Code Input",
       Expression: "Test Value",
     } as XplaneInputAction)
+  })
+
+  test("Shows loading spinner while X-Plane presets are loading", async ({
+    configListPage,
+    page,
+  }) => {
+    let continueLoading!: () => void
+
+    const loadingPromise = new Promise<void>((resolve) => {
+      continueLoading = resolve
+    })
+
+    await page.route("**/presets/xplane_hubhop_presets.json", async (route) => {
+      await loadingPromise
+      await route.continue()
+    })
+
+    const actionEditor = await CreateNewInputConfigItemAndReturnActionEditor(
+      configListPage,
+      page,
+    )
+
+    const actionTypeComboBox = actionEditor.getByTestId("action-type-combobox")
+
+    await expect(actionTypeComboBox).toBeVisible()
+    await actionTypeComboBox.click()
+
+    const actionInputOption = page.getByRole("option", {
+      name: "Microsoft Flight Simulator (all versions)",
+    })
+
+    await expect(actionInputOption).toBeVisible()
+    await actionInputOption.click()
+
+    const loadingSpinner = page.getByTestId("loading-spinner")
+
+    // Verify that the loading state is displayed
+    await expect(loadingSpinner).toBeVisible()
+
+    // Allow the presets request to complete
+    continueLoading()
+
+    // Verify that the loading state disappears
+    await expect(loadingSpinner).toBeHidden()
   })
 })
 


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->

- Added a loading state while HubHop presets are being fetched for MSFS and X-Plane.
- Displayed a loading spinner to provide visual feedback during preset initialization.
- Added a Playwright test to verify the loading state before continuing with the input action workflow.
- 
### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->

https://github.com/user-attachments/assets/b89411bb-76b0-4aec-8883-7ddf4ed57a38


### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] A loading indicator is shown while HubHop presets are being loaded for MSFS and X-Plane.
- [x] The preset selection UI is displayed once the presets finish loading.
- [x] The existing preset selection and input action workflow continues to work as before.

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Frontend tests
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3221