### PR TITLE
Fix size of variable name field

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VariablePanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VariablePanel.tsx
@@ -115,6 +115,8 @@ export const VariablePanel = ({
                 )}
               </Label>
               <ComboBox
+                widthClass="w-26"
+                align="start"
                 items={variableTypeOptions}
                 getLabel={(item) => item.label}
                 getValue={(item) => item.value}
@@ -143,6 +145,7 @@ export const VariablePanel = ({
                 )}
               </Label>
               <Input
+                className="w-auto"
                 value={variable?.Name ?? ""}
                 onChange={(e) => {
                   onVariableChange({

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VariablePanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VariablePanel.tsx
@@ -145,7 +145,7 @@ export const VariablePanel = ({
                 )}
               </Label>
               <Input
-                className="max-w-50"
+                className="max-w-50 truncate"
                 value={variable?.Name ?? ""}
                 onChange={(e) => {
                   onVariableChange({

--- a/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VariablePanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/wizard/components/InputActions/VariablePanel.tsx
@@ -145,7 +145,7 @@ export const VariablePanel = ({
                 )}
               </Label>
               <Input
-                className="w-auto"
+                className="max-w-50"
                 value={variable?.Name ?? ""}
                 onChange={(e) => {
                   onVariableChange({


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Reduce the width of the Item Type field and increase the width of the Name field in the new Input Config dialog. This allows longer variable names, such as "Current LCD page", to be displayed without being cut off.
### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="1174" height="870" alt="image" src="https://github.com/user-attachments/assets/4d912baf-c7cc-40c7-b614-0d066e2417ae" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Can see the whole name

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
 - [x] Frontend

     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3238 
