### PR TITLE
Fix HID joystick exclusion handling

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
@@ -33,7 +33,7 @@ namespace MobiFlight
         public readonly List<JoystickDefinition> Definitions = new List<JoystickDefinition>();
         public event EventHandler Connected;
         public event ButtonEventHandler OnButtonPressed;
-        private readonly Timer PollTimer = new Timer(); 
+        private readonly Timer PollTimer = new Timer();
         private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Joystick> Joysticks = new System.Collections.Concurrent.ConcurrentDictionary<string, Joystick>();
         private readonly List<Joystick> ExcludedJoysticks = new List<Joystick>();
         private IntPtr Handle;
@@ -79,7 +79,7 @@ namespace MobiFlight
             var schemaFilePath = "Joysticks/mfjoystick.schema.json";
 
             var rawDefinitions = JsonBackedObject.LoadDefinitions<JoystickDefinition>(
-                jsonFiles, 
+                jsonFiles,
                 schemaFilePath,
                 onSuccess: (joystick, definitionFile) => Log.Instance.log($"Loaded joystick definition for {joystick.InstanceName}", LogSeverity.Debug),
                 onError: () => LoadingError = true
@@ -203,7 +203,7 @@ namespace MobiFlight
                 var diJoystick = new SharpDX.DirectInput.Joystick(di, d.InstanceGuid);
                 var productId = diJoystick.Properties.ProductId;
                 var vendorId = diJoystick.Properties.VendorId;
-                
+
                 // Check if this device should be handled later as an HID controller
                 if (HidControllerFactory.CanCreate(d.InstanceName))
                 {
@@ -218,7 +218,7 @@ namespace MobiFlight
 
                 // Use factory to create appropriate controller instance
                 var js = ControllerFactory.Create(d, diJoystick, vendorId, productId, definition, WSServer);
-                
+
                 // If factory returns null, create a standard Joystick
                 if (js == null)
                 {
@@ -269,13 +269,17 @@ namespace MobiFlight
             // Try to get definition by product name first, then by product ID
             return GetDefinitionByInstanceName(productName) ?? GetDefinitionByProductId(vendorId, productId);
         }
-
+        internal static bool ShouldConnectHidJoystick(string joystickName,List<string> excludedJoysticks)
+        {
+            return !excludedJoysticks.Contains(joystickName);
+        }
         private void ConnectHidController()
         {
             try
             {
                 var allHidDevices = DeviceList.Local.GetHidDevices().ToList();
                 Log.Instance.log($"Found {allHidDevices.Count} HID devices, checking for supported devices", LogSeverity.Debug);
+                List<string> settingsExcludedJoysticks = JsonConvert.DeserializeObject<List<string>>(Properties.Settings.Default.ExcludedJoysticks);
 
                 allHidDevices.ForEach(hidDevice =>
                 {
@@ -293,16 +297,21 @@ namespace MobiFlight
                         var joystick = HidControllerFactory.Create(definition);
 
                         if (joystick == null) return;
-
-                        joystick.Connect(new IntPtr());
-                        joystick.OnButtonPressed += Js_OnButtonPressed;
-                        joystick.OnDisconnected += Js_OnDisconnected;
-                        if (!Joysticks.TryAdd(joystick.Serial, joystick))
+                        // Check against exclusion list
+                        if (ShouldConnectHidJoystick(
+                                               joystick.Name,
+                                            settingsExcludedJoysticks))
                         {
-                            Log.Instance.log($"Error adding HID device: {definition.InstanceName} / {joystick.Serial}. Likely Joystick Serial conflict.", LogSeverity.Error);
-                            return;
+                            joystick.Connect(new IntPtr());
+                            Joysticks.TryAdd(joystick.Serial, joystick);
                         }
-                        Log.Instance.log($"Connected HID device: {definition.InstanceName} / {joystick.Serial}", LogSeverity.Info);
+                        else
+                        {
+                            Log.Instance.log(
+                                $"Ignore attached joystick device: {joystick.Name}.",
+                                LogSeverity.Info
+                            );
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
@@ -269,9 +269,9 @@ namespace MobiFlight
             // Try to get definition by product name first, then by product ID
             return GetDefinitionByInstanceName(productName) ?? GetDefinitionByProductId(vendorId, productId);
         }
-        internal static bool ShouldConnectHidJoystick(string joystickName,List<string> excludedJoysticks)
+        internal static bool IsExcludedJoystick(string joystickName, List<string> excludedJoysticks)
         {
-            return !excludedJoysticks.Contains(joystickName);
+            return excludedJoysticks.Contains(joystickName);
         }
         private void ConnectHidController()
         {
@@ -297,21 +297,29 @@ namespace MobiFlight
                         var joystick = HidControllerFactory.Create(definition);
 
                         if (joystick == null) return;
-                        // Check against exclusion list
-                        if (ShouldConnectHidJoystick(
-                                               joystick.Name,
-                                            settingsExcludedJoysticks))
-                        {
-                            joystick.Connect(new IntPtr());
-                            Joysticks.TryAdd(joystick.Serial, joystick);
-                        }
-                        else
+
+                        if (IsExcludedJoystick(joystick.Name, settingsExcludedJoysticks))
                         {
                             Log.Instance.log(
                                 $"Ignore attached joystick device: {joystick.Name}.",
                                 LogSeverity.Info
                             );
+                            return;
                         }
+
+                        if (!Joysticks.TryAdd(joystick.Serial, joystick))
+                        {
+                            Log.Instance.log(
+                                $"Error adding HID device: {definition.InstanceName} / {joystick.Serial}. Likely Joystick Serial conflict.",
+                                LogSeverity.Error
+                            );
+                            return;
+                        }
+
+                        joystick.Connect(new IntPtr());
+                        joystick.OnButtonPressed += Js_OnButtonPressed;
+                        joystick.OnDisconnected += Js_OnDisconnected;
+
                     }
                     catch (Exception ex)
                     {

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickManagerTests.cs
@@ -8,15 +8,32 @@ namespace MobiFlightUnitTests.MobiFlight.Joysticks
     public class JoystickManagerTests
     {
         [TestMethod()]
-        public void ShouldConnectHidJoystick_WhenJoystickIsExcluded_ReturnsFalse()
+        public void IsExcludedJoystick_WhenJoystickIsExcluded_ReturnsTrue()
         {
             var excludedJoysticks = new List<string>
-            {
+              {
                 "WingFlex EFIS"
-            };
 
-            var result = JoystickManager.ShouldConnectHidJoystick(
+              };
+
+            var result = JoystickManager.IsExcludedJoystick(
                 "WingFlex EFIS",
+                excludedJoysticks
+            );
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod()]
+        public void IsExcludedJoystick_WhenJoystickIsNotExcluded_ReturnsFalse()
+        {
+            var excludedJoysticks = new List<string>
+             {
+               "WingFlex EFIS"
+             };
+
+            var result = JoystickManager.IsExcludedJoystick(
+                "WingFlex FCU",
                 excludedJoysticks
             );
 
@@ -24,32 +41,16 @@ namespace MobiFlightUnitTests.MobiFlight.Joysticks
         }
 
         [TestMethod()]
-        public void ShouldConnectHidJoystick_WhenJoystickIsNotExcluded_ReturnsTrue()
-        {
-            var excludedJoysticks = new List<string>
-            {
-                "WingFlex EFIS"
-            };
-
-            var result = JoystickManager.ShouldConnectHidJoystick(
-                "WingFlex FCU",
-                excludedJoysticks
-            );
-
-            Assert.IsTrue(result);
-        }
-
-        [TestMethod()]
-        public void ShouldConnectHidJoystick_WhenNoJoysticksAreExcluded_ReturnsTrue()
+        public void IsExcludedJoystick_WhenNoJoysticksAreExcluded_ReturnsFalse()
         {
             var excludedJoysticks = new List<string>();
 
-            var result = JoystickManager.ShouldConnectHidJoystick(
+            var result = JoystickManager.IsExcludedJoystick(
                 "WingFlex EFIS",
                 excludedJoysticks
             );
 
-            Assert.IsTrue(result);
+            Assert.IsFalse(result);
         }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickManagerTests.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight;
+using System.Collections.Generic;
+
+namespace MobiFlightUnitTests.MobiFlight.Joysticks
+{
+    [TestClass()]
+    public class JoystickManagerTests
+    {
+        [TestMethod()]
+        public void ShouldConnectHidJoystick_WhenJoystickIsExcluded_ReturnsFalse()
+        {
+            var excludedJoysticks = new List<string>
+            {
+                "WingFlex EFIS"
+            };
+
+            var result = JoystickManager.ShouldConnectHidJoystick(
+                "WingFlex EFIS",
+                excludedJoysticks
+            );
+
+            Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void ShouldConnectHidJoystick_WhenJoystickIsNotExcluded_ReturnsTrue()
+        {
+            var excludedJoysticks = new List<string>
+            {
+                "WingFlex EFIS"
+            };
+
+            var result = JoystickManager.ShouldConnectHidJoystick(
+                "WingFlex FCU",
+                excludedJoysticks
+            );
+
+            Assert.IsTrue(result);
+        }
+
+        [TestMethod()]
+        public void ShouldConnectHidJoystick_WhenNoJoysticksAreExcluded_ReturnsTrue()
+        {
+            var excludedJoysticks = new List<string>();
+
+            var result = JoystickManager.ShouldConnectHidJoystick(
+                "WingFlex EFIS",
+                excludedJoysticks
+            );
+
+            Assert.IsTrue(result);
+        }
+    }
+}


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Fixed HID joystick exclusion handling by checking the user's ExcludedJoysticks settings before connecting HID controllers. Added unit tests to verify that excluded devices are ignored while non-excluded devices are still connected.
### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Excluded HID devices are not connected.
- [x] Non-excluded HID devices are still connected.

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend

## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3239 
