### PR TITLE
Use a synthetic event generator for raising synthetic input events

### DIFF
--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -1,0 +1,332 @@
+# Virtual button events (Hold / Repeat / LongRelease / Encoder-from-buttons)
+
+Status: Hold, Repeat, and LongRelease implemented (`SyntheticButtonEventGenerator`, wired into
+`MobiFlightCache`/`JoystickManager`/`MidiBoardManager`). Encoder-from-button-pairs and the
+precondition-facing button state extension remain design discussion only - see "Non-goals" below.
+
+## Problem
+
+Real button events (`PRESS`, `RELEASE`) run through one shared pipeline:
+
+`mobiFlightCache_OnButtonPressed` (`ExecutionManager.cs:1445`) → `InputEventExecutor.Execute`
+(`InputEventExecutor.cs:59`) → precondition check → Modifiers → `cfg.execute(...)` → status/UI
+update (`updatedValues`).
+
+`onHold` and `onLongRelease` ("virtual" events, since nothing on the wire actually reports them)
+do not go through this pipeline consistently:
+
+- **`onHold`** is fired directly from a `System.Timers.Timer` inside `ButtonInputConfig`
+  (`ButtonInputConfig.cs:196-244`), calling `onHold.execute(...)` itself. It skips the Modifiers
+  pipeline, skips `cfg.RawValue`/`cfg.Value`/`updatedValues` (so it never reaches the UI —
+  `ExecutionManager.updatedValues` is only ever written from the `Execute(e, ...)`/`Execute(cfg, ...)`
+  call sites, `ExecutionManager.cs:1461/1469/1087`), skips the shared try/catch → `cfg.Status`
+  error reporting, and reuses config refs/cache collection captured once at press time
+  (`LastOnPressCacheCollection`/`LastOnPressConfigRefs`) rather than resolving them fresh. It also
+  runs on a threadpool thread, racing the thread that drives `Execute()`.
+- **`onLongRelease`** does reach the shared pipeline, but only because
+  `CheckAndAdaptForLongButtonRelease` (`ButtonInputConfig.cs:273-288`) mutates `args.Value` from
+  `RELEASE` to `LONG_RELEASE` *after* `InputEventExecutor` has already computed the log line and
+  `cfg.RawValue` from the pre-mutation value (`InputEventExecutor.cs:105,110` run before `:137`).
+  The log/UI label says "Release" even when `onLongRelease` is what actually fired.
+- `InputConfigItem.GetInputAction` (`InputConfigItem.cs:379-413`) has no `case HOLD` — harmless
+  today only because Hold never reaches it, but a silent trap (`default: return null`) waiting for
+  the day it does.
+- There is no separate identity at all for "the button is still being held and firing again" —
+  `RepeatTimer_Elapsed` (`ButtonInputConfig.cs:208-218`) calls the exact same `ExecuteOnHoldAction`
+  as the first `HoldTimer_Elapsed` fire, so a repeat looks identical to the initial HOLD in every
+  log line and status update. There's no way for a user to see, from the UI, whether repeat
+  detection is actually working versus HOLD just firing once.
+- `MobiFlightButton.InputEventIdToString` (`MobiFlightButton.cs:18-36`) has no `case HOLD` either —
+  a second, independent instance of the same gap as `GetInputAction`'s. A HOLD event's label falls
+  through to `"n/a"` today, so even a real HOLD firing through the pipeline wouldn't display
+  correctly.
+- No unit test exercises actual hold/repeat timing or the long-release boundary; the two existing
+  hold tests reach a private `Timer` field via reflection to assert it stopped
+  (`InputEventExecutorTests.cs:591-671`), because there's no injectable clock.
+
+## Goals
+
+- One execution path for all button-derived events — real or synthetic — so preconditions,
+  Modifiers, status reporting, and UI updates behave identically regardless of which event fired.
+- Timer/thread-safety issues resolved by construction, not by discipline.
+- The system that detects "is this button held long enough" is testable without reflection or
+  real-time sleeps.
+
+## Non-goals (explicitly deferred)
+
+- **Splitting `InputEventArgs` into three typed events with three delegates** (`ButtonInputEvent` /
+  `EncoderInputEvent` / `AnalogInputEvent`, replacing the single `ButtonEventHandler`/`InputEventArgs`
+  pair used for all three today). This is a real problem — the delegate is called `OnButtonPressed`
+  but carries Button, Encoder, and AnalogInput events; `InputEventArgs.Value` is an untyped `double`
+  whose meaning depends entirely on `InputType`; `GetInputAction`'s switch-on-`InputType` is exactly
+  what let `HOLD` fall through silently. But `InputEventArgs` is touched in 46 files, and the ~15
+  `InputAction` subclasses (`FsuipcOffsetInputAction`, `MSFS2020CustomInputAction`, `VariableInputAction`,
+  etc.) all consume it identically and generically (`args.Value.ToString()` for `@` placeholder
+  substitution) — none of them care about the button/encoder/analog distinction. Worth doing later
+  as its own change (three delegates, one shared base class so the generic consumers don't need to
+  change), but out of scope here.
+- Any change to `Device.Type` (the config-side `TYPE_BUTTON`/`TYPE_ENCODER`/`TYPE_ANALOG` string
+  tagging) — separate, pre-existing classification, tangential to this work.
+- **Exposing per-controller button state to preconditions** (a `"button"` precondition type,
+  answering "is this other physical button currently held," closing the gap where
+  `PreconditionChecker.CheckPrecondition` — `PreconditionChecker.cs:28-67` — only supports `"pin"`/
+  `"variable"`/`"config"` today and the only current workaround is relaying state through a
+  MobiFlight Variable). Real gap, not needed to make Hold/LongRelease/Encoder work, so deferred —
+  KISS, smallest workable scope. The one thing to keep in mind while building the generator so this
+  doesn't get designed shut: keep its per-button tracking state (pressed / since-when / hold-fired)
+  as a small dedicated internal type, not inlined loose fields — see "Generator's internal state"
+  below. Promoting that later to something preconditions can query is then a visibility/query-surface
+  change, not a rewrite.
+
+## Design
+
+### Ownership: inside the controller, not the config item
+
+Detection state (is this physical button currently pressed, since when, has hold already fired)
+does **not** belong on `ButtonInputConfig`/`InputConfigItem`. A physical button can be bound by
+multiple `InputConfigItem`s — even across simultaneously-loaded config files, since
+`_inputEventExecutors` is keyed per `ConfigFile` and `mobiFlightCache_OnButtonPressed` fans one raw
+event out to all of them (`ExecutionManager.cs:1456-1467`). Tracking detection per binding means
+duplicate, independent timers for what is physically one button, and was the direct cause of the
+`08179c39` bug class (cleanup/lifecycle tied to whether a specific binding happened to configure an
+action).
+
+Detection moves to the controller layer instead — a **synthetic button event generator** owned
+internally by each controller manager (`MobiFlightCache`, `JoystickManager`, `MidiBoardManager`),
+one physical button tracked once regardless of how many configs bind to it.
+
+### Stays transparent to everything downstream
+
+All three controller managers already funnel real events through an identical one-line method:
+
+```csharp
+// MobiFlightCache.cs:415-417 / JoystickManager.cs:350-352 / MidiBoardManager.cs:278-280
+public void Module_OnButtonPressed(object sender, InputEventArgs e)
+{
+    OnButtonPressed?.Invoke(sender, e);
+}
+```
+
+The generator is a private field on each manager, wired into that same funnel:
+
+```csharp
+private readonly SyntheticButtonEventGenerator _virtualEvents = new SyntheticButtonEventGenerator();
+
+public MobiFlightCache()
+{
+    _virtualEvents.OnSyntheticEvent += (s, e) => OnButtonPressed?.Invoke(s, e);
+}
+
+public void Module_OnButtonPressed(object sender, InputEventArgs e)
+{
+    // classify RELEASE vs LONG_RELEASE per bound config before forwarding - usually one event,
+    // more if multiple configs are bound to this button with different LongReleaseDelay
+    foreach (var classified in _virtualEvents.Observe(e))
+        OnButtonPressed?.Invoke(sender, classified);
+}
+```
+
+`ExecutionManager`'s subscriptions (`mobiFlightCache.OnButtonPressed += ...`,
+`joystickManager.OnButtonPressed += ...`, `midiBoardManager.OnButtonPressed += ...`,
+`ExecutionManager.cs:218,221,231`) do not change. It has no knowledge the generator exists — it
+just sees a stream of already-fully-classified `InputEventArgs`, same as today.
+
+`InputEventExecutor`/`InputConfigItem` need exactly one change: `GetInputAction` gets a `case HOLD`
+(and `case REPEAT`, alongside it - both resolve to `onHold`, there is no separate `onRepeat`
+binding), since Hold now genuinely flows through it instead of bypassing it. REPEAT exists as its
+own `MobiFlightButton.InputEvent` value, distinct from HOLD, purely so the log/UI can show that
+repeat detection is what's firing on the Nth tick of a held button, not the same HOLD firing again
+with no way to tell them apart.
+
+With detection moved out, `ButtonInputConfig` sheds everything that isn't config data: no more
+`HoldTimer`/`RepeatTimer`, `LastOnPressEvent`/`LastOnPressCacheCollection`/`LastOnPressConfigRefs`,
+`CanExecute` backchannel, or `CheckAndAdaptForLongButtonRelease`'s in-place mutation. It keeps
+`onPress`/`onRelease`/`onLongRelease`/`onHold`, the delay settings, and dispatches on `e.Value` in
+`execute()`.
+
+### Stage taxonomy
+
+Three distinct shapes of processing sit in the same funnel, composed in a chain:
+
+- **Inject** (0-to-1, time-triggered): not triggered by any incoming event — triggered by elapsed
+  time since one. `HOLD` and its repeat cadence are the only things in this design that are
+  actually this shape.
+- **Reclassify** (1-to-1, event-triggered): given one incoming event plus a bit of memory, forward
+  it unchanged, forward it relabeled, or drop it — nothing fabricated that didn't correspond to a
+  real input. RELEASE → LONG_RELEASE promotion is this shape.
+- **Aggregate** (N-to-1, event-triggered): given a raw event belonging to a known group, consume it
+  and, once the group resolves, emit a differently-typed event instead. Button-pair-to-Encoder
+  (below) is this shape.
+
+### No new timer mechanism — ride whichever cadence a device already has
+
+Not every controller gets its button state the same way, so there's no single precedent to copy
+uniformly. Two real transports exist side by side under `JoystickManager` alone:
+
+- **DirectInput-polled joysticks**: `JoystickManager.PollTimer` (`JoystickManager.cs:36,46-47`,
+  20ms) drives `PollTimer_Tick` (`JoystickManager.cs:106-134`), which loops every joystick it
+  manages under one lock and calls `Update()` on each (each wrapped in its own try/catch, so one
+  device's failure doesn't block the others in the same tick). One shared tick genuinely serves
+  this whole family.
+- **HID-push boards** (Bodnar, WinCtrl, WingFlex/Dap500, VKB, Octavi): `Update()` does nothing but
+  keep the connection alive (`BodnarBoard.cs:127-134`). Real button events come from
+  `HidReportReceiver` (`HidReportReceiver.cs`), which every one of these device classes owns as its
+  **own dedicated background thread**, blocking-reading HID reports and raising `OnButtonPressed`
+  directly — entirely decoupled from `PollTimer`. Serial boards under `MobiFlightCache` look the
+  same shape: events arrive from a callback on their own connection thread, not from any shared
+  poll.
+
+So there's no single "the" timer to hang hold/repeat detection off. The right move is to not invent
+a new timer mechanism at all, and instead let the generator's periodic check ride whatever cadence
+already exists for that specific device's actual transport:
+
+- DirectInput-polled joysticks: piggyback on `JoystickManager.PollTimer_Tick`'s existing loop.
+- HID-push boards: piggyback on `HidReportReceiver`'s own read loop, which already wakes up at
+  least every `ReadPollTimeoutMilliseconds` (200ms) even with no report to notice its stop flag
+  (`HidReportReceiver.cs:23,131-135`) — check on every loop iteration, report or timeout alike.
+
+A `System.Timers.Timer` per device instance would not be expensive if one were needed somewhere —
+it's a lightweight registration on the runtime's shared timer queue, not a dedicated OS thread, and
+MobiFlight's realistic device counts (tens, not hundreds) make that a non-concern even without the
+piggybacking above. But piggybacking means no new timer object is needed at all for either
+transport. Isolation between devices sharing one cadence (the DirectInput family) comes from
+wrapping each device's own check in its own try/catch inside the loop, the same way
+`PollTimer_Tick` already isolates `Update()` failures — not from giving each device a separate
+timer. LongRelease doesn't need any of this — it's decided synchronously the moment a real RELEASE
+arrives, comparing elapsed time against `LongReleaseDelay`.
+
+This isn't a new concurrency model: `OnButtonPressed` already fires concurrently from independent
+threads today (the joystick poll-timer thread; whatever thread `MobiFlightCache`/`MidiBoardManager`
+raise events from on serial/MIDI callback), so `ExecutionManager`/`InputEventExecutor` already have
+to tolerate it.
+
+### Delay values don't need to align to the tick interval - but RepeatDelay has a floor anyway
+
+Two different questions worth keeping separate, because they sound related but aren't:
+
+- **Does a `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` need to be a multiple of the tick interval
+  for detection to work correctly?** No. The check is `now - reference >= TimeSpan.FromMilliseconds(delay)`,
+  computed fresh from real timestamps every tick, not an incrementing counter - any positive value
+  is handled correctly regardless of alignment. The only consequence of a value that doesn't line up
+  with the tick interval is bounded jitter (fires somewhere in `[delay, delay + tickInterval)`,
+  never early, never skipped) - the same jitter any polling loop checking "has T elapsed" has,
+  imperceptible at the 300ms+ scale these delays actually use. No drift accumulates across repeat
+  cycles either, since `LastHoldFire` resets to the real timestamp each time, not a stepped counter.
+- **Does `RepeatDelay` need a floor anyway?** Yes, but for a different reason: REPEAT is the only
+  one of the three that can fire indefinitely for as long as a button stays held, and every firing
+  dispatches to `onHold`, which typically calls into the sim API (FSUIPC/SimConnect/XPlane/a custom
+  event). A `RepeatDelay` configured too low - or loaded from an old/hand-edited config predating
+  this floor - risks flooding that API fast enough to cause performance issues or instability. This
+  is a rate limit for the sim API's sake, not a timer-precision requirement, and it's scoped to
+  `RepeatDelay` only: `HoldDelay`/`LongReleaseDelay` each decide at most one classification per
+  press/release gesture, so neither carries the same sustained-flooding risk.
+
+  Enforced in one place - `ButtonTimings`'s constructor (`ButtonTimings.MinRepeatDelay`, 200ms) -
+  so every path that constructs one (the generator's own fallback, and
+  `InputEventExecutor.ResolveButtonTimingsPerConfig`) gets the floor automatically; a positive value
+  below it is raised to it, `0` (repeat disabled) is exempt. Not currently enforced at the UI editing
+  layer (wherever `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` get set on a `ButtonInputConfig`) -
+  someone could still type `10` into the config and it would silently behave as `200` at runtime
+  rather than being rejected or corrected at entry time. Worth adding UI-level validation as a
+  follow-up so the discrepancy is visible where it's authored, not just where it's enforced.
+
+### Generator's internal state
+
+The generator needs, per physical button (keyed by serial + device name, the same identity
+`InputEventExecutor.MatchesControllerAndDeviceName` uses): pressed?, since when, has hold already
+fired. That's it for now — not exposed outside the generator, not a public property on the
+controller manager, no provider interface. `Joystick` already keeps a live snapshot for its own
+diffing purposes (`JoystickState`, `Joystick.cs:39`, refreshed every poll tick to decide what
+`OnButtonPressed` events to raise from `UpdateButtons`), so there's precedent for a controller
+holding this kind of state — the difference here is scope: keep it private to the generator, as a
+small dedicated type rather than loose dictionary/tuple fields, purely so that widening it later
+(see the deferred precondition extension above) doesn't mean rebuilding it.
+
+### Encoder-from-button-pairs (joystick-specific)
+
+Some joystick encoders are physically reported as two independent momentary buttons (an INC pulse,
+a DEC pulse) rather than a native encoder device. `VKBEncoder`
+(`Joysticks/VKB/VKBEncoder.cs`) already does the mirror transformation for one manufacturer — VKB
+reports a real rotary encoder as a wrapping counter, and `VKBEncoder.Update()` synthesizes virtual
+button `PRESS` events out of the delta. The button-pair case runs the other direction: two button
+devices in, one `Encoder` device out.
+
+This is an **aggregate** stage, joystick-specific, composed inside `Joystick`/`JoystickManager`
+only (boards and MIDI controllers don't have this hardware quirk). It has to run **before** the
+Hold/LongRelease chain in the same manager's funnel: once two buttons are claimed as an encoder
+pairing, they must stop surfacing as ordinary bindable/holdable buttons — otherwise a config could
+bind `onHold` to what's really half an encoder pulse. The Hold/LongRelease chain only ever sees
+`Button`-typed events that survive aggregation.
+
+Fast-vs-normal turning ("5 consecutive left turns in under 1s" → `LEFT_FAST`) is a **reclassify**
+stage layered after aggregation, operating on the already-produced `Encoder` events — not an inject
+stage, since nothing is fabricated that didn't correspond to a real turn; the already-typed `LEFT`
+event just gets relabeled before being forwarded. It needs a short rolling count/window per
+direction, not a single last-timestamp the way Hold's threshold check does — a related but not
+identical shape of timing-based state.
+
+Open question, not yet resolved: where the button-index-to-encoder pairing is authored. VKB gets it
+for free from its own per-manufacturer definition scheme (`VKBEncoder.CreateDevices`,
+`VKBEncoder.cs:50-68`); a generalized version needs an equivalent place to declare it per joystick
+definition.
+
+## Consequences / open questions to resolve before implementation
+
+- **Delay ownership — resolved.** Initially assumed delay could become a property of the physical
+  input/controller, shared across every binding on it. That's wrong: a multi-mode panel (a mode
+  switch's precondition determines which config is active for a given physical button) can
+  legitimately want different `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` for what is physically
+  one button, depending on which config currently governs it. Detection still lives on the
+  controller (physical-button-scoped, one canonical timer per button), but the delay *values* it
+  uses are resolved from whichever config is currently active with satisfied preconditions -
+  `InputEventExecutor.ResolveButtonTimingsPerConfig` does this lookup (reusing the same `GetMatchingInputConfigs`/
+  `CheckPreconditions` the normal pipeline already has), `ExecutionManager` composes one resolver
+  across every loaded config file and hands it to each controller manager's generator
+  (`SyntheticButtonEventGenerator.ResolveTimings`). Resolved once at PRESS time and held for that
+  press's lifecycle - not re-resolved every tick, so a mode switch mid-hold doesn't retroactively
+  change an in-progress press's timing. If no config currently claims the button, the generator
+  falls back to its own fixed defaults and still detects - it fires unconditionally either way,
+  same as a real PRESS on an unbound button; the *existing* `Active`/`CheckPreconditions` gating in
+  `Execute()` (unchanged) is what actually decides whether anything executes. This means
+  preconditions get evaluated twice, but for different questions at different times, not
+  redundantly: once at PRESS (which delays govern this press, decided once), and again at every
+  fire (should this execute right now, using live state - deliberately not cached, mirroring how
+  `ButtonInputConfig`'s old `CanExecute` closure worked before this redesign).
+
+  **Two configs simultaneously active on the same physical button, with different delays, is fully
+  supported, not just tolerated.** An earlier version of this resolved to a single "winning" config
+  and broadcast the resulting event to every matching config regardless - which was a real
+  correctness bug, not just an ambiguity: a config whose own (longer) delay hadn't elapsed yet would
+  still get triggered early, by a different config's (shorter) one, the moment that one fired.
+  `InputEventExecutor.ResolveButtonTimingsPerConfig` returns *every* currently active,
+  precondition-satisfied config bound to a button, each with its own delays - `ExecutionManager`'s
+  resolver concatenates these across every loaded config file, no single-winner tie-break. Each
+  synthetic HOLD/REPEAT/LONG_RELEASE `SyntheticButtonEventGenerator` produces is stamped with the
+  specific config's GUID that governs it (`InputEventArgs.TargetConfigGUID`), and `Execute()` only
+  dispatches a targeted event to that one config, skipping every other match - a one-line addition
+  to the existing loop. Real events (PRESS/RELEASE with no reclassification) stay untargeted
+  (`null`) and broadcast to every matching config, same as always - only the events whose *timing*
+  came from one specific config's delay are restricted to that config.
+
+  This does widen `SyntheticButtonEventGenerator`'s internal state: a tracked button now holds one
+  `HoldFired`/`LastHoldFire`/delay-set per bound config (not one canonical set for the whole
+  button), and a RELEASE can fan out into multiple events - one per bound config, each
+  independently classified as RELEASE or LONG_RELEASE against *that* config's own
+  `LongReleaseDelay`, so two configs on one button can correctly disagree about whether a given
+  release counts as long. `Observe()`'s signature changed accordingly, from returning one
+  `InputEventArgs` to a `List<InputEventArgs>` (usually one element - the fan-out is dormant, not
+  extra work, for the common single-config-per-button case).
+- **Encoder pairing configuration.** Where the button-pair-to-encoder mapping is authored (joystick
+  definition file vs. runtime user configuration).
+- **Fast-turn threshold shape.** Rolling window/count vs. some other rate measure; not yet designed
+  in detail.
+
+## Testing
+
+Once detection has an owner that isn't a bare `System.Timers.Timer` + `DateTime.Now`, inject the
+clock (`Func<DateTime> Now`) so tests can fake elapsed time instead of sleeping or reflecting into
+private fields. Add coverage for: hold firing once at `HoldDelay` then repeating at `RepeatDelay`;
+the long-release boundary (just under vs. just over `LongReleaseDelay`); a config being deactivated
+mid-hold actually stopping execution, not just stopping the timer; an exception in `onHold`
+surfacing the same `cfg.Status[Device]` error a failing `onPress` would; the encoder fast-turn
+threshold.

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -50,12 +50,6 @@ namespace MobiFlight.Execution
             inputCache.Clear();
         }
 
-        public void StopAllHoldTimers()
-        {
-            foreach (var cfg in _configItems.OfType<InputConfigItem>())
-                cfg.button?.StopTimers();
-        }
-
         public Dictionary<string, IConfigItem> Execute(InputEventArgs e, bool isStarted)
         {
             var updatedValues = new Dictionary<string, IConfigItem>();
@@ -82,10 +76,15 @@ namespace MobiFlight.Execution
 
             foreach (var cfg in inputCache[inputKey])
             {
+                // targeted event (HOLD/REPEAT/LONG_RELEASE) only triggers its own config
+                if (e.TargetConfigGUID != null && e.TargetConfigGUID != cfg.GUID)
+                {
+                    continue;
+                }
+
                 if (!cfg.Active)
                 {
                     Log.Instance.log($"{msgEventLabel} => Skipping inactive config \"{cfg.Name}\".", LogSeverity.Warn);
-                    cfg.button?.StopTimers();
                     continue;
                 }
 
@@ -94,7 +93,6 @@ namespace MobiFlight.Execution
                     if (!CheckPreconditions(cfg))
                     {
                         Log.Instance.log($"{msgEventLabel} => Preconditions not satisfied for \"{cfg.Name}\".", LogSeverity.Debug);
-                        cfg.button?.StopTimers();
                         continue;
                     }
 
@@ -104,8 +102,6 @@ namespace MobiFlight.Execution
                     {
                         Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({e.GetEventActionLabel()})", LogSeverity.Info);
                     }
-
-                    cfg.button?.CanExecute = () => cfg.Active && CheckPreconditions(cfg);
 
                     cfg.RawValue = e.GetEventActionLabel();
                     cfg.Value = " ";
@@ -149,6 +145,31 @@ namespace MobiFlight.Execution
         private string CreateInputKey(InputEventArgs e)
         {
             var result = e.Controller.Serial + e.Device.Type + e.Device.Name;
+            return result;
+        }
+
+        /// <summary>Hold/Repeat/LongRelease delays for every active, precondition-satisfied config bound to this button. Empty if none match.</summary>
+        public List<ButtonBinding> ResolveButtonTimingsPerConfig(InputEventArgs e)
+        {
+            string inputKey = CreateInputKey(e);
+            if (!inputCache.ContainsKey(inputKey))
+            {
+                inputCache[inputKey] = GetMatchingInputConfigs(e);
+            }
+
+            var result = new List<ButtonBinding>();
+
+            foreach (var cfg in inputCache[inputKey])
+            {
+                if (!cfg.Active) continue;
+                if (cfg.button == null) continue;
+                if (!CheckPreconditions(cfg)) continue;
+
+                result.Add(new ButtonBinding(
+                    cfg.GUID,
+                    new ButtonTimings(cfg.button.HoldDelay, cfg.button.RepeatDelay, cfg.button.LongReleaseDelay)));
+            }
+
             return result;
         }
 

--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -235,6 +235,21 @@ namespace MobiFlight
                 OnMidiBoardConnectedFinished?.Invoke(sender, e);
             };
 
+            // Hold/Repeat/LongRelease delays are per config, not per physical button - collect
+            // every match across all loaded config files.
+            Func<InputEventArgs, List<ButtonBinding>> resolveButtonTimings = e =>
+            {
+                var bindings = new List<ButtonBinding>();
+                foreach (var executor in _inputEventExecutors.Values)
+                {
+                    bindings.AddRange(executor.ResolveButtonTimingsPerConfig(e));
+                }
+                return bindings;
+            };
+            mobiFlightCache.SetButtonTimingsResolver(resolveButtonTimings);
+            joystickManager.SetButtonTimingsResolver(resolveButtonTimings);
+            midiBoardManager.SetButtonTimingsResolver(resolveButtonTimings);
+
             OnProjectChanged += (s, p) =>
             {
                 ActiveConfigIndex = 0;
@@ -637,9 +652,6 @@ namespace MobiFlight
             var configItemIndex = ConfigItems.FindIndex(i => i.GUID == item.GUID);
             if (configItemIndex == -1) return;
 
-            if (ConfigItems[configItemIndex] is InputConfigItem oldInputConfig)
-                oldInputConfig.button?.StopTimers();
-
             ConfigItems[configItemIndex] = item;
             MessageExchange.Instance.Publish(new ConfigValuePartialUpdate(item));
             OnInputConfigSettingsChanged(item, null);
@@ -879,8 +891,6 @@ namespace MobiFlight
             mobiFlightCache.StopKeepAwake();
 
             isExecuting = false;
-            foreach (var executor in _inputEventExecutors.Values)
-                executor.StopAllHoldTimers();
 #if ARCAZE
             arcazeCache.Clear();
 #endif

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Timers;
+using System;
 using System.Collections.Generic;
 using System.Xml.Serialization;
 using Newtonsoft.Json;
@@ -8,35 +7,16 @@ namespace MobiFlight.InputConfig
 {
     public class ButtonInputConfig : IXmlSerializable, ICloneable
     {
-        public InputAction onPress;        
-        public InputAction onRelease;        
+        public InputAction onPress;
+        public InputAction onRelease;
         public InputAction onLongRelease;
         public InputAction onHold;
-
-        private InputEventArgs LastOnPressEvent;
-        private CacheCollection LastOnPressCacheCollection;        
-        private List<ConfigRefValue> LastOnPressConfigRefs;
-        private object LastOnPressLock = new object();
-        
         public int LongReleaseDelay = 350; //ms
         public int HoldDelay = 350;
         public int RepeatDelay = 0;
 
-        private Timer HoldTimer = new Timer();
-        private Timer RepeatTimer = new Timer();
-
-        // Func<bool> rather than bool so the check is deferred — the closure captures cfg
-        // and CheckPreconditions, evaluating current state on each timer fire rather than
-        // at press time.
-        [XmlIgnore]
-        [JsonIgnore]
-        public Func<bool> CanExecute { get; set; }
-
         public ButtonInputConfig()
         {
-            RepeatTimer.AutoReset = true;
-            HoldTimer.Elapsed += HoldTimer_Elapsed;            
-            RepeatTimer.Elapsed += RepeatTimer_Elapsed;
         }
 
         /// <summary>
@@ -69,7 +49,7 @@ namespace MobiFlight.InputConfig
             reader.Read(); // this should be the opening tag "onPress"
             if (reader.LocalName == "") reader.Read();
             if (reader.LocalName == "onPress")
-            {                
+            {
                 onPress = InputActionFactory.CreateByType(reader["type"]);
                 onPress?.ReadXml(reader);
                 reader.Read(); // Closing onPress
@@ -77,7 +57,7 @@ namespace MobiFlight.InputConfig
 
             if (reader.LocalName == "") reader.Read();
             if (reader.LocalName == "onRelease")
-            {                
+            {
                 onRelease = InputActionFactory.CreateByType(reader["type"]);
                 onRelease?.ReadXml(reader);
                 reader.Read(); // closing onRelease
@@ -99,7 +79,7 @@ namespace MobiFlight.InputConfig
             if (reader.LocalName == "onHold")
             {
                 HoldDelay = int.Parse(reader["holdDelay"]);
-                RepeatDelay = int.Parse(reader["repeatDelay"]);                
+                RepeatDelay = int.Parse(reader["repeatDelay"]);
                 onHold = InputActionFactory.CreateByType(reader["type"]);
                 onHold?.ReadXml(reader);
                 reader.Read(); // closing onLongRelease
@@ -118,7 +98,7 @@ namespace MobiFlight.InputConfig
                     break;
                 case "onRelease":
                     onRelease = inputAction;
-                    break;                   
+                    break;
                 case "onLongRelease":
                     onLongRelease = inputAction;
                     break;
@@ -142,7 +122,7 @@ namespace MobiFlight.InputConfig
                     return onHold;
                 default:
                     return null;
-            }        
+            }
         }
 
         public List<InputAction> GetInputActionsByType(Type type)
@@ -187,166 +167,34 @@ namespace MobiFlight.InputConfig
             {
                 writer.WriteStartElement("onHold");
                 writer.WriteAttributeString("holdDelay", HoldDelay.ToString());
-                writer.WriteAttributeString("repeatDelay", RepeatDelay.ToString());               
+                writer.WriteAttributeString("repeatDelay", RepeatDelay.ToString());
                 onHold.WriteXml(writer);
                 writer.WriteEndElement();
             }
         }
 
-        private void ExecuteOnHoldAction()
-        {
-            if (CanExecute != null && !CanExecute()) { StopTimers(); return; }
-            lock (LastOnPressLock)
-            {
-                InputEventArgs args = (InputEventArgs)LastOnPressEvent.Clone();
-                args.Value = (int)MobiFlightButton.InputEvent.HOLD;
-                Log.Instance.log($"{args.Controller.Name} => {args.Device.Label}  => Execute HOLD", LogSeverity.Info);
-                onHold.execute(LastOnPressCacheCollection, args, LastOnPressConfigRefs);
-            }            
-        }
-
-        private void RepeatTimer_Elapsed(object sender, EventArgs e)
-        {
-            try
-            {
-                ExecuteOnHoldAction();
-            }
-            catch (Exception ex)
-            {
-                Log.Instance.log($"Error executing onHold action: {ex.Message}", LogSeverity.Error);
-            }
-        }
-
-        private void ExecuteRepeatOnHold()
-        {
-            if (RepeatDelay > 0)
-            {
-                RepeatTimer.Interval = RepeatDelay;
-                RepeatTimer.Start();
-            }
-        }
-
-        private void HoldTimer_Elapsed(object sender, EventArgs e)
-        {
-            try
-            {
-                ExecuteOnHoldAction();
-            }
-            catch (Exception ex)
-            {
-                Log.Instance.log($"Error executing onHold action: {ex.Message}", LogSeverity.Error);
-            }
-            finally
-            {
-                HoldTimer.Stop();
-                ExecuteRepeatOnHold();
-            }
-        }
-
-        private void ExecuteOnHoldWithTimer()
-        {
-            if (HoldDelay > 0)
-            {                
-                HoldTimer.Interval = HoldDelay;
-                HoldTimer.Start();
-            }
-            else
-            {
-                ExecuteOnHoldAction();
-                ExecuteRepeatOnHold();
-            }
-        }
-
-        private void CheckAndStopTimer()
-        {
-            if (HoldTimer.Enabled)
-                HoldTimer.Stop();
-            if (RepeatTimer.Enabled)
-                RepeatTimer.Stop();
-        }
-
-        public void StopTimers()
-        {
-            CheckAndStopTimer();
-        }
-
-        private void CheckAndAdaptForLongButtonRelease(InputEventArgs current, InputEventArgs previous)
-        {
-            var inputEvent = (MobiFlightButton.InputEvent)current.Value;
-
-            if (inputEvent == MobiFlightButton.InputEvent.RELEASE &&
-                onLongRelease != null &&
-                previous != null)
-            {
-                TimeSpan timeSpanToPreviousInput = current.Time - previous.Time;
-                if (timeSpanToPreviousInput > TimeSpan.FromMilliseconds(LongReleaseDelay))
-                {
-                    current.Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE;
-                    Log.Instance.log($"{current.Controller.Name} => {current.Device.Label}  => Execute as LONG_RELEASE", LogSeverity.Info);
-                }
-            }
-        }
-
-        private void ExecuteOnPressAction(CacheCollection cacheCollection,
-                                          InputEventArgs args,
-                                          List<ConfigRefValue> configRefs)
-        {
-            lock (LastOnPressLock)
-            {
-                LastOnPressEvent = args;
-                LastOnPressCacheCollection = cacheCollection;
-                LastOnPressConfigRefs = configRefs;
-                if (onPress != null)
-                {
-                    onPress.execute(cacheCollection, args, configRefs);
-                }
-            }
-            if (onHold != null)
-            {               
-                ExecuteOnHoldWithTimer();
-            }
-        }
-
-        private void ExecuteOnReleaseAction(CacheCollection cacheCollection,
-                                            InputEventArgs args,
-                                            List<ConfigRefValue> configRefs)
-        {
-            CheckAndStopTimer();
-            if (onRelease != null)
-            {
-                onRelease.execute(cacheCollection, args, configRefs);
-            }
-        }
-
-        private void ExecuteOnLongReleaseAction(CacheCollection cacheCollection,
-                                                InputEventArgs args,
-                                                List<ConfigRefValue> configRefs)
-        {
-            CheckAndStopTimer();
-            if (onLongRelease != null)
-            {
-                onLongRelease.execute(cacheCollection, args, configRefs);
-            }
-        }
-
-        internal void execute(CacheCollection cacheCollection, 
-                              InputEventArgs args, 
+        /// <summary>
+        /// Dispatches one already-classified event to the matching InputAction. REPEAT has no
+        /// binding of its own - it dispatches to onHold, same as HOLD.
+        /// </summary>
+        internal void execute(CacheCollection cacheCollection,
+                              InputEventArgs args,
                               List<ConfigRefValue> configRefs)
         {
-            CheckAndAdaptForLongButtonRelease(args, LastOnPressEvent);
-
             switch ((MobiFlightButton.InputEvent)args.Value)
             {
                 case MobiFlightButton.InputEvent.PRESS:
-                    ExecuteOnPressAction(cacheCollection, args, configRefs);
+                    onPress?.execute(cacheCollection, args, configRefs);
                     break;
                 case MobiFlightButton.InputEvent.RELEASE:
-                    ExecuteOnReleaseAction(cacheCollection, args, configRefs);
+                    onRelease?.execute(cacheCollection, args, configRefs);
                     break;
                 case MobiFlightButton.InputEvent.LONG_RELEASE:
-                    ExecuteOnLongReleaseAction(cacheCollection, args, configRefs);
+                    onLongRelease?.execute(cacheCollection, args, configRefs);
                     break;
-                default:
+                case MobiFlightButton.InputEvent.HOLD:
+                case MobiFlightButton.InputEvent.REPEAT:
+                    onHold?.execute(cacheCollection, args, configRefs);
                     break;
             }
         }

--- a/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
@@ -390,6 +390,10 @@ namespace MobiFlight
                         case MobiFlightButton.InputEvent.LONG_RELEASE:
                             return button?.onLongRelease;
 
+                        case MobiFlightButton.InputEvent.HOLD:
+                        case MobiFlightButton.InputEvent.REPEAT:
+                            return button?.onHold;
+
                         default:
                             return null;
                     }

--- a/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
@@ -13,6 +13,9 @@ namespace MobiFlight
 
         public String StrValue { get; set; }
 
+        /// <summary>Null (default) broadcasts to every matching config. Non-null restricts Execute() to that one config's GUID - used for HOLD/REPEAT/LONG_RELEASE, timed per-config.</summary>
+        public string TargetConfigGUID { get; set; }
+
         public readonly DateTime Time = DateTime.Now;
 
         public string GetEventActionLabel()
@@ -46,6 +49,7 @@ namespace MobiFlight
             clone.InputType = InputType;
             clone.Value = Value;
             clone.StrValue = StrValue;
+            clone.TargetConfigGUID = TargetConfigGUID;
 
             return clone;
         }

--- a/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
@@ -53,5 +53,20 @@ namespace MobiFlight
 
             return clone;
         }
+
+        /// <summary>
+        /// Label is a UI/i18n concern and shouldn't really live on a backend type - that's why plain
+        /// Clone() (and DeviceReference.Clone()) drop it. But backend log formatting still needs a
+        /// display string today, so use this clone where that's the case, e.g. deriving
+        /// RELEASE/HOLD/REPEAT/LONG_RELEASE from a PRESS (same physical button, same label). Once
+        /// logging no longer needs Label, this method should go away rather than get replaced by
+        /// plain Clone().
+        /// </summary>
+        public InputEventArgs CloneWithLabel()
+        {
+            var clone = (InputEventArgs)Clone();
+            if (clone.Device != null) clone.Device.Label = Device.Label;
+            return clone;
+        }
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
@@ -34,6 +34,9 @@ namespace MobiFlight
         public event EventHandler Connected;
         public event ButtonEventHandler OnButtonPressed;
         private readonly Timer PollTimer = new Timer();
+
+        /// <summary>Produces HOLD/REPEAT/LONG_RELEASE from joysticks' raw PRESS/RELEASE events.</summary>
+        private readonly SyntheticButtonEventGenerator VirtualButtonEvents = new SyntheticButtonEventGenerator();
         private readonly System.Collections.Concurrent.ConcurrentDictionary<string, Joystick> Joysticks = new System.Collections.Concurrent.ConcurrentDictionary<string, Joystick>();
         private readonly List<Joystick> ExcludedJoysticks = new List<Joystick>();
         private IntPtr Handle;
@@ -47,6 +50,8 @@ namespace MobiFlight
             PollTimer.Elapsed += PollTimer_Tick;
             MobiFlight.Joysticks.ControllerDefinitionMigrator.MigrateJoysticks();
             LoadDefinitions();
+
+            VirtualButtonEvents.OnSyntheticEvent += (s, e) => OnButtonPressed?.Invoke(s, e);
         }
 
         /// <summary>
@@ -141,6 +146,7 @@ namespace MobiFlight
         public void Shutdown()
         {
             PollTimer.Stop();
+            VirtualButtonEvents.Stop();
             foreach (var js in Joysticks.Values)
             {
                 js.Shutdown();
@@ -155,6 +161,7 @@ namespace MobiFlight
 
         public void Stop()
         {
+            VirtualButtonEvents.Stop();
             foreach (var j in Joysticks.Values)
             {
                 j.Stop();
@@ -349,7 +356,16 @@ namespace MobiFlight
 
         private void Js_OnButtonPressed(object sender, InputEventArgs e)
         {
-            OnButtonPressed?.Invoke(sender, e);
+            foreach (var classified in VirtualButtonEvents.Observe(e))
+            {
+                OnButtonPressed?.Invoke(sender, classified);
+            }
+        }
+
+        /// <summary>See SyntheticButtonEventGenerator.ResolveTimings.</summary>
+        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonBinding>> resolver)
+        {
+            VirtualButtonEvents.ResolveTimings = resolver;
         }
 
         internal Joystick GetJoystickBySerial(string serial)

--- a/src/MobiFlightConnector/MobiFlight/MidiBoard/MidiBoardManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/MidiBoard/MidiBoardManager.cs
@@ -25,12 +25,17 @@ namespace MobiFlight
         private readonly Timer ProcessTimer = new System.Windows.Forms.Timer();
         private int CheckAttachedRemovedCounter = 0;
 
+        /// <summary>Produces HOLD/REPEAT/LONG_RELEASE from MIDI boards' raw PRESS/RELEASE events.</summary>
+        private readonly SyntheticButtonEventGenerator VirtualButtonEvents = new SyntheticButtonEventGenerator();
+
         public MidiBoardManager ()
         {
             MobiFlight.Joysticks.ControllerDefinitionMigrator.MigrateMidiControllers();
             Load();
             ProcessTimer.Interval = 50;
             ProcessTimer.Tick += ProcessTimer_Tick;
+
+            VirtualButtonEvents.OnSyntheticEvent += (s, e) => OnButtonPressed?.Invoke(s, e);
         }
 
         private List<string> CollectErrorsInInputDefinition(MidiBoardDefinition def)
@@ -151,7 +156,8 @@ namespace MobiFlight
         }
 
         public void Stop()
-        {           
+        {
+            VirtualButtonEvents.Stop();
             foreach (var mb in MidiBoards)
             {
                 mb.Stop();
@@ -161,6 +167,7 @@ namespace MobiFlight
         public void Shutdown()
         {
             ProcessTimer.Stop();
+            VirtualButtonEvents.Stop();
             foreach (var mb in MidiBoards)
             {
                 mb.Shutdown();
@@ -277,7 +284,16 @@ namespace MobiFlight
 
         private void Mb_OnButtonPressed(object sender, InputEventArgs e)
         {
-            OnButtonPressed?.Invoke(sender, e);
+            foreach (var classified in VirtualButtonEvents.Observe(e))
+            {
+                OnButtonPressed?.Invoke(sender, classified);
+            }
+        }
+
+        /// <summary>See SyntheticButtonEventGenerator.ResolveTimings.</summary>
+        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonBinding>> resolver)
+        {
+            VirtualButtonEvents.ResolveTimings = resolver;
         }
 
         public MidiBoard GetMidiBoardBySerial(string serial)

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightButton.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightButton.cs
@@ -8,7 +8,10 @@
             PRESS = 0,
             RELEASE = 1,
             LONG_RELEASE = 2,
-            HOLD = 3
+            HOLD = 3,
+            // Fired instead of HOLD for every repeat tick after the first HOLD, while the button
+            // is still held down
+            REPEAT = 4
         }
 
         public string Name { get; set; }
@@ -29,6 +32,14 @@
 
                 case (int)InputEvent.LONG_RELEASE:
                     eventAction = InputEvent.LONG_RELEASE.ToString();
+                    break;
+
+                case (int)InputEvent.HOLD:
+                    eventAction = InputEvent.HOLD.ToString();
+                    break;
+
+                case (int)InputEvent.REPEAT:
+                    eventAction = InputEvent.REPEAT.ToString();
                     break;
             }
 

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightCache.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightCache.cs
@@ -46,6 +46,9 @@ namespace MobiFlight
 
         private readonly Timer KeepAwakeTimer = new Timer();
         const int KeepAwakeIntervalInMinutes = 5; // 5 Minutes
+
+        /// <summary>Produces HOLD/REPEAT/LONG_RELEASE from modules' raw PRESS/RELEASE events.</summary>
+        private readonly SyntheticButtonEventGenerator VirtualButtonEvents = new SyntheticButtonEventGenerator();
         
         /// <summary>
         /// list of known modules.
@@ -63,6 +66,8 @@ namespace MobiFlight
             // ticks every KeepAwakeIntervalInMinutes
             KeepAwakeTimer.Interval = KeepAwakeIntervalInMinutes * 60 * 1000;
             KeepAwakeTimer.Tick += (s, e) => DeactivateConnectedModulePowerSave();
+
+            VirtualButtonEvents.OnSyntheticEvent += (s, e) => OnButtonPressed?.Invoke(s, e);
         }
 
         public void Start()
@@ -414,7 +419,16 @@ namespace MobiFlight
 
         public void Module_OnButtonPressed(object sender, InputEventArgs e)
         {
-            OnButtonPressed?.Invoke(sender, e);
+            foreach (var classified in VirtualButtonEvents.Observe(e))
+            {
+                OnButtonPressed?.Invoke(sender, classified);
+            }
+        }
+
+        /// <summary>See SyntheticButtonEventGenerator.ResolveTimings.</summary>
+        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonBinding>> resolver)
+        {
+            VirtualButtonEvents.ResolveTimings = resolver;
         }
 
         /// <summary>
@@ -424,6 +438,7 @@ namespace MobiFlight
         public bool Shutdown()
         {
             Log.Instance.log("Disconnecting all modules.", LogSeverity.Debug);
+            VirtualButtonEvents.Stop();
             if (Available())
             {
                 foreach (MobiFlightModule module in Modules.Values)
@@ -704,11 +719,12 @@ namespace MobiFlight
 
         public void Stop()
         {
+            VirtualButtonEvents.Stop();
             foreach (MobiFlightModule module in Modules.Values)
             {
                 module.Stop();
             }
-            
+
             variables.Clear();
             StopKeepAwake();
         }

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -240,7 +240,7 @@ namespace MobiFlight
     public struct ButtonTimings
     {
         /// <summary>Floor for a positive RepeatDelay - protects the sim API from a too-fast repeat. 0 (disabled) is exempt.</summary>
-        public const int MinRepeatDelay = 200; // ms
+        public const int MinRepeatDelay = 100; // ms
 
         public int HoldDelay;
         public int RepeatDelay;

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.Timers;
+
+namespace MobiFlight
+{
+    /// <summary>
+    /// Produces HOLD/REPEAT/LONG_RELEASE from a controller's raw PRESS/RELEASE events. Owned by a
+    /// controller manager (MobiFlightCache/JoystickManager/MidiBoardManager) and wired into its
+    /// OnButtonPressed funnel, so downstream code sees virtual events exactly like real ones. See
+    /// docs/architecture/virtual-button-events.md.
+    /// </summary>
+    public class SyntheticButtonEventGenerator : IDisposable
+    {
+        /// <summary>Fallback timing when <see cref="ResolveTimings"/> is unset or has no match.</summary>
+        public int HoldDelay { get; set; } = 350; // ms
+
+        /// <summary>Fallback, see <see cref="HoldDelay"/>.</summary>
+        public int LongReleaseDelay { get; set; } = 350; // ms
+
+        /// <summary>Fallback, see <see cref="HoldDelay"/>. 0 disables repeating.</summary>
+        public int RepeatDelay { get; set; } = 0; // ms
+
+        /// <summary>
+        /// Resolves every config currently bound to a button and its delays. Resolved once at
+        /// PRESS, held for that press's lifecycle. Empty/null uses the fallback values above.
+        /// </summary>
+        public Func<InputEventArgs, List<ButtonBinding>> ResolveTimings { get; set; }
+
+        /// <summary>Raised for HOLD/REPEAT. LONG_RELEASE is classified in-place by <see cref="Observe"/> instead.</summary>
+        public event EventHandler<InputEventArgs> OnSyntheticEvent;
+
+        private class BindingState
+        {
+            public string ConfigGuid;
+            public ButtonTimings Timings;
+            public bool HoldFired;
+            public DateTime LastHoldFire;
+        }
+
+        private class TrackedButton
+        {
+            public InputEventArgs LastPress;
+            public DateTime PressedAt;
+            public List<BindingState> Bindings;
+        }
+
+        private readonly Dictionary<string, TrackedButton> _pressed = new Dictionary<string, TrackedButton>();
+        private readonly object _lock = new object();
+        private readonly Func<DateTime> _now;
+        private readonly Timer _timer;
+
+        /// <param name="now">Clock for timing decisions; tests inject a fake one.</param>
+        /// <param name="tickIntervalMs">Poll interval while at least one button is pressed. Idle otherwise.</param>
+        public SyntheticButtonEventGenerator(Func<DateTime> now = null, int tickIntervalMs = 20)
+        {
+            _now = now ?? (() => DateTime.Now);
+            _timer = new Timer(tickIntervalMs) { AutoReset = true };
+            _timer.Elapsed += (s, e) => Tick();
+        }
+
+        private static string KeyFor(InputEventArgs e) => $"{e.Controller?.Serial}:{e.Device?.Name}";
+
+        /// <summary>
+        /// Feed one real PRESS/RELEASE through. Returns the event(s) to forward: one untargeted
+        /// event for PRESS; one per bound config for RELEASE, each classified RELEASE/LONG_RELEASE
+        /// against that config's own delay.
+        /// </summary>
+        public List<InputEventArgs> Observe(InputEventArgs e)
+        {
+            if (e == null || e.InputType != DeviceType.Button) return new List<InputEventArgs> { e };
+
+            MobiFlightButton.InputEvent value;
+            try
+            {
+                value = (MobiFlightButton.InputEvent)Convert.ToInt32(e.Value);
+            }
+            catch (Exception)
+            {
+                return new List<InputEventArgs> { e };
+            }
+
+            var key = KeyFor(e);
+
+            if (value == MobiFlightButton.InputEvent.PRESS)
+            {
+                // Resolved once here, held for the whole press - not re-resolved per tick.
+                var bindings = ResolveTimings?.Invoke(e);
+                if (bindings == null || bindings.Count == 0)
+                {
+                    bindings = new List<ButtonBinding> { new ButtonBinding(null, new ButtonTimings(HoldDelay, RepeatDelay, LongReleaseDelay)) };
+                }
+
+                lock (_lock)
+                {
+                    _pressed[key] = new TrackedButton
+                    {
+                        LastPress = e,
+                        PressedAt = _now(),
+                        Bindings = bindings.ConvertAll(b => new BindingState { ConfigGuid = b.ConfigGuid, Timings = b.Timings })
+                    };
+                }
+                EnsureTimerRunning();
+
+                return new List<InputEventArgs> { e };
+            }
+
+            if (value == MobiFlightButton.InputEvent.RELEASE)
+            {
+                TrackedButton tracked;
+                lock (_lock)
+                {
+                    _pressed.TryGetValue(key, out tracked);
+                    _pressed.Remove(key);
+                }
+                StopTimerIfIdle();
+
+                if (tracked == null)
+                {
+                    // No matching PRESS was tracked - forward as-is.
+                    return new List<InputEventArgs> { e };
+                }
+
+                var now = _now();
+                var result = new List<InputEventArgs>(tracked.Bindings.Count);
+                foreach (var binding in tracked.Bindings)
+                {
+                    var classified = (InputEventArgs)e.Clone();
+                    classified.TargetConfigGUID = binding.ConfigGuid;
+                    if ((now - tracked.PressedAt) > TimeSpan.FromMilliseconds(binding.Timings.LongReleaseDelay))
+                    {
+                        classified.Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE;
+                    }
+                    result.Add(classified);
+                }
+                return result;
+            }
+
+            return new List<InputEventArgs> { e };
+        }
+
+        /// <summary>Fires due HOLD/REPEAT per binding. Called by the internal timer or directly by tests.</summary>
+        public void Tick()
+        {
+            var dueHold = new List<InputEventArgs>();
+            var dueRepeat = new List<InputEventArgs>();
+            var now = _now();
+
+            lock (_lock)
+            {
+                foreach (var kvp in _pressed)
+                {
+                    var tracked = kvp.Value;
+                    foreach (var binding in tracked.Bindings)
+                    {
+                        try
+                        {
+                            if (!binding.HoldFired)
+                            {
+                                if ((now - tracked.PressedAt) >= TimeSpan.FromMilliseconds(binding.Timings.HoldDelay))
+                                {
+                                    binding.HoldFired = true;
+                                    binding.LastHoldFire = now;
+                                    dueHold.Add(Classify(tracked.LastPress, binding.ConfigGuid, MobiFlightButton.InputEvent.HOLD));
+                                }
+                            }
+                            else if (binding.Timings.RepeatDelay > 0 && (now - binding.LastHoldFire) >= TimeSpan.FromMilliseconds(binding.Timings.RepeatDelay))
+                            {
+                                binding.LastHoldFire = now;
+                                dueRepeat.Add(Classify(tracked.LastPress, binding.ConfigGuid, MobiFlightButton.InputEvent.REPEAT));
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Log.Instance.log($"Error checking hold state for {kvp.Key} ({binding.ConfigGuid}): {ex.Message}", LogSeverity.Error);
+                        }
+                    }
+                }
+            }
+
+            // Raised outside the lock - subscribers must never run while we hold it.
+            foreach (var due in dueHold) RaiseSynthetic(due);
+            foreach (var due in dueRepeat) RaiseSynthetic(due);
+        }
+
+        private static InputEventArgs Classify(InputEventArgs lastPress, string targetConfigGuid, MobiFlightButton.InputEvent value)
+        {
+            var e = (InputEventArgs)lastPress.Clone();
+            e.Value = (int)value;
+            e.TargetConfigGUID = targetConfigGuid;
+            return e;
+        }
+
+        private void RaiseSynthetic(InputEventArgs e)
+        {
+            try
+            {
+                OnSyntheticEvent?.Invoke(this, e);
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.log($"Error raising synthetic button event: {ex.Message}", LogSeverity.Error);
+            }
+        }
+
+        private void EnsureTimerRunning()
+        {
+            lock (_lock)
+            {
+                if (!_timer.Enabled) _timer.Start();
+            }
+        }
+
+        private void StopTimerIfIdle()
+        {
+            lock (_lock)
+            {
+                if (_pressed.Count == 0 && _timer.Enabled) _timer.Stop();
+            }
+        }
+
+        /// <summary>Stops the timer and drops all tracked state. No Start() - it self-starts on the next PRESS.</summary>
+        public void Stop()
+        {
+            lock (_lock) // same lock as start/stop elsewhere, to avoid racing a concurrent PRESS
+            {
+                _pressed.Clear();
+                _timer.Stop();
+            }
+        }
+
+        public void Dispose()
+        {
+            _timer.Stop();
+            _timer.Dispose();
+        }
+    }
+
+    /// <summary>Hold/Repeat/LongRelease delays for one button press, one config. See <see cref="SyntheticButtonEventGenerator.ResolveTimings"/>.</summary>
+    public struct ButtonTimings
+    {
+        /// <summary>Floor for a positive RepeatDelay - protects the sim API from a too-fast repeat. 0 (disabled) is exempt.</summary>
+        public const int MinRepeatDelay = 200; // ms
+
+        public int HoldDelay;
+        public int RepeatDelay;
+        public int LongReleaseDelay;
+
+        public ButtonTimings(int holdDelay, int repeatDelay, int longReleaseDelay)
+        {
+            HoldDelay = holdDelay;
+            RepeatDelay = ClampRepeatDelay(repeatDelay);
+            LongReleaseDelay = longReleaseDelay;
+        }
+
+        public static int ClampRepeatDelay(int repeatDelay) =>
+            repeatDelay > 0 && repeatDelay < MinRepeatDelay ? MinRepeatDelay : repeatDelay;
+    }
+
+    /// <summary>One config's claim on a button: its GUID and requested delays.</summary>
+    public struct ButtonBinding
+    {
+        public string ConfigGuid;
+        public ButtonTimings Timings;
+
+        public ButtonBinding(string configGuid, ButtonTimings timings)
+        {
+            ConfigGuid = configGuid;
+            Timings = timings;
+        }
+    }
+}

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -125,7 +125,7 @@ namespace MobiFlight
                 var result = new List<InputEventArgs>(tracked.Bindings.Count);
                 foreach (var binding in tracked.Bindings)
                 {
-                    var classified = (InputEventArgs)e.Clone();
+                    var classified = e.CloneWithLabel();
                     classified.TargetConfigGUID = binding.ConfigGuid;
                     if ((now - tracked.PressedAt) > TimeSpan.FromMilliseconds(binding.Timings.LongReleaseDelay))
                     {
@@ -185,7 +185,7 @@ namespace MobiFlight
 
         private static InputEventArgs Classify(InputEventArgs lastPress, string targetConfigGuid, MobiFlightButton.InputEvent value)
         {
-            var e = (InputEventArgs)lastPress.Clone();
+            var e = lastPress.CloneWithLabel();
             e.Value = (int)value;
             e.TargetConfigGUID = targetConfigGuid;
             return e;

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -1,12 +1,10 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using MobiFlight.Base;
+﻿using MobiFlight.Base;
 using MobiFlight.FSUIPC;
 using MobiFlight.InputConfig;
 using MobiFlight.ProSim;
 using MobiFlight.SimConnectMSFS;
 using MobiFlight.xplane;
 using Moq;
-using System.Collections.Generic;
 
 namespace MobiFlight.Execution.Tests
 {
@@ -588,55 +586,52 @@ namespace MobiFlight.Execution.Tests
 
         #endregion
 
-        #region Hold Timer Cleanup on Skip
+        #region HOLD events are gated exactly like real events
 
-        private static System.Timers.Timer GetHoldTimer(ButtonInputConfig button)
+        // HOLD is now an ordinary InputEventArgs into Execute() - same Active/precondition gating.
+
+        private static InputEventArgs CreateHoldEventArgs(string serial, string deviceId)
         {
-            return (System.Timers.Timer)typeof(ButtonInputConfig)
-                .GetField("HoldTimer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                .GetValue(button);
+            return new InputEventArgs
+            {
+                Controller = new Controller() { Serial = serial },
+                InputType = DeviceType.Button,
+                Device = new DeviceReference() { Name = deviceId },
+                Value = (int)MobiFlightButton.InputEvent.HOLD
+            };
         }
 
         [TestMethod]
-        public void Execute_ConfigDeactivatedWhileButtonHeld_StopsHoldTimer()
+        public void Execute_HoldEvent_DeactivatedConfig_IsSkipped()
         {
             var serial = "SN-deact001";
             var deviceName = "Button1";
 
             var configItem = new InputConfigItem
             {
-                Active = true,
+                Active = false,
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "DeactivatedConfig",
                 button = new ButtonInputConfig
                 {
-                    onPress = new VariableInputAction(),
-                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
-                    HoldDelay = 10000
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" }
                 }
             };
             _configItems.Add(configItem);
 
-            _executor.Execute(CreateButtonEventArgs(serial, deviceName, isOnPress: true), isStarted: true);
+            var result = _executor.Execute(CreateHoldEventArgs(serial, deviceName), isStarted: true);
 
-            var holdTimer = GetHoldTimer(configItem.button);
-            Assert.IsTrue(holdTimer.Enabled, "Timer should be running after press.");
-
-            configItem.Active = false;
-
-            _executor.Execute(CreateButtonEventArgs(serial, deviceName, isOnPress: false), isStarted: true);
-
-            Assert.IsFalse(holdTimer.Enabled, "Timer should be stopped when the config is deactivated.");
+            Assert.IsFalse(result.ContainsKey(configItem.GUID), "A HOLD event for a deactivated config should not execute.");
         }
 
         [TestMethod]
-        public void Execute_PreconditionFailsWhileButtonHeld_StopsHoldTimer()
+        public void Execute_HoldEvent_PreconditionNotSatisfied_IsSkipped()
         {
             var serial = "SN-precond001";
             var deviceName = "Button1";
 
-            _configItems[0].Value = "ExpectedValue";
+            _configItems[0].Value = "DifferentValue";
 
             var configItem = new InputConfigItem
             {
@@ -646,9 +641,7 @@ namespace MobiFlight.Execution.Tests
                 Name = "PreconditionConfig",
                 button = new ButtonInputConfig
                 {
-                    onPress = new VariableInputAction(),
-                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p2" },
-                    HoldDelay = 10000
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p2" }
                 },
                 Preconditions = new PreconditionList
                 {
@@ -657,16 +650,247 @@ namespace MobiFlight.Execution.Tests
             };
             _configItems.Add(configItem);
 
-            _executor.Execute(CreateButtonEventArgs(serial, deviceName, isOnPress: true), isStarted: true);
+            var result = _executor.Execute(CreateHoldEventArgs(serial, deviceName), isStarted: true);
 
-            var holdTimer = GetHoldTimer(configItem.button);
-            Assert.IsTrue(holdTimer.Enabled, "Timer should be running after press with precondition satisfied.");
+            Assert.IsFalse(result.ContainsKey(configItem.GUID), "A HOLD event should not execute while its precondition is not satisfied.");
+        }
 
-            _configItems[0].Value = "DifferentValue";
+        [TestMethod]
+        public void Execute_HoldEvent_ActiveConfigWithSatisfiedPrecondition_Executes()
+        {
+            var serial = "SN-active001";
+            var deviceName = "Button1";
 
-            _executor.Execute(CreateButtonEventArgs(serial, deviceName, isOnPress: false), isStarted: true);
+            var configItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ActiveConfig",
+                button = new ButtonInputConfig
+                {
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p3" }
+                }
+            };
+            _configItems.Add(configItem);
 
-            Assert.IsFalse(holdTimer.Enabled, "Timer should be stopped when the precondition is not satisfied.");
+            var result = _executor.Execute(CreateHoldEventArgs(serial, deviceName), isStarted: true);
+
+            Assert.IsTrue(result.ContainsKey(configItem.GUID), "A HOLD event for an active, precondition-satisfied config should execute.");
+        }
+
+        #endregion
+
+        #region ResolveButtonTimingsPerConfig - delay, and which config, are per binding
+
+        [TestMethod]
+        public void ResolveButtonTimingsPerConfig_ActiveConfig_ReturnsItsDelaysTargetedAtIt()
+        {
+            var serial = "SN-timings001";
+            var deviceName = "Button1";
+
+            var configItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ModeAConfig",
+                button = new ButtonInputConfig
+                {
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
+                    HoldDelay = 123,
+                    RepeatDelay = 45, // below ButtonTimings.MinRepeatDelay - e.g. an old/hand-edited config
+                    LongReleaseDelay = 678
+                }
+            };
+            _configItems.Add(configItem);
+
+            var bindings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+
+            Assert.HasCount(1, bindings);
+            Assert.AreEqual(configItem.GUID, bindings[0].ConfigGuid);
+            Assert.AreEqual(123, bindings[0].Timings.HoldDelay, "HoldDelay is not clamped.");
+            Assert.AreEqual(ButtonTimings.MinRepeatDelay, bindings[0].Timings.RepeatDelay,
+                "The stored 45ms RepeatDelay must be raised to the floor - ButtonTimings' constructor clamps it regardless of where the value came from.");
+            Assert.AreEqual(678, bindings[0].Timings.LongReleaseDelay, "LongReleaseDelay is not clamped.");
+        }
+
+        [TestMethod]
+        public void ResolveButtonTimingsPerConfig_NoActiveConfigForButton_ReturnsEmpty()
+        {
+            var result = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs("SN-unbound", "NoSuchButton", isOnPress: true));
+
+            Assert.HasCount(0, result);
+        }
+
+        [TestMethod]
+        public void ResolveButtonTimingsPerConfig_InactiveConfig_IsSkipped()
+        {
+            var serial = "SN-timings002";
+            var deviceName = "Button1";
+
+            var configItem = new InputConfigItem
+            {
+                Active = false,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "InactiveConfig",
+                button = new ButtonInputConfig { HoldDelay = 999 }
+            };
+            _configItems.Add(configItem);
+
+            var result = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+
+            Assert.HasCount(0, result, "An inactive config must not govern timings, same as it does not govern execution.");
+        }
+
+        [TestMethod]
+        public void ResolveButtonTimingsPerConfig_MultiModePanel_DifferentPreconditionGatedConfigsYieldDifferentDelays()
+        {
+            var serial = "SN-multimode";
+            var deviceName = "Button1";
+
+            var modeSwitch = _configItems[0]; // an existing InputConfigItem used as the mode reference
+            modeSwitch.Value = "ModeA";
+
+            var modeAConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ModeAConfig",
+                button = new ButtonInputConfig { HoldDelay = 200 },
+                Preconditions = new PreconditionList
+                {
+                    new Precondition { Type = "config", Active = true, Ref = modeSwitch.GUID, Value = "ModeA" }
+                }
+            };
+            var modeBConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ModeBConfig",
+                button = new ButtonInputConfig { HoldDelay = 800 },
+                Preconditions = new PreconditionList
+                {
+                    new Precondition { Type = "config", Active = true, Ref = modeSwitch.GUID, Value = "ModeB" }
+                }
+            };
+            _configItems.Add(modeAConfig);
+            _configItems.Add(modeBConfig);
+
+            var bindingsInModeA = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            Assert.HasCount(1, bindingsInModeA, "Mode B's precondition is not satisfied, so only Mode A's config should match.");
+            Assert.AreEqual(200, bindingsInModeA[0].Timings.HoldDelay, "Mode A's precondition is satisfied, so its 200ms HoldDelay should apply.");
+
+            modeSwitch.Value = "ModeB"; // re-evaluated fresh each call, no cache invalidation needed
+
+            var bindingsInModeB = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            Assert.HasCount(1, bindingsInModeB);
+            Assert.AreEqual(800, bindingsInModeB[0].Timings.HoldDelay, "Switching modes should change which HoldDelay applies to the same physical button.");
+        }
+
+        [TestMethod]
+        public void ResolveButtonTimingsPerConfig_TwoSimultaneouslyActiveConfigs_ReturnsBothTargetedIndependently()
+        {
+            var serial = "SN-conflict001";
+            var deviceName = "Button1";
+
+            var firstConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "FirstConfig",
+                button = new ButtonInputConfig { HoldDelay = 100 }
+            };
+            var secondConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "SecondConfig",
+                button = new ButtonInputConfig { HoldDelay = 900 }
+            };
+            _configItems.Add(firstConfig);
+            _configItems.Add(secondConfig);
+
+            var bindings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+
+            Assert.HasCount(2, bindings);
+            Assert.AreEqual(100, bindings.Single(b => b.ConfigGuid == firstConfig.GUID).Timings.HoldDelay);
+            Assert.AreEqual(900, bindings.Single(b => b.ConfigGuid == secondConfig.GUID).Timings.HoldDelay);
+        }
+
+        #endregion
+
+        #region TargetConfigGUID - a HOLD/REPEAT/LONG_RELEASE targeted at one config skips the others
+
+        [TestMethod]
+        public void Execute_TargetedEvent_OnlyExecutesTheTargetedConfig()
+        {
+            var serial = "SN-target001";
+            var deviceName = "Button1";
+
+            var targeted = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "TargetedConfig",
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
+            };
+            var other = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "OtherConfig",
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" } }
+            };
+            _configItems.Add(targeted);
+            _configItems.Add(other);
+
+            var holdEvent = CreateHoldEventArgs(serial, deviceName);
+            holdEvent.TargetConfigGUID = targeted.GUID;
+
+            var result = _executor.Execute(holdEvent, isStarted: true);
+
+            Assert.IsTrue(result.ContainsKey(targeted.GUID), "The targeted config must execute.");
+            Assert.IsFalse(result.ContainsKey(other.GUID), "A targeted event must not execute any other matching config.");
+        }
+
+        [TestMethod]
+        public void Execute_UntargetedEvent_ExecutesEveryMatchingActiveConfig()
+        {
+            var serial = "SN-broadcast001";
+            var deviceName = "Button1";
+
+            var first = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "First",
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
+            };
+            var second = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "Second",
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" } }
+            };
+            _configItems.Add(first);
+            _configItems.Add(second);
+
+            // TargetConfigGUID left null, e.g. a real PRESS/RELEASE - must still broadcast to both.
+            var result = _executor.Execute(CreateHoldEventArgs(serial, deviceName), isStarted: true);
+
+            Assert.IsTrue(result.ContainsKey(first.GUID));
+            Assert.IsTrue(result.ContainsKey(second.GUID));
         }
 
         #endregion

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -197,31 +197,66 @@ namespace MobiFlight.InputConfig.Tests
             Assert.AreEqual(typeof(VariableInputAction), result[2].GetType());
         }
 
-        [TestMethod()]
-        public void StopTimers_WithNoOnHold_DoesNotThrow()
+        // execute() is now pure dispatch to the matching InputAction - see SyntheticButtonEventGeneratorTests for detection.
+
+        private class RecordingInputAction : InputAction
         {
-            ButtonInputConfig o = new ButtonInputConfig();
-            o.onPress = new EventIdInputAction() { EventId = 12345 };
-            o.StopTimers();
+            public int ExecuteCount = 0;
+
+            public override void execute(CacheCollection cacheCollection, InputEventArgs args, List<ConfigRefValue> configRefs)
+            {
+                ExecuteCount++;
+            }
+
+            public override object Clone() => new RecordingInputAction();
+            public override void ReadXml(XmlReader reader) { }
+            public override void WriteXml(XmlWriter writer) { }
         }
 
         [TestMethod()]
-        public void StopTimers_WithRunningHoldTimer_StopsTimer()
+        public void Execute_DispatchesToMatchingActionOnly()
         {
-            ButtonInputConfig o = new ButtonInputConfig();
-            o.onHold = new XplaneInputAction() { Expression = "", InputType = "Command", Path = "sim/test" };
+            var press = new RecordingInputAction();
+            var release = new RecordingInputAction();
+            var longRelease = new RecordingInputAction();
+            var hold = new RecordingInputAction();
 
-            var holdTimer = typeof(ButtonInputConfig)
-                .GetField("HoldTimer", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
-                .GetValue(o) as System.Timers.Timer;
+            ButtonInputConfig cfg = new ButtonInputConfig
+            {
+                onPress = press,
+                onRelease = release,
+                onLongRelease = longRelease,
+                onHold = hold
+            };
 
-            holdTimer.Interval = 10000;
-            holdTimer.Start();
-            Assert.IsTrue(holdTimer.Enabled, "HoldTimer should be running before StopTimers()");
+            void ExecuteWith(MobiFlightButton.InputEvent value)
+            {
+                cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)value }, new List<ConfigRefValue>());
+            }
 
-            o.StopTimers();
+            ExecuteWith(MobiFlightButton.InputEvent.PRESS);
+            Assert.AreEqual(1, press.ExecuteCount);
+            Assert.AreEqual(0, release.ExecuteCount + longRelease.ExecuteCount + hold.ExecuteCount);
 
-            Assert.IsFalse(holdTimer.Enabled, "HoldTimer should be stopped after StopTimers()");
+            ExecuteWith(MobiFlightButton.InputEvent.RELEASE);
+            Assert.AreEqual(1, release.ExecuteCount);
+
+            ExecuteWith(MobiFlightButton.InputEvent.LONG_RELEASE);
+            Assert.AreEqual(1, longRelease.ExecuteCount);
+
+            ExecuteWith(MobiFlightButton.InputEvent.HOLD);
+            Assert.AreEqual(1, hold.ExecuteCount);
+
+            // REPEAT has no binding of its own - it dispatches to onHold, same as HOLD.
+            ExecuteWith(MobiFlightButton.InputEvent.REPEAT);
+            Assert.AreEqual(2, hold.ExecuteCount);
+        }
+
+        [TestMethod()]
+        public void Execute_WithNoMatchingAction_DoesNotThrow()
+        {
+            ButtonInputConfig cfg = new ButtonInputConfig();
+            cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.HOLD }, new List<ConfigRefValue>());
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
@@ -353,6 +353,8 @@ namespace MobiFlight.Tests
         [DataRow((int)MobiFlightButton.InputEvent.PRESS, "onPress")]
         [DataRow((int)MobiFlightButton.InputEvent.RELEASE, "onRelease")]
         [DataRow((int)MobiFlightButton.InputEvent.LONG_RELEASE, "onLongRelease")]
