### PR TITLE
Migrate user config settings when updating to .NET10 based MobiFlight version

### DIFF
--- a/src/MobiFlightConnector/Base/Legacy/UserSettingsMigration.cs
+++ b/src/MobiFlightConnector/Base/Legacy/UserSettingsMigration.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
+using System.Xml.Serialization;
 
 namespace MobiFlight.Base.Legacy
 {
@@ -14,86 +15,152 @@ namespace MobiFlight.Base.Legacy
 
         public static void MigrateLegacySettingsIfNeeded()
         {
-            if (Properties.Settings.Default.LegacySettingsMigrated)
+            var localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            var companyFolder = Path.Combine(localAppData, Company);
+            var currentVersion = typeof(UserSettingsMigration).Assembly.GetName().Version;
+
+            MigrateLegacySettingsIfNeeded(Properties.Settings.Default, companyFolder, currentVersion);
+        }
+
+        /// <summary>
+        /// Does the actual migration work. Takes the settings to migrate into and the folder to look
+        /// for legacy "MFConnector.exe_*" installs under as parameters so this can be exercised in
+        /// tests without touching the real %LOCALAPPDATA% or the process-wide Properties.Settings.Default.
+        /// </summary>
+        internal static void MigrateLegacySettingsIfNeeded(Properties.Settings settings, string companyFolder, Version currentVersion)
+        {
+            if (settings.LegacySettingsMigrated)
                 return;
 
             try
             {
-                string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-                string companyFolder = Path.Combine(localAppData, Company);
-
-                if (!Directory.Exists(companyFolder))
-                    return;
-
-                // Legacy folders look like: MFConnector.exe_Url_<hash>  (hash varies)
-                var legacyFolders = Directory.GetDirectories(companyFolder, $"{LegacyFolderPrefix}_*");
-
-                if (legacyFolders.Length == 0)
-                    return;
-
-                var candidates = new List<(string ConfigPath, DateTime LastModified)>();
-
-                foreach (var legacyFolder in legacyFolders)
-                {
-                    // Within this hash folder, find the highest version subfolder that actually has a user.config
-                    var bestVersionConfig = Directory.GetDirectories(legacyFolder).ToList()
-                        .Select(d => new { Path = d, Name = Path.GetFileName(d) })
-                        .Where(x => Version.TryParse(x.Name, out _))
-                        .OrderByDescending(x => Version.Parse(x.Name))
-                        .Select(x => Path.Combine(x.Path, "user.config"))
-                        .FirstOrDefault(File.Exists);
-
-                    if (bestVersionConfig != null)
-                    {
-                        candidates.Add((bestVersionConfig, File.GetLastWriteTimeUtc(bestVersionConfig)));
-                    }
-                }
-
-                if (candidates.Count == 0)
+                string legacyConfigPath = FindMostRecentLegacyConfigPath(companyFolder, LegacyFolderPrefix, currentVersion);
+                if (legacyConfigPath == null)
                 {
                     Log.Instance.log("No legacy user.config files found for migration.", LogSeverity.Debug);
-                    return;
                 }
 
-                // Across all lineages, take the most recently modified user.config
-                string legacyConfigPath = candidates
-                    .OrderByDescending(c => c.LastModified)
-                    .First()
-                    .ConfigPath;
-
-                var doc = XDocument.Load(legacyConfigPath);
-                foreach (var el in doc.Descendants("setting"))
+                foreach (var setting in ParseLegacySettings(legacyConfigPath))
                 {
-                    string name = el.Attribute("name")?.Value;
-                    string value = el.Element("value")?.Value;
-                    if (name == null || value == null) continue;
-
-                    var prop = Properties.Settings.Default.Properties[name];
+                    var prop = settings.Properties[setting.Key];
                     if (prop == null) continue;
 
-                    try
+                    if (TryConvertSettingValue(setting.Value, prop.PropertyType, out object converted))
                     {
-                        var converter = TypeDescriptor.GetConverter(prop.PropertyType);
-                        object converted = converter.CanConvertFrom(typeof(string))
-                            ? converter.ConvertFromInvariantString(value)
-                            : Convert.ChangeType(value, prop.PropertyType);
-
-                        Properties.Settings.Default[name] = converted;
-                    }
-                    catch
-                    {
-                        // skip settings that fail to convert (e.g. complex serialized types)
+                        settings[setting.Key] = converted;
                     }
                 }
+            }
+            catch(Exception ex)
+            {
+                Log.Instance.log($"Exception during user.config migration: {ex}", LogSeverity.Debug);
+            }
 
-                Properties.Settings.Default.LegacySettingsMigrated = true;
-                Properties.Settings.Default.Save();
+            // in all cases mark as migrated so we don't keep scanning for legacy configs on every startup
+            settings.LegacySettingsMigrated = true;
+            settings.Save();
+        }
+
+        /// <summary>
+        /// Finds the most recently modified legacy user.config across all "MFConnector.exe_*" hash
+        /// folders under <paramref name="companyFolder"/>, taking the highest version subfolder
+        /// within each hash folder that actually contains a user.config. Returns null if none exist.
+        /// </summary>
+        private static string FindMostRecentLegacyConfigPath(string companyFolder, string legacyFolderPrefix, Version currentVersion)
+        {
+            if (!Directory.Exists(companyFolder))
+                return null;
+
+            // Legacy folders look like: MFConnector.exe_Url_<hash>  (hash varies)
+            var legacyFolders = Directory.GetDirectories(companyFolder, $"{legacyFolderPrefix}_*");
+
+            if (legacyFolders.Length == 0)
+                return null;
+
+            var candidates = new List<(string ConfigPath, DateTime LastModified)>();
+
+            foreach (var legacyFolder in legacyFolders)
+            {
+                // Within this hash folder, find the highest version subfolder that actually has a user.config
+                var bestVersionConfig = Directory.GetDirectories(legacyFolder).ToList()
+                    .Select(d => new { Path = d, Name = Path.GetFileName(d) })
+                    // only consider versions <= the current version, to avoid migrating from a newer install
+                    .Where(x => Version.TryParse(x.Name, out var version) && version.CompareTo(currentVersion) <= 0)
+                    .OrderByDescending(x => Version.Parse(x.Name))
+                    .Select(x => Path.Combine(x.Path, "user.config"))
+                    .FirstOrDefault(File.Exists);
+
+                if (bestVersionConfig != null)
+                {
+                    candidates.Add((bestVersionConfig, File.GetLastWriteTimeUtc(bestVersionConfig)));
+                }
+            }
+
+            if (candidates.Count == 0)
+                return null;
+
+            // Across all lineages, take the most recently modified user.config
+            return candidates
+                .OrderByDescending(c => c.LastModified)
+                .First()
+                .ConfigPath;
+        }
+
+        // Reads each <setting> element out of a legacy .NET user.config file, keyed by name.
+        // Purely parses XML, no dependency on Properties.Settings.Default.
+        private static Dictionary<string, XElement> ParseLegacySettings(string legacyConfigPath)
+        {
+            var result = new Dictionary<string, XElement>();
+
+            if (legacyConfigPath == null || !File.Exists(legacyConfigPath))
+                return result;
+
+            var doc = XDocument.Load(legacyConfigPath);
+            foreach (var el in doc.Descendants("setting"))
+            {
+                string name = el.Attribute("name")?.Value;
+                if (name == null || el.Element("value") == null) continue;
+
+                result[name] = el;
+            }
+
+            return result;
+        }
+
+        // Converts a legacy <setting> element to the given target type, the same way
+        // System.Configuration would when loading a .config file: serializeAs="String" goes
+        // through a TypeConverter, serializeAs="Xml" (e.g. StringCollection) through XmlSerializer.
+        private static bool TryConvertSettingValue(XElement settingElement, Type targetType, out object converted)
+        {
+            converted = null;
+            var valueElement = settingElement.Element("value");
+
+            try
+            {
+                if (settingElement.Attribute("serializeAs")?.Value == "Xml")
+                {
+                    var xml = valueElement.Elements().FirstOrDefault();
+                    if (xml == null) return false;
+
+                    using (var reader = xml.CreateReader())
+                    {
+                        converted = new XmlSerializer(targetType).Deserialize(reader);
+                    }
+                    return true;
+                }
+
+                var converter = TypeDescriptor.GetConverter(targetType);
+                converted = converter.CanConvertFrom(typeof(string))
+                    ? converter.ConvertFromInvariantString(valueElement.Value)
+                    : Convert.ChangeType(valueElement.Value, targetType);
+                return true;
             }
             catch
             {
-                // log, don't block startup
+                // skip settings that fail to convert (e.g. an unrecognized complex type)
+                converted = null;
+                return false;
             }
         }
-
     }
 }

