### PR TITLE
Improve performance for app message handlers

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/CommunityMenu.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/CommunityMenu.tsx
@@ -3,15 +3,15 @@ import {
   IconBrandYoutubeFilled,
   IconHeartDollar,
 } from "@tabler/icons-react"
+import messageExchange from "@/lib/messageExchange"
 import { Button } from "./ui/button"
 import IconBrandHubHopLogo from "./icons/IconBrandHubHopLogo"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
 import { CommandMainMenuPayload } from "@/types/commands"
 import { useUserProfileStore } from "@/stores/userProfileStore"
 
 export const CommunityMenu = () => {
   const { userProfile } = useUserProfileStore()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const handleMenuItemClick = (payload: CommandMainMenuPayload) => {
     publish({
       key: "CommandMainMenu",

--- a/src/MobiFlightConnector/frontend/src/components/ConfigItemRowContextMenu.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/ConfigItemRowContextMenu.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuLabel,
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { useRowInteraction } from "@/lib/hooks/useRowInteraction"
 import { IConfigItem } from "@/types"
 import { CommandConfigContextMenu } from "@/types/commands"
@@ -37,7 +37,7 @@ function MenuItems({
   Label: typeof DropdownMenuLabel | typeof ContextMenuLabel
   Separator: typeof DropdownMenuSeparator | typeof ContextMenuSeparator
 }) {
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const navigate = useNavigate()
   const { startNameEdit } = useRowInteraction()
   const context = useContext(ConfigItemTableContext)

--- a/src/MobiFlightConnector/frontend/src/components/ExecutionToolbar.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/ExecutionToolbar.tsx
@@ -6,7 +6,7 @@ import {
 import { Button } from "./ui/button"
 import { useExecutionStateStore } from "@/stores/executionStateStore"
 import { useSettingsStore } from "@/stores/settingsStore"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { CommandProjectToolbarPayload } from "@/types/commands"
 import IconAutoRun from "./icons/IconAutoRun"
 import TwoStateIcon from "./icons/TwoStateIcon"
@@ -18,7 +18,7 @@ export const ExecutionToolbar = () => {
   const { settings } = useSettingsStore()
   const { isRunning, isTesting } =
     useExecutionStateStore()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
 
   const handleMenuItemClick = (payload: CommandProjectToolbarPayload) => {
     publish({

--- a/src/MobiFlightConnector/frontend/src/components/LogPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/LogPanel.tsx
@@ -7,7 +7,7 @@ import {
   IconPlayerPlay,
   IconX,
 } from "@tabler/icons-react"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { LogLevel } from "@/types/log"
 import { useSettingsStore } from "@/stores/settingsStore"
 import { useTranslation } from "react-i18next"
@@ -49,7 +49,7 @@ const SEVERITY_CLASS: Record<LogLevel, string> = {
 
 const LogPanel = () => {
   const { t } = useTranslation()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const { logs } = useLogsStore()
 
   // don't auto scroll, don't append new logs

--- a/src/MobiFlightConnector/frontend/src/components/MainMenu.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/MainMenu.tsx
@@ -12,7 +12,7 @@ import {
   MenubarTrigger,
 } from "./ui/menubar"
 import { CommunityMenu } from "./CommunityMenu"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { CommandMainMenuPayload } from "@/types/commands"
 import DarkModeToggle from "./DarkModeToggle"
 import { useProjectStore } from "@/stores/projectStore"
@@ -25,7 +25,7 @@ export const MainMenu = () => {
   const { t } = useTranslation()
   const { settings } = useSettingsStore()
   const { hasChanged } = useProjectStore()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const handleMenuItemClick = (payload: CommandMainMenuPayload) => {
     publish({
       key: "CommandMainMenu",

--- a/src/MobiFlightConnector/frontend/src/components/StartupProgress.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/StartupProgress.tsx
@@ -2,13 +2,14 @@ import SplashLogo from "@/components/SplashLogo"
 import { Progress } from "./ui/progress"
 import { StatusBarUpdate } from "@/types/messages"
 import { useEffect, useState } from "react"
-import { publishOnMessageExchange, useAppMessage } from "@/lib/hooks/appMessage"
+import { useAppMessage } from "@/lib/hooks/appMessage"
 import { useLocation, useNavigate, useSearchParams } from "react-router"
 import { useTranslation } from "react-i18next"
+import messageExchange from "@/lib/messageExchange"
 
 const StartupProgress = () => {
   const { t } = useTranslation()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const location = useLocation()
 
   // State for startup progress from app messages

--- a/src/MobiFlightConnector/frontend/src/components/auth/AuthCallback.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/auth/AuthCallback.tsx
@@ -1,4 +1,4 @@
-import useMessageExchange from "@/lib/hooks/useMessageExchange"
+import messageExchange from "@/lib/messageExchange"
 import {
   IconCircleCheck,
   IconExclamationCircle,
@@ -16,7 +16,7 @@ export type AuthCallbackProps = {
 export default function AuthCallback({ variant }: AuthCallbackProps) {
   const auth = useAuth()
   const navigate = useNavigate()
-  const { publish } = useMessageExchange()
+  const { publish } = messageExchange
   const { t } = useTranslation()
 
   useEffect(() => {

--- a/src/MobiFlightConnector/frontend/src/components/controllers/ControllerBindingsDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/controllers/ControllerBindingsDialog.tsx
@@ -11,7 +11,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import {
   Controller,
   ControllerBinding,
@@ -39,7 +39,7 @@ const ControllerBindingsDialog = ({
     useState<ControllerBinding[]>(bindings)
   const [finalBindings, setFinalBindings] =
     useState<ControllerBinding[]>(bindings)
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
 
   // This test ensures that our binding items
   // will be update if the prop passed into the component updates

--- a/src/MobiFlightConnector/frontend/src/components/modals/ProjectFormModal.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/modals/ProjectFormModal.tsx
@@ -1,7 +1,7 @@
 import { useLocation, useNavigate } from "react-router-dom"
 import type { ProjectInfo } from "@/types/project"
 import ProjectForm from "@/components/project/ProjectForm"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 
 export default function ProjectFormModal() {
   const navigate = useNavigate()
@@ -10,7 +10,7 @@ export default function ProjectFormModal() {
 
   const project = location.state?.project as ProjectInfo | { Name: "" } as ProjectInfo
   const isEdit = location.state?.mode === "edit"
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
 
   return (
     <ProjectForm

--- a/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -1,4 +1,5 @@
-import { publishOnMessageExchange, useAppMessage } from "@/lib/hooks/appMessage"
+import { useAppMessage } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { Notification } from "@/types/messages"
 import { toast } from "@/components/ui/ToastWrapper"
 import { CommandMainMenu } from "@/types/commands"
@@ -6,7 +7,7 @@ import HubHopUpdateToast from "./HubHopUpdateToast"
 import { useTranslation } from "react-i18next"
 
 export const ToastNotificationHandler = () => {
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const { t } = useTranslation()
 
   useAppMessage("Notification", (message) => {

--- a/src/MobiFlightConnector/frontend/src/components/project/ProfileTab.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProfileTab.tsx
@@ -1,6 +1,6 @@
 import { ConfigFile } from "@/types"
 import { VariantProps } from "class-variance-authority"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { CommandFileContextMenu } from "@/types/commands"
 import { Button } from "@/components/ui/button"
 import { buttonVariants } from "@/components/ui/variants"
@@ -28,7 +28,7 @@ export const ProfileTab = forwardRef<HTMLDivElement, ProfileTabProps>(
     }: ProfileTabProps,
     ref,
   ) => {
-    const { publish } = publishOnMessageExchange()
+    const { publish } = messageExchange
     const inlineEditRef = useRef<InlineEditLabelRef>(null)
     const buttonRef = useRef<HTMLButtonElement>(null)
 

--- a/src/MobiFlightConnector/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProfileTab/ProfileTabContextMenu.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { buttonVariants } from "@/components/ui/variants"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { cn } from "@/lib/utils"
 import { ConfigFile } from "@/types"
 import { CommandFileContextMenu } from "@/types/commands"
@@ -32,7 +32,7 @@ const ProfileTabContextMenu = ({
   inlineEditRef,
 }: ProfileTabContextMenuProps) => {
   const { t } = useTranslation()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
 
   return (
     <div className="relative">

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectCard.tsx
@@ -28,7 +28,7 @@ import {
   useProjectModal,
 } from "@/lib/hooks/useProjectModal"
 import { useExecutionStateStore } from "@/stores/executionStateStore"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import {
   CommandProjectToolbarPayload,
 } from "@/types/commands"
@@ -118,7 +118,7 @@ export const ProjectCardStartStopButton = ({
   className,
   ...props
 }: HtmlHTMLAttributes<HTMLButtonElement>) => {
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const { isRunning, isTesting } = useExecutionStateStore()
 
   const handleMenuItemClick = (payload: CommandProjectToolbarPayload) => {

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectList.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectList.tsx
@@ -8,7 +8,7 @@ import { useRef } from "react"
 import { ProjectCreateButton } from "@/components/project/ProjectCreateButton"
 import { cn } from "@/lib/utils"
 import ProjectListFilter from "@/components/project/ProjectListFilter"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 
 export type ProjectListProps = {
   className?: string
@@ -29,7 +29,7 @@ const ProjectList = ({
   const refActiveElement = useRef<HTMLDivElement | null>(null)
   const scrollTimeoutRef = useRef<number | null>(null)
 
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
 
 
   const [searchParams, setSearchParams] = useSearchParams()

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectMainCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectMainCard.tsx
@@ -10,9 +10,9 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card"
+import messageExchange from "@/lib/messageExchange"
 import { useAsynchronous } from "@/lib/hooks/useAsynchronous"
 import { useErrorFallbackTest } from "@/lib/hooks/useErrorFallbackTest"
-import useMessageExchange from "@/lib/hooks/useMessageExchange"
 import { useProjectStore } from "@/stores/projectStore"
 import { useRecentProjects } from "@/stores/settingsStore"
 import { CommandMainMenu } from "@/types/commands"
@@ -28,7 +28,7 @@ const ProjectMainCard = () => {
   trigger("project-main-card")
 
   const { t } = useTranslation()
-  const { publish } = useMessageExchange()
+  const { publish } = messageExchange
   const { recentProjects } = useRecentProjects()
   const { project, hasChanged, saveStatus, setSaveStatus } = useProjectStore()
   const activeProject = project

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectNameLabel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectNameLabel.tsx
@@ -3,7 +3,7 @@ import { IconDeviceGamepad2, IconDotsVertical, IconPencil, IconSettings } from "
 import { useTranslation } from "react-i18next"
 import { Button } from "../ui/button"
 import { useEffect, useRef, useState } from "react"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { CommandMainMenuPayload, CommandProjectToolbar } from "@/types/commands"
 import {
   DropdownMenu,
@@ -25,7 +25,7 @@ export type ProjectNameLabelProps = {
 const ProjectNameLabel = () => {
   const { t } = useTranslation()
   const { project, hasChanged } = useProjectStore()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const label = project?.Name ?? "Untitled Project"
   const [optimisticLabel, setOptimisticLabel] = useState(label)
   const { showOverlay : showModalOverlay } = useModal()

--- a/src/MobiFlightConnector/frontend/src/components/project/ProjectPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/project/ProjectPanel.tsx
@@ -6,7 +6,7 @@ import {
   IconChevronRight,
   IconMinusVertical,
 } from "@tabler/icons-react"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { useProjectStore } from "@/stores/projectStore"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
@@ -33,7 +33,7 @@ const ProjectPanel = () => {
   const overflowRef = useRef<HTMLDivElement | null>(null)
 
   const { t } = useTranslation()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const navigate = useNavigate()
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const { width, height } = useWindowSize()
@@ -72,7 +72,7 @@ const ProjectPanel = () => {
   )
 
   useEffect(() => {
-    publishOnMessageExchange().publish({
+    messageExchange.publish({
       key: "CommandActiveConfigFile",
       payload: {
         index: activeConfigFileIndex,
@@ -147,7 +147,7 @@ const ProjectPanel = () => {
   }, [width, height, scrollActiveProfileTabIntoViewWithDelay])
 
   const addConfigFile = () => {
-    publishOnMessageExchange().publish({
+    messageExchange.publish({
       key: "CommandAddConfigFile",
       payload: {
         type: "create",
@@ -159,7 +159,7 @@ const ProjectPanel = () => {
   }
 
   const mergeConfigFile = () => {
-    publish({
+    messageExchange.publish({
       key: "CommandAddConfigFile",
       payload: {
         type: "merge",

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/config-item-table.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/config-item-table.tsx
@@ -17,7 +17,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { DataTableToolbar } from "./data-table-toolbar"
 import { IConfigItem } from "@/types"
 import { Button } from "@/components/ui/button"
-import { publishOnMessageExchange, useAppMessage } from "@/lib/hooks/appMessage"
+import { useAppMessage } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import {
   CommandAddConfigItem,
   CommandConfigContextMenu,
@@ -104,7 +105,7 @@ export function ConfigItemTable<TValue>({
   //   overscan: 5
   // });
 
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const tableRef = useRef<HTMLTableElement>(null)
   const tableBodyRef = useRef<HTMLTableSectionElement>(null)
   const previousData = useRef(data)

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableActionsCell.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableActionsCell.tsx
@@ -3,7 +3,7 @@ import {
   DropdownMenu,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { CommandConfigContextMenu } from "@/types/commands"
 import { IConfigItem } from "@/types/config"
 import { IconDots, IconEdit } from "@tabler/icons-react"
@@ -19,7 +19,7 @@ function ConfigItemTableActionsCell({
   row,
 }: ConfigItemTableActionsCellProps) {
   const item = row.original
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const navigate = useNavigate()
 
   const isInputConfig = item.Type === "InputConfigItem"

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableActiveCell.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableActiveCell.tsx
@@ -1,5 +1,5 @@
 import { Switch } from "@/components/ui/switch"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { CommandUpdateConfigItem } from "@/types/commands"
 import { IConfigItem } from "@/types/config"
 import { useSortable } from "@dnd-kit/sortable"
@@ -12,7 +12,7 @@ interface ConfigItemTableActiveCellProps {
 }
 
 function ConfigItemTableActiveCell({ row }: ConfigItemTableActiveCellProps) {
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const item = row.original as IConfigItem
   const { attributes, listeners } = useSortable({ id: item.GUID })
 

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableBody.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableBody.tsx
@@ -2,7 +2,7 @@ import { TableBody, TableCell } from "@/components/ui/table"
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import { flexRender, Row, Table } from "@tanstack/react-table"
 import { DndTableRow } from "../DndTableRow"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { cn } from "@/lib/utils"
 import { useState, useEffect, forwardRef } from "react"
 import { RowInteractionProvider } from "../RowInteractionContext"
@@ -22,7 +22,7 @@ const ConfigItemTableBody = forwardRef<
   ConfigItemTableBodyProps<IConfigItem>
 >(({ table, dragItemId, onDeleteSelected, onToggleSelected }, ref) => {
   const navigate = useNavigate()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const rows = table.getRowModel().rows
   const [lastSelected, setLastSelected] = useState<Row<IConfigItem> | null>(
     null,

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableControllerCell.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableControllerCell.tsx
@@ -1,5 +1,5 @@
 import ToolTip from "@/components/ToolTip"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { IConfigItem } from "@/types"
 import { CommandConfigContextMenu } from "@/types/commands"
 import { IconBan, IconExternalLink } from "@tabler/icons-react"
@@ -14,7 +14,7 @@ function ConfigItemTableControllerCell({
   row,
 }: ConfigItemTableControllerCellProps) {
   const { t } = useTranslation()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const item = row.original as IConfigItem
 
   const label = item.Controller?.Name ?? ""

--- a/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableNameCell.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/tables/config-item-table/items/ConfigItemTableNameCell.tsx
@@ -2,7 +2,7 @@ import {
   InlineEditLabel,
   InlineEditLabelRef,
 } from "@/components/InlineEditLabel"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { CommandUpdateConfigItem } from "@/types/commands"
 import { IConfigItem } from "@/types/config"
 import { Row } from "@tanstack/react-table"
@@ -13,7 +13,7 @@ interface ConfigItemTableNameCellProps {
   row: Row<IConfigItem>
 }
 function ConfigItemTableNameCell({ row }: ConfigItemTableNameCellProps) {
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const { registerNameEdit } = useRowInteraction()
   const inlineEditRef = useRef<InlineEditLabelRef>(null)
 

--- a/src/MobiFlightConnector/frontend/src/components/user/UserMenuItem.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/user/UserMenuItem.tsx
@@ -8,8 +8,8 @@ import {
   DropdownMenuLabel,
 } from "@/components/ui/dropdown-menu"
 import { MenubarSeparator } from "@/components/ui/menubar"
+import messageExchange from "@/lib/messageExchange"
 import toast from "@/components/ui/ToastWrapper"
-import useMessageExchange from "@/lib/hooks/useMessageExchange"
 import { cn } from "@/lib/utils"
 import { useUserProfileStore } from "@/stores/userProfileStore"
 import { CommandOpenLinkInBrowser } from "@/types/commands"
@@ -51,7 +51,7 @@ const CopyToClipboardIcon = ({
 
 const UserMenuItem = () => {
   const auth = useAuth()
-  const { publish } = useMessageExchange()
+  const { publish } = messageExchange
   const { t } = useTranslation()
   const [open, setOpen] = useState(false)
   const { userProfile } = useUserProfileStore()

--- a/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/InputConfigDialog.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import ConfigWizard from "@/components/wizard/ConfigWizard"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { cn } from "@/lib/utils"
 import { useProjectStore } from "@/stores/projectStore"
 import { useConfigItemStateValue } from "@/stores/configItemStateStore"
@@ -60,7 +60,7 @@ const InputConfigDialog = ({ configId }: InputConfigDialogProps) => {
   }
 
   const saveChanges = () => {
-    const { publish } = publishOnMessageExchange()
+    const { publish } = messageExchange
 
     const finalConfigItem = resetTriggersBasedOnDeviceType(draftConfigItem)
     setCommittedConfigItem(finalConfigItem)

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/ConfigTrigger.tsx
@@ -1,7 +1,8 @@
 import ComboBox from "@/components/ComboBox"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
-import { publishOnMessageExchange, useAppMessage } from "@/lib/hooks/appMessage"
+import { useAppMessage } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 
 import { useControllerStore } from "@/stores/controllerStore"
 import { CommandScanForInput } from "@/types/commands"
@@ -119,7 +120,7 @@ const ConfigTrigger = ({ configItem, setConfigItem }: ConfigTriggerProps) => {
   })
 
   const scanForInput = () => {
-    const { publish } = publishOnMessageExchange()
+    const { publish } = messageExchange
     publish({
       key: "CommandScanForInput",
       payload: {

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/ProsimDataRefPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/ProsimDataRefPanel.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { cn } from "@/lib/utils"
 import {
   ProSimDataRefDefinition,
@@ -22,7 +22,7 @@ const ProSimDataRefPanel = ({
 }: ProSimDataRefPanelProps) => {
   const { t } = useTranslation()
   const { dataRefs } = useProSimDataRefStore()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const selectedPreset = selectedPath ? dataRefs[selectedPath] : null
 
   const [filter, setFilter] = useState({

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VJoyInputActionPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VJoyInputActionPanel.tsx
@@ -1,7 +1,8 @@
 import ComboBox from "@/components/ComboBox"
 import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { publishOnMessageExchange, useAppMessage } from "@/lib/hooks/appMessage"
+import { useAppMessage } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { useVJoyControllerStore } from "@/stores/controllerStore"
 import { VJoyInputAction } from "@/types/config"
 import { VJoyDefinitionsUpdate } from "@/types/messages"
@@ -23,7 +24,7 @@ const VJoyInputActionPanel = ({
   setConfig,
 }: VJoyInputActionPanelProps) => {
   const { t } = useTranslation()
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
   const { vJoyDefinitions, setVJoyDefinitions } = useVJoyControllerStore()
 
   useAppMessage("VJoyDefinitionsUpdate", (message) => {

--- a/src/MobiFlightConnector/frontend/src/lib/dnd/utilities.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/dnd/utilities.ts
@@ -1,7 +1,7 @@
 import type { DragEndEvent } from "@dnd-kit/core"
 import type { IConfigItem } from "@/types"
 import type { DragState } from "@/components/providers/DragDropProvider"
-import { publishOnMessageExchange } from "@/lib/hooks/appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { CommandResortConfigItem } from "@/types/commands"
 
 /**
@@ -132,7 +132,7 @@ export const executeDrop = (
   )
 
   // Notify backend
-  publishOnMessageExchange().publish({
+  messageExchange.publish({
     key: "CommandResortConfigItem",
     payload: {
       items: dragState.items.draggedItems,

--- a/src/MobiFlightConnector/frontend/src/lib/hooks/appMessage.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/hooks/appMessage.ts
@@ -16,15 +16,23 @@ function subscribeToAppMessageEventsOnce() {
   if (appMessageSubscriptionCreated) return
   appMessageSubscriptionCreated = true
 
-  window.chrome?.webview?.addEventListener("message", (event: Event) => {
-    try {
-      const appMessage = (event as MessageEvent).data as AppMessage
-      registeredAppMessageKeyHandlers
-        .get(appMessage.key)
-        ?.forEach((handler) => handler(appMessage))
-    } catch (error) {
-      console.error("Error parsing message", error)
+  const webview = window.chrome?.webview
+  if (!webview) return
+
+  webview?.addEventListener("message", (event: Event) => {
+    const appMessage = (event as MessageEvent)?.data as AppMessage
+    if (!appMessage) {
+      console.error("Error parsing message")
+      return
     }
+
+    registeredAppMessageKeyHandlers.get(appMessage.key)?.forEach((handler) => {
+      try {
+        handler(appMessage)
+      } catch (error) {
+        console.error("Error processing message", error)
+      }
+    })
   })
 }
 

--- a/src/MobiFlightConnector/frontend/src/lib/hooks/appMessage.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/hooks/appMessage.ts
@@ -1,13 +1,32 @@
-import { CommandMessage } from "@/types/commands"
 import { AppMessage, AppMessageKey } from "@/types/messages"
 import { useEffect } from "react"
 
-export const publishOnMessageExchange = () => ({
-  publish: (message: CommandMessage) => {
-    console.log(`Publishing FrontendMessage -> ${message.key} : ${message.payload ? JSON.stringify(message.payload) : "no payload"}`)
-    window.chrome?.webview?.postMessage(message)
-  },
-})
+// Use Map for efficient lookup of registered message key handlers
+// Use Set to deduplicate handlers for the same callback function
+const registeredAppMessageKeyHandlers = new Map<
+  AppMessageKey,
+  Set<(message: AppMessage) => void>
+>()
+
+// Flag to ensure we only subscribe to the webview message event once
+let appMessageSubscriptionCreated = false
+
+// Subscribe to all messages from the webview and dispatch to registered handlers
+function subscribeToAppMessageEventsOnce() {
+  if (appMessageSubscriptionCreated) return
+  appMessageSubscriptionCreated = true
+
+  window.chrome?.webview?.addEventListener("message", (event: Event) => {
+    try {
+      const appMessage = (event as MessageEvent).data as AppMessage
+      registeredAppMessageKeyHandlers
+        .get(appMessage.key)
+        ?.forEach((handler) => handler(appMessage))
+    } catch (error) {
+      console.error("Error parsing message", error)
+    }
+  })
+}
 
 // create a useAppMessage hook that listens for messages
 // the paramaters are the AppMessageKey and the onReceiveMessage callback
@@ -17,25 +36,20 @@ export const useAppMessage = (
   onReceiveMessage: (message: AppMessage) => void,
 ) => {
   useEffect(() => {
-    const onReveiveMessageHandler = (event: Event) => {
-      try {
-        const appMessage = (event as MessageEvent).data as AppMessage
-        if (appMessage.key === key) {
-          onReceiveMessage(appMessage)
-        }
-      } catch (error) {
-        console.error("Error parsing message", error)
-      }
-    }
+    // ensure global listener is registered
+    subscribeToAppMessageEventsOnce()
 
-    // add an event listener for the message key
-    window.chrome?.webview?.addEventListener("message", onReveiveMessageHandler)
+    // add additional handler for this key
+    let appMessageKeyHandlers = registeredAppMessageKeyHandlers.get(key)
+    if (!appMessageKeyHandlers) {
+      appMessageKeyHandlers = new Set()
+      registeredAppMessageKeyHandlers.set(key, appMessageKeyHandlers)
+    }
+    appMessageKeyHandlers.add(onReceiveMessage)
+
     return () => {
-      // remove the event listener when the component is unmounted
-      window.chrome?.webview?.removeEventListener(
-        "message",
-        onReveiveMessageHandler,
-      )
+      // simply remove the handler from the set
+      appMessageKeyHandlers?.delete(onReceiveMessage)
     }
   }, [key, onReceiveMessage])
 }

--- a/src/MobiFlightConnector/frontend/src/lib/hooks/useKeyAccelerators.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/hooks/useKeyAccelerators.ts
@@ -1,12 +1,12 @@
 import { useEffect } from "react"
-import { publishOnMessageExchange } from "./appMessage"
+import messageExchange from "@/lib/messageExchange"
 import { KeyAccelerator } from "@/types/accelerator"
 
 export const useKeyAccelerators = (
   accelerators: KeyAccelerator[],
   enabled: boolean = true,
 ) => {
-  const { publish } = publishOnMessageExchange()
+  const { publish } = messageExchange
 
   useEffect(() => {
     if (!enabled) return

--- a/src/MobiFlightConnector/frontend/src/lib/hooks/useOpenUrl.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/hooks/useOpenUrl.ts
@@ -1,7 +1,7 @@
-import useMessageExchange from "@/lib/hooks/useMessageExchange"
+import messageExchange from "@/lib/messageExchange"
 
 const useOpenUrl = () => {
-  const { publish } = useMessageExchange()
+  const { publish } = messageExchange
 
   const openUrl = (url: string) => {
     publish({

--- a/src/MobiFlightConnector/frontend/src/lib/messageExchange.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/messageExchange.ts
@@ -1,10 +1,10 @@
 import { CommandMessage } from "@/types/commands"
 
-const useMessageExchange = () => ({
+const messageExchange = {
   publish: (message: CommandMessage) => {
     console.log(`Publishing FrontendMessage -> ${message.key} : ${message.payload ? JSON.stringify(message.payload) : "no payload"}`)
     window.chrome?.webview?.postMessage(message)
   },
-})
+}
 
-export default useMessageExchange
+export default messageExchange


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
We change the way how to check if a valid subscriber is registered for a specific app message key (AppMessageKey)

Old implementation registered app message handlers inefficiently.
New implementation now only registers one message event listener and uses a Map to efficiently invoke the correct callback handlers.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] One global message event subscription
- [x] Use Map for efficient callback invocation

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Frontend tests
     
## Related issues
<!-- fixes, relates to existing #issues -->
n/a