### PR TITLE
Properly convert SimVar float to double

### DIFF
--- a/src/MobiFlightConnector/Base/ConnectorValue.cs
+++ b/src/MobiFlightConnector/Base/ConnectorValue.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Windows.Forms.VisualStyles;
 
 namespace MobiFlight
 {
     public class ConnectorValue : ICloneable
     {
         public FSUIPCOffsetType type;
-        public Double           Float64;
+        public double           Float64;
         public String           String;
 
         public override string ToString()

--- a/src/MobiFlightConnector/SimConnectMSFS/SimConnectCache.cs
+++ b/src/MobiFlightConnector/SimConnectMSFS/SimConnectCache.cs
@@ -493,7 +493,7 @@ namespace MobiFlight.SimConnectMSFS
             bool isString = false;
 
             stringVal = "0";
-            doubleValue = 0.0F;
+            doubleValue = 0.0D;
 
             if (!IsConnected()) 
                 return simVarType;

--- a/src/MobiFlightConnector/SimConnectMSFS/SimConnectCache.cs
+++ b/src/MobiFlightConnector/SimConnectMSFS/SimConnectCache.cs
@@ -486,14 +486,14 @@ namespace MobiFlight.SimConnectMSFS
             );
         }
 
-        public FSUIPCOffsetType GetSimVar(String simVarName, out String stringVal, out double floatVal)
+        public FSUIPCOffsetType GetSimVar(String simVarName, out String stringVal, out double doubleValue)
         {
             FSUIPCOffsetType simVarType = FSUIPCOffsetType.Float;
             bool isFloat = false;
             bool isString = false;
 
             stringVal = "0";
-            floatVal = 0.0F;
+            doubleValue = 0.0F;
 
             if (!IsConnected()) 
                 return simVarType;
@@ -526,7 +526,8 @@ namespace MobiFlight.SimConnectMSFS
 
             if(simVarType == FSUIPCOffsetType.Float)
             {
-                floatVal = SimVars.Find(lvar => lvar.Name == simVarName).Data;
+                // new decimal is important to maintain the precision of the float value, otherwise it will be rounded to 15 digits
+                doubleValue = Convert.ToDouble(new decimal(SimVars.Find(lvar => lvar.Name == simVarName).Data));
             }
             else
             {

--- a/tests/MobiFlightUnitTests/SimConnectMSFS/SimConnectCacheTests.cs
+++ b/tests/MobiFlightUnitTests/SimConnectMSFS/SimConnectCacheTests.cs
@@ -1,0 +1,39 @@
+﻿using MobiFlight;
+using MobiFlight.SimConnectMSFS;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace MobiFlightUnitTests.SimConnectMSFS
+{
+    [TestClass()]
+    public class SimConnectCacheTests
+    {
+        [TestMethod()]
+        public void GetSimVar_ReturnsFloatAsDoubleCorrectly()
+        {
+            // Arrange
+            var simConnectCache = new SimConnectCache();
+            var simVar = new SimVar { ID = 1, Name = "TestVar", Data = 123.456f };
+
+            // Mark the module as connected so Stop() enters the device loop.
+            var connectedField = typeof(SimConnectCache).GetField(
+                "_wasmConnected",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.IsNotNull(connectedField, "connected field should exist.");
+            connectedField.SetValue(simConnectCache, true);
+
+            var simVarsField = typeof(SimConnectCache).GetField(
+                "SimVars",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            (simVarsField.GetValue(simConnectCache) as List<SimVar>).Add(simVar);
+
+            // Act
+            var result = simConnectCache.GetSimVar("TestVar", out var stringValue, out var doubleValue);
+
+            // Assert
+            Assert.AreEqual(123.456, doubleValue, "The double value should match the float value.");
+        }
+    }
+}


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
We are now explicitly converting the float value (32-bit) coming from the SimConnect API to the internal double representation (64-bit). Conversion maintains the original value - otherwise float values become incorrect when only assigned to a double field. See related issue for more details.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Float values from SimConnect show same values in Raw Values (internal representation)

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3285