### PR TITLE
Ensure shutdown order of WebView2 and unsubscribe from publishers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,7 +19,7 @@
     <PackageVersion Include="Microsoft.Testing.Extensions.VSTestBridge" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Testing.Platform" Version="2.1.0" />
     <PackageVersion Include="Microsoft.Testing.Platform.MSBuild" Version="2.1.0" />
-    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4129.50" />
+    <PackageVersion Include="Microsoft.Web.WebView2" Version="1.0.4191.47" />
     <PackageVersion Include="MSTest.TestAdapter" Version="4.3.3" />
     <PackageVersion Include="MSTest.TestFramework" Version="4.3.3" />
     <PackageVersion Include="Moq" Version="4.20.72" />

--- a/src/MobiFlightConnector/Base/Log.cs
+++ b/src/MobiFlightConnector/Base/Log.cs
@@ -153,36 +153,6 @@ namespace MobiFlight
         void log(String message, LogSeverity severity);
     }
 
-    public class LogAppenderTextBox : ILogAppender
-    {
-        private TextBox textBox = null;
-        // This delegate enables asynchronous calls for setting
-        // the text property on a TextBox control.
-        delegate void logCallback(string message, LogSeverity severity);
-
-        public LogAppenderTextBox(TextBox newTextBox)
-        {
-            textBox = newTextBox;
-        }
-
-        public void log(string message, LogSeverity severity)
-        {
-            if (textBox == null) return;
-
-            // InvokeRequired required compares the thread ID of the
-            // calling thread to the thread ID of the creating thread.
-            // If these threads are different, it returns true.
-            if (textBox.InvokeRequired)
-            {
-                textBox.BeginInvoke(new logCallback(log), new object[] { message, severity });
-            }
-            else
-            {
-                    textBox.Text = DateTime.Now + "(" + DateTime.Now.Millisecond + ")" + ": " + message + Environment.NewLine + textBox.Text;
-            }
-        }
-    }
-
     public class LogAppenderFile : ILogAppender
     {
         private String FileName = "log.txt";

--- a/src/MobiFlightConnector/Base/Log.cs
+++ b/src/MobiFlightConnector/Base/Log.cs
@@ -2,8 +2,8 @@
 using Newtonsoft.Json.Converters;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
@@ -83,12 +83,12 @@ namespace MobiFlight
 
         public LogSeverity Severity { get; set; }
 
-        public string GetCallingMethod()
+        public string GetCallingMethod(
+            string memberName,
+            string sourceFile)
         {
-            var stackTrace = new StackTrace();
-            var callingMethod = stackTrace.GetFrame(2).GetMethod();
-            var callingClass = callingMethod.ReflectedType;
-            return $"{callingClass.Name}.{callingMethod.Name}()";
+            var sourceFileName = Path.GetFileNameWithoutExtension(sourceFile);
+            return $"{sourceFileName}.{memberName}()";
 
         }
 
@@ -97,14 +97,19 @@ namespace MobiFlight
             appenderList.Clear();
         }
 
-        public void log(String message, LogSeverity severity)
+        public void log(
+            String message,
+            LogSeverity severity,
+            [CallerMemberName] string memberName = "",
+            [CallerFilePath] string sourceFilePath = "",
+            [CallerLineNumber] int lineNumber = 0)
         {
             if (!Enabled) return;
             if ((int)severity < (int)Severity) return;
 
             if (Severity == LogSeverity.Debug)
             {
-                message = $"{GetCallingMethod()}: {message}";
+                message = $"{GetCallingMethod(memberName, sourceFilePath)}#{lineNumber}: {message}";
             }
 
             foreach (ILogAppender appender in appenderList)
@@ -112,6 +117,14 @@ namespace MobiFlight
                 appender.log(message, severity);
             }
         }
