### PR TITLE
Improve input events log entries

### DIFF
--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -98,7 +98,15 @@ namespace MobiFlight.Execution
                         continue;
                     }
 
-                    Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({e.GetEventActionLabel()})", LogSeverity.Info);
+                    var action = cfg.GetInputAction(e);
+
+                    if (action != null)
+                    {
+                        Log.Instance.log(
+                            $"{e.Controller.Name} => Executing \"{cfg.Name}\". ({e.GetEventActionLabel()})",
+                            LogSeverity.Info
+                        );
+                    }
 
                     if (cfg.button != null)
                         cfg.button.CanExecute = () => cfg.Active && CheckPreconditions(cfg);

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -59,7 +59,7 @@ namespace MobiFlight.Execution
         public Dictionary<string, IConfigItem> Execute(InputEventArgs e, bool isStarted)
         {
             var updatedValues = new Dictionary<string, IConfigItem>();
-            string inputKey = CreateInputKey(e);            
+            string inputKey = CreateInputKey(e);
             var msgEventLabel = e.GetMsgEventLabel();
 
             if (!inputCache.ContainsKey(inputKey))
@@ -68,7 +68,7 @@ namespace MobiFlight.Execution
             }
 
             if (inputCache[inputKey].Count == 0)
-            {                
+            {
                 return updatedValues;
             }
 
@@ -100,14 +100,11 @@ namespace MobiFlight.Execution
 
                     var action = cfg.GetInputAction(e);
 
-                    if (action != null)
+                    if (action == null)
                     {
-                        Log.Instance.log(
-                            $"{e.Controller.Name} => Executing \"{cfg.Name}\". ({e.GetEventActionLabel()})",
-                            LogSeverity.Info
-                        );
+                        continue;
                     }
-
+                    Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({e.GetEventActionLabel()})", LogSeverity.Info);
                     if (cfg.button != null)
                         cfg.button.CanExecute = () => cfg.Active && CheckPreconditions(cfg);
 
@@ -192,13 +189,13 @@ namespace MobiFlight.Execution
                 return false;
 
             bool deviceNameMatches = cfg.Device.Name == e.Device.Name;
-            
+
             // For backward compatibility we have to make this check
             // because we used to have the label in the config
             // but now we want to store the internal button identifier
             // so that the label can change any time without breaking the config
             bool isJoystickWithLabelMatch = Joystick.IsJoystickSerial(cfg.Controller.Serial) && cfg.Device.Name == e.Device.Label;
-            
+
             return deviceNameMatches || isJoystickWithLabelMatch;
         }
 

--- a/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
@@ -405,18 +405,18 @@ namespace MobiFlight
                             return null;
                     }
                 case DeviceType.Encoder:
-                    switch (Convert.ToInt32(e.Value))
+                    switch ((MobiFlightEncoder.InputEvent)e.Value)
                     {
-                        case 0:
+                        case MobiFlightEncoder.InputEvent.LEFT:
                             return encoder?.onLeft;
 
-                        case 1:
+                        case MobiFlightEncoder.InputEvent.LEFT_FAST:
                             return encoder?.onLeftFast ?? encoder?.onLeft;
 
-                        case 2:
+                        case MobiFlightEncoder.InputEvent.RIGHT:
                             return encoder?.onRight;
 
-                        case 3:
+                        case MobiFlightEncoder.InputEvent.RIGHT_FAST:
                             return encoder?.onRightFast ?? encoder?.onRight;
 
                         default:

--- a/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
@@ -385,6 +385,50 @@ namespace MobiFlight
                     Preconditions.Equals(item.Preconditions) &&
                     ConfigRefs.Equals(item.ConfigRefs);
         }
+       public InputAction GetInputAction(InputEventArgs e)
+        {
+            switch (e.InputType)
+            {
+                case DeviceType.Button:
+                    switch ((MobiFlightButton.InputEvent)e.Value)
+                    {
+                        case MobiFlightButton.InputEvent.PRESS:
+                            return button?.onPress;
+
+                        case MobiFlightButton.InputEvent.RELEASE:
+                            return button?.onRelease;
+
+                        case MobiFlightButton.InputEvent.LONG_RELEASE:
+                            return button?.onLongRelease;
+
+                        default:
+                            return null;
+                    }
+                case DeviceType.Encoder:
+                    switch (Convert.ToInt32(e.Value))
+                    {
+                        case 0:
+                            return encoder?.onLeft;
+
+                        case 1:
+                            return encoder?.onLeftFast ?? encoder?.onLeft;
+
+                        case 2:
+                            return encoder?.onRight;
+
+                        case 3:
+                            return encoder?.onRightFast ?? encoder?.onRight;
+
+                        default:
+                            return null;
+                    }
+                case DeviceType.AnalogInput:
+                    return analog?.onChange;
+                default:
+                    return null;
+            }
+        }
+
 
         protected override IDeviceConfig GetDeviceConfig()
         {

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -172,7 +172,18 @@ namespace MobiFlight.Execution.Tests
                 Active = true,
                 Controller = SerialNumber.CreateController("/ 123"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
-                Name = "TestConfig"
+                Name = "TestConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable()
+                        {
+                            Name = "TestVariable",
+                            Number = 100
+                        }
+                    }
+                }
             };
 
             _configItems.Add(activeConfigItem);
