### PR TITLE
Add external LED control for FreeJoy boards

### DIFF
--- a/src/MobiFlightConnector/Joysticks/freejoy/freejoy.joystick.json
+++ b/src/MobiFlightConnector/Joysticks/freejoy/freejoy.joystick.json
@@ -1,0 +1,152 @@
+{
+  "$schema": "./mfjoystick.schema.json",
+  "InstanceName": "FreeJoy",
+  "VendorId": "0x0483",
+  "ProductId": "0x5757",
+  "Outputs": [
+    {
+      "Label": "LED 0",
+      "Id": "led.0",
+      "Byte": 0,
+      "Bit": 0
+    },
+    {
+      "Label": "LED 1",
+      "Id": "led.1",
+      "Byte": 0,
+      "Bit": 1
+    },
+    {
+      "Label": "LED 2",
+      "Id": "led.2",
+      "Byte": 0,
+      "Bit": 2
+    },
+    {
+      "Label": "LED 3",
+      "Id": "led.3",
+      "Byte": 0,
+      "Bit": 3
+    },
+    {
+      "Label": "LED 4",
+      "Id": "led.4",
+      "Byte": 0,
+      "Bit": 4
+    },
+    {
+      "Label": "LED 5",
+      "Id": "led.5",
+      "Byte": 0,
+      "Bit": 5
+    },
+    {
+      "Label": "LED 6",
+      "Id": "led.6",
+      "Byte": 0,
+      "Bit": 6
+    },
+    {
+      "Label": "LED 7",
+      "Id": "led.7",
+      "Byte": 0,
+      "Bit": 7
+    },
+    {
+      "Label": "LED 8",
+      "Id": "led.8",
+      "Byte": 1,
+      "Bit": 0
+    },
+    {
+      "Label": "LED 9",
+      "Id": "led.9",
+      "Byte": 1,
+      "Bit": 1
+    },
+    {
+      "Label": "LED 10",
+      "Id": "led.10",
+      "Byte": 1,
+      "Bit": 2
+    },
+    {
+      "Label": "LED 11",
+      "Id": "led.11",
+      "Byte": 1,
+      "Bit": 3
+    },
+    {
+      "Label": "LED 12",
+      "Id": "led.12",
+      "Byte": 1,
+      "Bit": 4
+    },
+    {
+      "Label": "LED 13",
+      "Id": "led.13",
+      "Byte": 1,
+      "Bit": 5
+    },
+    {
+      "Label": "LED 14",
+      "Id": "led.14",
+      "Byte": 1,
+      "Bit": 6
+    },
+    {
+      "Label": "LED 15",
+      "Id": "led.15",
+      "Byte": 1,
+      "Bit": 7
+    },
+    {
+      "Label": "LED 16",
+      "Id": "led.16",
+      "Byte": 2,
+      "Bit": 0
+    },
+    {
+      "Label": "LED 17",
+      "Id": "led.17",
+      "Byte": 2,
+      "Bit": 1
+    },
+    {
+      "Label": "LED 18",
+      "Id": "led.18",
+      "Byte": 2,
+      "Bit": 2
+    },
+    {
+      "Label": "LED 19",
+      "Id": "led.19",
+      "Byte": 2,
+      "Bit": 3
+    },
+    {
+      "Label": "LED 20",
+      "Id": "led.20",
+      "Byte": 2,
+      "Bit": 4
+    },
+    {
+      "Label": "LED 21",
+      "Id": "led.21",
+      "Byte": 2,
+      "Bit": 5
+    },
+    {
+      "Label": "LED 22",
+      "Id": "led.22",
+      "Byte": 2,
+      "Bit": 6
+    },
+    {
+      "Label": "LED 23",
+      "Id": "led.23",
+      "Byte": 2,
+      "Bit": 7
+    }
+  ]
+}

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/ControllerFactory.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/ControllerFactory.cs
@@ -1,3 +1,4 @@
+using MobiFlight.Joysticks.FreeJoy;
 using MobiFlight.Joysticks.VKB;
 using MobiFlight.Joysticks.WinCtrl;
 using MobiFlight.Joysticks.IIDB;
@@ -38,6 +39,12 @@ namespace MobiFlight.Joysticks
 
             // Check for IIDB devices
             if (vendorId == IIDBDevice.IIDB_VENDOR_ID)
+            {
+                return true;
+            }
+
+            // Check for FreeJoy boards
+            if (vendorId == FreeJoyController.FREEJOY_VENDOR_ID && productId == FreeJoyController.FREEJOY_PRODUCT_ID)
             {
                 return true;
             }