+        
+        public void log(
+            Exception exception, 
+            string message, 
+            LogSeverity severity,
+            [CallerMemberName] string memberName = "",
+            [CallerFilePath] string sourceFilePath = "",
+            [CallerLineNumber] int lineNumber = 0) => log($"{message} {exception}", severity, memberName, sourceFilePath, lineNumber);
 
         public void AddAppender(ILogAppender appender)
         {

--- a/src/MobiFlightConnector/MobiFlight/BrowserMessages/IMessagePublisher.cs
+++ b/src/MobiFlightConnector/MobiFlight/BrowserMessages/IMessagePublisher.cs
@@ -2,7 +2,7 @@
 
 namespace MobiFlight.BrowserMessages
 {
-    public interface IMessagePublisher
+    public interface IMessagePublisher : IDisposable
     {
         void Publish<TEvent>(TEvent eventToPublish);
         void OnMessageReceived(Action<string> callback);

--- a/src/MobiFlightConnector/MobiFlight/BrowserMessages/Publisher/CompositePublisher.cs
+++ b/src/MobiFlightConnector/MobiFlight/BrowserMessages/Publisher/CompositePublisher.cs
@@ -32,7 +32,7 @@ namespace MobiFlight.BrowserMessages.Publisher
                 catch (Exception ex)
                 {
                     // Log but don't fail entire publish chain
-                    Log.Instance.log($"Publish failed: {ex.Message}", LogSeverity.Warn);
+                    Log.Instance.log(ex, $"Publish failed: {ex.Message} for publisher {publisher}", LogSeverity.Warn);
                 }
             });
         }