+        [DataRow((int)MobiFlightButton.InputEvent.HOLD, "onHold")]
+        [DataRow((int)MobiFlightButton.InputEvent.REPEAT, "onHold")]
         public void GetInputAction_Button_ReturnsCorrectAction(
      int inputEvent,
      string actionName)

--- a/tests/MobiFlightUnitTests/MobiFlight/InputEventArgsTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputEventArgsTests.cs
@@ -57,6 +57,40 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void GetEventActionLabel_ButtonHoldEvent_ReturnsCorrectString()
+        {
+            // Arrange
+            var inputEvent = new InputEventArgs
+            {
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.HOLD
+            };
+
+            // Act
+            var result = inputEvent.GetEventActionLabel();
+
+            // Assert
+            Assert.AreEqual("HOLD", result);
+        }
+
+        [TestMethod]
+        public void GetEventActionLabel_ButtonRepeatEvent_ReturnsCorrectString()
+        {
+            // Arrange
+            var inputEvent = new InputEventArgs
+            {
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.REPEAT
+            };
+
+            // Act
+            var result = inputEvent.GetEventActionLabel();
+
+            // Assert
+            Assert.AreEqual("REPEAT", result);
+        }
+
+        [TestMethod]
         public void GetEventActionLabel_ButtonInvalidEvent_ReturnsNA()
         {
             // Arrange

--- a/tests/MobiFlightUnitTests/MobiFlight/InputEventArgsTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputEventArgsTests.cs
@@ -566,5 +566,41 @@ namespace MobiFlight.Tests
             // Assert
             Assert.AreEqual("TestModule => ShiftReg1 - 0 => PRESS", result);
         }
