### PR TITLE
Fix ProSim dataref startup race

### DIFF
--- a/src/MobiFlightConnector/ProSim/ProSimCache.cs
+++ b/src/MobiFlightConnector/ProSim/ProSimCache.cs
@@ -47,7 +47,6 @@ namespace MobiFlight.ProSim
             public object Value { get; set; }
             public DataRef DataRefObject { get; set; }
             public int UpdateInterval { get; set; }
-            public DataRefDescription DataRefDescription { get; set; }
         }
 
         public bool Connect()
@@ -195,7 +194,7 @@ namespace MobiFlight.ProSim
 
         private void UpdateCachedValue(string datarefPath, object value)
         {
-            lock (_cacheLock)
+            lock (_subscribedDataRefs)
             {
                 if (_subscribedDataRefs.TryGetValue(datarefPath, out var cachedRef))
                 {
@@ -210,12 +209,6 @@ namespace MobiFlight.ProSim
                         Path = datarefPath,
                         Value = value,
                     };
-
-                    // Set DataRefDescription if available
-                    if (_dataRefDescriptions.TryGetValue(datarefPath, out var description))
-                    {
-                        newCachedRef.DataRefDescription = description;
-                    }
 
                     _subscribedDataRefs[datarefPath] = newCachedRef;
                 }
@@ -460,28 +453,32 @@ mutation ($name: String!, $value: {graphqlType}) {{
                     return (double)0;
                 }
 
+                object value;
                 lock (_subscribedDataRefs)
                 {
-                    if (!_subscribedDataRefs.ContainsKey(datarefPath))
+                    if (!_subscribedDataRefs.TryGetValue(datarefPath, out var subscribedDataRef))
                     {
                         // Wait for data to be returned by the subscription
                         return (double)0;
                     }
 
-                    // Cache the dictionary value to avoid redundant lookups
-                    var subscribedDataRef = _subscribedDataRefs[datarefPath];
-                    var value = subscribedDataRef.Value;
-
-                    if (subscribedDataRef.DataRefDescription.DataType == "System.String")
-                    {
-                        return value;
-                    }
-
-                    var returnValue = (value == null) ? 0 : Convert.ToDouble(value);
-
-                    return returnValue;
+                    value = subscribedDataRef.Value;
                 }
 
+                DataRefDescription description;
+                lock (_cacheLock)
+                {
+                    _dataRefDescriptions.TryGetValue(datarefPath, out description);
+                }
+
+                // Subscription values can arrive before the asynchronous definition refresh.
+                // Use the runtime value type until the definition becomes available.
+                if (description?.DataType == "System.String" || value is string)
+                {
+                    return value;
+                }
+
+                return (value == null) ? 0 : Convert.ToDouble(value);
             }
             catch (Exception ex)
             {

--- a/tests/MobiFlightUnitTests/ProSim/ProSimCacheTests.cs
+++ b/tests/MobiFlightUnitTests/ProSim/ProSimCacheTests.cs
@@ -464,12 +464,15 @@ namespace MobiFlight.Tests.ProSim
         [TestMethod()]
         public void ReadDataref_WhenValueArrivesBeforeDefinitions_ShouldReturnNumericValue()
         {
+            // Arrange
             const string datarefPath = "system.numerical.test";
             SetupConnectedCache(_cache, new Mock<IGraphQLWebSocketClient>().Object, new Dictionary<string, DataRefDescription>());
             SetSubscribedDataRefValue(_cache, datarefPath, 123);
 
+            // Act
             var result = _cache.readDataref(datarefPath);
 
+            // Assert
             Assert.AreEqual(123.0, result);
         }
 

--- a/tests/MobiFlightUnitTests/ProSim/ProSimCacheTests.cs
+++ b/tests/MobiFlightUnitTests/ProSim/ProSimCacheTests.cs
@@ -3,6 +3,7 @@ using GraphQL.Client.Abstractions.Websocket;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight.ProSim;
 using Moq;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 
@@ -458,6 +459,41 @@ namespace MobiFlight.Tests.ProSim
 
             // Assert
             Assert.AreEqual(0.0, result);
+        }
+
+        [TestMethod()]
+        public void ReadDataref_WhenValueArrivesBeforeDefinitions_ShouldReturnNumericValue()
+        {
+            const string datarefPath = "system.numerical.test";
+            SetupConnectedCache(_cache, new Mock<IGraphQLWebSocketClient>().Object, new Dictionary<string, DataRefDescription>());
+            SetSubscribedDataRefValue(_cache, datarefPath, 123);
+
+            var result = _cache.readDataref(datarefPath);
+
+            Assert.AreEqual(123.0, result);
+        }
+
+        [TestMethod()]
+        public void ReadDataref_WhenStringValueArrivesBeforeDefinitions_ShouldReturnStringValue()
+        {
+            const string datarefPath = "system.string.test";
+            SetupConnectedCache(_cache, new Mock<IGraphQLWebSocketClient>().Object, new Dictionary<string, DataRefDescription>());
+            SetSubscribedDataRefValue(_cache, datarefPath, "MCP SPEED");
+
+            var result = _cache.readDataref(datarefPath);
+
+            Assert.AreEqual("MCP SPEED", result);
+        }
+
+        private void SetSubscribedDataRefValue(ProSimCache cache, string datarefPath, object value)
+        {
+            var type = typeof(ProSimCache);
+            var subscriptionsField = type.GetField("_subscriptions", BindingFlags.NonPublic | BindingFlags.Instance);
+            var subscriptions = (Dictionary<string, IDisposable>)subscriptionsField.GetValue(cache);
+            subscriptions[datarefPath] = new Mock<IDisposable>().Object;
+
+            var updateCachedValue = type.GetMethod("UpdateCachedValue", BindingFlags.NonPublic | BindingFlags.Instance);
+            updateCachedValue.Invoke(cache, new[] { datarefPath, value });
         }
 
         #endregion


### PR DESCRIPTION
## What changed

- stop storing definition metadata in subscription value entries
- read the current data-ref definition safely when returning cached values
- fall back to the runtime value type while definitions are still loading
- use the same lock for subscription cache reads and writes
- add numeric and string regression tests for values arriving before definitions

## Why

With auto-run enabled, ProSim subscription values can arrive before the asynchronous data-definition refresh completes. The old cache permanently stored a null `DataRefDescription` and `readDataref()` dereferenced it on every execution cycle, producing repeated `Object reference not set` errors. Waiting before manually starting happened to hide the race.

This change makes either startup order safe without delaying unrelated project execution or requiring users to disable auto-run.

## Validation

- Release/x86 CI-style MSBuild target passed
- focused `ProSimCacheTests`: 18/18 passed
- full `MobiFlightUnitTests`: 903 passed, 31 skipped, 0 failed

Fixes #3316
