### PR TITLE
Update config list view values more efficiently

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableDeviceCell.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableDeviceCell.tsx
@@ -13,6 +13,7 @@ import { useTranslation } from "react-i18next"
 import StackedIcons from "@/components/icons/StackedIcons"
 import { useControllerDefinitionsStore } from "@/stores/definitionStore"
 import { mapJoystickDeviceNameToLabel } from "@/types/definitions"
+import { useConfigItemStateValue } from "@/stores/configItemStateStore"
 
 interface ConfigItemTableDeviceCellProps {
   row: Row<IConfigItem>
@@ -21,14 +22,14 @@ interface ConfigItemTableDeviceCellProps {
 function DetermineDeviceName(item: IConfigItem): string[] {
   const deviceType = (item.Device as IDeviceConfig)?.Type ?? item.DeviceType
   const deviceName = (item.Device as IDeviceConfig)?.Name ?? item.DeviceName
-  
+
   if (!deviceName || isEmpty(deviceName)) {
     if (deviceType === "InputAction") {
       return ["Input Action"]
     }
     return ["-"]
   }
-  
+
   const deviceNames = deviceName.split("|").map((name) => name.trim())
   return deviceNames
 }
@@ -57,8 +58,12 @@ function ConfigItemTableDeviceCell({ row }: ConfigItemTableDeviceCellProps) {
   const { t } = useTranslation()
   const { JoystickDefinitions, MidiControllerDefinitions } =
     useControllerDefinitionsStore()
+
   const item = row.original as IConfigItem
-  const Status = item.Status
+  // access the runtime state efficiently
+  const runtimeState = useConfigItemStateValue(item.GUID)
+
+  const Status = runtimeState?.Status ?? item.Status
   const Device = Status && !isEmpty(Status["Device"])
 
   const controllerName = item.Controller?.Name ?? ""
@@ -115,10 +120,18 @@ function ConfigItemTableDeviceCell({ row }: ConfigItemTableDeviceCellProps) {
     <ToolTip content={tooltipLabel}>
       <div className="flex flex-row items-center gap-2">
         {statusIcon}
-        <div className="hidden flex-col lg:flex truncate">
-          <div className="max-w-full inline-block truncate" data-testid="device-name">{mappedLabel}</div>
+        <div className="hidden flex-col truncate lg:flex">
+          <div
+            className="inline-block max-w-full truncate"
+            data-testid="device-name"
+          >
+            {mappedLabel}
+          </div>
           {subIndices.length > 0 && (
-            <div className="flex flex-row items-center gap-2 truncate text-xs text-slate-400" data-testid="device-sub-index">
+            <div
+              className="flex flex-row items-center gap-2 truncate text-xs text-slate-400"
+              data-testid="device-sub-index"
+            >
               {subIndices.filter((index) => index != null).join(", ")}
             </div>
           )}

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableFinalValueCell.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableFinalValueCell.tsx
@@ -2,6 +2,7 @@ import StatusIcon from "@/components/icons/StatusIcon"
 import ValueIcon from "@/components/icons/ValueIcon"
 import ToolTip from "@/components/ToolTip"
 import { Badge } from "@/components/ui/badge"
+import { useConfigItemStateValue } from "@/stores/configItemStateStore"
 import { IConfigItem } from "@/types"
 import { IconMathSymbols } from "@tabler/icons-react"
 import { Row } from "@tanstack/react-table"
@@ -16,11 +17,14 @@ function ConfigItemTableFinalValueCell({
   row,
 }: ConfigItemTableFinalValueCellProps) {
   const item = row.original as IConfigItem
-  const Status = item.Status
+  // access the runtime state efficiently
+  const runtimeState = useConfigItemStateValue(item.GUID)
+
+  const Status = runtimeState?.Status ?? item.Status
   const Modifier = Status && !isEmpty(Status["Modifier"])
 
   const { t } = useTranslation()
-  const label = item.Value
+  const label = runtimeState?.Value ?? item.Value
 
   return (
     <div className="text-md" data-testid="final-value">

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableRawValueCell.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableRawValueCell.tsx
@@ -2,6 +2,7 @@ import StatusIcon from "@/components/icons/StatusIcon"
 import ValueIcon from "@/components/icons/ValueIcon"
 import ToolTip from "@/components/ToolTip"
 import { Badge } from "@/components/ui/badge"
+import { useConfigItemStateValue } from "@/stores/configItemStateStore"
 import { IConfigItem } from "@/types"
 import { IconBuildingBroadcastTower } from "@tabler/icons-react"
 import { Row } from "@tanstack/react-table"
@@ -16,12 +17,14 @@ function ConfigItemTableRawValueCell({
   row,
 }: ConfigItemTableRawValueCellProps) {
   const item = row.original as IConfigItem
+  // access the runtime state efficiently
+  const runtimeState = useConfigItemStateValue(item.GUID)
 
-  const Status = item.Status
+  const Status = runtimeState?.Status ?? item.Status
   const Source = Status && !isEmpty(Status["Source"])
 
   const { t } = useTranslation()
-  const label = item.RawValue
+  const label = runtimeState?.RawValue ?? item.RawValue
 
   return (
     <div className="text-md" data-testid="raw-value">

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableStatusCell.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableStatusCell.tsx
@@ -1,4 +1,5 @@
 import StatusIcon from "@/components/icons/StatusIcon"
+import { useConfigItemStateValue } from "@/stores/configItemStateStore"
 import { IConfigItem } from "@/types"
 import {
   IconAlertSquareRounded,
@@ -13,51 +14,52 @@ interface ConfigItemTableStatusCellProps {
   row: Row<IConfigItem>
 }
 
-function ConfigItemTableStatusCell({
-  row,
-}: ConfigItemTableStatusCellProps) {
-    const item = row.original as IConfigItem
-    const Status = item.Status
-    const Precondition = Status && !isEmpty(Status["Precondition"])
-    const Test = Status && !isEmpty(Status["Test"])
-    const ConfigRef = Status && !isEmpty(Status["ConfigRef"])
+function ConfigItemTableStatusCell({ row }: ConfigItemTableStatusCellProps) {
+  const item = row.original as IConfigItem
+  // access the runtime state efficiently
+  const runtimeState = useConfigItemStateValue(item.GUID)
 
-    const { t } = useTranslation()
+  const Status = runtimeState?.Status ?? item.Status
+  const Precondition = Status && !isEmpty(Status["Precondition"])
+  const Test = Status && !isEmpty(Status["Test"])
+  const ConfigRef = Status && !isEmpty(Status["ConfigRef"])
 
-    return (
-      <div className="flex flex-row gap-1">
-        <StatusIcon
-          status="Precondition"
-          condition={Precondition ?? false}
-          title={
-            Precondition
-              ? t(`ConfigList.Status.Precondition.${Status["Precondition"]}`)
-              : t(`ConfigList.Status.Precondition.normal`)
-          }
-          IconComponent={IconAlertSquareRounded}
-        />
-        <StatusIcon
-          status="Test"
-          condition={Test ?? false}
-          title={
-            Test
-              ? t(`ConfigList.Status.Test.Executing`)
-              : t(`ConfigList.Status.Test.NotExecuting`)
-          }
-          IconComponent={IconFlask}
-        />
-        <StatusIcon
-          status="ConfigRef"
-          condition={ConfigRef ?? false}
-          title={
-            ConfigRef
-              ? t(`ConfigList.Status.ConfigRef.Missing`)
-              : t(`ConfigList.Status.ConfigRef.OK`)
-          }
-          IconComponent={IconRouteOff}
-        />
-      </div>
-    )
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-row gap-1">
+      <StatusIcon
+        status="Precondition"
+        condition={Precondition ?? false}
+        title={
+          Precondition
+            ? t(`ConfigList.Status.Precondition.${Status["Precondition"]}`)
+            : t(`ConfigList.Status.Precondition.normal`)
+        }
+        IconComponent={IconAlertSquareRounded}
+      />
+      <StatusIcon
+        status="Test"
+        condition={Test ?? false}
+        title={
+          Test
+            ? t(`ConfigList.Status.Test.Executing`)
+            : t(`ConfigList.Status.Test.NotExecuting`)
+        }
+        IconComponent={IconFlask}
+      />
+      <StatusIcon
+        status="ConfigRef"
+        condition={ConfigRef ?? false}
+        title={
+          ConfigRef
+            ? t(`ConfigList.Status.ConfigRef.Missing`)
+            : t(`ConfigList.Status.ConfigRef.OK`)
+        }
+        IconComponent={IconRouteOff}
+      />
+    </div>
+  )
 }
 
 export default ConfigItemTableStatusCell

--- a/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
@@ -16,6 +16,7 @@ import ConfigWizard from "@/components/wizard/ConfigWizard"
 import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { cn } from "@/lib/utils"
 import { useProjectStore } from "@/stores/projectStore"
+import { useConfigItemStateValue } from "@/stores/configItemStateStore"
 import { IConfigItem } from "@/types/config"
 import { IconChevronRight, IconExclamationCircle } from "@tabler/icons-react"
 import _ from "lodash"
@@ -52,6 +53,7 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
   const configItem = configFile?.ConfigItems?.find(
     (item) => item.GUID === configId,
   )
+  const runtimeState = useConfigItemStateValue(configId)
 
   const closeDialog = () => {
     navigate(-1)
@@ -182,8 +184,8 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
                   }}
                   drawerContainer={containerRef}
                   liveData={{
-                    rawValue: configItem?.RawValue,
-                    finalValue: configItem?.Value,
+                    rawValue: runtimeState?.RawValue ?? configItem?.RawValue,
+                    finalValue: runtimeState?.Value ?? configItem?.Value,
                   }}
                 />
               )}

--- a/src/MobiFlightConnector/frontend/src/pages/ConfigList.tsx
+++ b/src/MobiFlightConnector/frontend/src/pages/ConfigList.tsx
@@ -14,7 +14,10 @@ import ProjectPanel from "@/components/project/ProjectPanel"
 import { ConfigItemTable } from "@/components/tables/config-item-table/config-item-table"
 import ErrorFallback from "@/components/ErrorFallback"
 import { ErrorBoundary } from "react-error-boundary"
-import { useConfigItemStateStore } from "@/stores/configItemStateStore"
+import {
+  useConfigItemStateSet,
+  useConfigItemStateUpdate,
+} from "@/stores/configItemStateStore"
 
 const ConfigListPage = () => {
   const {
@@ -25,11 +28,14 @@ const ConfigListPage = () => {
     updateConfigItem,
   } = useProjectStore()
 
-  const { updateConfigItemState } = useConfigItemStateStore()
+  const updateConfigItemState = useConfigItemStateUpdate()
+  const setConfigItemState = useConfigItemStateSet()
 
   useAppMessage("ConfigValuePartialUpdate", (message) => {
     console.log("ConfigValuePartialUpdate", message.payload)
     const update = message.payload as ConfigValuePartialUpdate
+    // keep our special store in sync with potentially new runtime values
+    updateConfigItemState(update.ConfigItems)
     // better performance for single updates
     if (update.ConfigItems.length === 1) {
       updateConfigItem(activeConfigFileIndex, update.ConfigItems[0], true)
@@ -52,6 +58,8 @@ const ConfigListPage = () => {
   useAppMessage("ConfigValueFullUpdate", (message) => {
     const update = message.payload as ConfigValueFullUpdate
     console.log("ConfigValueFullUpdate", update)
+    // init our special store with potentially new runtime values
+    setConfigItemState(update.ConfigItems)
     setConfigItems(update.ConfigIndex, update.ConfigItems)
   })
 

--- a/src/MobiFlightConnector/frontend/src/pages/ConfigList.tsx
+++ b/src/MobiFlightConnector/frontend/src/pages/ConfigList.tsx
@@ -14,6 +14,7 @@ import ProjectPanel from "@/components/project/ProjectPanel"
 import { ConfigItemTable } from "@/components/tables/config-item-table/config-item-table"
 import ErrorFallback from "@/components/ErrorFallback"
 import { ErrorBoundary } from "react-error-boundary"
+import { useConfigItemStateStore } from "@/stores/configItemStateStore"
 
 const ConfigListPage = () => {
   const {
@@ -22,8 +23,9 @@ const ConfigListPage = () => {
     setActiveConfigFileIndex,
     setConfigItems,
     updateConfigItem,
-    updateConfigItems,
   } = useProjectStore()
+
+  const { updateConfigItemState } = useConfigItemStateStore()
 
   useAppMessage("ConfigValuePartialUpdate", (message) => {
     console.log("ConfigValuePartialUpdate", message.payload)
@@ -42,22 +44,9 @@ const ConfigListPage = () => {
       message.payload as ConfigValueRawAndFinalUpdate,
     )
     const update = message.payload as ConfigValueRawAndFinalUpdate
-    // update raw and final values for the store items
-    const newItems = update.ConfigItems.map((newItem) => {
-      const configItems =
-        project?.ConfigFiles[activeConfigFileIndex].ConfigItems ?? []
 
-      const item = configItems.find((i) => i.GUID === newItem.GUID)
-      if (item === undefined) return newItem
-
-      return {
-        ...item,
-        RawValue: newItem.RawValue,
-        Value: newItem.Value,
-        Status: newItem.Status,
-      }
-    }) as IConfigItem[]
-    updateConfigItems(activeConfigFileIndex, newItems)
+    // We only update our special store with runtime values
+    updateConfigItemState(update.ConfigItems)
   })
 
   useAppMessage("ConfigValueFullUpdate", (message) => {

--- a/src/MobiFlightConnector/frontend/src/stores/configItemStateStore.ts
+++ b/src/MobiFlightConnector/frontend/src/stores/configItemStateStore.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand"
 import { IConfigValueOnlyItem } from "@/types/config"
 
-
 interface ConfigItemState {
   values: Record<string, IConfigValueOnlyItem>
   updateConfigItemState: (items: IConfigValueOnlyItem[]) => void
@@ -28,3 +27,9 @@ export const useConfigItemStateStore = create<ConfigItemState>((set) => ({
 
 export const useConfigItemStateValue = (guid: string | undefined) =>
   useConfigItemStateStore((s) => (guid ? s.values[guid] : undefined))
+
+export const useConfigItemStateUpdate = () =>
+  useConfigItemStateStore((s) => s.updateConfigItemState)
+
+export const useConfigItemStateSet = () =>
+  useConfigItemStateStore((s) => s.setConfigItemState)

--- a/src/MobiFlightConnector/frontend/src/stores/configItemStateStore.ts
+++ b/src/MobiFlightConnector/frontend/src/stores/configItemStateStore.ts
@@ -1,0 +1,30 @@
+import { create } from "zustand"
+import { IConfigValueOnlyItem } from "@/types/config"
+
+
+interface ConfigItemState {
+  values: Record<string, IConfigValueOnlyItem>
+  updateConfigItemState: (items: IConfigValueOnlyItem[]) => void
+  setConfigItemState: (items: IConfigValueOnlyItem[]) => void
+}
+
+export const useConfigItemStateStore = create<ConfigItemState>((set) => ({
+  values: {},
+  updateConfigItemState: (items) => set((state) => {
+    const newValues = { ...state.values }
+    items.forEach(item => {
+      newValues[item.GUID] = { GUID: item.GUID, RawValue: item.RawValue, Value: item.Value, Status: item.Status }
+    })
+    return { values: newValues }
+  }),
+  setConfigItemState: (items) => set(() => {
+    const newValues: Record<string, IConfigValueOnlyItem> = {}
+    items.forEach(item => {
+      newValues[item.GUID] = { GUID: item.GUID, RawValue: item.RawValue, Value: item.Value, Status: item.Status }
+    })
+    return { values: newValues }
+  })
+}))
+
+export const useConfigItemStateValue = (guid: string | undefined) =>
+  useConfigItemStateStore((s) => (guid ? s.values[guid] : undefined))

--- a/src/MobiFlightConnector/frontend/src/types/config.d.ts
+++ b/src/MobiFlightConnector/frontend/src/types/config.d.ts
@@ -25,7 +25,6 @@ export interface IConfigItem extends IConfigValueOnlyItem {
   DeviceName?: string | null
   // Tags: string[];
   Preconditions?: Precondition[]
-  Status?: IDictionary<string, ConfigItemStatusType>
   button?: ButtonTrigger
   inputMultiplexer?: ButtonTrigger
   inputShiftRegister?: ButtonTrigger


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
This PR improves the render performance for the config list view when many raw values and/or final values receive updates.
We measured a reduction of 30% memory usage and up to 10 times less CPU usage.

### Screenshots / recordings
n/a

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] config list view is responsive even when receiving many raw value and final value updates
- [x] status updates only trigger cell re-renders and don't re-render the entire table
- [x] Input config wizard modifier values subscribe to the same new store that contains the runtime data

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Frontend tests still pass
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3247 

### Out-of-scope
<!-- mention what is not covered by this PR -->

### Notes
The test file has 84 items and subscribes to many values that are updating with every MSFS frame, e.g. CHT, Oil Temp, etc.
26 fast updating values are in the visible part of the screen.
Screen resolution 4k.

Before:
CPU Usage: 4%
Memory Usage: 380MB

After:
CPU Usage: 0.4% (10%)
Memory Usage: 250MB (30%)