+
+        // Clone()/CloneWithLabel() - Label is dropped by plain Clone() (DeviceReference.Label is a
+        // discovery workaround, not stable state). Missing this the first time is what let the
+        // synthetic RELEASE/HOLD/LONG_RELEASE log lines go blank - see SyntheticButtonEventGeneratorTests.
+
+        [TestMethod]
+        public void Clone_DropsDeviceLabel()
+        {
+            var inputEvent = new InputEventArgs
+            {
+                Controller = new Base.Controller { Name = "TestModule" },
+                Device = new Base.DeviceReference { Name = "Button1", Label = "Button 1" },
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.PRESS
+            };
+
+            var clone = (InputEventArgs)inputEvent.Clone();
+
+            Assert.IsNull(clone.Device.Label, "Plain Clone() must not carry Label - see DeviceReference.Clone().");
+        }
+
+        [TestMethod]
+        public void CloneWithLabel_KeepsDeviceLabel()
+        {
+            var inputEvent = new InputEventArgs
+            {
+                Controller = new Base.Controller { Name = "TestModule" },
+                Device = new Base.DeviceReference { Name = "Button1", Label = "Button 1" },
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.PRESS
+            };
+
+            var clone = inputEvent.CloneWithLabel();
+
+            Assert.AreEqual("Button 1", clone.Device.Label);
+        }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
@@ -36,12 +36,12 @@ namespace MobiFlight.Tests
             _generator.Dispose();
         }
 