@@ -777,7 +788,7 @@ namespace MobiFlight.Execution.Tests
                     Type = DeviceType.InputShiftRegister,
                 },
                 InputType = DeviceType.Button,
-                Value = 0 
+                Value = 0
             };
 
             var configItem = new InputConfigItem

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -788,7 +788,7 @@ namespace MobiFlight.Execution.Tests
                     Type = DeviceType.InputShiftRegister,
                 },
                 InputType = DeviceType.Button,
-                Value = 0
+                Value = (int)MobiFlightButton.InputEvent.PRESS
             };
 
             var configItem = new InputConfigItem

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -611,6 +611,7 @@ namespace MobiFlight.Execution.Tests
                 Name = "DeactivatedConfig",
                 button = new ButtonInputConfig
                 {
+                    onPress = new VariableInputAction(),
                     onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
                     HoldDelay = 10000
                 }
@@ -645,6 +646,7 @@ namespace MobiFlight.Execution.Tests
                 Name = "PreconditionConfig",
                 button = new ButtonInputConfig
                 {
+                    onPress = new VariableInputAction(),
                     onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p2" },
                     HoldDelay = 10000
                 },

--- a/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -1176,7 +1176,7 @@ namespace MobiFlight.Tests
                 Controller = Controller,
                 Device = Device,
                 InputType = DeviceType.Button,
-                Value = 1
+                Value = (int)MobiFlightButton.InputEvent.PRESS
             };
 
             // Set up logging to verify expected log messages when config item is executed

--- a/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -1158,7 +1158,7 @@ namespace MobiFlight.Tests
                 button = new InputConfig.ButtonInputConfig()
                 {
                     
-                    onRelease = new VariableInputAction()
+                    onPress = new VariableInputAction()
                     {
                         Variable = new MobiFlightVariable() { Name = "Var1", Number = 100 },
                     }
@@ -1177,7 +1177,7 @@ namespace MobiFlight.Tests
                 Controller = Controller,
                 Device = Device,
                 InputType = DeviceType.Button,
-                Value = (int)MobiFlightButton.InputEvent.RELEASE
+                Value = (int)MobiFlightButton.InputEvent.PRESS
             };
 
             // Set up logging to verify expected log messages when config item is executed

--- a/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -1299,6 +1299,7 @@ namespace MobiFlight.Tests
             _executionManager.Start();
 
             // Act
+            // The RELEASE event has no configured action, so it should be skipped without logging execution.
             methodInfo.Invoke(
                 _executionManager,
                 new object[] { _mockXplaneCache.Object, inputEventArgs });

--- a/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -1157,6 +1157,7 @@ namespace MobiFlight.Tests
                 Device = new Button() { Name = Device.Name },
                 button = new InputConfig.ButtonInputConfig()
                 {
+                    
                     onRelease = new VariableInputAction()
                     {
                         Variable = new MobiFlightVariable() { Name = "Var1", Number = 100 },
@@ -1176,7 +1177,7 @@ namespace MobiFlight.Tests
                 Controller = Controller,
                 Device = Device,
                 InputType = DeviceType.Button,
-                Value = (int)MobiFlightButton.InputEvent.PRESS
+                Value = (int)MobiFlightButton.InputEvent.RELEASE
             };
 
             // Set up logging to verify expected log messages when config item is executed

--- a/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -1237,5 +1237,83 @@ namespace MobiFlight.Tests
             // Clean up
             _executionManager.Stop();
         }