--- a/src/MobiFlightConnector/MobiFlight/BrowserMessages/Publisher/CompositePublisher.cs
+++ b/src/MobiFlightConnector/MobiFlight/BrowserMessages/Publisher/CompositePublisher.cs
@@ -9,9 +9,15 @@ namespace MobiFlight.BrowserMessages.Publisher
     {
         private readonly ConcurrentDictionary<string, IMessagePublisher> publishers = new ConcurrentDictionary<string, IMessagePublisher>();
         private readonly List<string> pausedPublishers = new List<string>();
+        private bool _isDisposed;
 
         public void AddPublisher(string name, IMessagePublisher publisher)
         {
+            if (_isDisposed)
+            {
+                return;
+            }
+
             publishers.AddOrUpdate(name, publisher, (key, existing) => publisher);
         }
 
@@ -23,6 +29,8 @@ namespace MobiFlight.BrowserMessages.Publisher
 
         public void Publish<TEvent>(TEvent eventToPublish)
         {
+            if (_isDisposed) return;
+
             publishers.Values.ToList().ForEach(publisher =>
             {
                 try
@@ -39,6 +47,8 @@ namespace MobiFlight.BrowserMessages.Publisher
 
         public void OnMessageReceived(Action<string> callback)
         {
+            if (_isDisposed) return;
+
             var activePublishers = publishers
                                     .Where(p => !pausedPublishers.Contains(p.Key))
                                     .Select(p => p.Value)
@@ -68,6 +78,21 @@ namespace MobiFlight.BrowserMessages.Publisher
         internal void ResumePublisher(string publisher)
         {
             pausedPublishers.Remove(publisher);
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed) return;
+            _isDisposed = true;
+
+            foreach (var publisher in publishers.Values)
+            {
+                publisher?.Dispose();
+            }
+
+            publishers.Clear();
+            pausedPublishers.Clear();
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/BrowserMessages/Publisher/PostMessagePublisher.cs
+++ b/src/MobiFlightConnector/MobiFlight/BrowserMessages/Publisher/PostMessagePublisher.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace MobiFlight.BrowserMessages.Publisher
 {
-    public class PostMessagePublisher : IMessagePublisher
+    public class PostMessagePublisher : IMessagePublisher, IDisposable
     {
         private readonly ThreadSafeWebView2 _webView;
         private Action<object> _onMessageReceived;
@@ -39,6 +39,12 @@ namespace MobiFlight.BrowserMessages.Publisher
         {
             var message = args.WebMessageAsJson;
             _onMessageReceived?.Invoke(message);
+        }
+
+        public void Dispose()
+        {
+            _webView.WebMessageReceived -= WebView_WebMessageReceived;
+            _onMessageReceived = null;
         }
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/BrowserMessages/Publisher/WebsocketPublisher.cs
+++ b/src/MobiFlightConnector/MobiFlight/BrowserMessages/Publisher/WebsocketPublisher.cs
@@ -61,5 +61,10 @@ namespace MobiFlight.BrowserMessages.Publisher
                 }
             }
         }
+
+        public void Dispose()
+        {
+            _webSocket?.Dispose();
+        }
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/WebView/AddCloseButtonHandlerOnNavigationCompleted.cs
+++ b/src/MobiFlightConnector/MobiFlight/WebView/AddCloseButtonHandlerOnNavigationCompleted.cs
@@ -24,6 +24,14 @@ namespace MobiFlight.WebView
             webView.NavigationCompleted += NavigationCompleted;
         }
 
+        internal void Unregister()
+        {
+            if (webViewAdapter == null) return;
+
+            webViewAdapter.NavigationCompleted -= NavigationCompleted;
+            webViewAdapter = null;
+        }
+
         private async void NavigationCompleted(object sender, CoreWebView2NavigationCompletedEventArgs e)
         {
             if (webViewAdapter == null) return;

--- a/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
+++ b/src/MobiFlightConnector/MobiFlight/WebView/StaticPageWebResourceRequestHandler.cs
@@ -54,6 +54,16 @@ namespace MobiFlight.WebView
             webView.CoreWebView2.WebResourceRequested += CoreWebView2_WebResourceRequested;
         }
 
+        internal void UnregisterFromWebView(WebView2 webView)
+        {
+            if (webView.CoreWebView2 == null) return;
+
+            webView.CoreWebView2.WebResourceRequested -= CoreWebView2_WebResourceRequested;
+            webView.CoreWebView2.RemoveWebResourceRequestedFilter(
+                $"{BaseUrl}/*",
+                CoreWebView2WebResourceContext.All);
+        }
+
         public void CoreWebView2_WebResourceRequested(object sender, CoreWebView2WebResourceRequestedEventArgs e)
         {
             try

--- a/src/MobiFlightConnector/MobiFlight/WebView/ThreadSafeWebView2.cs
+++ b/src/MobiFlightConnector/MobiFlight/WebView/ThreadSafeWebView2.cs
@@ -9,12 +9,23 @@ namespace MobiFlight.WebView
     {
         public void PostWebMessageAsJsonThreadSafe(string jsonMessage)
         {
-            if (this.InvokeRequired)
+            if (InvokeRequired)
             {
-                this.Invoke(new Action(() => CoreWebView2?.PostWebMessageAsJson(jsonMessage)));
+                Invoke(InternalPostWebMessageAsJsonThreadSafe);
             }
             else
             {
+                InternalPostWebMessageAsJsonThreadSafe();
+            }
+
+            return;
+            void InternalPostWebMessageAsJsonThreadSafe()
+            {
+                if (IsDisposed || Disposing || !IsHandleCreated)
+                {
+                    return;
+                }
+
                 CoreWebView2?.PostWebMessageAsJson(jsonMessage);
             }
         }
@@ -25,11 +36,11 @@ namespace MobiFlight.WebView
         async Task<string> IWebView2Adapter.ExecuteScriptAsync(string script)
         {
             if (CoreWebView2 == null) return null;
-            
-            if (this.InvokeRequired)
+
+            if (InvokeRequired)
             {
-                return await (Task<string>)this.Invoke(new Func<Task<string>>(async () => 
-                    await CoreWebView2.ExecuteScriptAsync(script)));
+                return await Invoke(async () =>
+                    await CoreWebView2.ExecuteScriptAsync(script));
             }
             else
             {

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<UseWindowsForms>true</UseWindowsForms>
-		<UseWPF>true</UseWPF>
 		<Platforms>AnyCPU;x86</Platforms>
 		<RootNamespace>MobiFlight</RootNamespace>
 		<ProductName>MFConnector</ProductName>

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -2487,7 +2487,6 @@ namespace MobiFlight.UI
 
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            execManager.Stop();
             if (ProjectHasUnsavedChanges && MessageBox.Show(
                        i18n._tr("uiMessageConfirmDiscardUnsaved"),
                        i18n._tr("uiMessageConfirmDiscardUnsavedTitle"),
@@ -2495,9 +2494,17 @@ namespace MobiFlight.UI
             {
                 // only cancel closing if not saved before
                 // which is indicated by empty CurrentFilename
-                e.Cancel = (execManager.Project.FilePath == null);
+                e.Cancel = (execManager?.Project.FilePath == null);
                 saveToolStripButton_Click(this, new EventArgs());
             }
+            
+            if (e.Cancel)
+            {
+                return;
+            }
+            
+            frontendPanel1.StopPublishing();
+            execManager?.Stop();
         }
 
         public void documentationToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -2502,7 +2502,7 @@ namespace MobiFlight.UI
                 return;
             }
             
-            frontendPanel1.StopPublishing();
+            frontendPanel1.Shutdown();
             execManager?.Stop();
             execManager?.Shutdown();
         }

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -870,7 +870,6 @@ namespace MobiFlight.UI
         private void Form1_FormClosed(object sender, FormClosedEventArgs e)
         {
             AppTelemetry.Instance.TrackShutdown();
-            execManager.Shutdown();
             SaveWindowPositionAndZoomLevel();
             Properties.Settings.Default.Save();
             runningStateBadge?.Dispose();
@@ -2505,6 +2504,7 @@ namespace MobiFlight.UI
             
             frontendPanel1.StopPublishing();
             execManager?.Stop();
+            execManager?.Shutdown();
         }
 
         public void documentationToolStripMenuItem_Click(object sender, EventArgs e)

--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.Designer.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.Designer.cs
@@ -1,4 +1,5 @@
-﻿using MobiFlight.WebView;
+﻿using MobiFlight.BrowserMessages;
+using MobiFlight.WebView;
 
 namespace MobiFlight.UI.Panels
 {
@@ -17,6 +18,7 @@ namespace MobiFlight.UI.Panels
         {
             if (disposing)
             {
+                Shutdown();
                 components?.Dispose();
             }
             base.Dispose(disposing);

--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.Designer.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.Designer.cs
@@ -15,9 +15,9 @@ namespace MobiFlight.UI.Panels
         /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
-            if (disposing && (components != null))
+            if (disposing)
             {
-                components.Dispose();
+                components?.Dispose();
             }
             base.Dispose(disposing);
         }

--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
@@ -30,10 +30,9 @@ namespace MobiFlight.UI.Panels
 
         private double _desiredZoomFactor;
         private Task _initializationTask;
-        private bool _isStopping;
+        private bool _isShuttingDown;
         private readonly List<(ThreadSafeWebView2 WebView, StaticPageWebResourceRequestHandler Handler)> _webResourceHandlers = new();
         private readonly List<AddCloseButtonHandlerOnNavigationCompleted> _navigationHandlers = new();
-        private readonly List<PostMessagePublisher> _messagePublishers = new();
 
         public FrontendPanel()
         {
@@ -62,32 +61,20 @@ namespace MobiFlight.UI.Panels
         {
             try
             {
-                if (_isStopping || IsDisposed || Disposing)
+                if (_isShuttingDown || IsDisposed || Disposing)
                 {
                     return;
                 }
 
                 await FrontendWebView.EnsureCoreWebView2Async(null);
-
-                if (_isStopping || IsDisposed || Disposing)
-                {
-                    return;
-                }
-
                 await UserAuthenticationWebView.EnsureCoreWebView2Async(null);
-
-                if (_isStopping || IsDisposed || Disposing)
-                {
-                    return;
-                }
 
                 InitializeWebView(FrontendWebView, "/start");
                 InitializeWebView(UserAuthenticationWebView);
 
                 var frontendPublisher = new PostMessagePublisher(FrontendWebView);
                 var authPublisher = new PostMessagePublisher(UserAuthenticationWebView);
-                _messagePublishers.Add(frontendPublisher);
-                _messagePublishers.Add(authPublisher);
+                
                 _compositePublisher.AddPublisher("frontend", frontendPublisher);
                 _compositePublisher.AddPublisher("auth", authPublisher);
 
@@ -102,14 +89,12 @@ namespace MobiFlight.UI.Panels
                 Log.Instance.log(exception, "Unable to initialize frontend WebView2.", LogSeverity.Error);
             }
         }
-        
-        public void StopPublishing()
-        {
-            if (_isStopping) return;
-            _isStopping = true;
 
-            _compositePublisher.RemovePublisher("frontend");
-            _compositePublisher.RemovePublisher("auth");
+        public void Shutdown()
+        {
+            if (_isShuttingDown) return;
+
+            _isShuttingDown = true;
 
             if (ReferenceEquals(MessageExchange.Instance.GetPublisher(), _compositePublisher))
             {
@@ -117,6 +102,7 @@ namespace MobiFlight.UI.Panels
             }
 
             DisposeWebViewCallbacks();
+            _compositePublisher.Dispose();
         }
 
         private void InitializeWebView(ThreadSafeWebView2 webView, string route = "/")
@@ -183,12 +169,6 @@ namespace MobiFlight.UI.Panels
 
         private void DisposeWebViewCallbacks()
         {
-            foreach (var publisher in _messagePublishers)
-            {
-                publisher.Dispose();
-            }
-            _messagePublishers.Clear();
-
             foreach (var navigationHandler in _navigationHandlers)
             {
                 navigationHandler.Unregister();

--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
@@ -48,6 +48,11 @@ namespace MobiFlight.UI.Panels
             await FrontendWebView.EnsureCoreWebView2Async(null);
             await UserAuthenticationWebView.EnsureCoreWebView2Async(null);
 
+            if (IsDisposed || Disposing)
+            {
+                return;
+            }
+            
             InitializeWebView(FrontendWebView, "/start");
             InitializeWebView(UserAuthenticationWebView);
 
@@ -55,6 +60,17 @@ namespace MobiFlight.UI.Panels
             compositePublisher.AddPublisher("auth", new PostMessagePublisher(UserAuthenticationWebView));
 
             MessageExchange.Instance.SetPublisher(compositePublisher);
+        }
+        
+        public void StopPublishing()
+        {
+            compositePublisher.RemovePublisher("frontend");
+            compositePublisher.RemovePublisher("auth");
+
+            if (ReferenceEquals(MessageExchange.Instance.GetPublisher(), compositePublisher))
+            {
+                MessageExchange.Instance.SetPublisher(null);
+            }
         }
 
         private void InitializeWebView(ThreadSafeWebView2 webView, string route = "/")

--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
@@ -2,14 +2,16 @@
 using MobiFlight.BrowserMessages.Publisher;
 using MobiFlight.WebView;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace MobiFlight.UI.Panels
 {
     public partial class FrontendPanel : UserControl
     {
-        CompositePublisher compositePublisher = new CompositePublisher();
+        private readonly CompositePublisher _compositePublisher = new();
         private string _frontendBaseUrl = "http://localhost:5173";
         private string _frontendDistPath;
         private string _presetPath;
@@ -26,7 +28,12 @@ namespace MobiFlight.UI.Panels
             }
         }
 
-        double _desiredZoomFactor = 0.0;
+        private double _desiredZoomFactor;
+        private Task _initializationTask;
+        private bool _isStopping;
+        private readonly List<(ThreadSafeWebView2 WebView, StaticPageWebResourceRequestHandler Handler)> _webResourceHandlers = new();
+        private readonly List<AddCloseButtonHandlerOnNavigationCompleted> _navigationHandlers = new();
+        private readonly List<PostMessagePublisher> _messagePublishers = new();
 
         public FrontendPanel()
         {
@@ -39,38 +46,77 @@ namespace MobiFlight.UI.Panels
             _presetPath = Path.Combine(Application.StartupPath);
 
             InitializeComponent();
-            if (!DesignMode)
-                InitializeAsync();
         }
 
-        async void InitializeAsync()
+        protected override void OnLoad(EventArgs e)
         {
-            await FrontendWebView.EnsureCoreWebView2Async(null);
-            await UserAuthenticationWebView.EnsureCoreWebView2Async(null);
+            base.OnLoad(e);
 
-            if (IsDisposed || Disposing)
+            if (!DesignMode && _initializationTask == null)
+            {
+                _initializationTask = InitializeAsync();
+            }
+        }
+
+        private async Task InitializeAsync()
+        {
+            try
+            {
+                if (_isStopping || IsDisposed || Disposing)
+                {
+                    return;
+                }
+
+                await FrontendWebView.EnsureCoreWebView2Async(null);
+
+                if (_isStopping || IsDisposed || Disposing)
+                {
+                    return;
+                }
+
+                await UserAuthenticationWebView.EnsureCoreWebView2Async(null);
+
+                if (_isStopping || IsDisposed || Disposing)
+                {
+                    return;
+                }
+
+                InitializeWebView(FrontendWebView, "/start");
+                InitializeWebView(UserAuthenticationWebView);
+
+                var frontendPublisher = new PostMessagePublisher(FrontendWebView);
+                var authPublisher = new PostMessagePublisher(UserAuthenticationWebView);
+                _messagePublishers.Add(frontendPublisher);
+                _messagePublishers.Add(authPublisher);
+                _compositePublisher.AddPublisher("frontend", frontendPublisher);
+                _compositePublisher.AddPublisher("auth", authPublisher);
+
+                MessageExchange.Instance.SetPublisher(_compositePublisher);
+            }
+            catch (ObjectDisposedException)
             {
                 return;
             }
-            
-            InitializeWebView(FrontendWebView, "/start");
-            InitializeWebView(UserAuthenticationWebView);
-
-            compositePublisher.AddPublisher("frontend", new PostMessagePublisher(FrontendWebView));
-            compositePublisher.AddPublisher("auth", new PostMessagePublisher(UserAuthenticationWebView));
-
-            MessageExchange.Instance.SetPublisher(compositePublisher);
+            catch (Exception exception)
+            {
+                Log.Instance.log(exception, "Unable to initialize frontend WebView2.", LogSeverity.Error);
+            }
         }
         
         public void StopPublishing()
         {
-            compositePublisher.RemovePublisher("frontend");
-            compositePublisher.RemovePublisher("auth");
+            if (_isStopping) return;
+            _isStopping = true;
 
-            if (ReferenceEquals(MessageExchange.Instance.GetPublisher(), compositePublisher))
+            _compositePublisher.RemovePublisher("frontend");
+            _compositePublisher.RemovePublisher("auth");
+
+            if (ReferenceEquals(MessageExchange.Instance.GetPublisher(), _compositePublisher))
             {
                 MessageExchange.Instance.SetPublisher(null);
             }
+
+            DisposeWebViewCallbacks();
         }
 
         private void InitializeWebView(ThreadSafeWebView2 webView, string route = "/")
@@ -88,7 +134,7 @@ namespace MobiFlight.UI.Panels
                     new string[] { _frontendBaseUrl + "/presets" }
                 );
 
-                staticPageHandler.RegisterWithWebView(webView);
+                RegisterWebResourceHandler(webView, staticPageHandler);
 
                 webView.CoreWebView2.Settings.AreDefaultContextMenusEnabled = false;
                 webView.CoreWebView2.Settings.AreBrowserAcceleratorKeysEnabled = false;
@@ -102,11 +148,11 @@ namespace MobiFlight.UI.Panels
             {
                 IndexFallback = false
             };
-            staticPresetsHandler.RegisterWithWebView(webView);
+            RegisterWebResourceHandler(webView, staticPresetsHandler);
 
             var addButtonHandler = new AddCloseButtonHandlerOnNavigationCompleted();
             addButtonHandler.AddExclusionFilter(_frontendBaseUrl);
-            addButtonHandler.RegisterWithWebView(webView);
+            RegisterNavigationHandler(webView, addButtonHandler);
 
             webView.CoreWebView2.Settings.IsWebMessageEnabled = true;
             webView.CoreWebView2.Settings.IsStatusBarEnabled = false;
@@ -117,6 +163,43 @@ namespace MobiFlight.UI.Panels
             {
                 webView.ZoomFactor = _desiredZoomFactor;
             }
+        }
+
+        private void RegisterWebResourceHandler(
+            ThreadSafeWebView2 webView,
+            StaticPageWebResourceRequestHandler handler)
+        {
+            handler.RegisterWithWebView(webView);
+            _webResourceHandlers.Add((webView, handler));
+        }
+
+        private void RegisterNavigationHandler(
+            ThreadSafeWebView2 webView,
+            AddCloseButtonHandlerOnNavigationCompleted handler)
+        {
+            handler.RegisterWithWebView(webView);
+            _navigationHandlers.Add(handler);
+        }
+
+        private void DisposeWebViewCallbacks()
+        {
+            foreach (var publisher in _messagePublishers)
+            {
+                publisher.Dispose();
+            }
+            _messagePublishers.Clear();
+
+            foreach (var navigationHandler in _navigationHandlers)
+            {
+                navigationHandler.Unregister();
+            }
+            _navigationHandlers.Clear();
+
+            foreach (var (webView, handler) in _webResourceHandlers)
+            {
+                handler.UnregisterFromWebView(webView);
+            }
+            _webResourceHandlers.Clear();
         }
 
         public void SetZoomFactor(double zoomFactor)
@@ -155,6 +238,13 @@ namespace MobiFlight.UI.Panels
         public void BeginAuthProcess(string url)
         {
             Log.Instance.log($"Starting authentication process, navigating to: {url}", LogSeverity.Debug);
+
+            if (UserAuthenticationWebView.CoreWebView2 == null || IsDisposed || Disposing)
+            {
+                Log.Instance.log("Authentication navigation was requested before WebView2 initialization completed.", LogSeverity.Warn);
+                return;
+            }
+
             UserAuthenticationWebView.CoreWebView2.Navigate(url);
             UserAuthenticationWebView.Visible = true;
         }
@@ -166,6 +256,12 @@ namespace MobiFlight.UI.Panels
         public void EndAuthProcess()
         {
             UserAuthenticationWebView.Visible = false;
+
+            if (UserAuthenticationWebView.CoreWebView2 == null || IsDisposed || Disposing)
+            {
+                return;
+            }
+
             UserAuthenticationWebView.CoreWebView2.Navigate($"{_frontendBaseUrl}/auth");
         }
         public bool FrontendWebViewVisible

--- a/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
+++ b/src/MobiFlightConnector/UI/Panels/FrontendPanel.cs
@@ -69,6 +69,11 @@ namespace MobiFlight.UI.Panels
                 await FrontendWebView.EnsureCoreWebView2Async(null);
                 await UserAuthenticationWebView.EnsureCoreWebView2Async(null);
 
+                if (_isShuttingDown || IsDisposed || Disposing)
+                {
+                    return;
+                }
+
                 InitializeWebView(FrontendWebView, "/start");
                 InitializeWebView(UserAuthenticationWebView);
 

--- a/tests/MobiFlightUnitTests/Base/LogTests.cs
+++ b/tests/MobiFlightUnitTests/Base/LogTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+
+namespace MobiFlight.Base.Tests
+{
+    [TestClass]
+    public class LogTests
+    {
+        private Mock<ILogAppender> _appender;
+        private bool _originalEnabled;
+        private LogSeverity _originalSeverity;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _appender = new Mock<ILogAppender>();
+            _originalEnabled = Log.Instance.Enabled;
+            _originalSeverity = Log.Instance.Severity;
+
+            Log.Instance.ClearAppenders();
+            Log.Instance.AddAppender(_appender.Object);
+            Log.Instance.Enabled = true;
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            Log.Instance.ClearAppenders();
+            Log.Instance.Enabled = _originalEnabled;
+            Log.Instance.Severity = _originalSeverity;
+        }
+
+        [TestMethod]
+        public void GetCallingMethod_ShouldCombineSourceFileAndMemberName()
+        {
+            var callingMethod = Log.Instance.GetCallingMethod(
+                "HandleMessage",
+                @"C:\\Source\\MobiFlight\\MessageHandler.cs");
+
+            Assert.AreEqual("MessageHandler.HandleMessage()", callingMethod);
+        }
+
+        [TestMethod]
+        public void Log_ShouldIncludeCallerMemberAndSourceFile_WhenDebugLogging()
+        {
+            Log.Instance.Severity = LogSeverity.Debug;
+
+            LogFromHelper();
+
+            _appender.Verify(appender => appender.log(
+                It.Is<string>(message =>
+                    message.StartsWith("LogTests.LogFromHelper()#") &&
+                    message.EndsWith(": caller metadata")),
+                LogSeverity.Debug),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public void Log_WithException_ShouldIncludeMessageAndException()
+        {
+            Log.Instance.Severity = LogSeverity.Info;
+            var exception = new InvalidOperationException("test failure");
+
+            Log.Instance.log(exception, "Unable to process message.", LogSeverity.Error);
+
+            _appender.Verify(appender => appender.log(
+                "Unable to process message. System.InvalidOperationException: test failure",
+                LogSeverity.Error),
+                Times.Once);
+        }
+
+        private static void LogFromHelper()
+        {
+            Log.Instance.log("caller metadata", LogSeverity.Debug);
+        }
+    }
+}

--- a/tests/MobiFlightUnitTests/MobiFlight/BrowserMessages/Publisher/CompositePublisherTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/BrowserMessages/Publisher/CompositePublisherTests.cs
@@ -255,5 +255,20 @@ namespace MobiFlightUnitTests.MobiFlight.BrowserMessages.Publisher
             mockPublisher2.Verify(p => p.OnMessageReceived(callback1), Times.Once);
             mockPublisher2.Verify(p => p.OnMessageReceived(callback2), Times.Once);
         }
+
+        [TestMethod]
+        public void Dispose_ShouldDisposePublishersOnceAndStopFurtherPublishing()
+        {
+            compositePublisher.AddPublisher("test1", mockPublisher1.Object);
+            compositePublisher.AddPublisher("test2", mockPublisher2.Object);
+
+            compositePublisher.Dispose();
+            compositePublisher.Publish("test message");
+
+            mockPublisher1.Verify(p => p.Dispose(), Times.Once);
+            mockPublisher2.Verify(p => p.Dispose(), Times.Once);
+            mockPublisher1.Verify(p => p.Publish(It.IsAny<string>()), Times.Never);
+            mockPublisher2.Verify(p => p.Publish(It.IsAny<string>()), Times.Never);
+        }
     }
 }

--- a/tests/MobiFlightUnitTests/UI/MainFormTests.cs
+++ b/tests/MobiFlightUnitTests/UI/MainFormTests.cs
@@ -563,6 +563,10 @@ namespace MobiFlight.UI.Tests
                 _onMessageReceived?.Invoke(jsonMessage);
                 MessageExchange.Instance.SetSynchronizationContextProvider(null);
             }
+
+            public void Dispose()
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary

1. This enriches logs a bit with exception stack traces to make it easier to pinpoint issues
2. Replaces `GetCallingMethod` with `CallerMemberName` and `CallerFilePath`. `CallerLineNumber` is also in there now.
3. Refactors `ThreadSafeWebView2` to introduce reusable local function
4. Ignore `ThreadSafeWebView2` events if the underlying object has been disposed.
5. Introduce a `StopPublishing` function on `FrontendPanel` to remove the publishers
6. Calls `StopPublishing` upon main form shutdown

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Reduced startup and shutdown exceptions

~~- [ ] Developer docs (e.g., readme.md)~~
     
## Related issues
<!-- fixes, relates to existing #issues -->
https://discord.com/channels/608690978081210392/1542458812689162250