-        private static InputEventArgs ButtonEvent(string serial, string device, MobiFlightButton.InputEvent value)
+        private static InputEventArgs ButtonEvent(string serial, string device, MobiFlightButton.InputEvent value, string label = null)
         {
             return new InputEventArgs
             {
                 Controller = new Controller { Serial = serial },
-                Device = new DeviceReference { Name = device },
+                Device = new DeviceReference { Name = device, Label = label },
                 InputType = DeviceType.Button,
                 Value = (int)value
             };
@@ -352,6 +352,60 @@ namespace MobiFlight.Tests
             var timings = new ButtonTimings(holdDelay: 300, repeatDelay: configured, longReleaseDelay: 300);
 
             Assert.AreEqual(expected, timings.RepeatDelay);
+        }
+
+        // Device.Label - the value the log line displays. All of these are built by cloning
+        // internally, and DeviceReference.Clone() drops Label - CloneWithLabel() is what's supposed
+        // to prevent it going blank here. This is the exact regression that shipped unnoticed until
+        // manual testing caught it: PRESS kept its label because it's never cloned, everything else
+        // silently lost it.
+
+        [TestMethod]
+        public void Tick_Hold_PreservesDeviceLabelFromPress()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS, "Button 1"));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick();
+
+            Assert.AreEqual("Button 1", _synthetic[0].Device.Label);
+        }
+
+        [TestMethod]
+        public void Tick_Repeat_PreservesDeviceLabelFromPress()
+        {
+            _generator.RepeatDelay = ButtonTimings.MinRepeatDelay;
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS, "Button 1"));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick(); // HOLD
+
+            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay);
+            _generator.Tick(); // REPEAT
+
+            Assert.AreEqual("Button 1", _synthetic[1].Device.Label);
+        }
+
+        [TestMethod]
+        public void Observe_Release_PreservesDeviceLabel()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS, "Button 1"));
+
+            var released = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE, "Button 1"));
+
+            Assert.AreEqual("Button 1", released.Device.Label);
+        }
+
+        [TestMethod]
+        public void Observe_LongRelease_PreservesDeviceLabel()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS, "Button 1"));
+
+            _now = _now.AddMilliseconds(350); // > LongReleaseDelay (300)
+            var result = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE, "Button 1"));
+
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, result.Value);
+            Assert.AreEqual("Button 1", result.Device.Label);
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
@@ -1,0 +1,379 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MobiFlight.Base;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MobiFlight.Tests
+{
+    [TestClass()]
+    public class SyntheticButtonEventGeneratorTests
+    {
+        // huge so the internal timer never fires during a test - time is driven via _now/Tick()
+        private const int NeverFiresIntervalMs = 60000;
+
+        private DateTime _now;
+        private SyntheticButtonEventGenerator _generator;
+        private List<InputEventArgs> _synthetic;
+
+        [TestInitialize]
+        public void Setup()
+        {
+            _now = new DateTime(2026, 1, 1, 12, 0, 0);
+            _generator = new SyntheticButtonEventGenerator(() => _now, NeverFiresIntervalMs)
+            {
+                HoldDelay = 300,
+                LongReleaseDelay = 300,
+                RepeatDelay = 0
+            };
+            _synthetic = new List<InputEventArgs>();
+            _generator.OnSyntheticEvent += (s, e) => _synthetic.Add(e);
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _generator.Dispose();
+        }
+
+        private static InputEventArgs ButtonEvent(string serial, string device, MobiFlightButton.InputEvent value)
+        {
+            return new InputEventArgs
+            {
+                Controller = new Controller { Serial = serial },
+                Device = new DeviceReference { Name = device },
+                InputType = DeviceType.Button,
+                Value = (int)value
+            };
+        }
+
+        /// <summary>Convenience for tests where exactly one config (or none) is expected to match.</summary>
+        private InputEventArgs ObserveOne(InputEventArgs e) => _generator.Observe(e).Single();
+
+        [TestMethod]
+        public void Tick_BeforeHoldDelayElapsed_DoesNotFireHold()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(100); // < HoldDelay (300)
+            _generator.Tick();
+
+            Assert.HasCount(0, _synthetic);
+        }
+
+        [TestMethod]
+        public void Tick_AfterHoldDelayElapsed_FiresHoldOnce()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick();
+
+            Assert.HasCount(1, _synthetic);
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.HOLD, _synthetic[0].Value);
+            Assert.AreEqual("S1", _synthetic[0].Controller.Serial);
+            Assert.AreEqual("Btn1", _synthetic[0].Device.Name);
+            Assert.IsNull(_synthetic[0].TargetConfigGUID, "No resolver wired, so this is the untargeted fallback - broadcasts like a real event.");
+        }
+
+        [TestMethod]
+        public void Tick_CalledRepeatedlyWithRepeatDisabled_FiresHoldOnlyOnce()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick();
+            _generator.Tick();
+            _now = _now.AddMilliseconds(1000);
+            _generator.Tick();
+
+            Assert.HasCount(1, _synthetic, "RepeatDelay is 0 (disabled), HOLD should not repeat.");
+        }
+
+        [TestMethod]
+        public void Tick_WithRepeatDelayElapsed_FiresRepeatAfterInitialHold()
+        {
+            _generator.RepeatDelay = ButtonTimings.MinRepeatDelay;
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick(); // first HOLD
+
+            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay);
+            _generator.Tick(); // repeat
+
+            Assert.HasCount(2, _synthetic);
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.HOLD, _synthetic[0].Value, "The first firing must be HOLD.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[1].Value, "Every firing after the first must be REPEAT, not HOLD again.");
+        }
+
+        [TestMethod]
+        public void Tick_WithRepeatDelayElapsedTwice_FiresRepeatEachTime()
+        {
+            _generator.RepeatDelay = ButtonTimings.MinRepeatDelay;
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick(); // HOLD
+
+            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay);
+            _generator.Tick(); // REPEAT #1
+
+            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay);
+            _generator.Tick(); // REPEAT #2
+
+            Assert.HasCount(3, _synthetic);
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.HOLD, _synthetic[0].Value);
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[1].Value);
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[2].Value);
+        }
+
+        [TestMethod]
+        public void Observe_ReleaseBeforeLongReleaseDelay_StaysRelease()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(100); // < LongReleaseDelay (300)
+            var result = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
+
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, result.Value);
+        }
+
+        [TestMethod]
+        public void Observe_ReleaseAfterLongReleaseDelay_IsReclassifiedAsLongRelease()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(350); // > LongReleaseDelay (300)
+            var result = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
+
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, result.Value);
+        }
+
+        [TestMethod]
+        public void Observe_Release_StopsTrackingSoHoldNeverFires()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(100);
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
+
+            _now = _now.AddMilliseconds(1000); // well past HoldDelay
+            _generator.Tick();
+
+            Assert.HasCount(0, _synthetic, "A released button must never fire HOLD.");
+        }
+
+        [TestMethod]
+        public void Observe_TwoButtonsAreTrackedIndependently()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(200);
+            ObserveOne(ButtonEvent("S1", "Btn2", MobiFlightButton.InputEvent.PRESS)); // pressed 200ms later
+
+            _now = _now.AddMilliseconds(150); // Btn1: 350ms since press (fires), Btn2: 150ms (does not)
+            _generator.Tick();
+
+            Assert.HasCount(1, _synthetic);
+            Assert.AreEqual("Btn1", _synthetic[0].Device.Name);
+        }
+
+        [TestMethod]
+        public void Observe_NonButtonEvent_IsIgnored()
+        {
+            var encoderEvent = new InputEventArgs
+            {
+                Controller = new Controller { Serial = "S1" },
+                Device = new DeviceReference { Name = "Enc1" },
+                InputType = DeviceType.Encoder,
+                Value = (int)MobiFlightEncoder.InputEvent.LEFT
+            };
+
+            var result = ObserveOne(encoderEvent);
+
+            Assert.AreSame(encoderEvent, result);
+            Assert.AreEqual((double)MobiFlightEncoder.InputEvent.LEFT, result.Value, "Non-button events must pass through untouched.");
+
+            _now = _now.AddMilliseconds(1000);
+            _generator.Tick();
+            Assert.HasCount(0, _synthetic, "A non-button event must never be tracked for HOLD.");
+        }
+
+        [TestMethod]
+        public void Stop_StopsTrackingEveryPressedButton()
+        {
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _generator.Stop();
+
+            _now = _now.AddMilliseconds(1000);
+            _generator.Tick();
+
+            Assert.HasCount(0, _synthetic, "Stop() must stop tracking so no HOLD fires afterwards.");
+        }
+
+        // ResolveTimings: delay is per config, not per physical button.
+
+        [TestMethod]
+        public void ResolveTimings_OverridesDefaultHoldDelayForThatPress()
+        {
+            _generator.ResolveTimings = e => new List<ButtonBinding> { new ButtonBinding("cfgA", new ButtonTimings(50, 0, 300)) };
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(50); // well under the generator's own 300ms default
+            _generator.Tick();
+
+            Assert.HasCount(1, _synthetic, "The resolved 50ms HoldDelay should govern, not the generator's 300ms default.");
+            Assert.AreEqual("cfgA", _synthetic[0].TargetConfigGUID);
+        }
+
+        [TestMethod]
+        public void ResolveTimings_ReturningEmpty_FallsBackToGeneratorDefaults()
+        {
+            _generator.ResolveTimings = e => new List<ButtonBinding>(); // no active/precondition-satisfied config for this button
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(100); // < the generator's 300ms default HoldDelay
+            _generator.Tick();
+            Assert.HasCount(0, _synthetic);
+
+            _now = _now.AddMilliseconds(250); // now past 300ms total
+            _generator.Tick();
+            Assert.HasCount(1, _synthetic);
+            Assert.IsNull(_synthetic[0].TargetConfigGUID);
+        }
+
+        [TestMethod]
+        public void ResolveTimings_IsResolvedOnceAtPress_NotReResolvedEveryTick()
+        {
+            int callCount = 0;
+            _generator.ResolveTimings = e =>
+            {
+                callCount++;
+                return new List<ButtonBinding> { new ButtonBinding("cfgA", new ButtonTimings(300, 0, 300)) };
+            };
+
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+            Assert.AreEqual(1, callCount, "Resolving should happen exactly once, at PRESS.");
+
+            _now = _now.AddMilliseconds(100);
+            _generator.Tick();
+            _now = _now.AddMilliseconds(100);
+            _generator.Tick();
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick();
+
+            Assert.AreEqual(1, callCount, "Tick() must not re-resolve timings for an already-tracked press.");
+        }
+
+        [TestMethod]
+        public void ResolveTimings_DifferentButtonsCanHaveDifferentDelays()
+        {
+            _generator.ResolveTimings = e => new List<ButtonBinding>
+            {
+                e.Device.Name == "Btn1"
+                    ? new ButtonBinding("cfgBtn1", new ButtonTimings(50, 0, 300))
+                    : new ButtonBinding("cfgBtn2", new ButtonTimings(500, 0, 300))
+            };
+
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+            ObserveOne(ButtonEvent("S1", "Btn2", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(50);
+            _generator.Tick();
+
+            Assert.HasCount(1, _synthetic, "Only Btn1's shorter, resolved HoldDelay should have elapsed.");
+            Assert.AreEqual("Btn1", _synthetic[0].Device.Name);
+        }
+
+        // Two configs on the same button - the case that needs targeting, not just resolving.
+
+        [TestMethod]
+        public void ResolveTimings_TwoConfigsOnSameButton_OnlyTheOneWhoseDelayElapsedFires()
+        {
+            _generator.ResolveTimings = e => new List<ButtonBinding>
+            {
+                new ButtonBinding("fastConfig", new ButtonTimings(holdDelay: 50, repeatDelay: 0, longReleaseDelay: 300)),
+                new ButtonBinding("slowConfig", new ButtonTimings(holdDelay: 900, repeatDelay: 0, longReleaseDelay: 300))
+            };
+
+            _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(50);
+            _generator.Tick();
+
+            Assert.HasCount(1, _synthetic, "slowConfig's 900ms HoldDelay has not elapsed - it must not fire yet.");
+            Assert.AreEqual("fastConfig", _synthetic[0].TargetConfigGUID);
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.HOLD, _synthetic[0].Value);
+
+            _now = _now.AddMilliseconds(850); // total 900ms
+            _generator.Tick();
+
+            Assert.HasCount(2, _synthetic, "slowConfig's own HoldDelay has now elapsed.");
+            Assert.AreEqual("slowConfig", _synthetic[1].TargetConfigGUID);
+        }
+
+        [TestMethod]
+        public void ResolveTimings_TwoConfigsOnSameButton_ReleaseFansOutOneEventPerConfig()
+        {
+            _generator.ResolveTimings = e => new List<ButtonBinding>
+            {
+                new ButtonBinding("shortLongRelease", new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 200)),
+                new ButtonBinding("longLongRelease", new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 800))
+            };
+
+            _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300); // > shortLongRelease's 200ms, < longLongRelease's 800ms
+            var released = _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
+
+            Assert.HasCount(2, released, "One release event must be produced per config bound to the button.");
+
+            var forShort = released.Single(e => e.TargetConfigGUID == "shortLongRelease");
+            var forLong = released.Single(e => e.TargetConfigGUID == "longLongRelease");
+
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, forShort.Value,
+                "300ms exceeds shortLongRelease's own 200ms threshold - this config must see LONG_RELEASE.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, forLong.Value,
+                "300ms is under longLongRelease's own 800ms threshold - this config must see a plain RELEASE, not LONG_RELEASE.");
+        }
+
+        // RepeatDelay floor - protects the sim API from a too-fast repeat.
+
+        [TestMethod]
+        [DataRow(0, 0, DisplayName = "0 (disabled) is exempt from the floor")]
+        [DataRow(1, ButtonTimings.MinRepeatDelay, DisplayName = "a tiny positive value is raised to the floor")]
+        [DataRow(ButtonTimings.MinRepeatDelay - 1, ButtonTimings.MinRepeatDelay, DisplayName = "just under the floor is raised to it")]
+        [DataRow(ButtonTimings.MinRepeatDelay, ButtonTimings.MinRepeatDelay, DisplayName = "exactly the floor is unchanged")]
+        [DataRow(900, 900, DisplayName = "comfortably above the floor is unchanged")]
+        public void ButtonTimings_ClampsRepeatDelayToTheFloor(int configured, int expected)
+        {
+            var timings = new ButtonTimings(holdDelay: 300, repeatDelay: configured, longReleaseDelay: 300);
+
+            Assert.AreEqual(expected, timings.RepeatDelay);
+        }
+
+        [TestMethod]
+        public void ResolveTimings_RepeatDelayBelowFloor_ActualRepeatCadenceUsesFloorNotConfiguredValue()
+        {
+            _generator.ResolveTimings = e => new List<ButtonBinding>
+            {
+                new ButtonBinding("cfgA", new ButtonTimings(holdDelay: 300, repeatDelay: 10, longReleaseDelay: 300))
+            };
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick(); // HOLD
+
+            _now = _now.AddMilliseconds(10); // the configured (but floored) 10ms
+            _generator.Tick();
+            Assert.HasCount(1, _synthetic, "10ms is below the floor - no repeat yet.");
+
+            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay - 10); // total: the floor
+            _generator.Tick();
+            Assert.HasCount(2, _synthetic, "The floor has now elapsed since the HOLD - repeat fires.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[1].Value);
+        }
+    }
+}


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
Buttons have two real, physical events: PRESS and RELEASE.  MobiFlight also generates synthetic events like Hold,
Repeat, and LongRelease on top of those. 

This PR introduces a SyntheticButtonEventGenerator, owned by each controller (MobiFlight boards, joysticks, MIDI boards), that produces Hold/Repeat/LongRelease and feeds them back through the exact same event pipeline real button presses use. Synthetic and real events are now processed identically. 

Real and synthetic event information is now displayed equally in the UI too.


### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Hold/Repeat/LongRelease execute through the same pipeline as Press/Release (preconditions, modifiers, status/UI updates all apply)
- [x] Repeat is a distinct, loggable event from the initial Hold
- [x] LongRelease is labeled correctly in logs/UI (previously showed as "Release")
- [x] Hold/Repeat/LongRelease delays remain configurable per binding, including multi-mode panels where a precondition determines which config governs a physical button
- [x] Two configs simultaneously bound to the same physical button each fire strictly on their own delay, never triggered early by the other's
- [x] RepeatDelay has a floor (100ms) to prevent flooding the sim API
- [x] Existing saved configs continue to load and behave correctly

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
- [x] documentation
  - [x] Developer docs (e.g., readme.md)
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3315 

### Notes
We added a md file with more information, reasoning and design decisions.