@@ -119,6 +126,12 @@ namespace MobiFlight.Joysticks
             if (vendorId == IIDBDevice.IIDB_VENDOR_ID)
             {
                 return new IIDBDevice(diJoystick, definition);
+            }
+
+            // Handle FreeJoy boards by vendor/product ID
+            if (vendorId == FreeJoyController.FREEJOY_VENDOR_ID && productId == FreeJoyController.FREEJOY_PRODUCT_ID)
+            {
+                return new FreeJoyController(diJoystick, definition);
             }
 
             // Handle AuthentiKit by instance name

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/FreeJoy/FreeJoyController.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/FreeJoy/FreeJoyController.cs
@@ -1,0 +1,176 @@
+using HidSharp;
+using System;
+using System.Linq;
+
+namespace MobiFlight.Joysticks.FreeJoy
+{
+    /// <summary>
+    /// Adds external LED control for FreeJoy boards (https://github.com/FreeJoy-Team/FreeJoyWiki).
+    /// </summary>
+    /// <remarks>
+    /// Buttons and axes keep using the regular DirectInput path in the base class: FreeJoy is
+    /// user-flashed firmware, so there is no fixed input report layout to parse.
+    /// <para>
+    /// Only the LEDs need a device of their own. They are addressed on a second, vendor-specific
+    /// HID interface with an output report, so neither the <c>GetHidDeviceOrNull</c> lookup nor
+    /// the <c>SetFeature</c> write in the base class can reach them.
+    /// </para>
+    /// <para>
+    /// Only LEDs flagged "External" in the FreeJoy Configurator follow this report, the rest keep
+    /// following the board's own button logic.
+    /// </para>
+    /// </remarks>
+    internal class FreeJoyController : Joystick
+    {
+        public const int FREEJOY_VENDOR_ID = 0x0483;
+        public const int FREEJOY_PRODUCT_ID = 0x5757;
+
+        /// <summary>
+        /// Usage page of the vendor-specific interface carrying the LED reports.
+        /// </summary>
+        private const uint LED_USAGE_PAGE = 0xFF00;
+
+        /// <summary>
+        /// Set once the "interface not found" warning has been logged, so a board that never
+        /// exposes the LED interface does not flood the log on every poll cycle while an output
+        /// update is pending.
+        /// </summary>
+        private bool LedInterfaceMissingLogged;
+
+        public FreeJoyController(SharpDX.DirectInput.Joystick joystick, JoystickDefinition definition) : base(joystick, definition)
+        {
+        }
+
+        public override void Connect(IntPtr handle)
+        {
+            base.Connect(handle);
+
+            // Opening the LED interface here keeps the failure visible in the log at startup
+            // instead of on the first output event.
+            ConnectLedInterface();
+        }
+
+        /// <summary>
+        /// Opens the LED interface, unless it is already open. Called again before every write so
+        /// a board that shows up late, or comes back after a reconnect, is picked up.
+        /// </summary>
+        /// <returns>True if the interface is ready to be written to.</returns>
+        private bool ConnectLedInterface()
+        {
+            if (Definition?.Outputs == null || Definition.Outputs.Count == 0) return false;
+
+            if (Device == null)
+            {
+                Device = FindLedInterface(Definition.VendorId, Definition.ProductId);
+                if (Device == null)
+                {
+                    if (!LedInterfaceMissingLogged)
+                    {
+                        Log.Instance.log($"No FreeJoy LED interface with usage page 0x{LED_USAGE_PAGE:X4} found for VID:{Definition.VendorId:X4} PID:{Definition.ProductId:X4}, external LED control unavailable.", LogSeverity.Warn);
+                        LedInterfaceMissingLogged = true;
+                    }
+                    return false;
+                }
+                LedInterfaceMissingLogged = false;
+            }
+
+            if (Stream == null)
+            {
+                try
+                {
+                    Stream = Device.Open();
+                }
+                catch (Exception ex)
+                {
+                    // Connect runs on the joystick scan's thread - an open failure
+                    // (e.g. the device is held exclusively by another tool) must not
+                    // abort the scan.
+                    Log.Instance.log($"Failed to open the FreeJoy LED interface: {ex.Message}", LogSeverity.Error);
+                    Device = null;
+                    return false;
+                }
+
+                Log.Instance.log($"Connected to the FreeJoy LED interface of {Name}.", LogSeverity.Debug);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// The board exposes its joystick interface and its LED interface behind the same
+        /// vendor and product id, so they can only be told apart by their usage page.
+        /// </summary>
+        private static HidDevice FindLedInterface(int vendorId, int productId)
+        {
+            return DeviceList.Local
+                             .GetHidDevices(vendorID: vendorId, productID: productId)
+                             .FirstOrDefault(HasLedUsagePage);
+        }
+
+        private static bool HasLedUsagePage(HidDevice device)
+        {
+            try
+            {
+                return device.GetReportDescriptor()
+                             .DeviceItems
+                             .SelectMany(item => item.Usages.GetAllValues())
+                             .Any(usage => (usage >> 16) == LED_USAGE_PAGE);
+            }
+            catch (Exception)
+            {
+                // A device that will not hand out its report descriptor is not the one
+                // we are looking for, and must not abort the search for the others.
+                return false;
+            }
+        }
+
+        public override void UpdateOutputDeviceStates()
+        {
+            if (!RequiresOutputUpdate) return;
+
+            SendData(FreeJoyReport.FromOutputDeviceState(Lights));
+        }
+
+        protected override void SendData(byte[] data)
+        {
+            if (data == null) return;
+            if (!ConnectLedInterface()) return;
+
+            try
+            {
+                // HidSharp expects the report ID at index 0. The payload is padded out to the
+                // length the board declares because Windows rejects an output report of any
+                // other size.
+                var report = new byte[Device.GetMaxOutputReportLength()];
+                report[0] = FreeJoyReport.ReportId;
+                Array.Copy(data, 0, report, 1, Math.Min(data.Length, report.Length - 1));
+
+                Stream.Write(report, 0, report.Length);
+                RequiresOutputUpdate = false;
+            }
+            catch (Exception ex)
+            {
+                // Catch-all to prevent unhandled exceptions from the write from crashing the
+                // application, in line with how the other HID controllers handle device removal.
+                Log.Instance.log($"Exception during write to the FreeJoy LED interface ({ex.GetType().Name}): {ex.Message}", LogSeverity.Error);
+                CloseLedInterface();
+                OnDeviceRemoved();
+            }
+        }
+
+        public override void Shutdown()
+        {
+            CloseLedInterface();
+
+            base.Shutdown();
+        }
+
+        private void CloseLedInterface()
+        {
+            Stream?.Close();
+            Stream = null;
+            Device = null;
+            LedInterfaceMissingLogged = false;
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/FreeJoy/FreeJoyReport.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/FreeJoy/FreeJoyReport.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+
+namespace MobiFlight.Joysticks.FreeJoy
+{
+    /// <summary>
+    /// Builds the FreeJoy external LED output report.
+    /// </summary>
+    /// <remarks>
+    /// The report is a little-endian bitmask, one bit per LED, addressed by the
+    /// <c>Byte</c> and <c>Bit</c> values of the outputs in the definition file.
+    /// Protocol reference:
+    /// https://github.com/FreeJoy-Team/FreeJoyWiki/blob/master/rus/%D0%92%D0%BD%D0%B5%D1%88%D0%BD%D0%B5%D0%B5-%D1%83%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D1%81%D0%B2%D0%B5%D1%82%D0%BE%D0%B4%D0%B8%D0%BE%D0%B4%D0%B0%D0%BC%D0%B8.md
+    /// </remarks>
+    internal static class FreeJoyReport
+    {
+        /// <summary>
+        /// Report ID of the external LED output report.
+        /// </summary>
+        public const byte ReportId = 6;
+
+        /// <summary>
+        /// Length of the bitmask, as defined by the protocol.
+        /// </summary>
+        public const int BitmaskLength = 4;
+
+        /// <summary>
+        /// Number of LEDs the firmware can address. The bitmask has room for 32 bits,
+        /// the firmware only acts on the first 24.
+        /// </summary>
+        public const int MaxLedCount = 24;
+
+        /// <summary>
+        /// Turns the current output device states into the LED bitmask.
+        /// </summary>
+        /// <param name="state">
+        /// The output devices. Outputs addressing an LED beyond <see cref="MaxLedCount"/>
+        /// are ignored rather than silently wrapping into another LED.
+        /// </param>
+        /// <returns>The bitmask, without the leading report ID byte.</returns>
+        public static byte[] FromOutputDeviceState(IEnumerable<JoystickOutputDevice> state)
+        {
+            var bitmask = new byte[BitmaskLength];
+
+            if (state == null) return bitmask;
+
+            foreach (var light in state)
+            {
+                if (light == null || light.State == 0) continue;
+                if (light.Bit > 7) continue;
+                if (light.Byte >= BitmaskLength) continue;
+                if (light.Byte * 8 + light.Bit >= MaxLedCount) continue;
+
+                bitmask[light.Byte] |= (byte)(1 << light.Bit);
+            }
+
+            return bitmask;
+        }
+    }
+}

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/ControllerFactoryTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/ControllerFactoryTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.Joysticks.FreeJoy;
 using MobiFlight.Joysticks.VKB;
 using SharpDX.DirectInput;
 
@@ -76,6 +77,23 @@ namespace MobiFlight.Joysticks.Tests
             var deviceInstance = CreateDeviceInstance("Some VKB Device");
             var result = ControllerFactory.CanCreate(deviceInstance, VKBDevice.VKB_VENDOR_ID, 0x0000);
             Assert.IsTrue(result);
+        }
+
+        [TestMethod()]
+        public void CanCreate_WithFreeJoyBoard_ReturnsTrue()
+        {
+            var deviceInstance = CreateDeviceInstance("FreeJoy v1.7.1");
+            var result = ControllerFactory.CanCreate(deviceInstance, FreeJoyController.FREEJOY_VENDOR_ID, FreeJoyController.FREEJOY_PRODUCT_ID);
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod()]
+        public void CanCreate_WithFreeJoyVendorIdButOtherProductId_ReturnsFalse()
+        {
+            // The vendor id is the STM32 default, shared with plenty of unrelated devices.
+            var deviceInstance = CreateDeviceInstance("Some STM32 Device");
+            var result = ControllerFactory.CanCreate(deviceInstance, FreeJoyController.FREEJOY_VENDOR_ID, 0x0000);
+            Assert.IsFalse(result);
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/FreeJoy/FreeJoyReportTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/FreeJoy/FreeJoyReportTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+
+namespace MobiFlight.Joysticks.FreeJoy.Tests
+{
+    /// <summary>
+    /// Pins the layout of the FreeJoy external LED bitmask. Offsets are payload-relative,
+    /// i.e. without the leading report ID byte, matching the protocol table in
+    /// <see cref="FreeJoyReport"/>.
+    /// </summary>
+    [TestClass]
+    public class FreeJoyReportTests
+    {
+        private static JoystickOutputDevice Led(int index, byte state)
+        {
+            return new JoystickOutputDevice()
+            {
+                Name = $"led.{index}",
+                Label = $"LED {index}",
+                Byte = (byte)(index / 8),
+                Bit = (byte)(index % 8),
+                State = state
+            };
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_NoLights_ReturnsEmptyBitmask()
+        {
+            var result = FreeJoyReport.FromOutputDeviceState(new List<JoystickOutputDevice>());
+
+            Assert.HasCount(FreeJoyReport.BitmaskLength, result);
+            CollectionAssert.AreEqual(new byte[] { 0, 0, 0, 0 }, result);
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_NullState_ReturnsEmptyBitmask()
+        {
+            var result = FreeJoyReport.FromOutputDeviceState(null);
+
+            CollectionAssert.AreEqual(new byte[] { 0, 0, 0, 0 }, result);
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_SetsOneBitPerLed()
+        {
+            var state = new List<JoystickOutputDevice>() { Led(0, 1), Led(9, 1), Led(23, 1) };
+
+            var result = FreeJoyReport.FromOutputDeviceState(state);
+
+            CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x80, 0x00 }, result);
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_UnlitLedsStayCleared()
+        {
+            var state = new List<JoystickOutputDevice>() { Led(3, 1), Led(4, 0) };
+
+            var result = FreeJoyReport.FromOutputDeviceState(state);
+
+            CollectionAssert.AreEqual(new byte[] { 0x08, 0x00, 0x00, 0x00 }, result);
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_AllLedsLit_FillsFirstThreeBytes()
+        {
+            var state = new List<JoystickOutputDevice>();
+            for (var i = 0; i < FreeJoyReport.MaxLedCount; i++)
+            {
+                state.Add(Led(i, 1));
+            }
+
+            var result = FreeJoyReport.FromOutputDeviceState(state);
+
+            CollectionAssert.AreEqual(new byte[] { 0xFF, 0xFF, 0xFF, 0x00 }, result);
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_LedBeyondSupportedCount_IsIgnored()
+        {
+            // The bitmask has room for 32 bits but the firmware only drives 24 LEDs.
+            // Such an output must be dropped rather than land on a bit the board ignores.
+            var state = new List<JoystickOutputDevice>() { Led(FreeJoyReport.MaxLedCount, 1) };
+
+            var result = FreeJoyReport.FromOutputDeviceState(state);
+
+            CollectionAssert.AreEqual(new byte[] { 0, 0, 0, 0 }, result);
+        }
+
+        [TestMethod]
+        public void FromOutputDeviceState_OutOfRangeAddress_IsIgnored()
+        {
+            var state = new List<JoystickOutputDevice>()
+            {
+                new JoystickOutputDevice() { Byte = (byte)FreeJoyReport.BitmaskLength, Bit = 0, State = 1 },
+                new JoystickOutputDevice() { Byte = 0, Bit = 8, State = 1 }
+            };
+
+            var result = FreeJoyReport.FromOutputDeviceState(state);
+
+            CollectionAssert.AreEqual(new byte[] { 0, 0, 0, 0 }, result);
+        }
+    }
+}


### PR DESCRIPTION
### Summary

Adds support for the LEDs on FreeJoy boards, so they can be bound to sim variables like any other MobiFlight output. Buttons and axes on these boards already worked through DirectInput and are untouched — this only adds the output side.

FreeJoy firmware has a documented "external LED control" mode. The board exposes a second, vendor specific HID interface (usage page `0xFF00`) which takes an Output Report with report ID 6 carrying a little-endian bitmask, one bit per LED, for up to 24 LEDs. Only LEDs flagged "External" in the FreeJoy Configurator follow the bitmask, the rest keep using the board's own button logic. Protocol reference: https://github.com/FreeJoy-Team/FreeJoyWiki/blob/master/rus/%D0%92%D0%BD%D0%B5%D1%88%D0%BD%D0%B5%D0%B5-%D1%83%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5-%D1%81%D0%B2%D0%B5%D1%82%D0%BE%D0%B4%D0%B8%D0%BE%D0%B4%D0%B0%D0%BC%D0%B8.md

The output path in the `Joystick` base class could not be reused: it sends a Feature Report rather than an Output Report, and it resolves the device with `GetHidDeviceOrNull(vid, pid)`, which is ambiguous here because the board exposes both its joystick interface and its LED interface under the same ids. `FreeJoyController` therefore picks the interface by usage page and writes an output report, while leaving everything else to the base class.

Changes:
- `MobiFlight/Joysticks/FreeJoy/FreeJoyReport.cs` — builds the bitmask from the output device states. No device access, so it is unit tested like the other report classes.
- `MobiFlight/Joysticks/FreeJoy/FreeJoyController.cs` — keeps input on DirectInput, opens the vendor specific interface only for the LED report.
- `Joysticks/freejoy/freejoy.joystick.json` — vendor/product id and the LED addresses, so the LED list is not hardcoded. `EnumerateOutputDevices`, `SetOutputDeviceState` and `Stop` are all the base class implementations.
- vendor/product id dispatch in `ControllerFactory`, next to the existing vendor branches.

No build file changes: source globbing and the existing `<None Update="Joysticks\**">` item cover everything.

This no longer depends on #3236. `Joystick` on main already exposes the HidSharp `Device`/`Stream` fields this uses, and `HidReportReceiver` is not needed here because only the output direction is involved.

### Acceptance criteria

- [x] FreeJoy LEDs are exposed as outputs and can be assigned in the UI
- [x] Setting an output on/off drives the matching LED on the board
- [x] Buttons and axes on the FreeJoy board still work through the regular DirectInput path
- [x] LEDs are turned off on stop, and the LED interface is closed on shutdown
- [x] Boards without the external LED interface log one warning and otherwise behave as before

### DoD Checklist

- [x] Unit tests available
  - [x] .NET backend
  - [x] ~~Frontend~~
- [x] ~~Frontend tests~~
- [x] ~~i18n - All user-facing strings are translated~~
- [ ] documentation
  - [x] User docs (docs.mobiflight.com) https://github.com/neilenns-projects/mobiflight-docs/pull/556
  - [x] ~~Developer docs~~

Happy to write the user docs section if you want this merged.

## Related issues

fixes #3230

### Out-of-scope

- Vendor/product ids are still hardcoded in `ControllerFactory` for dispatch, `0x0483` / `0x5757`, the FreeJoy defaults, the same way the other vendor branches do it. The device itself is then resolved from the definition file. The FreeJoy Configurator lets users change these ids, and such boards will not be picked up.
- The shipped definition can only offer generic `LED 0` … `LED 23` labels, because every FreeJoy board is different. See the open question in #3230 about user-supplied definitions — that only changes the definition file, not this code.
- LED brightness and RGB are not covered, the external control protocol is a plain on/off bitmask.
- No changes to button or axis handling.

### Notes

Verified on hardware: FreeJoy v1.7.1 board (VID `0x0483` / PID `0x5757`) with MSFS, LEDs switching on and off from the Output Config Wizard. Enumeration on that board shows the two interfaces, `mi_00` with usage `0x00010004` for the joystick and `mi_01` with usage page `0xFF00` and a 64 byte output report for the LEDs. Full unit test run is green.

This is my first PR to this repo, so please tell me if you'd prefer the feature shaped differently.
