### PR TITLE
Enable dismissing HubHop update toast

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -114,6 +114,8 @@ export const ToastNotificationHandler = () => {
             } as CommandMainMenu)
           },
         },
+        // The toast uses onCancel to enable the built-in click-to-dismiss behavior.
+        // No cancellation action is needed here; the toast wrapper handles dismissal.
         onCancel: () => {},
       })
     }

--- a/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/notifications/ToastNotificationHandler.tsx
@@ -114,6 +114,7 @@ export const ToastNotificationHandler = () => {
             } as CommandMainMenu)
           },
         },
+        onCancel: () => {},
       })
     }
 

--- a/src/MobiFlightConnector/frontend/tests/General.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/General.spec.ts
@@ -59,6 +59,33 @@ test("Confirm HubHop update notifications show correctly", async ({
   await expect(hubhopToast).not.toBeVisible({ timeout: 5000 })
 })
 
+test("HubHop update notification can be dismissed by clicking it", async ({
+  configListPage,
+  page,
+}) => {
+  await configListPage.gotoPage()
+  await configListPage.mobiFlightPage.initWithTestData()
+
+  const hubhopToast = page.getByTestId("toast-hubhop-auto-update")
+  await expect(hubhopToast).not.toBeVisible()
+
+  await configListPage.mobiFlightPage.publishCommand({
+    key: "HubHopState",
+    payload: {
+      ShouldUpdate: true,
+      Result: "Pending",
+      UpdateProgress: 0,
+    } as HubHopState,
+  })
+
+  await expect(hubhopToast).toBeVisible()
+
+  await hubhopToast.click()
+
+  await expect(hubhopToast).not.toBeVisible()
+
+})
+
 test.describe("Generic Notifications tests", () => {
   test("Confirm Auto-Bind Controller Notification shows correctly", async ({
     configListPage,


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Enabled the existing click-to-dismiss behavior for the HubHop update toast. Users can now dismiss the notification by clicking on it instead of having to wait for it to disappear or select "Update Now".

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] HubHop update toast can be dismissed by clicking on it


### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
 - [x] Frontend
- [x] Frontend tests

## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3234 