### PR TITLE
Exrternal links open without exception

### DIFF
--- a/src/MobiFlightConnector/Base/AutoUpdateChecker.cs
+++ b/src/MobiFlightConnector/Base/AutoUpdateChecker.cs
@@ -132,7 +132,7 @@ namespace MobiFlight.UpdateChecker
                     dialog.ShowDisableBetaButton = updatePath == UpdatePath.StableToBeta //Show "DisableBetaButton" if update from stable to beta
                         && Properties.Settings.Default.BetaUpdates;
                     dialog.Text = $"{i18n._tr("uiMessageNewUpdateAvailable")} - MobiFlight {releaseVersion}{releaseLabel} - Release Notes";
-                    dialog.ReleaseNotesClicked += (sender, e) => Process.Start(releaseUrl);
+                    dialog.ReleaseNotesClicked += (sender, e) => ProcessHelpers.OpenUrl(releaseUrl);
                     dialog.DisableBetaClicked += (sender, e) =>
                     {
                         Properties.Settings.Default.BetaUpdates = false;

--- a/src/MobiFlightConnector/MobiFlight/ProcessHelpers.cs
+++ b/src/MobiFlightConnector/MobiFlight/ProcessHelpers.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Text;
+﻿using System.Diagnostics;
 
 namespace MobiFlight
 {

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -275,7 +275,7 @@ namespace MobiFlight.UI
                     Log.Instance.log($"Invalid URL: {message.Url}", LogSeverity.Warn);
                     return;
                 }
-                Process.Start(message.Url);
+                ProcessHelpers.OpenUrl(message.Url);
             });
 
             MessageExchange.Instance.Subscribe<CommandControllerBindingsUpdate>((message) =>
@@ -791,7 +791,7 @@ namespace MobiFlight.UI
             wd.WebsiteUrl = $"https://github.com/MobiFlight/MobiFlight-Connector/releases/tag/{CurrentVersion()}";
             wd.ReleaseNotesClicked += (sender, e) =>
             {
-                Process.Start($"https://github.com/MobiFlight/MobiFlight-Connector/releases/tag/{CurrentVersion()}");
+                ProcessHelpers.OpenUrl($"https://github.com/MobiFlight/MobiFlight-Connector/releases/tag/{CurrentVersion()}");
             };
 
             wd.StartPosition = FormStartPosition.CenterParent;
@@ -2502,12 +2502,12 @@ namespace MobiFlight.UI
 
         public void documentationToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Process.Start(i18n._tr("WebsiteUrlHelp"));
+            ProcessHelpers.OpenUrl(i18n._tr("WebsiteUrlHelp"));
         }
 
         public void donateToolStripButton_Click(object sender, EventArgs e)
         {
-            Process.Start("https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7GV3DCC7BXWLY");
+            ProcessHelpers.OpenUrl("https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7GV3DCC7BXWLY");
         }
 
         /// <summary>
@@ -2777,7 +2777,7 @@ namespace MobiFlight.UI
 
         public void openDiscordServer_Click(object sender, EventArgs e)
         {
-            Process.Start("https://discord.gg/U28QeEJpBV");
+            ProcessHelpers.OpenUrl("https://discord.gg/U28QeEJpBV");
         }
 
         private void StatusBarToolStripButton_Click(object sender, EventArgs e)
@@ -2787,17 +2787,17 @@ namespace MobiFlight.UI
 
         public void YouTubeToolStripButton_Click(object sender, EventArgs e)
         {
-            Process.Start("https://www.youtube.com/channel/UCxsoCWDKRyu3MpQKNZEXUYA");
+            ProcessHelpers.OpenUrl("https://www.youtube.com/channel/UCxsoCWDKRyu3MpQKNZEXUYA");
         }
 
         public void HubHopToolStripButton_Click(object sender, EventArgs e)
         {
-            Process.Start("https://hubhop.mobiflight.com/");
+            ProcessHelpers.OpenUrl("https://hubhop.mobiflight.com/");
         }
 
         public void releaseNotesToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            Process.Start($"https://github.com/MobiFlight/MobiFlight-Connector/releases/tag/{CurrentVersion()}");
+            ProcessHelpers.OpenUrl($"https://github.com/MobiFlight/MobiFlight-Connector/releases/tag/{CurrentVersion()}");
         }
 
         public static bool ContainsConfigOfSourceType(List<IConfigItem> configItems, Source type)


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
External links open correctly in system's default browser. 

For .NET10 update, we introduced a ProcessHelpers class that offers the correct way to open an external link. We had forgotten to update all code locations to use it.

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] External links now open correctly like before .NET10

### DoD Checklist
n/a 

## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3299 