### PR TITLE
Add awaited task in debug builds to avoid build error

### DIFF
--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -449,8 +449,10 @@ namespace MobiFlight.UI
 
         private async void MainForm_Shown(object sender, EventArgs e)
         {
+#if (DEBUG)
+            await Task.CompletedTask; // Avoid compiler errors about an unneeded "async" modifier on the function definition in debug builds
+#else
             // Check for updates before loading anything else
-#if (!DEBUG)
             try
             {
                 await AutoUpdateChecker.CheckForUpdate(true);

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -449,9 +449,7 @@ namespace MobiFlight.UI
 
         private async void MainForm_Shown(object sender, EventArgs e)
         {
-#if (DEBUG)
-            await Task.CompletedTask; // Avoid compiler errors about an unneeded "async" modifier on the function definition in debug builds
-#else
+#if (!DEBUG)
             // Check for updates before loading anything else
             try
             {
@@ -459,6 +457,8 @@ namespace MobiFlight.UI
             } catch (Exception ex) {
                 Log.Instance.log($"Error checking for updates: {ex.Message}", LogSeverity.Error);
             }
+#else
+            await Task.CompletedTask; // Avoid compiler errors about an unneeded "async" modifier on the function definition in debug builds
 #endif
         }
 


### PR DESCRIPTION
### Summary
A compile-time #if check was omitting all of the update checking code in debug builds. This is fine, but the function definition includes `async` so the compiler was failing the build with an error about how `async` was unnecessary.

Resolved the issue by adding an `#else` and doing an await of an immediately completing task to make the compiler happy in debug builds.

### Acceptance criteria
- [X] No more compiler warnings in debug builds
- [X] Update checks still happen in release builds

### DoD Checklist
None required
     
## Related issues
Fixes #3258
