### PR TITLE
Use *.* for zip file creation to avoid breaking MobiFlight-Installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: package
         run: |
           Copy-Item -Path "${{ github.workspace }}/${{ env.INSTALLER_OUTPUT }}/MobiFlight-Installer.exe" -Destination "${{ github.workspace }}/dist/MobiFlightConnector-${{ env.VERSION }}"
-          & "${{ github.workspace }}\Build\utils\7z\7z.exe" a ${{ github.workspace }}/dist/MobiFlightConnector-${{ env.VERSION }}.zip ${{ github.workspace }}/dist/MobiFlightConnector-${{ env.VERSION }}/* -r
+          & "${{ github.workspace }}\Build\utils\7z\7z.exe" a ${{ github.workspace }}/dist/MobiFlightConnector-${{ env.VERSION }}.zip ${{ github.workspace }}/dist/MobiFlightConnector-${{ env.VERSION }}/*.* -r
 
       - name: store latest setup file
         if: github.event_name != 'release'


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
We are using `*.*` instead of `*` for zip creation to make sure that the old installer doesn't fail while processing folders (which are included when using *).

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] The zip file doesn't contain folder items

### DoD Checklist
n/a 
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3295 

### Notes
We will have to introduce a new update check url if we really have files that won't match `*.*` - e.g., when going cross platform.
With a new update url, we can ensure that users who skip versions will also be able to update smoothly.

11.1 - `*.*` pattern in zip, Installer can't handle folders
11.2 - `*.*` pattern in zip, Installer can already handle folders.
11.3 - `*` pattern in zip. Installer can handle folders.

Update from 11.1 to 11.3 will not be possible.
We have to force 11.1 to 11.2 and then 11.3.
This can be achieved if we introduce a new update URI in 11.2.

Old clients will only know the old URI and the latest version will be 11.2
New clients will check using the new URI as soon as they have updated to 11.2