--- a/src/MobiFlightConnector/Base/Legacy/UserSettingsMigration.cs
+++ b/src/MobiFlightConnector/Base/Legacy/UserSettingsMigration.cs
@@ -37,7 +37,7 @@ namespace MobiFlight.Base.Legacy
                 string legacyConfigPath = FindMostRecentLegacyConfigPath(companyFolder, LegacyFolderPrefix, currentVersion);
                 if (legacyConfigPath == null)
                 {
-                    Log.Instance.log("No legacy user.config files found for migration.", LogSeverity.Debug);
+                    Log.Instance.log("No legacy user.config files found for migration.", LogSeverity.Info);
                 }
 
                 foreach (var setting in ParseLegacySettings(legacyConfigPath))
@@ -51,9 +51,9 @@ namespace MobiFlight.Base.Legacy
                     }
                 }
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
-                Log.Instance.log($"Exception during user.config migration: {ex}", LogSeverity.Debug);
+                Log.Instance.log($"Exception during user.config migration: {ex}", LogSeverity.Error);
             }
 
             // in all cases mark as migrated so we don't keep scanning for legacy configs on every startup

--- a/src/MobiFlightConnector/Base/Legacy/UserSettingsMigration.cs
+++ b/src/MobiFlightConnector/Base/Legacy/UserSettingsMigration.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+
+namespace MobiFlight.Base.Legacy
+{
+    static public class UserSettingsMigration
+    {
+        static readonly string Company = "MobiFlight";
+        static readonly string LegacyFolderPrefix = "MFConnector.exe";
+
+        public static void MigrateLegacySettingsIfNeeded()
+        {
+            if (Properties.Settings.Default.LegacySettingsMigrated)
+                return;
+
+            try
+            {
+                string localAppData = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                string companyFolder = Path.Combine(localAppData, Company);
+
+                if (!Directory.Exists(companyFolder))
+                    return;
+
+                // Legacy folders look like: MFConnector.exe_Url_<hash>  (hash varies)
+                var legacyFolders = Directory.GetDirectories(companyFolder, $"{LegacyFolderPrefix}_*");
+
+                if (legacyFolders.Length == 0)
+                    return;
+
+                var candidates = new List<(string ConfigPath, DateTime LastModified)>();
+
+                foreach (var legacyFolder in legacyFolders)
+                {
+                    // Within this hash folder, find the highest version subfolder that actually has a user.config
+                    var bestVersionConfig = Directory.GetDirectories(legacyFolder).ToList()
+                        .Select(d => new { Path = d, Name = Path.GetFileName(d) })
+                        .Where(x => Version.TryParse(x.Name, out _))
+                        .OrderByDescending(x => Version.Parse(x.Name))
+                        .Select(x => Path.Combine(x.Path, "user.config"))
+                        .FirstOrDefault(File.Exists);
+
+                    if (bestVersionConfig != null)
+                    {
+                        candidates.Add((bestVersionConfig, File.GetLastWriteTimeUtc(bestVersionConfig)));
+                    }
+                }
+
+                if (candidates.Count == 0)
+                {
+                    Log.Instance.log("No legacy user.config files found for migration.", LogSeverity.Debug);
+                    return;
+                }
+
+                // Across all lineages, take the most recently modified user.config
+                string legacyConfigPath = candidates
+                    .OrderByDescending(c => c.LastModified)
+                    .First()
+                    .ConfigPath;
+
+                var doc = XDocument.Load(legacyConfigPath);
+                foreach (var el in doc.Descendants("setting"))
+                {
+                    string name = el.Attribute("name")?.Value;
+                    string value = el.Element("value")?.Value;
+                    if (name == null || value == null) continue;
+
+                    var prop = Properties.Settings.Default.Properties[name];
+                    if (prop == null) continue;
+
+                    try
+                    {
+                        var converter = TypeDescriptor.GetConverter(prop.PropertyType);
+                        object converted = converter.CanConvertFrom(typeof(string))
+                            ? converter.ConvertFromInvariantString(value)
+                            : Convert.ChangeType(value, prop.PropertyType);
+
+                        Properties.Settings.Default[name] = converted;
+                    }
+                    catch
+                    {
+                        // skip settings that fail to convert (e.g. complex serialized types)
+                    }
+                }
+
+                Properties.Settings.Default.LegacySettingsMigrated = true;
+                Properties.Settings.Default.Save();
+            }
+            catch
+            {
+                // log, don't block startup
+            }
+        }
+
+    }
+}

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<UseWindowsForms>true</UseWindowsForms>
@@ -16,6 +16,7 @@
 		<Description>Open Source Flight Simulator Solution</Description>
 		<Product>MobiFlight Connector</Product>
 		<Copyright>Copyright Sebastian Moebius 2014 - 2026</Copyright>