+        [TestMethod]
+        public void Execute_WhenActionIsNotConfigured_DoesNotLogExecution()
+        {
+            // Arrange
+            var controller = new Controller
+            {
+                Serial = "SN-000-001",
+                Name = "TestController"
+            };
+
+            var device = new DeviceReference
+            {
+                Name = "TestDevice:1",
+                Label = "Test Button",
+                Type = DeviceType.Button
+            };
+
+            var configItem = new InputConfigItem
+            {
+                GUID = Guid.NewGuid().ToString(),
+                Active = true,
+                Name = "Test config without action",
+                Controller = controller,
+                Device = new Button { Name = device.Name },
+
+                // No onRelease action configured
+                button = new InputConfig.ButtonInputConfig()
+            };
+
+            var project = new Project();
+            project.ConfigFiles.Add(new ConfigFile
+            {
+                ConfigItems = { configItem }
+            });
+
+            var inputEventArgs = new InputEventArgs
+            {
+                Controller = controller,
+                Device = device,
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.RELEASE
+            };
+
+            var mockLogAppender = new Mock<ILogAppender>();
+
+            Log.Instance.ClearAppenders();
+            Log.Instance.AddAppender(mockLogAppender.Object);
+            Log.Instance.Enabled = true;
+            Log.Instance.Severity = LogSeverity.Info;
+
+            _executionManager.Project = project;
+
+            var methodInfo = typeof(ExecutionManager).GetMethod(
+                "mobiFlightCache_OnButtonPressed",
+                System.Reflection.BindingFlags.NonPublic |
+                System.Reflection.BindingFlags.Instance);
+
+            Assert.IsNotNull(methodInfo);
+
+            _executionManager.Start();
+
+            // Act
+            methodInfo.Invoke(
+                _executionManager,
+                new object[] { _mockXplaneCache.Object, inputEventArgs });
+
+            // Assert
+            mockLogAppender.Verify(
+                appender => appender.log(
+                    It.Is<string>(msg =>
+                        msg.Contains($"Executing \"{configItem.Name}\"")),
+                    LogSeverity.Info),
+                Times.Never,
+                "No execution log should be written when no action is configured."
+            );
+
+            _executionManager.Stop();
+        }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/ExecutionManagerTests.cs
@@ -1157,7 +1157,7 @@ namespace MobiFlight.Tests
                 Device = new Button() { Name = Device.Name },
                 button = new InputConfig.ButtonInputConfig()
                 {
-                    onPress = new VariableInputAction()
+                    onRelease = new VariableInputAction()
                     {
                         Variable = new MobiFlightVariable() { Name = "Var1", Number = 100 },
                     }

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
@@ -398,6 +398,155 @@ namespace MobiFlight.Tests
 
             Assert.IsNull(result);
         }
+
+        [TestMethod]
+        [DataRow((int)MobiFlightEncoder.InputEvent.LEFT)]
+        [DataRow((int)MobiFlightEncoder.InputEvent.LEFT_FAST)]
+        [DataRow((int)MobiFlightEncoder.InputEvent.RIGHT)]
+        [DataRow((int)MobiFlightEncoder.InputEvent.RIGHT_FAST)]
+        public void GetInputAction_Encoder_ReturnsConfiguredAction(int inputEvent)
+        {
+            var leftAction = new VariableInputAction();
+            var leftFastAction = new VariableInputAction();
+            var rightAction = new VariableInputAction();
+            var rightFastAction = new VariableInputAction();
+
+            var config = new InputConfigItem
+            {
+                encoder = new EncoderInputConfig
+                {
+                    onLeft = leftAction,
+                    onLeftFast = leftFastAction,
+                    onRight = rightAction,
+                    onRightFast = rightFastAction
+                }
+            };
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.Encoder,
+                Value = inputEvent
+            };
+
+            var result = config.GetInputAction(args);
+
+            var expected = inputEvent switch
+            {
+                (int)MobiFlightEncoder.InputEvent.LEFT => leftAction,
+                (int)MobiFlightEncoder.InputEvent.LEFT_FAST => leftFastAction,
+                (int)MobiFlightEncoder.InputEvent.RIGHT => rightAction,
+                (int)MobiFlightEncoder.InputEvent.RIGHT_FAST => rightFastAction,
+                _ => null
+            };
+
+            Assert.AreSame(expected, result);
+        }
+
+        [TestMethod]
+        [DataRow((int)MobiFlightEncoder.InputEvent.LEFT_FAST)]
+        [DataRow((int)MobiFlightEncoder.InputEvent.RIGHT_FAST)]
+        public void GetInputAction_Encoder_FallsBackToNormalActionWhenFastActionIsNotConfigured(
+    int inputEvent)
+        {
+            var leftAction = new VariableInputAction();
+            var rightAction = new VariableInputAction();
+
+            var config = new InputConfigItem
+            {
+                encoder = new EncoderInputConfig
+                {
+                    onLeft = leftAction,
+                    onRight = rightAction
+                }
+            };
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.Encoder,
+                Value = inputEvent
+            };
+
+            var result = config.GetInputAction(args);
+
+            var expected = inputEvent == (int)MobiFlightEncoder.InputEvent.LEFT_FAST
+                ? leftAction
+                : rightAction;
+
+            Assert.AreSame(expected, result);
+        }
+
+        [TestMethod]
+        [DataRow(-1)]
+        [DataRow(999)]
+        public void GetInputAction_Encoder_ReturnsNullForUnknownEvent(int inputEvent)
+        {
+            var config = new InputConfigItem
+            {
+                encoder = new EncoderInputConfig
+                {
+                    onLeft = new VariableInputAction(),
+                    onLeftFast = new VariableInputAction(),
+                    onRight = new VariableInputAction(),
+                    onRightFast = new VariableInputAction()
+                }
+            };
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.Encoder,
+                Value = inputEvent
+            };
+
+            var result = config.GetInputAction(args);
+
+            Assert.IsNull(result);
+        }
+
+        [TestMethod]
+        [DataRow(0)]
+        [DataRow(100)]
+        [DataRow(1023)]
+        public void GetInputAction_Analog_ReturnsOnChange(double value)
+        {
+            var action = new VariableInputAction();
+
+            var config = new InputConfigItem
+            {
+                analog = new AnalogInputConfig
+                {
+                    onChange = action
+                }
+            };
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.AnalogInput,
+                Value = value
+            };
+
+            var result = config.GetInputAction(args);
+
+            Assert.AreSame(action, result);
+        }
+
+        [TestMethod]
+        public void GetInputAction_Analog_ReturnsNullWhenActionIsNotConfigured()
+        {
+            var config = new InputConfigItem
+            {
+                analog = new AnalogInputConfig()
+            };
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.AnalogInput,
+                Value = 100
+            };
+
+            var result = config.GetInputAction(args);
+
+            Assert.IsNull(result);
+        }
         #region CreateInputDevice() tests
         [TestMethod()]
         public void CreateInputDevice_Button_ReturnsButtonDevice()

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
@@ -430,14 +430,31 @@ namespace MobiFlight.Tests
 
             var result = config.GetInputAction(args);
 