+        <Company>MobiFlight</Company>
 		<ApplicationIcon>mobiflight.ico</ApplicationIcon>
 	</PropertyGroup>
 

--- a/src/MobiFlightConnector/Properties/Settings.Designer.cs
+++ b/src/MobiFlightConnector/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace MobiFlight.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.14.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "18.10.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -645,6 +645,18 @@ namespace MobiFlight.Properties {
             }
             set {
                 this["ProSimMaxRetryAttempts"] = value;
+            }
+        }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool LegacySettingsMigrated {
+            get {
+                return ((bool)(this["LegacySettingsMigrated"]));
+            }
+            set {
+                this["LegacySettingsMigrated"] = value;
             }
         }
     }

--- a/src/MobiFlightConnector/Properties/Settings.settings
+++ b/src/MobiFlightConnector/Properties/Settings.settings
@@ -159,5 +159,8 @@
     <Setting Name="ProSimMaxRetryAttempts" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">5</Value>
     </Setting>
+    <Setting Name="LegacySettingsMigrated" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -29,7 +29,7 @@ using System.ComponentModel;
 using MobiFlight.Controllers;
 using MobiFlight.UI.StateBadge;
 using MobiFlight.Base.LogAppender;
-using System.Threading;
+using MobiFlight.Base.Legacy;
 
 namespace MobiFlight.UI
 {
@@ -1150,20 +1150,26 @@ namespace MobiFlight.UI
         // when updating to a new MobiFlight Version
         private void UpgradeSettingsFromPreviousInstallation()
         {
+            // Perform upgrade step after version update
             if (Properties.Settings.Default.UpgradeRequired)
             {
                 try
                 {
                     Properties.Settings.Default.Upgrade();
+
+                    // Perform optional one-time migration step coming from NET4.8 to NET10
+                    UserSettingsMigration.MigrateLegacySettingsIfNeeded();
                 }
                 catch
                 {
                     // If the properties file is corrupted for some reason catch the exception and
                     // reset back to a default version.
-
                     Properties.Settings.Default.Reset();
                 }
+
+                // mark the upgrade as complete so that we don't do this again next time
                 Properties.Settings.Default.UpgradeRequired = false;
+
                 Properties.Settings.Default.StartedTotal += Properties.Settings.Default.Started;
                 Properties.Settings.Default.Started = 0;
                 Properties.Settings.Default.Save();

--- a/src/MobiFlightConnector/app.config
+++ b/src/MobiFlightConnector/app.config
@@ -173,6 +173,9 @@
       <setting name="ProSimMaxRetryAttempts" serializeAs="String">
         <value>5</value>
       </setting>
+      <setting name="LegacySettingsMigrated" serializeAs="String">
+        <value>False</value>
+      </setting>
     </MobiFlight.Properties.Settings>
     <ArcazeUSB.Properties.Settings>
       <setting name="RecentFiles" serializeAs="Xml">

--- a/tests/MobiFlightUnitTests/Base/Legacy/UserSettingsMigrationTests.cs
+++ b/tests/MobiFlightUnitTests/Base/Legacy/UserSettingsMigrationTests.cs
@@ -1,0 +1,232 @@
+namespace MobiFlight.Base.Legacy.Tests
+{
+    [TestClass]
+    public class UserSettingsMigrationTests
+    {
+        private static readonly Version DefaultCurrentVersion = new Version(11, 0, 0, 0);
+        private string _testDirectory;
+        [TestInitialize]
+        public void Setup()
+        {
+            _testDirectory = Path.Combine(Path.GetTempPath(), "UserSettingsMigrationTests", Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_testDirectory);
+        }
+        [TestCleanup]
+        public void Cleanup()
+        {
+            if (Directory.Exists(_testDirectory))
+            {
+                Directory.Delete(_testDirectory, true);
+            }
+        }
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_AlreadyMigrated_DoesNothing()
+        {
+            // Arrange: reach an already-migrated state via a real migration, then change state
+            CreateLegacyUserConfig("MFConnector.exe_Url_abc123", "10.5.2.0", @"
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>75</value>
+                </setting>");
+            var settings = CreateFreshSettings();
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            settings.PollInterval = 123;
+            CreateLegacyUserConfig("MFConnector.exe_Url_abc123", "10.5.2.0", @"
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>999</value>
+                </setting>");
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.AreEqual(123, settings.PollInterval);
+        }
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_NoLegacyInstallFound_MarksMigratedWithoutChangingValues()
+        {
+            // Arrange
+            var settings = CreateFreshSettings();
+            var defaultPollInterval = settings.PollInterval;
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.IsTrue(settings.LegacySettingsMigrated);
+            Assert.AreEqual(defaultPollInterval, settings.PollInterval);
+        }
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_RealisticLegacyConfig_MigratesKnownSettings()
+        {
+            // Arrange
+            CreateLegacyUserConfig("MFConnector.exe_Url_abc123", "10.5.2.0", @"
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>75</value>
+                </setting>
+                <setting name=""BetaUpdates"" serializeAs=""String"">
+                    <value>True</value>
+                </setting>
+                <setting name=""CacheId"" serializeAs=""String"">
+                    <value>d290f1ee-6c54-4b01-90e6-d701748f0851</value>
+                </setting>
+                <setting name=""Language"" serializeAs=""String"">
+                    <value>de-DE</value>
+                </setting>
+                <setting name=""LedIntensity"" serializeAs=""String"">
+                    <value>128</value>
+                </setting>");
+            var settings = CreateFreshSettings();
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.IsTrue(settings.LegacySettingsMigrated);
+            Assert.AreEqual(75, settings.PollInterval);
+            Assert.IsTrue(settings.BetaUpdates);
+            Assert.AreEqual("d290f1ee-6c54-4b01-90e6-d701748f0851", settings.CacheId);
+            Assert.AreEqual("de-DE", settings.Language);
+            Assert.AreEqual((byte)128, settings.LedIntensity);
+        }
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_UnknownSetting_IsSkippedWithoutFailingMigration()
+        {
+            // Arrange: "NoLongerExists" simulates a setting removed since the legacy version
+            CreateLegacyUserConfig("MFConnector.exe_Url_abc123", "10.5.2.0", @"
+                <setting name=""NoLongerExists"" serializeAs=""String"">
+                    <value>SomeOldValue</value>
+                </setting>
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>90</value>
+                </setting>");
+            var settings = CreateFreshSettings();
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.IsTrue(settings.LegacySettingsMigrated);
+            Assert.AreEqual(90, settings.PollInterval);
+        }
+
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_XmlSerializedRecentFiles_MigratesCorrectly()
+        {
+            // Arrange: RecentFiles is a StringCollection, serialized as Xml (not a plain string value)
+            CreateLegacyUserConfig("MFConnector.exe_Url_abc123", "10.5.2.0", @"
+                <setting name=""RecentFiles"" serializeAs=""Xml"">
+                    <value>
+                        <ArrayOfString xmlns:xsi=""http://www.w3.org/2001/XMLSchema-instance"" xmlns:xsd=""http://www.w3.org/2001/XMLSchema"">
+                            <string>C:\configs\one.mcc</string>
+                            <string>C:\configs\two.mcc</string>
+                        </ArrayOfString>
+                    </value>
+                </setting>");
+            var settings = CreateFreshSettings();
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.HasCount(2, settings.RecentFiles);
+            Assert.AreEqual(@"C:\configs\one.mcc", settings.RecentFiles[0]);
+            Assert.AreEqual(@"C:\configs\two.mcc", settings.RecentFiles[1]);
+        }
+
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_LinkedConfigSettings_AreRestored()
+        {
+            // Arrange: the auto-load-linked-config feature and its per-aircraft config mapping
+            CreateLegacyUserConfig("MFConnector.exe_Url_abc123", "10.5.2.0", @"
+                <setting name=""AutoLoadLinkedConfig"" serializeAs=""String"">
+                    <value>True</value>
+                </setting>
+                <setting name=""AutoLoadLinkedConfigList"" serializeAs=""String"">
+                    <value>{&quot;PMDG 737&quot;:&quot;C:\\configs\\737.mcc&quot;}</value>
+                </setting>");
+            var settings = CreateFreshSettings();
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.IsTrue(settings.AutoLoadLinkedConfig);
+            Assert.AreEqual(@"{""PMDG 737"":""C:\\configs\\737.mcc""}", settings.AutoLoadLinkedConfigList);
+        }
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_MultipleVersionFolders_UsesHighestVersion()
+        {
+            // Arrange
+            CreateLegacyUserConfig("MFConnector.exe_Url_abc123", "10.0.0.0", @"
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>10</value>
+                </setting>");
+            CreateLegacyUserConfig("MFConnector.exe_Url_abc123", "10.5.2.0", @"
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>75</value>
+                </setting>");
+            var settings = CreateFreshSettings();
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.AreEqual(75, settings.PollInterval);
+        }
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_HigherVersionThanCurrent_WillBeIgnored()
+        {
+            // Arrange
+            var settings = CreateFreshSettings();
+            var defaultPollInterval = settings.PollInterval;
+            CreateLegacyUserConfig("MFConnector.exe_Url_newVersion", "11.1.0.0", @"
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>10</value>
+                </setting>");
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, new Version(11, 0));
+            // Assert
+            Assert.AreEqual(defaultPollInterval, settings.PollInterval);
+        }
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_MultipleHashFolders_UsesMostRecentlyModified()
+        {
+            // Arrange
+            var olderConfig = CreateLegacyUserConfig("MFConnector.exe_Url_older", "10.5.2.0", @"
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>10</value>
+                </setting>");
+            File.SetLastWriteTimeUtc(olderConfig, DateTime.UtcNow.AddDays(-2));
+            var newerConfig = CreateLegacyUserConfig("MFConnector.exe_Url_newer", "10.5.2.0", @"
+                <setting name=""PollInterval"" serializeAs=""String"">
+                    <value>60</value>
+                </setting>");
+            File.SetLastWriteTimeUtc(newerConfig, DateTime.UtcNow.AddDays(-1));
+            var settings = CreateFreshSettings();
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.AreEqual(60, settings.PollInterval);
+        }
+        [TestMethod]
+        public void MigrateLegacySettingsIfNeeded_NoUserConfigAnywhere_MarksMigratedWithoutThrowing()
+        {
+            // Arrange: hash folder and version folder exist, but no user.config inside
+            Directory.CreateDirectory(Path.Combine(_testDirectory, "MFConnector.exe_Url_abc123", "10.5.2.0"));
+            var settings = CreateFreshSettings();
+            // Act
+            UserSettingsMigration.MigrateLegacySettingsIfNeeded(settings, _testDirectory, DefaultCurrentVersion);
+            // Assert
+            Assert.IsTrue(settings.LegacySettingsMigrated);
+        }
+        // Isolates the test from whatever a previous test in this process may have Save()d to disk.
+        private Properties.Settings CreateFreshSettings()
+        {
+            var settings = new Properties.Settings();
+            settings.Reset();
+            return settings;
+        }
+        // Writes a legacy user.config at {companyFolder}\{hashFolderName}\{version}\user.config
+        private string CreateLegacyUserConfig(string hashFolderName, string version, string settingsXml)
+        {
+            var versionFolder = Path.Combine(_testDirectory, hashFolderName, version);
+            Directory.CreateDirectory(versionFolder);
+            var configPath = Path.Combine(versionFolder, "user.config");
+            File.WriteAllText(configPath, $@"<?xml version=""1.0"" encoding=""utf-8""?>
+                <configuration>
+                    <userSettings>
+                        <MobiFlight.Properties.Settings>
+                            {settingsXml}
+                        </MobiFlight.Properties.Settings>
+                    </userSettings>
+                </configuration>");
+            return configPath;
+        }
+    }
+}


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
Application Settings are handled a bit different in .NET10 - this PR ensures that existing user-specific application settings are restored correctly when upgrading from a .NET Framework based MobiFlight version (<=11.2.0) to .NET10 based (>11.2)

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Existing user config settings are restored

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3297 

### Out-of-scope
<!-- mention what is not covered by this PR -->

### Notes
<!-- provide furhter information that might be of interest -->