-            var expected = inputEvent switch
+            InputAction expected;
+
+            switch (inputEvent)
             {
-                (int)MobiFlightEncoder.InputEvent.LEFT => leftAction,
-                (int)MobiFlightEncoder.InputEvent.LEFT_FAST => leftFastAction,
-                (int)MobiFlightEncoder.InputEvent.RIGHT => rightAction,
-                (int)MobiFlightEncoder.InputEvent.RIGHT_FAST => rightFastAction,
-                _ => null
-            };
+                case (int)MobiFlightEncoder.InputEvent.LEFT:
+                    expected = leftAction;
+                    break;
+
+                case (int)MobiFlightEncoder.InputEvent.LEFT_FAST:
+                    expected = leftFastAction;
+                    break;
+
+                case (int)MobiFlightEncoder.InputEvent.RIGHT:
+                    expected = rightAction;
+                    break;
+
+                case (int)MobiFlightEncoder.InputEvent.RIGHT_FAST:
+                    expected = rightFastAction;
+                    break;
+
+                default:
+                    expected = null;
+                    break;
+            }
+
 
             Assert.AreSame(expected, result);
         }

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
@@ -348,6 +348,56 @@ namespace MobiFlight.Tests
             Assert.HasCount(3, result);
         }
 
+
+        [TestMethod()]
+        [DataRow((int)MobiFlightButton.InputEvent.PRESS, "onPress")]
+        [DataRow((int)MobiFlightButton.InputEvent.RELEASE, "onRelease")]
+        [DataRow((int)MobiFlightButton.InputEvent.LONG_RELEASE, "onLongRelease")]
+        public void GetInputAction_Button_ReturnsCorrectAction(
+     int inputEvent,
+     string actionName)
+        {
+            var action = new VariableInputAction();
+
+            var config = new InputConfigItem
+            {
+                button = new ButtonInputConfig()
+            };
+
+            config.button.SetInputActionByName(actionName, action);
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.Button,
+                Value = inputEvent
+            };
+
+            var result = config.GetInputAction(args);
+
+            Assert.AreSame(action, result);
+        }
+
+        [TestMethod()]
+        public void GetInputAction_Button_ReturnsNullWhenActionIsNotConfigured()
+        {
+            var config = new InputConfigItem
+            {
+                button = new ButtonInputConfig
+                {
+                    onPress = new VariableInputAction()
+                }
+            };
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.RELEASE
+            };
+
+            var result = config.GetInputAction(args);
+
+            Assert.IsNull(result);
+        }
         #region CreateInputDevice() tests
         [TestMethod()]
         public void CreateInputDevice_Button_ReturnsButtonDevice()


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->

Only log `Executing...` when an action is actually defined for the triggered event.
This prevents the log from showing that an undefined action was executed.

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="582" height="60" alt="image" src="https://github.com/user-attachments/assets/06c26793-c818-4ccb-9aa2-a57694dbfa80" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Only log `Executing...` when an action is defined for the event

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend

     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3152 


