### PR TITLE
Switches are working like before the Synthetic Event refactoring

### DIFF
--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -212,23 +212,20 @@ Two different questions worth keeping separate, because they sound related but a
   never early, never skipped) - the same jitter any polling loop checking "has T elapsed" has,
   imperceptible at the 300ms+ scale these delays actually use. No drift accumulates across repeat
   cycles either, since `LastHoldFire` resets to the real timestamp each time, not a stepped counter.
-- **Does `RepeatDelay` need a floor anyway?** Yes, but for a different reason: REPEAT is the only
-  one of the three that can fire indefinitely for as long as a button stays held, and every firing
-  dispatches to `onHold`, which typically calls into the sim API (FSUIPC/SimConnect/XPlane/a custom
-  event). A `RepeatDelay` configured too low - or loaded from an old/hand-edited config predating
-  this floor - risks flooding that API fast enough to cause performance issues or instability. This
-  is a rate limit for the sim API's sake, not a timer-precision requirement, and it's scoped to
-  `RepeatDelay` only: `HoldDelay`/`LongReleaseDelay` each decide at most one classification per
-  press/release gesture, so neither carries the same sustained-flooding risk.
-
-  Enforced in one place - `ButtonTimings`'s constructor (`ButtonTimings.MinRepeatDelay`, 200ms) -
-  so every path that constructs one (the generator's own fallback, and
-  `InputEventExecutor.ResolveButtonTimingsPerConfig`) gets the floor automatically; a positive value
-  below it is raised to it, `0` (repeat disabled) is exempt. Not currently enforced at the UI editing
-  layer (wherever `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` get set on a `ButtonInputConfig`) -
-  someone could still type `10` into the config and it would silently behave as `200` at runtime
-  rather than being rejected or corrected at entry time. Worth adding UI-level validation as a
-  follow-up so the discrepancy is visible where it's authored, not just where it's enforced.
+- **Should `RepeatDelay` have a floor?** Conceptually yes - REPEAT is the only one of the three that
+  can fire indefinitely for as long as a button stays held, and every firing dispatches to `onHold`,
+  which typically calls into the sim API (FSUIPC/SimConnect/XPlane/a custom event); a value
+  configured too low risks flooding that API. But this is **not enforced anywhere in the runtime
+  evaluation path** (`ButtonTimings`'s constructor stores `RepeatDelay` exactly as given - no
+  clamping). Three reasons: the tick interval itself already imposes a real mechanical floor on how
+  fast REPEAT can actually fire, regardless of what's configured; a silent runtime clamp only on the
+  *scheduling* side would silently diverge from the raw value a config matches its own events against
+  (`ButtonInputConfig.MatchesSyntheticDelay`, see below) unless clamped identically on both sides;
+  and configs already exist in the field with sub-floor values authored before this floor was even a
+  concept - silently changing their behavior on migration to this pipeline isn't backward compatible.
+  `ButtonTimings.MinRepeatDelay`/`ClampRepeatDelay` still exist as a ready-to-use utility, intended
+  for config-authoring-time validation (the UI, on save) in a follow-up change - only the UI can tell
+  a user *why* a value is rejected, which a silent runtime rewrite can't.
 
 ### Generator's internal state
 
@@ -294,29 +291,37 @@ definition.
   `Execute()` - evaluating live state at each actual fire - that decides which one (if any) actually
   runs.
 
-  **Two configs simultaneously active on the same physical button, with different delays, is fully
+  **Two configs simultaneously bound to the same physical button, with different delays, is fully
   supported, not just tolerated.** An earlier version of this resolved to a single "winning" config
   and broadcast the resulting event to every matching config regardless - which was a real
   correctness bug, not just an ambiguity: a config whose own (longer) delay hadn't elapsed yet would
   still get triggered early, by a different config's (shorter) one, the moment that one fired.
-  `InputEventExecutor.ResolveButtonTimingsPerConfig` returns *every* currently active,
-  precondition-satisfied config bound to a button, each with its own delays - `ExecutionManager`'s
-  resolver concatenates these across every loaded config file, no single-winner tie-break. Each
-  synthetic HOLD/REPEAT/LONG_RELEASE `SyntheticButtonEventGenerator` produces is stamped with the
-  specific config's GUID that governs it (`InputEventArgs.TargetConfigGUID`), and `Execute()` only
-  dispatches a targeted event to that one config, skipping every other match - a one-line addition
-  to the existing loop. Real events (PRESS/RELEASE with no reclassification) stay untargeted
-  (`null`) and broadcast to every matching config, same as always - only the events whose *timing*
-  came from one specific config's delay are restricted to that config.
+  `InputEventExecutor.ResolveButtonTimingsPerConfig` returns the *distinct* `HoldDelay`/`RepeatDelay`/
+  `LongReleaseDelay` settings among every config bound to a button (`.Distinct()` on the
+  `ButtonTimings` struct) - `ExecutionManager`'s resolver concatenates these across every loaded
+  config file and dedupes again at that level.
+
+  **No config identity is carried through the generator at all** - `SyntheticButtonEventGenerator`
+  only ever sees delay *values*, never a config GUID (there is no `ButtonBinding` type; `ResolveTimings`
+  is `Func<InputEventArgs, List<ButtonTimings>>`). A produced HOLD/REPEAT/LONG_RELEASE just carries
+  the delay value that classified it (`InputEventArgs.SyntheticDelayMs`) - `Execute()` asks each
+  bound config directly, "is this delay yours?" (`ButtonInputConfig.MatchesSyntheticDelay`, one
+  switch comparing `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` against `SyntheticDelayMs`), true for
+  PRESS/RELEASE (nothing to match, so those still broadcast to every matching config, same as
+  always). This is simpler than ID-based targeting and self-correcting: two configs that happen to
+  share a delay are indistinguishable to the generator by construction, so they're naturally treated
+  as one group everywhere - including in the log, which would otherwise show the same physical
+  HOLD/REPEAT/LONG_RELEASE once per bound config instead of once per distinct setting.
 
   This does widen `SyntheticButtonEventGenerator`'s internal state: a tracked button now holds one
-  `HoldFired`/`LastHoldFire`/delay-set per bound config (not one canonical set for the whole
-  button), and a RELEASE can fan out into multiple events - one per bound config, each
-  independently classified as RELEASE or LONG_RELEASE against *that* config's own
-  `LongReleaseDelay`, so two configs on one button can correctly disagree about whether a given
-  release counts as long. `Observe()`'s signature changed accordingly, from returning one
-  `InputEventArgs` to a `List<InputEventArgs>` (usually one element - the fan-out is dormant, not
-  extra work, for the common single-config-per-button case).
+  `HoldFired`/`LastHoldFire`/timings entry per distinct setting (not one canonical set for the whole
+  button), and a RELEASE can fan out into multiple events - one per distinct `LongReleaseDelay` among
+  bound configs, each independently classified as RELEASE or LONG_RELEASE against *that* delay, so
+  two configs on one button can correctly disagree about whether a given release counts as long.
+  `Observe()`'s signature changed accordingly, from returning one `InputEventArgs` to a
+  `List<InputEventArgs>` (usually one element - the fan-out is dormant, not extra work, for the
+  common single-setting-per-button case, and configs sharing a setting collapse back to one element
+  too).
 - **Encoder pairing configuration.** Where the button-pair-to-encoder mapping is authored (joystick
   definition file vs. runtime user configuration).
 - **Fast-turn threshold shape.** Rolling window/count vs. some other rate measure; not yet designed

--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -409,6 +409,15 @@ definition.
   further in. So a physical event with no matching action updates RawValue but logs nothing and
   executes nothing; a config that fails isStarted/Active/Preconditions still gets neither, same as
   before this whole rule existed.
+
+  **Modifiers and the action see the dispatched value, not the raw one.** The Modifiers
+  pipeline used to seed itself from `e.Value` directly - correct when `dispatchedValue == value`, but
+  wrong for a config that resolved to LONG_RELEASE, which fed the pipeline the raw RELEASE(1) instead
+  of LONG_RELEASE(2). `Execute()` now resolves `dispatchedNumericValue` alongside the label (the cast
+  `dispatchedValue` for a button, `e.Value` unchanged for encoder/analog) and seeds Modifiers from
+  that instead. `e.Value` is written back with the Modifiers result afterward as before, so
+  `cfg.execute(...)`/`ButtonInputConfig.execute()`'s own dispatch re-check sees the already-resolved
+  value too.
 - **Encoder pairing configuration.** Where the button-pair-to-encoder mapping is authored (joystick
   definition file vs. runtime user configuration).
 - **Fast-turn threshold shape.** Rolling window/count vs. some other rate measure; not yet designed

--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -226,9 +226,9 @@ Two different questions worth keeping separate, because they sound related but a
   (`ButtonInputConfig.MatchesSyntheticDelay`, see below) unless clamped identically on both sides;
   and configs already exist in the field with sub-floor values authored before this floor was even a
   concept - silently changing their behavior on migration to this pipeline isn't backward compatible.
-  `ButtonTimings.MinRepeatDelay`/`ClampRepeatDelay` still exist as a ready-to-use utility, intended
-  for config-authoring-time validation (the UI, on save) in a follow-up change - only the UI can tell
-  a user *why* a value is rejected, which a silent runtime rewrite can't.
+  A floor, if one gets added, belongs entirely at config-authoring time (the UI, on save) in a
+  follow-up change - only the UI can tell a user *why* a value is rejected, which a silent runtime
+  rewrite can't. Nothing for it lives in this runtime layer today.
 
 ### Generator's internal state
 
@@ -374,7 +374,10 @@ definition.
   (`ExecutionManager.mobiFlightCache_OnButtonPressed`) answers "was an event raised at all," so it
   only ever logs a real PRESS/RELEASE - `isSyntheticEvent` (`e.SyntheticDelayMs.HasValue`) gates the
   line, meaning HOLD/REPEAT never appear there (LONG_RELEASE already couldn't, since RELEASE is the
-  only thing `Observe()` ever raises for a release). Stage 2
+  only thing `Observe()` ever raises for a release). `InputEventArgs.GetMsgEventLabel()` - stage 1's
+  only caller - has no delay-append branch of its own for exactly this reason: it's only ever asked
+  for a label when `!isSyntheticEvent` is already true, so a delay would never have anything to show.
+  Stage 2
   (`InputEventExecutor.Execute()`'s `"Executing ..."` line) answers "did this config actually fire,"
   so it logs uniformly for every event type, physical or synthetic, whenever a config has a matching
   action - and for a synthetic one it also names the delay that produced it, since stage 1 no longer

--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -310,9 +310,11 @@ definition.
   only ever sees delay *values*, never a config GUID (there is no `ButtonBinding` type; `ResolveTimings`
   is `Func<InputEventArgs, List<ButtonTimings>>`). A produced HOLD/REPEAT just carries the delay
   value that classified it (`InputEventArgs.SyntheticDelayMs`) - `Execute()` asks each bound config
-  directly, "is this delay yours?" (`ButtonInputConfig.MatchesSyntheticDelay`, comparing `HoldDelay`/
-  `RepeatDelay` against `SyntheticDelayMs`), true for anything else (PRESS/RELEASE carry no
-  `SyntheticDelayMs`, so those broadcast to every matching config, same as always). This is simpler
+  directly, "is this delay yours?" (`ButtonInputConfig.MatchesSyntheticDelay`, requiring `onHold` to
+  be defined before comparing `HoldDelay`/`RepeatDelay` against `SyntheticDelayMs` for a HOLD/REPEAT -
+  a config without `onHold` never matches one, regardless of what its unused `HoldDelay`/`RepeatDelay`
+  fields happen to hold), true for anything else (PRESS/RELEASE carry no `SyntheticDelayMs`, so those
+  broadcast to every matching config, same as always). This is simpler
   than ID-based targeting and self-correcting: two configs that happen to share a delay are
   indistinguishable to the generator by construction, so they're naturally treated as one group
   everywhere - including in the log, which would otherwise show the same physical HOLD/REPEAT once
@@ -384,13 +386,29 @@ definition.
 
   **A skip reason only logs for a config that actually has an action bound to the resolved event.**
   All three skip reasons ("MobiFlight not running", "Skipping inactive config", "Preconditions not
-  satisfied") are gated on `cfg.GetInputAction(e) != null`, checked once per config alongside the
-  label resolution above. Without this, e.g. an onPress-only config logged "Skipping ... MobiFlight
-  not running" on every RELEASE too - RELEASE was never going to do anything for that config, so the
-  line was pure noise. This mirrors "Executing," which already only logs `action != null` - a skip
-  and an execute are the same event, just with a different outcome, so they share the same gate. The
-  gate only governs whether a *log line* appears; a config that does have a matching action but
-  fails one of these checks still doesn't get `cfg.RawValue`/`updatedValues` touched, same as before.
+  satisfied") are gated on `hasMatchingAction` (`cfg.GetInputAction(e) != null`), checked once per
+  config alongside the label resolution above. Without this, e.g. an onPress-only config logged
+  "Skipping ... MobiFlight not running" on every RELEASE too - RELEASE was never going to do anything
+  for that config, so the line was pure noise. This mirrors "Executing," which likewise only logs -
+  and only actually dispatches to the config's action - when `hasMatchingAction` is true: a skip and
+  an execute are the same event, just with a different outcome, so they share the same gate.
+
+  **`cfg.RawValue` follows a wider rule than the skip/execute gate above, though: a physical
+  PRESS/RELEASE always updates it, matching action or not - only a synthetic HOLD/REPEAT needs one.**
+  RawValue is the "last event seen" indicator a user reads off the UI, and a real PRESS/RELEASE is
+  genuine hardware state worth showing even on a config with nothing bound to it (e.g. an onPress-only
+  config seeing a RELEASE) - it confirms the physical input was received at all. A synthetic HOLD/
+  REPEAT has no such standing on its own: without `onHold`, `MatchesSyntheticDelay` already excludes
+  the config entirely (above), and even a broadcast that slipped through must not show HOLD on a
+  config that never reacts to it - that was the actual "HOLD shows in RawValue for a config with no
+  onHold" bug this rule fixes. Concretely: `Execute()`'s top-of-loop gate is
+  `if (!hasMatchingAction && isSyntheticEvent) continue;` (skips entirely only for an unmatched
+  synthetic event); `cfg.RawValue`/`cfg.Value`/`updatedValues` are set right after the isStarted/
+  Active/Preconditions checks pass, unconditionally; the "Executing" log and the actual
+  Modifiers/`cfg.execute(...)` dispatch remain gated on `hasMatchingAction` specifically, one level
+  further in. So a physical event with no matching action updates RawValue but logs nothing and
+  executes nothing; a config that fails isStarted/Active/Preconditions still gets neither, same as
+  before this whole rule existed.
 - **Encoder pairing configuration.** Where the button-pair-to-encoder mapping is authored (joystick
   definition file vs. runtime user configuration).
 - **Fast-turn threshold shape.** Rolling window/count vs. some other rate measure; not yet designed

--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -320,6 +320,17 @@ definition.
   everywhere - including in the log, which would otherwise show the same physical HOLD/REPEAT once
   per bound config instead of once per distinct setting.
 
+  **REPEAT matches on the (HoldDelay, RepeatDelay) pair, not RepeatDelay alone.** Two configs on one
+  button can share a `RepeatDelay` while differing in `HoldDelay` (e.g. a 300ms-hold and a 1000ms-hold
+  binding both repeating every 200ms). `Tick()` tracked due repeats keyed on `RepeatDelay` alone, so
+  once the 300ms binding started repeating, its REPEAT events - stamped only with `RepeatDelay` -
+  would also match the 1000ms config, even though that config's own `HoldDelay` hadn't elapsed yet.
+  Fixed by keying `Tick()`'s due-repeat set on the full `ButtonTimings` pair, and stamping the raised
+  REPEAT with both `RepeatDelay` (`SyntheticDelayMs`, as before) and the originating binding's
+  `HoldDelay` (`InputEventArgs.SyntheticHoldDelayMs`, new) - `MatchesSyntheticDelay`'s REPEAT case now
+  requires both to match. HOLD never had this problem - it already matches on its own unambiguous
+  `HoldDelay` alone.
+
   This does widen `SyntheticButtonEventGenerator`'s internal state: a tracked button now holds one
   `HoldFired`/`LastHoldFire`/timings entry per distinct setting (not one canonical set for the whole
   button).

--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -153,7 +153,10 @@ Three distinct shapes of processing sit in the same funnel, composed in a chain:
   actually this shape.
 - **Reclassify** (1-to-1, event-triggered): given one incoming event plus a bit of memory, forward
   it unchanged, forward it relabeled, or drop it — nothing fabricated that didn't correspond to a
-  real input. RELEASE → LONG_RELEASE promotion is this shape.
+  real input. **Revised from the original design:** RELEASE → LONG_RELEASE promotion turned out not
+  to fit this shape at the generator level after all — see "LONG_RELEASE is a dispatch-time decision,
+  not a generator reclassification" below. What *does* still fit here is nothing generator-side for
+  buttons; the encoder fast-turn relabeling further down is the real example of this shape.
 - **Aggregate** (N-to-1, event-triggered): given a raw event belonging to a known group, consume it
   and, once the group resolves, emit a differently-typed event instead. Button-pair-to-Encoder
   (below) is this shape.
@@ -272,18 +275,20 @@ definition.
 - **Delay ownership — resolved.** Initially assumed delay could become a property of the physical
   input/controller, shared across every binding on it. That's wrong: a multi-mode panel (several
   mutually-exclusive precondition-gated configs on one physical button) can legitimately want
-  different `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` per config. Detection still lives on the
-  controller (physical-button-scoped, one canonical timer per button), but the delay *values* it
-  uses are resolved per config bound to that button -
+  different `HoldDelay`/`RepeatDelay` per config (`LongReleaseDelay` isn't resolved here at all
+  anymore - see "LONG_RELEASE is a dispatch-time decision" below). Detection still lives on the
+  controller (physical-button-scoped, one canonical timer per button), but the `HoldDelay`/
+  `RepeatDelay` values it uses are resolved per config bound to that button -
   `InputEventExecutor.ResolveButtonTimingsPerConfig` does this lookup (reusing the same
   `GetMatchingInputConfigs` the normal pipeline already has - not `Active`/`CheckPreconditions`,
   see below), `ExecutionManager` composes one resolver across every loaded config file and hands it
   to each controller manager's generator (`SyntheticButtonEventGenerator.ResolveTimings`). Resolved
   once at PRESS time and held for that press's lifecycle - not re-resolved every tick, so a mode
   switch mid-hold doesn't retroactively change an in-progress press's timing.
-  If `ResolveTimings` is unwired, or wired but returns an empty list (no config at all is bound to
-  this device/button), the generator doesn't track the press or synthesize anything - PRESS/RELEASE
-  pass through untouched, exactly as without this feature.
+  If `ResolveTimings` is unwired, or wired but returns an empty list (no config bound to this
+  device/button wants `onHold` *or* `onLongRelease`), the generator doesn't track the press at all -
+  PRESS/RELEASE pass through untouched, exactly as without this feature, and RELEASE carries no
+  `HeldDurationMs`.
   `Active`/`CheckPreconditions` gating happens exclusively in `Execute()`, not here - resolving a
   binding only answers "is a config bound to this button and what are its delays," never "should it
   currently run." A button's press-time binding set is therefore a purely static, device/button-only
@@ -291,49 +296,101 @@ definition.
   `Execute()` - evaluating live state at each actual fire - that decides which one (if any) actually
   runs.
 
-  **Two configs simultaneously bound to the same physical button, with different delays, is fully
-  supported, not just tolerated.** An earlier version of this resolved to a single "winning" config
-  and broadcast the resulting event to every matching config regardless - which was a real
+  **Two configs simultaneously bound to the same physical button, with different HOLD delays, is
+  fully supported, not just tolerated.** An earlier version of this resolved to a single "winning"
+  config and broadcast the resulting event to every matching config regardless - which was a real
   correctness bug, not just an ambiguity: a config whose own (longer) delay hadn't elapsed yet would
   still get triggered early, by a different config's (shorter) one, the moment that one fired.
-  `InputEventExecutor.ResolveButtonTimingsPerConfig` returns the *distinct* `HoldDelay`/`RepeatDelay`/
-  `LongReleaseDelay` settings among every config bound to a button (`.Distinct()` on the
-  `ButtonTimings` struct) - `ExecutionManager`'s resolver concatenates these across every loaded
-  config file and dedupes again at that level.
+  `InputEventExecutor.ResolveButtonTimingsPerConfig` returns the *distinct* `HoldDelay`/`RepeatDelay`
+  settings among every config bound to a button (`.Distinct()` on the `ButtonTimings` struct) -
+  `ExecutionManager`'s resolver concatenates these across every loaded config file and dedupes again
+  at that level.
 
   **No config identity is carried through the generator at all** - `SyntheticButtonEventGenerator`
   only ever sees delay *values*, never a config GUID (there is no `ButtonBinding` type; `ResolveTimings`
-  is `Func<InputEventArgs, List<ButtonTimings>>`). A produced HOLD/REPEAT/LONG_RELEASE just carries
-  the delay value that classified it (`InputEventArgs.SyntheticDelayMs`) - `Execute()` asks each
-  bound config directly, "is this delay yours?" (`ButtonInputConfig.MatchesSyntheticDelay`, one
-  switch comparing `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` against `SyntheticDelayMs`), true for
-  PRESS/RELEASE (nothing to match, so those still broadcast to every matching config, same as
-  always). This is simpler than ID-based targeting and self-correcting: two configs that happen to
-  share a delay are indistinguishable to the generator by construction, so they're naturally treated
-  as one group everywhere - including in the log, which would otherwise show the same physical
-  HOLD/REPEAT/LONG_RELEASE once per bound config instead of once per distinct setting.
+  is `Func<InputEventArgs, List<ButtonTimings>>`). A produced HOLD/REPEAT just carries the delay
+  value that classified it (`InputEventArgs.SyntheticDelayMs`) - `Execute()` asks each bound config
+  directly, "is this delay yours?" (`ButtonInputConfig.MatchesSyntheticDelay`, comparing `HoldDelay`/
+  `RepeatDelay` against `SyntheticDelayMs`), true for anything else (PRESS/RELEASE carry no
+  `SyntheticDelayMs`, so those broadcast to every matching config, same as always). This is simpler
+  than ID-based targeting and self-correcting: two configs that happen to share a delay are
+  indistinguishable to the generator by construction, so they're naturally treated as one group
+  everywhere - including in the log, which would otherwise show the same physical HOLD/REPEAT once
+  per bound config instead of once per distinct setting.
 
   This does widen `SyntheticButtonEventGenerator`'s internal state: a tracked button now holds one
   `HoldFired`/`LastHoldFire`/timings entry per distinct setting (not one canonical set for the whole
-  button), and a RELEASE can fan out into multiple events - one per distinct `LongReleaseDelay` among
-  bound configs, each independently classified as RELEASE or LONG_RELEASE against *that* delay, so
-  two configs on one button can correctly disagree about whether a given release counts as long.
-  `Observe()`'s signature changed accordingly, from returning one `InputEventArgs` to a
-  `List<InputEventArgs>` (usually one element - the fan-out is dormant, not extra work, for the
-  common single-setting-per-button case, and configs sharing a setting collapse back to one element
-  too).
+  button).
 
-  **A delay is only contributed if some action actually consumes it** -
-  `ResolveButtonTimingsPerConfig` substitutes `ButtonTimings.NoHold`/`NoLongRelease` (both
-  `int.MaxValue`, never elapses) for `HoldDelay`/`RepeatDelay` when `onHold` is null, and for
-  `LongReleaseDelay` when `onLongRelease` is null. Otherwise a config's own always-present but unused
-  default (every `ButtonInputConfig` has *some* value in these fields whether or not the matching
-  action is set) would keep HOLD/REPEAT/LONG_RELEASE alive for the whole button for as long as *any*
-  config remains bound to it - including, confusingly, after the one config that actually wanted them
-  is deleted, as long as some other onRelease/onPress-only config happens to still be there. Without
-  `onLongRelease`, `onRelease` dispatches identically regardless of RELEASE-vs-LONG_RELEASE (see
-  `ButtonInputConfig.ResolveDispatchedEvent`'s fallback above), so that delay is exactly as inert to
-  such a config as `HoldDelay` is to one with no `onHold` at all.
+  **`onHold`'s HoldDelay/RepeatDelay is only contributed if `onHold` is actually defined** -
+  `ResolveButtonTimingsPerConfig` substitutes `ButtonTimings.NoHold` (`int.MaxValue`, never elapses)
+  when `onHold` is null. Otherwise a config's own always-present but unused default `HoldDelay`
+  (every `ButtonInputConfig` has *some* value in that field whether or not `onHold` is set) would
+  keep HOLD/REPEAT alive for the whole button for as long as *any* config remains bound to it -
+  including, confusingly, after the one config that actually wanted them is deleted, as long as some
+  other onRelease/onPress-only config happens to still be there. A config with only `onLongRelease`
+  (no `onHold`) still needs an entry here despite contributing nothing real to HOLD/REPEAT scheduling
+  - it's what keeps the button *tracked at all*, which is what makes `HeldDurationMs` available on
+  RELEASE (below). Filtering such a config out entirely, rather than including it with the `NoHold`
+  sentinel, was tried and was a real bug: it silently broke LONG_RELEASE for buttons with an
+  `onLongRelease`-only config and no `onHold` anywhere.
+
+  **LONG_RELEASE is a dispatch-time decision, not a generator reclassification.** The original design
+  for this feature (and an intermediate revision of it) had `SyntheticButtonEventGenerator` decide
+  RELEASE-vs-LONG_RELEASE itself, grouping by distinct `LongReleaseDelay` among bound configs the same
+  way HOLD groups by `HoldDelay`. That shipped a real, if subtle, log-duplication bug: a button bound
+  to one config with a real `LongReleaseDelay` (has `onLongRelease`) and another without one (gets a
+  disabling sentinel, since without `onLongRelease` a config's `LongReleaseDelay` is exactly as inert
+  as `HoldDelay` is to a config without `onHold`) produces *two distinct* delay values - so a quick
+  tap, even though it resolves to the same "plain RELEASE" outcome for both, got logged twice, because
+  the generator was reasoning about *settings*, not *outcomes*. RELEASE isn't like HOLD/REPEAT: it's a
+  real, physical hardware transition (a press actually ended), not something manufactured out of
+  elapsed time with no wire-level counterpart. `SyntheticButtonEventGenerator.Observe()` now always
+  raises RELEASE exactly once, as plain `RELEASE`, carrying how long the press lasted
+  (`InputEventArgs.HeldDurationMs`) - full stop, no grouping, no per-binding fan-out. Each config
+  independently decides, at dispatch time, whether *its own* `LongReleaseDelay` was exceeded and it
+  has an `onLongRelease` to hand off to (`ButtonInputConfig.ResolveDispatchedEvent`); if not, `RELEASE`
+  dispatches to `onRelease` exactly as it always has, regardless of how long the button was held. Two
+  configs on one button can still correctly disagree about whether a given release counts as long -
+  that disagreement just lives entirely in `ResolveDispatchedEvent`, not in what gets raised or logged
+  at the device level. `Observe()`'s signature is still `List<InputEventArgs>` (from the earlier HOLD/
+  REPEAT grouping work), but for RELEASE it's now always exactly one element.
+
+  **Stage 1 shows only physical events; stage 2 always logs, with the delay that produced a
+  synthetic one.** The two log stages settled on different jobs: stage 1
+  (`ExecutionManager.mobiFlightCache_OnButtonPressed`) answers "was an event raised at all," so it
+  only ever logs a real PRESS/RELEASE - `isSyntheticEvent` (`e.SyntheticDelayMs.HasValue`) gates the
+  line, meaning HOLD/REPEAT never appear there (LONG_RELEASE already couldn't, since RELEASE is the
+  only thing `Observe()` ever raises for a release). Stage 2
+  (`InputEventExecutor.Execute()`'s `"Executing ..."` line) answers "did this config actually fire,"
+  so it logs uniformly for every event type, physical or synthetic, whenever a config has a matching
+  action - and for a synthetic one it also names the delay that produced it, since stage 1 no longer
+  will: `AppendSyntheticDelay` appends `:{ms}ms` to the label - `SyntheticDelayMs` (the configured
+  HoldDelay/RepeatDelay that fired) for HOLD/REPEAT, and the config's own `LongReleaseDelay` for
+  LONG_RELEASE. Both are the *configured setting*, not `HeldDurationMs` (the actual time held) - the
+  log answers "what threshold triggered this," and showing the exact elapsed duration for LONG_RELEASE
+  (a first attempt did) is misleading there, since it varies release to release and isn't what the
+  config is checked against for repeatability. `cfg.RawValue` stays the bare event name in both cases -
+  the delay suffix is a log-only detail, not part of the value shown/stored elsewhere.
+
+  This resolved-per-config label is computed once per config, at the top of `Execute()`'s loop, and
+  reused for every skip reason below it too ("MobiFlight not running", "Skipping inactive config",
+  "Preconditions not satisfied") as well as the final "Executing" line - not just one generic label
+  for the whole physical event. Two configs bound to the same button and RELEASE can otherwise
+  disagree (one resolves to RELEASE, one to LONG_RELEASE, per "LONG_RELEASE is a dispatch-time
+  decision" above), so a single shared label computed before the loop would silently show one
+  config's outcome on the other's log line - the "MobiFlight not running" skip originally worked this
+  way (computed once, before the loop, from the raw event only) and had exactly that bug.
+
+  **A skip reason only logs for a config that actually has an action bound to the resolved event.**
+  All three skip reasons ("MobiFlight not running", "Skipping inactive config", "Preconditions not
+  satisfied") are gated on `cfg.GetInputAction(e) != null`, checked once per config alongside the
+  label resolution above. Without this, e.g. an onPress-only config logged "Skipping ... MobiFlight
+  not running" on every RELEASE too - RELEASE was never going to do anything for that config, so the
+  line was pure noise. This mirrors "Executing," which already only logs `action != null` - a skip
+  and an execute are the same event, just with a different outcome, so they share the same gate. The
+  gate only governs whether a *log line* appears; a config that does have a matching action but
+  fails one of these checks still doesn't get `cfg.RawValue`/`updatedValues` touched, same as before.
 - **Encoder pairing configuration.** Where the button-pair-to-encoder mapping is authored (joystick
   definition file vs. runtime user configuration).
 - **Fast-turn threshold shape.** Rolling window/count vs. some other rate measure; not yet designed

--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -322,6 +322,18 @@ definition.
   `List<InputEventArgs>` (usually one element - the fan-out is dormant, not extra work, for the
   common single-setting-per-button case, and configs sharing a setting collapse back to one element
   too).
+
+  **A delay is only contributed if some action actually consumes it** -
+  `ResolveButtonTimingsPerConfig` substitutes `ButtonTimings.NoHold`/`NoLongRelease` (both
+  `int.MaxValue`, never elapses) for `HoldDelay`/`RepeatDelay` when `onHold` is null, and for
+  `LongReleaseDelay` when `onLongRelease` is null. Otherwise a config's own always-present but unused
+  default (every `ButtonInputConfig` has *some* value in these fields whether or not the matching
+  action is set) would keep HOLD/REPEAT/LONG_RELEASE alive for the whole button for as long as *any*
+  config remains bound to it - including, confusingly, after the one config that actually wanted them
+  is deleted, as long as some other onRelease/onPress-only config happens to still be there. Without
+  `onLongRelease`, `onRelease` dispatches identically regardless of RELEASE-vs-LONG_RELEASE (see
+  `ButtonInputConfig.ResolveDispatchedEvent`'s fallback above), so that delay is exactly as inert to
+  such a config as `HoldDelay` is to one with no `onHold` at all.
 - **Encoder pairing configuration.** Where the button-pair-to-encoder mapping is authored (joystick
   definition file vs. runtime user configuration).
 - **Fast-turn threshold shape.** Rolling window/count vs. some other rate measure; not yet designed

--- a/docs/architecture/virtual-button-events.md
+++ b/docs/architecture/virtual-button-events.md
@@ -273,25 +273,26 @@ definition.
 ## Consequences / open questions to resolve before implementation
 
 - **Delay ownership — resolved.** Initially assumed delay could become a property of the physical
-  input/controller, shared across every binding on it. That's wrong: a multi-mode panel (a mode
-  switch's precondition determines which config is active for a given physical button) can
-  legitimately want different `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` for what is physically
-  one button, depending on which config currently governs it. Detection still lives on the
+  input/controller, shared across every binding on it. That's wrong: a multi-mode panel (several
+  mutually-exclusive precondition-gated configs on one physical button) can legitimately want
+  different `HoldDelay`/`RepeatDelay`/`LongReleaseDelay` per config. Detection still lives on the
   controller (physical-button-scoped, one canonical timer per button), but the delay *values* it
-  uses are resolved from whichever config is currently active with satisfied preconditions -
-  `InputEventExecutor.ResolveButtonTimingsPerConfig` does this lookup (reusing the same `GetMatchingInputConfigs`/
-  `CheckPreconditions` the normal pipeline already has), `ExecutionManager` composes one resolver
-  across every loaded config file and hands it to each controller manager's generator
-  (`SyntheticButtonEventGenerator.ResolveTimings`). Resolved once at PRESS time and held for that
-  press's lifecycle - not re-resolved every tick, so a mode switch mid-hold doesn't retroactively
-  change an in-progress press's timing. If no config currently claims the button, the generator
-  falls back to its own fixed defaults and still detects - it fires unconditionally either way,
-  same as a real PRESS on an unbound button; the *existing* `Active`/`CheckPreconditions` gating in
-  `Execute()` (unchanged) is what actually decides whether anything executes. This means
-  preconditions get evaluated twice, but for different questions at different times, not
-  redundantly: once at PRESS (which delays govern this press, decided once), and again at every
-  fire (should this execute right now, using live state - deliberately not cached, mirroring how
-  `ButtonInputConfig`'s old `CanExecute` closure worked before this redesign).
+  uses are resolved per config bound to that button -
+  `InputEventExecutor.ResolveButtonTimingsPerConfig` does this lookup (reusing the same
+  `GetMatchingInputConfigs` the normal pipeline already has - not `Active`/`CheckPreconditions`,
+  see below), `ExecutionManager` composes one resolver across every loaded config file and hands it
+  to each controller manager's generator (`SyntheticButtonEventGenerator.ResolveTimings`). Resolved
+  once at PRESS time and held for that press's lifecycle - not re-resolved every tick, so a mode
+  switch mid-hold doesn't retroactively change an in-progress press's timing.
+  If `ResolveTimings` is unwired, or wired but returns an empty list (no config at all is bound to
+  this device/button), the generator doesn't track the press or synthesize anything - PRESS/RELEASE
+  pass through untouched, exactly as without this feature.
+  `Active`/`CheckPreconditions` gating happens exclusively in `Execute()`, not here - resolving a
+  binding only answers "is a config bound to this button and what are its delays," never "should it
+  currently run." A button's press-time binding set is therefore a purely static, device/button-only
+  question: every bound config gets one, active or not, precondition-satisfied or not, and it's
+  `Execute()` - evaluating live state at each actual fire - that decides which one (if any) actually
+  runs.
 
   **Two configs simultaneously active on the same physical button, with different delays, is fully
   supported, not just tolerated.** An earlier version of this resolved to a single "winning" config

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -88,10 +88,16 @@ namespace MobiFlight.Execution
                     dispatchedLabel = e.GetEventActionLabel();
                     logLabel = dispatchedLabel;
                 }
-                var cfgEventLabel = $"{e.Controller.Name} => {e.Device.Label} => {logLabel}";
 
-                var action = cfg.GetInputAction(e);
-                var hasMatchingAction = action != null;
+                var hasMatchingAction = cfg.GetInputAction(e) != null;
+
+                var isSyntheticEvent = e.SyntheticDelayMs.HasValue;
+                if (!hasMatchingAction && isSyntheticEvent)
+                {
+                    continue;
+                }
+
+                var cfgEventLabel = $"{e.Controller.Name} => {e.Device.Label} => {logLabel}";
 
                 if (!isStarted)
                 {
@@ -122,14 +128,17 @@ namespace MobiFlight.Execution
                         continue;
                     }
 
-                    if (action != null)
-                    {
-                        Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({logLabel})", LogSeverity.Info);
-                    }
-
                     cfg.RawValue = dispatchedLabel;
                     cfg.Value = " ";
                     updatedValues[cfg.GUID] = cfg;
+
+                    if (!hasMatchingAction)
+                    {
+                        continue;
+                    }
+
+                    Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({logLabel})", LogSeverity.Info);
+
                     var references = ResolveReferences(cfg.ConfigRefs);
                     var modifiableValue = new ConnectorValue()
                     {

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -54,7 +54,6 @@ namespace MobiFlight.Execution
         {
             var updatedValues = new Dictionary<string, IConfigItem>();
             string inputKey = CreateInputKey(e);
-            var msgEventLabel = e.GetMsgEventLabel();
 
             if (!inputCache.ContainsKey(inputKey))
             {
@@ -68,12 +67,6 @@ namespace MobiFlight.Execution
 
             var cacheCollection = CreateCacheCollection();
 
-            if (!isStarted)
-            {
-                Log.Instance.log($"{msgEventLabel} skipping, MobiFlight not running.", LogSeverity.Warn);
-                return updatedValues;
-            }
-
             foreach (var cfg in inputCache[inputKey])
             {
                 // A HOLD/REPEAT/LONG_RELEASE only applies to a config whose own delay produced it.
@@ -82,9 +75,39 @@ namespace MobiFlight.Execution
                     continue;
                 }
 
+                string dispatchedLabel;
+                string logLabel;
+                if (e.InputType == DeviceType.Button && cfg.button != null)
+                {
+                    var dispatchedValue = cfg.button.ResolveDispatchedEvent(e);
+                    dispatchedLabel = e.GetEventActionLabel((int)dispatchedValue);
+                    logLabel = AppendSyntheticDelay(dispatchedLabel, dispatchedValue, e, cfg.button);
+                }
+                else
+                {
+                    dispatchedLabel = e.GetEventActionLabel();
+                    logLabel = dispatchedLabel;
+                }
+                var cfgEventLabel = $"{e.Controller.Name} => {e.Device.Label} => {logLabel}";
+
+                var action = cfg.GetInputAction(e);
+                var hasMatchingAction = action != null;
+
+                if (!isStarted)
+                {
+                    if (hasMatchingAction)
+                    {
+                        Log.Instance.log($"{cfgEventLabel} => Skipping \"{cfg.Name}\", MobiFlight not running.", LogSeverity.Warn);
+                    }
+                    continue;
+                }
+
                 if (!cfg.Active)
                 {
-                    Log.Instance.log($"{msgEventLabel} => Skipping inactive config \"{cfg.Name}\".", LogSeverity.Warn);
+                    if (hasMatchingAction)
+                    {
+                        Log.Instance.log($"{cfgEventLabel} => Skipping inactive config \"{cfg.Name}\".", LogSeverity.Warn);
+                    }
                     continue;
                 }
 
@@ -92,20 +115,16 @@ namespace MobiFlight.Execution
                 {
                     if (!CheckPreconditions(cfg))
                     {
-                        Log.Instance.log($"{msgEventLabel} => Preconditions not satisfied for \"{cfg.Name}\".", LogSeverity.Debug);
+                        if (hasMatchingAction)
+                        {
+                            Log.Instance.log($"{cfgEventLabel} => Preconditions not satisfied for \"{cfg.Name}\".", LogSeverity.Debug);
+                        }
                         continue;
                     }
 
-                    var action = cfg.GetInputAction(e);
-
-                    // Log/display what this config actually dispatches, not the raw value.
-                    var dispatchedLabel = (e.InputType == DeviceType.Button && cfg.button != null)
-                        ? e.GetEventActionLabel((int)cfg.button.ResolveDispatchedEvent((MobiFlightButton.InputEvent)e.Value))
-                        : e.GetEventActionLabel();
-
                     if (action != null)
                     {
-                        Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({dispatchedLabel})", LogSeverity.Info);
+                        Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({logLabel})", LogSeverity.Info);
                     }
 
                     cfg.RawValue = dispatchedLabel;
@@ -153,18 +172,33 @@ namespace MobiFlight.Execution
             return result;
         }
 
+        /// <summary>":Nms" suffix for the log only - the configured delay/setting that produced this synthetic event.</summary>
+        private static string AppendSyntheticDelay(string label, MobiFlightButton.InputEvent value, InputEventArgs e, ButtonInputConfig button)
+        {
+            switch (value)
+            {
+                case MobiFlightButton.InputEvent.HOLD:
+                case MobiFlightButton.InputEvent.REPEAT:
+                    return e.SyntheticDelayMs.HasValue ? $"{label}:{e.SyntheticDelayMs}ms" : label;
+                case MobiFlightButton.InputEvent.LONG_RELEASE:
+                    return $"{label}:{button.LongReleaseDelay}ms";
+                default:
+                    return label;
+            }
+        }
+
         /// <summary>
-        /// The distinct Hold/Repeat/LongRelease delay settings among configs bound to this button.
-        /// Active/precondition gating happens in Execute(), not here - this only decides which delays
-        /// govern this press. No config identity is carried (see
+        /// The distinct Hold/Repeat delay settings among configs bound to this button - but also,
+        /// implicitly, "should this button be tracked at all." Empty means the generator won't track
+        /// this press (see SyntheticButtonEventGenerator.Observe) - no HOLD/REPEAT ever, AND no
+        /// HeldDurationMs on RELEASE (needed for LONG_RELEASE - see
+        /// ButtonInputConfig.ResolveDispatchedEvent). So a config bound with only onLongRelease (no
+        /// onHold) still needs an entry here to keep the button tracked, even though it contributes
+        /// nothing real to scheduling - it gets the ButtonTimings.NoHold sentinel instead, same as any
+        /// other config with no onHold. Active/precondition gating happens in Execute(), not here -
+        /// this only decides which delays govern this press. No config identity is carried (see
         /// SyntheticButtonEventGenerator.ResolveTimings) - two configs sharing a delay collapse to one
-        /// entry. Empty if no config is bound at all.
-        /// HoldDelay/RepeatDelay are only contributed when onHold is defined, and LongReleaseDelay only
-        /// when onLongRelease is defined - otherwise a config's own always-present but unused default
-        /// would keep HOLD/REPEAT/LONG_RELEASE alive for the whole button even after every config that
-        /// actually wanted them is gone. Without onLongRelease, onRelease dispatches identically either
-        /// way (see ButtonInputConfig.ResolveDispatchedEvent), so that delay is just as inert as
-        /// HoldDelay is without onHold.
+        /// entry.
         /// </summary>
         public List<ButtonTimings> ResolveButtonTimingsPerConfig(InputEventArgs e)
         {
@@ -175,16 +209,10 @@ namespace MobiFlight.Execution
             }
 
             return inputCache[inputKey]
-                .Where(cfg => cfg.button != null)
-                .Select(cfg =>
-                {
-                    var holdWanted = cfg.button.onHold != null;
-                    var longReleaseWanted = cfg.button.onLongRelease != null;
-                    return new ButtonTimings(
-                        holdWanted ? cfg.button.HoldDelay : ButtonTimings.NoHold,
-                        holdWanted ? cfg.button.RepeatDelay : 0,
-                        longReleaseWanted ? cfg.button.LongReleaseDelay : ButtonTimings.NoLongRelease);
-                })
+                .Where(cfg => cfg.button != null && (cfg.button.onHold != null || cfg.button.onLongRelease != null))
+                .Select(cfg => cfg.button.onHold != null
+                    ? new ButtonTimings(cfg.button.HoldDelay, cfg.button.RepeatDelay)
+                    : new ButtonTimings(ButtonTimings.NoHold, 0))
                 .Distinct()
                 .ToList();
         }

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -77,11 +77,13 @@ namespace MobiFlight.Execution
 
                 string dispatchedLabel;
                 string logLabel;
+                double dispatchedNumericValue = e.Value;
                 if (e.InputType == DeviceType.Button && cfg.button != null)
                 {
                     var dispatchedValue = cfg.button.ResolveDispatchedEvent(e);
                     dispatchedLabel = e.GetEventActionLabel((int)dispatchedValue);
                     logLabel = AppendSyntheticDelay(dispatchedLabel, dispatchedValue, e, cfg.button);
+                    dispatchedNumericValue = (int)dispatchedValue;
                 }
                 else
                 {
@@ -129,7 +131,7 @@ namespace MobiFlight.Execution
                     }
 
                     cfg.RawValue = dispatchedLabel;
-                    cfg.Value = " ";
+                    cfg.Value = dispatchedNumericValue.ToString();
                     updatedValues[cfg.GUID] = cfg;
 
                     if (!hasMatchingAction)
@@ -143,7 +145,7 @@ namespace MobiFlight.Execution
                     var modifiableValue = new ConnectorValue()
                     {
                         type = FSUIPCOffsetType.Float,
-                        Float64 = e.Value,
+                        Float64 = dispatchedNumericValue,
                     };
 
                     try

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -98,12 +98,17 @@ namespace MobiFlight.Execution
 
                     var action = cfg.GetInputAction(e);
 
+                    // Log/display what this config actually dispatches, not the raw value.
+                    var dispatchedLabel = (e.InputType == DeviceType.Button && cfg.button != null)
+                        ? e.GetEventActionLabel((int)cfg.button.ResolveDispatchedEvent((MobiFlightButton.InputEvent)e.Value))
+                        : e.GetEventActionLabel();
+
                     if (action != null)
                     {
-                        Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({e.GetEventActionLabel()})", LogSeverity.Info);
+                        Log.Instance.log($"{e.Controller.Name} => Executing \"{cfg.Name}\". ({dispatchedLabel})", LogSeverity.Info);
                     }
 
-                    cfg.RawValue = e.GetEventActionLabel();
+                    cfg.RawValue = dispatchedLabel;
                     cfg.Value = " ";
                     updatedValues[cfg.GUID] = cfg;
                     var references = ResolveReferences(cfg.ConfigRefs);
@@ -148,7 +153,11 @@ namespace MobiFlight.Execution
             return result;
         }
 
-        /// <summary>Hold/Repeat/LongRelease delays for every active, precondition-satisfied config bound to this button. Empty if none match.</summary>
+        /// <summary>
+        /// Hold/Repeat/LongRelease delays for every config bound to this button. Active/precondition
+        /// gating happens in Execute(), not here - this only decides which delays govern this press.
+        /// Empty if no config is bound at all.
+        /// </summary>
         public List<ButtonBinding> ResolveButtonTimingsPerConfig(InputEventArgs e)
         {
             string inputKey = CreateInputKey(e);
@@ -161,9 +170,7 @@ namespace MobiFlight.Execution
 
             foreach (var cfg in inputCache[inputKey])
             {
-                if (!cfg.Active) continue;
                 if (cfg.button == null) continue;
-                if (!CheckPreconditions(cfg)) continue;
 
                 result.Add(new ButtonBinding(
                     cfg.GUID,

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -76,8 +76,8 @@ namespace MobiFlight.Execution
 
             foreach (var cfg in inputCache[inputKey])
             {
-                // targeted event (HOLD/REPEAT/LONG_RELEASE) only triggers its own config
-                if (e.TargetConfigGUID != null && e.TargetConfigGUID != cfg.GUID)
+                // A HOLD/REPEAT/LONG_RELEASE only applies to a config whose own delay produced it.
+                if (cfg.button != null && !cfg.button.MatchesSyntheticDelay(e))
                 {
                     continue;
                 }
@@ -154,11 +154,13 @@ namespace MobiFlight.Execution
         }
 
         /// <summary>
-        /// Hold/Repeat/LongRelease delays for every config bound to this button. Active/precondition
-        /// gating happens in Execute(), not here - this only decides which delays govern this press.
-        /// Empty if no config is bound at all.
+        /// The distinct Hold/Repeat/LongRelease delay settings among configs bound to this button.
+        /// Active/precondition gating happens in Execute(), not here - this only decides which delays
+        /// govern this press. No config identity is carried (see
+        /// SyntheticButtonEventGenerator.ResolveTimings) - two configs sharing a delay collapse to one
+        /// entry. Empty if no config is bound at all.
         /// </summary>
-        public List<ButtonBinding> ResolveButtonTimingsPerConfig(InputEventArgs e)
+        public List<ButtonTimings> ResolveButtonTimingsPerConfig(InputEventArgs e)
         {
             string inputKey = CreateInputKey(e);
             if (!inputCache.ContainsKey(inputKey))
@@ -166,18 +168,11 @@ namespace MobiFlight.Execution
                 inputCache[inputKey] = GetMatchingInputConfigs(e);
             }
 
-            var result = new List<ButtonBinding>();
-
-            foreach (var cfg in inputCache[inputKey])
-            {
-                if (cfg.button == null) continue;
-
-                result.Add(new ButtonBinding(
-                    cfg.GUID,
-                    new ButtonTimings(cfg.button.HoldDelay, cfg.button.RepeatDelay, cfg.button.LongReleaseDelay)));
-            }
-
-            return result;
+            return inputCache[inputKey]
+                .Where(cfg => cfg.button != null)
+                .Select(cfg => new ButtonTimings(cfg.button.HoldDelay, cfg.button.RepeatDelay, cfg.button.LongReleaseDelay))
+                .Distinct()
+                .ToList();
         }
 
         private List<InputConfigItem> GetMatchingInputConfigs(InputEventArgs e)

--- a/src/MobiFlightConnector/Base/InputEventExecutor.cs
+++ b/src/MobiFlightConnector/Base/InputEventExecutor.cs
@@ -159,6 +159,12 @@ namespace MobiFlight.Execution
         /// govern this press. No config identity is carried (see
         /// SyntheticButtonEventGenerator.ResolveTimings) - two configs sharing a delay collapse to one
         /// entry. Empty if no config is bound at all.
+        /// HoldDelay/RepeatDelay are only contributed when onHold is defined, and LongReleaseDelay only
+        /// when onLongRelease is defined - otherwise a config's own always-present but unused default
+        /// would keep HOLD/REPEAT/LONG_RELEASE alive for the whole button even after every config that
+        /// actually wanted them is gone. Without onLongRelease, onRelease dispatches identically either
+        /// way (see ButtonInputConfig.ResolveDispatchedEvent), so that delay is just as inert as
+        /// HoldDelay is without onHold.
         /// </summary>
         public List<ButtonTimings> ResolveButtonTimingsPerConfig(InputEventArgs e)
         {
@@ -170,7 +176,15 @@ namespace MobiFlight.Execution
 
             return inputCache[inputKey]
                 .Where(cfg => cfg.button != null)
-                .Select(cfg => new ButtonTimings(cfg.button.HoldDelay, cfg.button.RepeatDelay, cfg.button.LongReleaseDelay))
+                .Select(cfg =>
+                {
+                    var holdWanted = cfg.button.onHold != null;
+                    var longReleaseWanted = cfg.button.onLongRelease != null;
+                    return new ButtonTimings(
+                        holdWanted ? cfg.button.HoldDelay : ButtonTimings.NoHold,
+                        holdWanted ? cfg.button.RepeatDelay : 0,
+                        longReleaseWanted ? cfg.button.LongReleaseDelay : ButtonTimings.NoLongRelease);
+                })
                 .Distinct()
                 .ToList();
         }

--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -388,6 +388,7 @@ namespace MobiFlight
                         var cfg = ConfigItems.Find(i => i.GUID == item.GUID);
                         ConfigItems.Remove(cfg);
                     });
+                    OnInputConfigSettingsChanged(this, null); // else InputEventExecutor's cache keeps the deleted item bound
                 }
                 else if (message.Action == "toggle")
                 {
@@ -410,6 +411,7 @@ namespace MobiFlight
                 {
                     case "delete":
                         ConfigItems.RemoveAll(i => i.GUID == message.Item.GUID);
+                        OnInputConfigSettingsChanged(this, null); // else InputEventExecutor's cache keeps the deleted item bound
                         break;
 
                     case "toggle":

--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -1460,7 +1460,9 @@ namespace MobiFlight
             var msgEventLabel = e.GetMsgEventLabel();
             var serial = e.Controller.Serial;
 
-            if (LogIfNotJoystickAxisOrJoystickAxisEnabled(serial, e.Device.Type))
+            // Synthetic (HOLD/REPEAT) events don't belong in this "an event was raised" log - see Execute() for those.
+            var isSyntheticEvent = e.SyntheticDelayMs.HasValue;
+            if (!isSyntheticEvent && LogIfNotJoystickAxisOrJoystickAxisEnabled(serial, e.Device.Type))
             {
                 Log.Instance.log(msgEventLabel, LogSeverity.Info);
             }

--- a/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/ExecutionManager.cs
@@ -236,15 +236,15 @@ namespace MobiFlight
             };
 
             // Hold/Repeat/LongRelease delays are per config, not per physical button - collect
-            // every match across all loaded config files.
-            Func<InputEventArgs, List<ButtonBinding>> resolveButtonTimings = e =>
+            // every distinct setting across all loaded config files.
+            Func<InputEventArgs, List<ButtonTimings>> resolveButtonTimings = e =>
             {
-                var bindings = new List<ButtonBinding>();
+                var timings = new List<ButtonTimings>();
                 foreach (var executor in _inputEventExecutors.Values)
                 {
-                    bindings.AddRange(executor.ResolveButtonTimingsPerConfig(e));
+                    timings.AddRange(executor.ResolveButtonTimingsPerConfig(e));
                 }
-                return bindings;
+                return timings.Distinct().ToList();
             };
             mobiFlightCache.SetButtonTimingsResolver(resolveButtonTimings);
             joystickManager.SetButtonTimingsResolver(resolveButtonTimings);

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -175,7 +175,8 @@ namespace MobiFlight.InputConfig
 
         /// <summary>
         /// Dispatches one already-classified event to the matching InputAction. REPEAT has no
-        /// binding of its own - it dispatches to onHold, same as HOLD.
+        /// binding of its own - it dispatches to onHold, same as HOLD. 
+        /// LONG_RELEASE falls back to onRelease when onLongRelease isn't configured
         /// </summary>
         internal void execute(CacheCollection cacheCollection,
                               InputEventArgs args,
@@ -190,7 +191,7 @@ namespace MobiFlight.InputConfig
                     onRelease?.execute(cacheCollection, args, configRefs);
                     break;
                 case MobiFlightButton.InputEvent.LONG_RELEASE:
-                    onLongRelease?.execute(cacheCollection, args, configRefs);
+                    (onLongRelease ?? onRelease)?.execute(cacheCollection, args, configRefs);
                     break;
                 case MobiFlightButton.InputEvent.HOLD:
                 case MobiFlightButton.InputEvent.REPEAT:

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -173,31 +173,52 @@ namespace MobiFlight.InputConfig
             }
         }
 
-        /// <summary>
-        /// Dispatches one already-classified event to the matching InputAction. REPEAT has no
-        /// binding of its own - it dispatches to onHold, same as HOLD. 
-        /// LONG_RELEASE falls back to onRelease when onLongRelease isn't configured
-        /// </summary>
+        /// <summary>LONG_RELEASE without onLongRelease resolves to RELEASE. Shared with GetInputAction/InputEventExecutor.</summary>
+        internal MobiFlightButton.InputEvent ResolveDispatchedEvent(MobiFlightButton.InputEvent value) =>
+            value == MobiFlightButton.InputEvent.LONG_RELEASE && onLongRelease == null
+                ? MobiFlightButton.InputEvent.RELEASE
+                : value;
+
+        /// <summary>Dispatches to the matching InputAction. REPEAT dispatches to onHold, same as HOLD.</summary>
         internal void execute(CacheCollection cacheCollection,
                               InputEventArgs args,
                               List<ConfigRefValue> configRefs)
         {
-            switch ((MobiFlightButton.InputEvent)args.Value)
+            var value = (MobiFlightButton.InputEvent)args.Value;
+            var dispatchedValue = ResolveDispatchedEvent(value);
+
+            InputAction action;
+            switch (dispatchedValue)
             {
                 case MobiFlightButton.InputEvent.PRESS:
-                    onPress?.execute(cacheCollection, args, configRefs);
+                    action = onPress;
                     break;
                 case MobiFlightButton.InputEvent.RELEASE:
-                    onRelease?.execute(cacheCollection, args, configRefs);
+                    action = onRelease;
                     break;
                 case MobiFlightButton.InputEvent.LONG_RELEASE:
-                    (onLongRelease ?? onRelease)?.execute(cacheCollection, args, configRefs);
+                    action = onLongRelease;
                     break;
                 case MobiFlightButton.InputEvent.HOLD:
                 case MobiFlightButton.InputEvent.REPEAT:
-                    onHold?.execute(cacheCollection, args, configRefs);
+                    action = onHold;
+                    break;
+                default:
+                    action = null;
                     break;
             }
+
+            if (action == null) return;
+
+            if (dispatchedValue == value)
+            {
+                action.execute(cacheCollection, args, configRefs);
+                return;
+            }
+
+            var normalizedArgs = args.CloneWithLabel();
+            normalizedArgs.Value = (int)dispatchedValue;
+            action.execute(cacheCollection, normalizedArgs, configRefs);
         }
 
         public Dictionary<String, int> GetStatistics()

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -173,6 +173,29 @@ namespace MobiFlight.InputConfig
             }
         }
 
+        /// <summary>
+        /// Does this config's own delay match the setting that produced this synthetic event? Always
+        /// true for PRESS/RELEASE (nothing to match). This is how InputEventExecutor decides which of
+        /// several configs sharing a physical button a HOLD/REPEAT/LONG_RELEASE actually belongs to -
+        /// no ID needed, just compare delays.
+        /// </summary>
+        internal bool MatchesSyntheticDelay(InputEventArgs e)
+        {
+            if (!e.SyntheticDelayMs.HasValue) return true;
+
+            switch ((MobiFlightButton.InputEvent)e.Value)
+            {
+                case MobiFlightButton.InputEvent.HOLD:
+                    return HoldDelay == e.SyntheticDelayMs.Value;
+                case MobiFlightButton.InputEvent.REPEAT:
+                    return RepeatDelay == e.SyntheticDelayMs.Value;
+                case MobiFlightButton.InputEvent.LONG_RELEASE:
+                    return LongReleaseDelay == e.SyntheticDelayMs.Value;
+                default:
+                    return true;
+            }
+        }
+
         /// <summary>LONG_RELEASE without onLongRelease resolves to RELEASE. Shared with GetInputAction/InputEventExecutor.</summary>
         internal MobiFlightButton.InputEvent ResolveDispatchedEvent(MobiFlightButton.InputEvent value) =>
             value == MobiFlightButton.InputEvent.LONG_RELEASE && onLongRelease == null

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -174,10 +174,11 @@ namespace MobiFlight.InputConfig
         }
 
         /// <summary>
-        /// Does this config's own delay match the setting that produced this synthetic event? Always
-        /// true for PRESS/RELEASE (nothing to match). This is how InputEventExecutor decides which of
-        /// several configs sharing a physical button a HOLD/REPEAT/LONG_RELEASE actually belongs to -
-        /// no ID needed, just compare delays.
+        /// Does this config's own delay match the setting that produced this HOLD/REPEAT? Always true
+        /// otherwise (nothing to match - RELEASE's LONG_RELEASE decision is made in
+        /// ResolveDispatchedEvent, not here). This is how InputEventExecutor decides which of several
+        /// configs sharing a physical button a HOLD/REPEAT actually belongs to - no ID needed, just
+        /// compare delays.
         /// </summary>
         internal bool MatchesSyntheticDelay(InputEventArgs e)
         {
@@ -189,18 +190,29 @@ namespace MobiFlight.InputConfig
                     return HoldDelay == e.SyntheticDelayMs.Value;
                 case MobiFlightButton.InputEvent.REPEAT:
                     return RepeatDelay == e.SyntheticDelayMs.Value;
-                case MobiFlightButton.InputEvent.LONG_RELEASE:
-                    return LongReleaseDelay == e.SyntheticDelayMs.Value;
                 default:
                     return true;
             }
         }
 
-        /// <summary>LONG_RELEASE without onLongRelease resolves to RELEASE. Shared with GetInputAction/InputEventExecutor.</summary>
-        internal MobiFlightButton.InputEvent ResolveDispatchedEvent(MobiFlightButton.InputEvent value) =>
-            value == MobiFlightButton.InputEvent.LONG_RELEASE && onLongRelease == null
-                ? MobiFlightButton.InputEvent.RELEASE
-                : value;
+        /// <summary>
+        /// What this config actually dispatches for args.Value. RELEASE becomes LONG_RELEASE only if
+        /// onLongRelease is defined and the held duration exceeded this config's own LongReleaseDelay -
+        /// a per-config decision, since the raw RELEASE carries no pre-made classification (see
+        /// SyntheticButtonEventGenerator.Observe - it always raises plain RELEASE, once).
+        /// </summary>
+        internal MobiFlightButton.InputEvent ResolveDispatchedEvent(InputEventArgs args)
+        {
+            var value = (MobiFlightButton.InputEvent)args.Value;
+            if (value == MobiFlightButton.InputEvent.RELEASE
+                && onLongRelease != null
+                && args.HeldDurationMs.HasValue
+                && args.HeldDurationMs.Value > LongReleaseDelay)
+            {
+                return MobiFlightButton.InputEvent.LONG_RELEASE;
+            }
+            return value;
+        }
 
         /// <summary>Dispatches to the matching InputAction. REPEAT dispatches to onHold, same as HOLD.</summary>
         internal void execute(CacheCollection cacheCollection,
@@ -208,7 +220,7 @@ namespace MobiFlight.InputConfig
                               List<ConfigRefValue> configRefs)
         {
             var value = (MobiFlightButton.InputEvent)args.Value;
-            var dispatchedValue = ResolveDispatchedEvent(value);
+            var dispatchedValue = ResolveDispatchedEvent(args);
 
             InputAction action;
             switch (dispatchedValue)

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -178,7 +178,8 @@ namespace MobiFlight.InputConfig
         /// otherwise (nothing to match - RELEASE's LONG_RELEASE decision is made in
         /// ResolveDispatchedEvent, not here). This is how InputEventExecutor decides which of several
         /// configs sharing a physical button a HOLD/REPEAT actually belongs to - no ID needed, just
-        /// compare delays.
+        /// compare delays. REPEAT compares both HoldDelay and RepeatDelay - RepeatDelay alone can't
+        /// tell apart two configs that share it but not HoldDelay.
         /// </summary>
         internal bool MatchesSyntheticDelay(InputEventArgs e)
         {
@@ -189,7 +190,7 @@ namespace MobiFlight.InputConfig
                 case MobiFlightButton.InputEvent.HOLD:
                     return onHold != null && HoldDelay == e.SyntheticDelayMs.Value;
                 case MobiFlightButton.InputEvent.REPEAT:
-                    return onHold != null && RepeatDelay == e.SyntheticDelayMs.Value;
+                    return onHold != null && RepeatDelay == e.SyntheticDelayMs.Value && HoldDelay == e.SyntheticHoldDelayMs;
                 default:
                     return true;
             }

--- a/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfig/ButtonInputConfig.cs
@@ -187,9 +187,9 @@ namespace MobiFlight.InputConfig
             switch ((MobiFlightButton.InputEvent)e.Value)
             {
                 case MobiFlightButton.InputEvent.HOLD:
-                    return HoldDelay == e.SyntheticDelayMs.Value;
+                    return onHold != null && HoldDelay == e.SyntheticDelayMs.Value;
                 case MobiFlightButton.InputEvent.REPEAT:
-                    return RepeatDelay == e.SyntheticDelayMs.Value;
+                    return onHold != null && RepeatDelay == e.SyntheticDelayMs.Value;
                 default:
                     return true;
             }

--- a/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
@@ -380,7 +380,7 @@ namespace MobiFlight
             {
                 case DeviceType.Button:
                     if (button == null) return null;
-                    switch (button.ResolveDispatchedEvent((MobiFlightButton.InputEvent)e.Value))
+                    switch (button.ResolveDispatchedEvent(e))
                     {
                         case MobiFlightButton.InputEvent.PRESS:
                             return button.onPress;

--- a/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputConfigItem.cs
@@ -379,20 +379,21 @@ namespace MobiFlight
             switch (e.InputType)
             {
                 case DeviceType.Button:
-                    switch ((MobiFlightButton.InputEvent)e.Value)
+                    if (button == null) return null;
+                    switch (button.ResolveDispatchedEvent((MobiFlightButton.InputEvent)e.Value))
                     {
                         case MobiFlightButton.InputEvent.PRESS:
-                            return button?.onPress;
+                            return button.onPress;
 
                         case MobiFlightButton.InputEvent.RELEASE:
-                            return button?.onRelease;
+                            return button.onRelease;
 
                         case MobiFlightButton.InputEvent.LONG_RELEASE:
-                            return button?.onLongRelease;
+                            return button.onLongRelease;
 
                         case MobiFlightButton.InputEvent.HOLD:
                         case MobiFlightButton.InputEvent.REPEAT:
-                            return button?.onHold;
+                            return button.onHold;
 
                         default:
                             return null;

--- a/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
@@ -56,16 +56,10 @@ namespace MobiFlight
             }
         }
 
-        /// <summary>
-        /// The one place SyntheticDelayMs is shown - "an event was raised" (RawValue and the
-        /// per-config "Executing" line show what actually dispatched instead, deliberately without it).
-        /// </summary>
+        /// <summary>"An event was raised" (stage 1) - only ever called for a physical PRESS/RELEASE, so never needs the synthetic delay (see the per-config "Executing" line for that).</summary>
         public string GetMsgEventLabel()
         {
-            var eventAction = GetEventActionLabel();
-            if (SyntheticDelayMs.HasValue) eventAction += $" ({SyntheticDelayMs}ms)";
-
-            return $"{Controller.Name} => {Device.Label} => {eventAction}";
+            return $"{Controller.Name} => {Device.Label} => {GetEventActionLabel()}";
         }
 
         public object Clone()

--- a/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
@@ -21,6 +21,13 @@ namespace MobiFlight
         public int? SyntheticDelayMs { get; set; }
 
         /// <summary>
+        /// The HoldDelay of the binding that produced this REPEAT - disambiguates two configs that
+        /// share the same RepeatDelay but not the same HoldDelay (see
+        /// ButtonInputConfig.MatchesSyntheticDelay). Null except on REPEAT.
+        /// </summary>
+        public int? SyntheticHoldDelayMs { get; set; }
+
+        /// <summary>
         /// How long the button was held (ms) before this RELEASE. RELEASE is always raised once, as
         /// RELEASE - LONG_RELEASE is a per-config decision made at dispatch time (see
         /// ButtonInputConfig.ResolveDispatchedEvent), not a reclassification of the raw event. Null
@@ -70,6 +77,7 @@ namespace MobiFlight
             clone.Value = Value;
             clone.StrValue = StrValue;
             clone.SyntheticDelayMs = SyntheticDelayMs;
+            clone.SyntheticHoldDelayMs = SyntheticHoldDelayMs;
             clone.HeldDurationMs = HeldDurationMs;
 
             return clone;

--- a/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
@@ -18,17 +18,20 @@ namespace MobiFlight
 
         public readonly DateTime Time = DateTime.Now;
 
-        public string GetEventActionLabel()
+        public string GetEventActionLabel() => GetEventActionLabel(Value);
+
+        /// <summary>Same as GetEventActionLabel(), for a value other than this instance's own.</summary>
+        public string GetEventActionLabel(double value)
         {
-            var value = Convert.ToInt32(Value);
+            var v = Convert.ToInt32(value);
             switch (InputType)
             {
                 case DeviceType.Button:
-                    return MobiFlightButton.InputEventIdToString(value);
+                    return MobiFlightButton.InputEventIdToString(v);
                 case DeviceType.Encoder:
-                    return MobiFlightEncoder.InputEventIdToString(value);
+                    return MobiFlightEncoder.InputEventIdToString(v);
                 case DeviceType.AnalogInput:
-                    return $"{MobiFlightAnalogInput.InputEventIdToString(0)} => {value}";
+                    return $"{MobiFlightAnalogInput.InputEventIdToString(0)} => {v}";
                 default:
                     return "n/a";
             }

--- a/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
@@ -13,8 +13,12 @@ namespace MobiFlight
 
         public String StrValue { get; set; }
 
-        /// <summary>Null (default) broadcasts to every matching config. Non-null restricts Execute() to that one config's GUID - used for HOLD/REPEAT/LONG_RELEASE, timed per-config.</summary>
-        public string TargetConfigGUID { get; set; }
+        /// <summary>
+        /// The HOLD/RepeatDelay/LongReleaseDelay (ms) that classified this event - also how a config
+        /// decides an event is its own (see ButtonInputConfig.MatchesSyntheticDelay), not just how
+        /// it's displayed. Null for PRESS/RELEASE.
+        /// </summary>
+        public int? SyntheticDelayMs { get; set; }
 
         public readonly DateTime Time = DateTime.Now;
 
@@ -27,7 +31,10 @@ namespace MobiFlight
             switch (InputType)
             {
                 case DeviceType.Button:
-                    return MobiFlightButton.InputEventIdToString(v);
+                    var label = MobiFlightButton.InputEventIdToString(v);
+                    // Only annotate when asking for this event's own value - a value normalized down
+                    // to a fallback (e.g. LONG_RELEASE -> RELEASE) has no delay of its own to show.
+                    return (SyntheticDelayMs.HasValue && v == Convert.ToInt32(Value)) ? $"{label} ({SyntheticDelayMs}ms)" : label;
                 case DeviceType.Encoder:
                     return MobiFlightEncoder.InputEventIdToString(v);
                 case DeviceType.AnalogInput:
@@ -52,7 +59,7 @@ namespace MobiFlight
             clone.InputType = InputType;
             clone.Value = Value;
             clone.StrValue = StrValue;
-            clone.TargetConfigGUID = TargetConfigGUID;
+            clone.SyntheticDelayMs = SyntheticDelayMs;
 
             return clone;
         }

--- a/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
@@ -31,10 +31,7 @@ namespace MobiFlight
             switch (InputType)
             {
                 case DeviceType.Button:
-                    var label = MobiFlightButton.InputEventIdToString(v);
-                    // Only annotate when asking for this event's own value - a value normalized down
-                    // to a fallback (e.g. LONG_RELEASE -> RELEASE) has no delay of its own to show.
-                    return (SyntheticDelayMs.HasValue && v == Convert.ToInt32(Value)) ? $"{label} ({SyntheticDelayMs}ms)" : label;
+                    return MobiFlightButton.InputEventIdToString(v);
                 case DeviceType.Encoder:
                     return MobiFlightEncoder.InputEventIdToString(v);
                 case DeviceType.AnalogInput:
@@ -44,9 +41,14 @@ namespace MobiFlight
             }
         }
 
+        /// <summary>
+        /// The one place SyntheticDelayMs is shown - "an event was raised" (RawValue and the
+        /// per-config "Executing" line show what actually dispatched instead, deliberately without it).
+        /// </summary>
         public string GetMsgEventLabel()
         {
             var eventAction = GetEventActionLabel();
+            if (SyntheticDelayMs.HasValue) eventAction += $" ({SyntheticDelayMs}ms)";
 
             return $"{Controller.Name} => {Device.Label} => {eventAction}";
         }

--- a/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
+++ b/src/MobiFlightConnector/MobiFlight/InputEventArgs.cs
@@ -14,11 +14,19 @@ namespace MobiFlight
         public String StrValue { get; set; }
 
         /// <summary>
-        /// The HOLD/RepeatDelay/LongReleaseDelay (ms) that classified this event - also how a config
-        /// decides an event is its own (see ButtonInputConfig.MatchesSyntheticDelay), not just how
-        /// it's displayed. Null for PRESS/RELEASE.
+        /// The HoldDelay/RepeatDelay (ms) that classified this event - also how a config decides a
+        /// HOLD/REPEAT is its own (see ButtonInputConfig.MatchesSyntheticDelay), not just how it's
+        /// displayed. Null except on HOLD/REPEAT.
         /// </summary>
         public int? SyntheticDelayMs { get; set; }
+
+        /// <summary>
+        /// How long the button was held (ms) before this RELEASE. RELEASE is always raised once, as
+        /// RELEASE - LONG_RELEASE is a per-config decision made at dispatch time (see
+        /// ButtonInputConfig.ResolveDispatchedEvent), not a reclassification of the raw event. Null
+        /// except on RELEASE.
+        /// </summary>
+        public int? HeldDurationMs { get; set; }
 
         public readonly DateTime Time = DateTime.Now;
 
@@ -62,6 +70,7 @@ namespace MobiFlight
             clone.Value = Value;
             clone.StrValue = StrValue;
             clone.SyntheticDelayMs = SyntheticDelayMs;
+            clone.HeldDurationMs = HeldDurationMs;
 
             return clone;
         }

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
@@ -363,7 +363,7 @@ namespace MobiFlight
         }
 
         /// <summary>See SyntheticButtonEventGenerator.ResolveTimings.</summary>
-        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonBinding>> resolver)
+        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonTimings>> resolver)
         {
             VirtualButtonEvents.ResolveTimings = resolver;
         }

--- a/src/MobiFlightConnector/MobiFlight/MidiBoard/MidiBoardManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/MidiBoard/MidiBoardManager.cs
@@ -291,7 +291,7 @@ namespace MobiFlight
         }
 
         /// <summary>See SyntheticButtonEventGenerator.ResolveTimings.</summary>
-        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonBinding>> resolver)
+        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonTimings>> resolver)
         {
             VirtualButtonEvents.ResolveTimings = resolver;
         }

--- a/src/MobiFlightConnector/MobiFlight/MobiFlightCache.cs
+++ b/src/MobiFlightConnector/MobiFlight/MobiFlightCache.cs
@@ -426,7 +426,7 @@ namespace MobiFlight
         }
 
         /// <summary>See SyntheticButtonEventGenerator.ResolveTimings.</summary>
-        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonBinding>> resolver)
+        public void SetButtonTimingsResolver(Func<InputEventArgs, List<ButtonTimings>> resolver)
         {
             VirtualButtonEvents.ResolveTimings = resolver;
         }

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Timers;
 
 namespace MobiFlight
@@ -13,18 +14,20 @@ namespace MobiFlight
     public class SyntheticButtonEventGenerator : IDisposable
     {
         /// <summary>
-        /// Resolves every config currently bound to a button and its delays. Resolved once at
-        /// PRESS, held for that press's lifecycle. Null or empty means no config is bound - no
-        /// synthetic events for that button at all.
+        /// The distinct Hold/Repeat/LongRelease delay settings among configs currently bound to a
+        /// button. Resolved once at PRESS, held for that press's lifecycle. Null or empty means no
+        /// config is bound - no synthetic events for that button at all. No config identity is
+        /// carried - a config later decides an event is its own by matching its own delay (see
+        /// ButtonInputConfig.MatchesSyntheticDelay), so two configs sharing a delay are
+        /// indistinguishable here by design and share one raised event.
         /// </summary>
-        public Func<InputEventArgs, List<ButtonBinding>> ResolveTimings { get; set; }
+        public Func<InputEventArgs, List<ButtonTimings>> ResolveTimings { get; set; }
 
         /// <summary>Raised for HOLD/REPEAT. LONG_RELEASE is classified in-place by <see cref="Observe"/> instead.</summary>
         public event EventHandler<InputEventArgs> OnSyntheticEvent;
 
         private class BindingState
         {
-            public string ConfigGuid;
             public ButtonTimings Timings;
             public bool HoldFired;
             public DateTime LastHoldFire;
@@ -56,9 +59,10 @@ namespace MobiFlight
 
         /// <summary>
         /// Feed one real PRESS/RELEASE through. Returns the event(s) to forward: one untargeted
-        /// event for PRESS; one per bound config for RELEASE, each classified RELEASE/LONG_RELEASE
-        /// against that config's own delay. A button with no bound config passes PRESS/RELEASE
-        /// through untouched and is never tracked for HOLD/REPEAT/LONG_RELEASE.
+        /// event for PRESS; for RELEASE, one event per distinct LongReleaseDelay among bound configs
+        /// (configs sharing a delay always agree on RELEASE vs LONG_RELEASE, so they share one event).
+        /// A button with no bound config passes PRESS/RELEASE through untouched and is never tracked
+        /// for HOLD/REPEAT/LONG_RELEASE.
         /// </summary>
         public List<InputEventArgs> Observe(InputEventArgs e)
         {
@@ -79,8 +83,8 @@ namespace MobiFlight
             if (value == MobiFlightButton.InputEvent.PRESS)
             {
                 // Resolved once here, held for the whole press - not re-resolved per tick.
-                var bindings = ResolveTimings?.Invoke(e);
-                if (bindings == null || bindings.Count == 0)
+                var timings = ResolveTimings?.Invoke(e);
+                if (timings == null || timings.Count == 0)
                 {
                     // No config bound to this button - no synthetic events at all.
                     return new List<InputEventArgs> { e };
@@ -92,7 +96,7 @@ namespace MobiFlight
                     {
                         LastPress = e,
                         PressedAt = _now(),
-                        Bindings = bindings.ConvertAll(b => new BindingState { ConfigGuid = b.ConfigGuid, Timings = b.Timings })
+                        Bindings = timings.ConvertAll(t => new BindingState { Timings = t })
                     };
                 }
                 EnsureTimerRunning();
@@ -117,14 +121,16 @@ namespace MobiFlight
                 }
 
                 var now = _now();
-                var result = new List<InputEventArgs>(tracked.Bindings.Count);
-                foreach (var binding in tracked.Bindings)
+                var result = new List<InputEventArgs>();
+                // Grouped by LongReleaseDelay - configs sharing a delay always agree on RELEASE vs
+                // LONG_RELEASE (same elapsed time, same threshold), so they share one raised event.
+                foreach (var longReleaseDelay in tracked.Bindings.Select(b => b.Timings.LongReleaseDelay).Distinct())
                 {
                     var classified = e.CloneWithLabel();
-                    classified.TargetConfigGUID = binding.ConfigGuid;
-                    if ((now - tracked.PressedAt) > TimeSpan.FromMilliseconds(binding.Timings.LongReleaseDelay))
+                    if ((now - tracked.PressedAt) > TimeSpan.FromMilliseconds(longReleaseDelay))
                     {
                         classified.Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE;
+                        classified.SyntheticDelayMs = longReleaseDelay;
                     }
                     result.Add(classified);
                 }
@@ -146,6 +152,9 @@ namespace MobiFlight
                 foreach (var kvp in _pressed)
                 {
                     var tracked = kvp.Value;
+                    var dueHoldDelays = new HashSet<int>();
+                    var dueRepeatDelays = new HashSet<int>();
+
                     foreach (var binding in tracked.Bindings)
                     {
                         try
@@ -156,20 +165,28 @@ namespace MobiFlight
                                 {
                                     binding.HoldFired = true;
                                     binding.LastHoldFire = now;
-                                    dueHold.Add(Classify(tracked.LastPress, binding.ConfigGuid, MobiFlightButton.InputEvent.HOLD));
+                                    dueHoldDelays.Add(binding.Timings.HoldDelay);
                                 }
                             }
                             else if (binding.Timings.RepeatDelay > 0 && (now - binding.LastHoldFire) >= TimeSpan.FromMilliseconds(binding.Timings.RepeatDelay))
                             {
                                 binding.LastHoldFire = now;
-                                dueRepeat.Add(Classify(tracked.LastPress, binding.ConfigGuid, MobiFlightButton.InputEvent.REPEAT));
+                                dueRepeatDelays.Add(binding.Timings.RepeatDelay);
                             }
                         }
                         catch (Exception ex)
                         {
-                            Log.Instance.log($"Error checking hold state for {kvp.Key} ({binding.ConfigGuid}): {ex.Message}", LogSeverity.Error);
+                            Log.Instance.log($"Error checking hold state for {kvp.Key}: {ex.Message}", LogSeverity.Error);
                         }
                     }
+
+                    // One raised event per distinct delay value, not per binding - bindings sharing a
+                    // delay become due on the same tick (same PressedAt) and share one event.
+                    foreach (var holdDelay in dueHoldDelays)
+                        dueHold.Add(Classify(tracked.LastPress, MobiFlightButton.InputEvent.HOLD, holdDelay));
+
+                    foreach (var repeatDelay in dueRepeatDelays)
+                        dueRepeat.Add(Classify(tracked.LastPress, MobiFlightButton.InputEvent.REPEAT, repeatDelay));
                 }
             }
 
@@ -178,11 +195,11 @@ namespace MobiFlight
             foreach (var due in dueRepeat) RaiseSynthetic(due);
         }
 
-        private static InputEventArgs Classify(InputEventArgs lastPress, string targetConfigGuid, MobiFlightButton.InputEvent value)
+        private static InputEventArgs Classify(InputEventArgs lastPress, MobiFlightButton.InputEvent value, int delayMs)
         {
             var e = lastPress.CloneWithLabel();
             e.Value = (int)value;
-            e.TargetConfigGUID = targetConfigGuid;
+            e.SyntheticDelayMs = delayMs;
             return e;
         }
 
@@ -231,10 +248,15 @@ namespace MobiFlight
         }
     }
 
-    /// <summary>Hold/Repeat/LongRelease delays for one button press, one config. See <see cref="SyntheticButtonEventGenerator.ResolveTimings"/>.</summary>
+    /// <summary>
+    /// Hold/Repeat/LongRelease delays for one button press, one config. Intentionally unclamped here -
+    /// RepeatDelay validation belongs at config authoring time (UI), not runtime evaluation, so a
+    /// config's own value and what the generator schedules/matches against always agree. See
+    /// <see cref="SyntheticButtonEventGenerator.ResolveTimings"/>.
+    /// </summary>
     public struct ButtonTimings
     {
-        /// <summary>Floor for a positive RepeatDelay - protects the sim API from a too-fast repeat. 0 (disabled) is exempt.</summary>
+        /// <summary>Not enforced here - reserved for config-authoring-time (UI) validation.</summary>
         public const int MinRepeatDelay = 100; // ms
 
         public int HoldDelay;
@@ -244,24 +266,11 @@ namespace MobiFlight
         public ButtonTimings(int holdDelay, int repeatDelay, int longReleaseDelay)
         {
             HoldDelay = holdDelay;
-            RepeatDelay = ClampRepeatDelay(repeatDelay);
+            RepeatDelay = repeatDelay;
             LongReleaseDelay = longReleaseDelay;
         }
 
         public static int ClampRepeatDelay(int repeatDelay) =>
             repeatDelay > 0 && repeatDelay < MinRepeatDelay ? MinRepeatDelay : repeatDelay;
-    }
-
-    /// <summary>One config's claim on a button: its GUID and requested delays.</summary>
-    public struct ButtonBinding
-    {
-        public string ConfigGuid;
-        public ButtonTimings Timings;
-
-        public ButtonBinding(string configGuid, ButtonTimings timings)
-        {
-            ConfigGuid = configGuid;
-            Timings = timings;
-        }
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -12,18 +12,10 @@ namespace MobiFlight
     /// </summary>
     public class SyntheticButtonEventGenerator : IDisposable
     {
-        /// <summary>Fallback timing when <see cref="ResolveTimings"/> is unset or has no match.</summary>
-        public int HoldDelay { get; set; } = 350; // ms
-
-        /// <summary>Fallback, see <see cref="HoldDelay"/>.</summary>
-        public int LongReleaseDelay { get; set; } = 350; // ms
-
-        /// <summary>Fallback, see <see cref="HoldDelay"/>. 0 disables repeating.</summary>
-        public int RepeatDelay { get; set; } = 0; // ms
-
         /// <summary>
         /// Resolves every config currently bound to a button and its delays. Resolved once at
-        /// PRESS, held for that press's lifecycle. Empty/null uses the fallback values above.
+        /// PRESS, held for that press's lifecycle. Null or empty means no config is bound - no
+        /// synthetic events for that button at all.
         /// </summary>
         public Func<InputEventArgs, List<ButtonBinding>> ResolveTimings { get; set; }
 
@@ -52,6 +44,7 @@ namespace MobiFlight
 
         /// <param name="now">Clock for timing decisions; tests inject a fake one.</param>
         /// <param name="tickIntervalMs">Poll interval while at least one button is pressed. Idle otherwise.</param>
+        /// <remarks>Wire <see cref="ResolveTimings"/> before feeding events through - without it, nothing is ever bound and no synthetic events fire.</remarks>
         public SyntheticButtonEventGenerator(Func<DateTime> now = null, int tickIntervalMs = 20)
         {
             _now = now ?? (() => DateTime.Now);
@@ -64,7 +57,8 @@ namespace MobiFlight
         /// <summary>
         /// Feed one real PRESS/RELEASE through. Returns the event(s) to forward: one untargeted
         /// event for PRESS; one per bound config for RELEASE, each classified RELEASE/LONG_RELEASE
-        /// against that config's own delay.
+        /// against that config's own delay. A button with no bound config passes PRESS/RELEASE
+        /// through untouched and is never tracked for HOLD/REPEAT/LONG_RELEASE.
         /// </summary>
         public List<InputEventArgs> Observe(InputEventArgs e)
         {
@@ -88,7 +82,8 @@ namespace MobiFlight
                 var bindings = ResolveTimings?.Invoke(e);
                 if (bindings == null || bindings.Count == 0)
                 {
-                    bindings = new List<ButtonBinding> { new ButtonBinding(null, new ButtonTimings(HoldDelay, RepeatDelay, LongReleaseDelay)) };
+                    // No config bound to this button - no synthetic events at all.
+                    return new List<InputEventArgs> { e };
                 }
 
                 lock (_lock)

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -143,7 +143,7 @@ namespace MobiFlight
                 {
                     var tracked = kvp.Value;
                     var dueHoldDelays = new HashSet<int>();
-                    var dueRepeatDelays = new HashSet<int>();
+                    var dueRepeatTimings = new HashSet<ButtonTimings>();
 
                     foreach (var binding in tracked.Bindings)
                     {
@@ -161,7 +161,7 @@ namespace MobiFlight
                             else if (binding.Timings.RepeatDelay > 0 && (now - binding.LastHoldFire) >= TimeSpan.FromMilliseconds(binding.Timings.RepeatDelay))
                             {
                                 binding.LastHoldFire = now;
-                                dueRepeatDelays.Add(binding.Timings.RepeatDelay);
+                                dueRepeatTimings.Add(binding.Timings);
                             }
                         }
                         catch (Exception ex)
@@ -170,13 +170,16 @@ namespace MobiFlight
                         }
                     }
 
-                    // One raised event per distinct delay value, not per binding - bindings sharing a
-                    // delay become due on the same tick (same PressedAt) and share one event.
+                    // One raised event per distinct HoldDelay (HOLD) or (HoldDelay, RepeatDelay) pair
+                    // (REPEAT), not per binding - bindings sharing a key become due on the same tick
+                    // (same PressedAt) and share one event. REPEAT keys on the pair, not RepeatDelay
+                    // alone, so two bindings sharing a RepeatDelay but not a HoldDelay stay distinct -
+                    // otherwise one could start repeating before the other's own HoldDelay elapsed.
                     foreach (var holdDelay in dueHoldDelays)
                         dueHold.Add(Classify(tracked.LastPress, MobiFlightButton.InputEvent.HOLD, holdDelay));
 
-                    foreach (var repeatDelay in dueRepeatDelays)
-                        dueRepeat.Add(Classify(tracked.LastPress, MobiFlightButton.InputEvent.REPEAT, repeatDelay));
+                    foreach (var timings in dueRepeatTimings)
+                        dueRepeat.Add(ClassifyRepeat(tracked.LastPress, timings));
                 }
             }
 
@@ -190,6 +193,13 @@ namespace MobiFlight
             var e = lastPress.CloneWithLabel();
             e.Value = (int)value;
             e.SyntheticDelayMs = delayMs;
+            return e;
+        }
+
+        private static InputEventArgs ClassifyRepeat(InputEventArgs lastPress, ButtonTimings timings)
+        {
+            var e = Classify(lastPress, MobiFlightButton.InputEvent.REPEAT, timings.RepeatDelay);
+            e.SyntheticHoldDelayMs = timings.HoldDelay;
             return e;
         }
 

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -256,9 +256,6 @@ namespace MobiFlight
     /// </summary>
     public struct ButtonTimings
     {
-        /// <summary>Not enforced here - reserved for config-authoring-time (UI) validation.</summary>
-        public const int MinRepeatDelay = 100; // ms
-
         /// <summary>HoldDelay sentinel meaning "never fires HOLD/REPEAT" - use when no onHold is defined, so a config that doesn't want it can't keep it alive for the whole button.</summary>
         public const int NoHold = int.MaxValue;
 
@@ -270,8 +267,5 @@ namespace MobiFlight
             HoldDelay = holdDelay;
             RepeatDelay = repeatDelay;
         }
-
-        public static int ClampRepeatDelay(int repeatDelay) =>
-            repeatDelay > 0 && repeatDelay < MinRepeatDelay ? MinRepeatDelay : repeatDelay;
     }
 }

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -259,6 +259,12 @@ namespace MobiFlight
         /// <summary>Not enforced here - reserved for config-authoring-time (UI) validation.</summary>
         public const int MinRepeatDelay = 100; // ms
 
+        /// <summary>HoldDelay sentinel meaning "never fires HOLD/REPEAT" - use when no onHold is defined, so a config that doesn't want it can't keep it alive for the whole button.</summary>
+        public const int NoHold = int.MaxValue;
+
+        /// <summary>LongReleaseDelay sentinel meaning "never reclassifies as LONG_RELEASE" - use when no onLongRelease is defined, since onRelease dispatches identically either way (see ButtonInputConfig.ResolveDispatchedEvent).</summary>
+        public const int NoLongRelease = int.MaxValue;
+
         public int HoldDelay;
         public int RepeatDelay;
         public int LongReleaseDelay;

--- a/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
+++ b/src/MobiFlightConnector/MobiFlight/SyntheticButtonEventGenerator.cs
@@ -6,24 +6,24 @@ using System.Timers;
 namespace MobiFlight
 {
     /// <summary>
-    /// Produces HOLD/REPEAT/LONG_RELEASE from a controller's raw PRESS/RELEASE events. Owned by a
-    /// controller manager (MobiFlightCache/JoystickManager/MidiBoardManager) and wired into its
-    /// OnButtonPressed funnel, so downstream code sees virtual events exactly like real ones. See
-    /// docs/architecture/virtual-button-events.md.
+    /// Produces HOLD/REPEAT from a controller's raw PRESS/RELEASE events, and stamps RELEASE with how
+    /// long the button was held. Owned by a controller manager (MobiFlightCache/JoystickManager/
+    /// MidiBoardManager) and wired into its OnButtonPressed funnel, so downstream code sees virtual
+    /// events exactly like real ones. See docs/architecture/virtual-button-events.md.
     /// </summary>
     public class SyntheticButtonEventGenerator : IDisposable
     {
         /// <summary>
-        /// The distinct Hold/Repeat/LongRelease delay settings among configs currently bound to a
-        /// button. Resolved once at PRESS, held for that press's lifecycle. Null or empty means no
-        /// config is bound - no synthetic events for that button at all. No config identity is
-        /// carried - a config later decides an event is its own by matching its own delay (see
+        /// The distinct Hold/Repeat delay settings among configs currently bound to a button. Resolved
+        /// once at PRESS, held for that press's lifecycle. Null or empty means no config is bound - no
+        /// HOLD/REPEAT for that button at all. No config identity is carried - a config later decides
+        /// a HOLD/REPEAT is its own by matching its own delay (see
         /// ButtonInputConfig.MatchesSyntheticDelay), so two configs sharing a delay are
         /// indistinguishable here by design and share one raised event.
         /// </summary>
         public Func<InputEventArgs, List<ButtonTimings>> ResolveTimings { get; set; }
 
-        /// <summary>Raised for HOLD/REPEAT. LONG_RELEASE is classified in-place by <see cref="Observe"/> instead.</summary>
+        /// <summary>Raised for HOLD/REPEAT.</summary>
         public event EventHandler<InputEventArgs> OnSyntheticEvent;
 
         private class BindingState
@@ -58,11 +58,13 @@ namespace MobiFlight
         private static string KeyFor(InputEventArgs e) => $"{e.Controller?.Serial}:{e.Device?.Name}";
 
         /// <summary>
-        /// Feed one real PRESS/RELEASE through. Returns the event(s) to forward: one untargeted
-        /// event for PRESS; for RELEASE, one event per distinct LongReleaseDelay among bound configs
-        /// (configs sharing a delay always agree on RELEASE vs LONG_RELEASE, so they share one event).
-        /// A button with no bound config passes PRESS/RELEASE through untouched and is never tracked
-        /// for HOLD/REPEAT/LONG_RELEASE.
+        /// Feed one real PRESS/RELEASE through. PRESS and RELEASE are each always forwarded exactly
+        /// once, untouched except RELEASE also carries HeldDurationMs - LONG_RELEASE is not decided
+        /// here at all; it's a per-config dispatch-time decision (see
+        /// ButtonInputConfig.ResolveDispatchedEvent) based on that duration, so the raw "an event was
+        /// raised" record for RELEASE can't disagree with itself depending on which configs happen to
+        /// be bound. A button with no bound config passes PRESS/RELEASE through untouched and is never
+        /// tracked for HOLD/REPEAT.
         /// </summary>
         public List<InputEventArgs> Observe(InputEventArgs e)
         {
@@ -86,7 +88,7 @@ namespace MobiFlight
                 var timings = ResolveTimings?.Invoke(e);
                 if (timings == null || timings.Count == 0)
                 {
-                    // No config bound to this button - no synthetic events at all.
+                    // No config bound to this button - no HOLD/REPEAT at all.
                     return new List<InputEventArgs> { e };
                 }
 
@@ -120,21 +122,9 @@ namespace MobiFlight
                     return new List<InputEventArgs> { e };
                 }
 
-                var now = _now();
-                var result = new List<InputEventArgs>();
-                // Grouped by LongReleaseDelay - configs sharing a delay always agree on RELEASE vs
-                // LONG_RELEASE (same elapsed time, same threshold), so they share one raised event.
-                foreach (var longReleaseDelay in tracked.Bindings.Select(b => b.Timings.LongReleaseDelay).Distinct())
-                {
-                    var classified = e.CloneWithLabel();
-                    if ((now - tracked.PressedAt) > TimeSpan.FromMilliseconds(longReleaseDelay))
-                    {
-                        classified.Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE;
-                        classified.SyntheticDelayMs = longReleaseDelay;
-                    }
-                    result.Add(classified);
-                }
-                return result;
+                var classified = e.CloneWithLabel();
+                classified.HeldDurationMs = (int)(_now() - tracked.PressedAt).TotalMilliseconds;
+                return new List<InputEventArgs> { classified };
             }
 
             return new List<InputEventArgs> { e };
@@ -249,9 +239,9 @@ namespace MobiFlight
     }
 
     /// <summary>
-    /// Hold/Repeat/LongRelease delays for one button press, one config. Intentionally unclamped here -
-    /// RepeatDelay validation belongs at config authoring time (UI), not runtime evaluation, so a
-    /// config's own value and what the generator schedules/matches against always agree. See
+    /// Hold/Repeat delays for one button press, one config. Intentionally unclamped here - RepeatDelay
+    /// validation belongs at config authoring time (UI), not runtime evaluation, so a config's own
+    /// value and what the generator schedules/matches against always agree. See
     /// <see cref="SyntheticButtonEventGenerator.ResolveTimings"/>.
     /// </summary>
     public struct ButtonTimings
@@ -262,18 +252,13 @@ namespace MobiFlight
         /// <summary>HoldDelay sentinel meaning "never fires HOLD/REPEAT" - use when no onHold is defined, so a config that doesn't want it can't keep it alive for the whole button.</summary>
         public const int NoHold = int.MaxValue;
 
-        /// <summary>LongReleaseDelay sentinel meaning "never reclassifies as LONG_RELEASE" - use when no onLongRelease is defined, since onRelease dispatches identically either way (see ButtonInputConfig.ResolveDispatchedEvent).</summary>
-        public const int NoLongRelease = int.MaxValue;
-
         public int HoldDelay;
         public int RepeatDelay;
-        public int LongReleaseDelay;
 
-        public ButtonTimings(int holdDelay, int repeatDelay, int longReleaseDelay)
+        public ButtonTimings(int holdDelay, int repeatDelay)
         {
             HoldDelay = holdDelay;
             RepeatDelay = repeatDelay;
-            LongReleaseDelay = longReleaseDelay;
         }
 
         public static int ClampRepeatDelay(int repeatDelay) =>

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -722,10 +722,10 @@ namespace MobiFlight.Execution.Tests
 
         #endregion
 
-        #region ResolveButtonTimingsPerConfig - delay, and which config, are per binding
+        #region ResolveButtonTimingsPerConfig - distinct delay settings among bound configs
 
         [TestMethod]
-        public void ResolveButtonTimingsPerConfig_ActiveConfig_ReturnsItsDelaysTargetedAtIt()
+        public void ResolveButtonTimingsPerConfig_ActiveConfig_ReturnsItsDelays()
         {
             var serial = "SN-timings001";
             var deviceName = "Button1";
@@ -740,20 +740,18 @@ namespace MobiFlight.Execution.Tests
                 {
                     onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
                     HoldDelay = 123,
-                    RepeatDelay = 45, // below ButtonTimings.MinRepeatDelay - e.g. an old/hand-edited config
+                    RepeatDelay = 45, // below ButtonTimings.MinRepeatDelay - not enforced here, that's a config-authoring-time (UI) concern
                     LongReleaseDelay = 678
                 }
             };
             _configItems.Add(configItem);
 
-            var bindings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            var timings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
 
-            Assert.HasCount(1, bindings);
-            Assert.AreEqual(configItem.GUID, bindings[0].ConfigGuid);
-            Assert.AreEqual(123, bindings[0].Timings.HoldDelay, "HoldDelay is not clamped.");
-            Assert.AreEqual(ButtonTimings.MinRepeatDelay, bindings[0].Timings.RepeatDelay,
-                "The stored 45ms RepeatDelay must be raised to the floor - ButtonTimings' constructor clamps it regardless of where the value came from.");
-            Assert.AreEqual(678, bindings[0].Timings.LongReleaseDelay, "LongReleaseDelay is not clamped.");
+            Assert.HasCount(1, timings);
+            Assert.AreEqual(123, timings[0].HoldDelay);
+            Assert.AreEqual(45, timings[0].RepeatDelay, "No runtime clamping - the config's own value is used as-is.");
+            Assert.AreEqual(678, timings[0].LongReleaseDelay);
         }
 
         [TestMethod]
@@ -786,8 +784,7 @@ namespace MobiFlight.Execution.Tests
             var result = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
 
             Assert.HasCount(1, result, "An inactive config is still bound to the button and must still get a timing binding.");
-            Assert.AreEqual(configItem.GUID, result[0].ConfigGuid);
-            Assert.AreEqual(999, result[0].Timings.HoldDelay);
+            Assert.AreEqual(999, result[0].HoldDelay);
         }
 
         [TestMethod]
@@ -829,19 +826,19 @@ namespace MobiFlight.Execution.Tests
             _configItems.Add(modeAConfig);
             _configItems.Add(modeBConfig);
 
-            var bindingsInModeA = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
-            Assert.HasCount(2, bindingsInModeA, "Both configs are bound to this button regardless of which mode is currently selected.");
-            Assert.AreEqual(200, bindingsInModeA.Single(b => b.ConfigGuid == modeAConfig.GUID).Timings.HoldDelay);
-            Assert.AreEqual(800, bindingsInModeA.Single(b => b.ConfigGuid == modeBConfig.GUID).Timings.HoldDelay);
+            var timingsInModeA = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            Assert.HasCount(2, timingsInModeA, "Both configs are bound to this button regardless of which mode is currently selected.");
+            Assert.IsTrue(timingsInModeA.Any(t => t.HoldDelay == 200));
+            Assert.IsTrue(timingsInModeA.Any(t => t.HoldDelay == 800));
 
-            modeSwitch.Value = "ModeB"; // resolving bindings no longer depends on this at all
+            modeSwitch.Value = "ModeB"; // resolving timings no longer depends on this at all
 
-            var bindingsInModeB = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
-            Assert.HasCount(2, bindingsInModeB, "Switching modes doesn't change which configs are bound - only Execute() cares about the current mode.");
+            var timingsInModeB = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            Assert.HasCount(2, timingsInModeB, "Switching modes doesn't change which configs are bound - only Execute() cares about the current mode.");
         }
 
         [TestMethod]
-        public void ResolveButtonTimingsPerConfig_TwoSimultaneouslyActiveConfigs_ReturnsBothTargetedIndependently()
+        public void ResolveButtonTimingsPerConfig_TwoSimultaneouslyActiveConfigs_ReturnsBoth()
         {
             var serial = "SN-conflict001";
             var deviceName = "Button1";
@@ -865,30 +862,60 @@ namespace MobiFlight.Execution.Tests
             _configItems.Add(firstConfig);
             _configItems.Add(secondConfig);
 
-            var bindings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            var timings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
 
-            Assert.HasCount(2, bindings);
-            Assert.AreEqual(100, bindings.Single(b => b.ConfigGuid == firstConfig.GUID).Timings.HoldDelay);
-            Assert.AreEqual(900, bindings.Single(b => b.ConfigGuid == secondConfig.GUID).Timings.HoldDelay);
+            Assert.HasCount(2, timings);
+            Assert.IsTrue(timings.Any(t => t.HoldDelay == 100));
+            Assert.IsTrue(timings.Any(t => t.HoldDelay == 900));
         }
 
-        #endregion
-
-        #region TargetConfigGUID - a HOLD/REPEAT/LONG_RELEASE targeted at one config skips the others
-
         [TestMethod]
-        public void Execute_TargetedEvent_OnlyExecutesTheTargetedConfig()
+        public void ResolveButtonTimingsPerConfig_TwoConfigsWithIdenticalSettings_ReturnsOneDistinctEntry()
         {
-            var serial = "SN-target001";
+            var serial = "SN-identical001";
             var deviceName = "Button1";
 
-            var targeted = new InputConfigItem
+            var firstConfig = new InputConfigItem
             {
                 Active = true,
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
-                Name = "TargetedConfig",
-                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
+                Name = "FirstConfig",
+                button = new ButtonInputConfig { HoldDelay = 350, RepeatDelay = 0, LongReleaseDelay = 350 }
+            };
+            var secondConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "SecondConfig",
+                button = new ButtonInputConfig { HoldDelay = 350, RepeatDelay = 0, LongReleaseDelay = 350 }
+            };
+            _configItems.Add(firstConfig);
+            _configItems.Add(secondConfig);
+
+            var timings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+
+            Assert.HasCount(1, timings, "Two configs with identical settings collapse to one distinct entry - no config identity is carried here.");
+        }
+
+        #endregion
+
+        #region MatchesSyntheticDelay - a HOLD/REPEAT/LONG_RELEASE only applies to a config whose own delay produced it
+
+        [TestMethod]
+        public void Execute_HoldEvent_OnlyExecutesTheConfigWhoseOwnDelayMatches()
+        {
+            var serial = "SN-target001";
+            var deviceName = "Button1";
+
+            var matching = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "MatchingConfig",
+                button = new ButtonInputConfig { HoldDelay = 300, onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
             };
             var other = new InputConfigItem
             {
@@ -896,22 +923,22 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "OtherConfig",
-                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" } }
+                button = new ButtonInputConfig { HoldDelay = 900, onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" } }
             };
-            _configItems.Add(targeted);
+            _configItems.Add(matching);
             _configItems.Add(other);
 
             var holdEvent = CreateHoldEventArgs(serial, deviceName);
-            holdEvent.TargetConfigGUID = targeted.GUID;
+            holdEvent.SyntheticDelayMs = 300; // matches only "matching"'s own HoldDelay
 
             var result = _executor.Execute(holdEvent, isStarted: true);
 
-            Assert.IsTrue(result.ContainsKey(targeted.GUID), "The targeted config must execute.");
-            Assert.IsFalse(result.ContainsKey(other.GUID), "A targeted event must not execute any other matching config.");
+            Assert.IsTrue(result.ContainsKey(matching.GUID), "The config whose own HoldDelay matches must execute.");
+            Assert.IsFalse(result.ContainsKey(other.GUID), "A config whose own HoldDelay doesn't match must not execute.");
         }
 
         [TestMethod]
-        public void Execute_UntargetedEvent_ExecutesEveryMatchingActiveConfig()
+        public void Execute_EventWithNoSyntheticDelay_ExecutesEveryMatchingActiveConfig()
         {
             var serial = "SN-broadcast001";
             var deviceName = "Button1";
@@ -922,7 +949,7 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "First",
-                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
+                button = new ButtonInputConfig { HoldDelay = 300, onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
             };
             var second = new InputConfigItem
             {
@@ -930,12 +957,12 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "Second",
-                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" } }
+                button = new ButtonInputConfig { HoldDelay = 900, onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" } }
             };
             _configItems.Add(first);
             _configItems.Add(second);
 
-            // TargetConfigGUID left null, e.g. a real PRESS/RELEASE - must still broadcast to both.
+            // SyntheticDelayMs left null, e.g. a real PRESS/RELEASE - nothing to match, so it broadcasts to both.
             var result = _executor.Execute(CreateHoldEventArgs(serial, deviceName), isStarted: true);
 
             Assert.IsTrue(result.ContainsKey(first.GUID));

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -739,6 +739,7 @@ namespace MobiFlight.Execution.Tests
                 button = new ButtonInputConfig
                 {
                     onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
+                    onLongRelease = new MSFS2020CustomInputAction { Command = "(>K:LongReleaseCommand)", PresetId = "p2" },
                     HoldDelay = 123,
                     RepeatDelay = 45, // below ButtonTimings.MinRepeatDelay - not enforced here, that's a config-authoring-time (UI) concern
                     LongReleaseDelay = 678
@@ -752,6 +753,124 @@ namespace MobiFlight.Execution.Tests
             Assert.AreEqual(123, timings[0].HoldDelay);
             Assert.AreEqual(45, timings[0].RepeatDelay, "No runtime clamping - the config's own value is used as-is.");
             Assert.AreEqual(678, timings[0].LongReleaseDelay);
+        }
+
+        [TestMethod]
+        public void ResolveButtonTimingsPerConfig_ConfigWithoutOnHoldOrOnLongRelease_ContributesSentinelsNotUnusedDefaults()
+        {
+            // A config with only onRelease has unused HoldDelay/LongReleaseDelay fields still sitting
+            // at their defaults (350/350). Contributing those would keep HOLD/REPEAT/LONG_RELEASE alive
+            // for the whole button even after every config that actually wanted them is gone.
+            var serial = "SN-timings003";
+            var deviceName = "Button1";
+
+            var configItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ReleaseOnlyConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new MSFS2020CustomInputAction { Command = "(>K:ReleaseCommand)", PresetId = "p1" }
+                    // onHold/onLongRelease left null; their delays stay at unused defaults (350/0/350).
+                }
+            };
+            _configItems.Add(configItem);
+
+            var timings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+
+            Assert.HasCount(1, timings);
+            Assert.AreEqual(ButtonTimings.NoHold, timings[0].HoldDelay, "No onHold - HoldDelay must be disabled, not the unused 350 default.");
+            Assert.AreEqual(0, timings[0].RepeatDelay);
+            Assert.AreEqual(ButtonTimings.NoLongRelease, timings[0].LongReleaseDelay,
+                "No onLongRelease - onRelease dispatches identically either way, so LongReleaseDelay must be disabled too, not the unused 350 default.");
+        }
+
+        [TestMethod]
+        public void ResolveButtonTimingsPerConfig_DeletingTheOnlyOnHoldConfig_LeavesNoHoldBindingForTheButton()
+        {
+            var serial = "SN-timings004";
+            var deviceName = "Button1";
+
+            var holdConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "HoldConfig",
+                button = new ButtonInputConfig
+                {
+                    onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
+                    HoldDelay = 300
+                }
+            };
+            var releaseConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ReleaseConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new MSFS2020CustomInputAction { Command = "(>K:ReleaseCommand)", PresetId = "p2" }
+                }
+            };
+            _configItems.Add(holdConfig);
+            _configItems.Add(releaseConfig);
+
+            var beforeDelete = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            Assert.IsTrue(beforeDelete.Any(t => t.HoldDelay == 300), "HoldConfig's own HoldDelay must be present while it's bound.");
+
+            _configItems.Remove(holdConfig);
+            _executor.ClearCache(); // same invalidation ExecutionManager now performs on delete
+
+            var afterDelete = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            Assert.IsFalse(afterDelete.Any(t => t.HoldDelay != ButtonTimings.NoHold),
+                "No remaining config defines onHold - nothing should be able to fire HOLD/REPEAT for this button anymore.");
+        }
+
+        [TestMethod]
+        public void ResolveButtonTimingsPerConfig_DeletingTheOnlyOnLongReleaseConfig_LeavesNoLongReleaseBindingForTheButton()
+        {
+            var serial = "SN-timings005";
+            var deviceName = "Button1";
+
+            var longReleaseConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "LongReleaseConfig",
+                button = new ButtonInputConfig
+                {
+                    onLongRelease = new MSFS2020CustomInputAction { Command = "(>K:LongReleaseCommand)", PresetId = "p1" },
+                    LongReleaseDelay = 300
+                }
+            };
+            var releaseConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ReleaseConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new MSFS2020CustomInputAction { Command = "(>K:ReleaseCommand)", PresetId = "p2" }
+                }
+            };
+            _configItems.Add(longReleaseConfig);
+            _configItems.Add(releaseConfig);
+
+            var beforeDelete = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            Assert.IsTrue(beforeDelete.Any(t => t.LongReleaseDelay == 300), "LongReleaseConfig's own LongReleaseDelay must be present while it's bound.");
+
+            _configItems.Remove(longReleaseConfig);
+            _executor.ClearCache();
+
+            var afterDelete = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
+            Assert.IsFalse(afterDelete.Any(t => t.LongReleaseDelay != ButtonTimings.NoLongRelease),
+                "No remaining config defines onLongRelease - nothing should be able to reclassify RELEASE as LONG_RELEASE for this button anymore.");
         }
 
         [TestMethod]
@@ -777,7 +896,7 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "InactiveConfig",
-                button = new ButtonInputConfig { HoldDelay = 999 }
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" }, HoldDelay = 999 }
             };
             _configItems.Add(configItem);
 
@@ -805,7 +924,7 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "ModeAConfig",
-                button = new ButtonInputConfig { HoldDelay = 200 },
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" }, HoldDelay = 200 },
                 Preconditions = new PreconditionList
                 {
                     new Precondition { Type = "config", Active = true, Ref = modeSwitch.GUID, Value = "ModeA" }
@@ -817,7 +936,7 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "ModeBConfig",
-                button = new ButtonInputConfig { HoldDelay = 800 },
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" }, HoldDelay = 800 },
                 Preconditions = new PreconditionList
                 {
                     new Precondition { Type = "config", Active = true, Ref = modeSwitch.GUID, Value = "ModeB" }
@@ -849,7 +968,7 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "FirstConfig",
-                button = new ButtonInputConfig { HoldDelay = 100 }
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" }, HoldDelay = 100 }
             };
             var secondConfig = new InputConfigItem
             {
@@ -857,7 +976,7 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "SecondConfig",
-                button = new ButtonInputConfig { HoldDelay = 900 }
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" }, HoldDelay = 900 }
             };
             _configItems.Add(firstConfig);
             _configItems.Add(secondConfig);
@@ -935,6 +1054,37 @@ namespace MobiFlight.Execution.Tests
 
             Assert.IsTrue(result.ContainsKey(matching.GUID), "The config whose own HoldDelay matches must execute.");
             Assert.IsFalse(result.ContainsKey(other.GUID), "A config whose own HoldDelay doesn't match must not execute.");
+        }
+
+        [TestMethod]
+        public void Execute_HoldEvent_RawValueAndExecutingLogDoNotShowTheDelay()
+        {
+            // The delay is shown exactly once, in the raw "an event was raised" log line - not
+            // repeated in RawValue or the per-config "Executing" line.
+            var serial = "SN-nodelay001";
+            var deviceName = "Button1";
+
+            var configItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "TestConfig",
+                button = new ButtonInputConfig { HoldDelay = 300, onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
+            };
+            _configItems.Add(configItem);
+
+            var holdEvent = CreateHoldEventArgs(serial, deviceName);
+            holdEvent.SyntheticDelayMs = 300;
+
+            _executor.Execute(holdEvent, isStarted: true);
+
+            Assert.AreEqual("HOLD", configItem.RawValue);
+
+            _mockLogAppender.Verify(
+                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Executing ""{configItem.Name}"". (HOLD)")), LogSeverity.Info),
+                Times.Once
+            );
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -549,6 +549,82 @@ namespace MobiFlight.Execution.Tests
         }
 
         [TestMethod]
+        public void Execute_PhysicalReleaseOnConfigWithoutMatchingAction_StillUpdatesRawValue()
+        {
+            // RELEASE is a real physical event - even a config with nothing bound to it (onPress
+            // only, here) should still show it happened, since it's genuine hardware state. No
+            // "Executing" log though, since nothing actually fired.
+            var inputEventArgs = new InputEventArgs
+            {
+                Controller = new Controller() { Serial = "123" },
+                InputType = DeviceType.Button,
+                Device = new DeviceReference() { Name = "Device1" },
+                Value = (int)MobiFlightButton.InputEvent.RELEASE
+            };
+
+            var pressOnlyConfigItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("/ 123"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
+                Name = "PressOnlyConfig",
+                button = new ButtonInputConfig
+                {
+                    onPress = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                }
+            };
+
+            _configItems.Add(pressOnlyConfigItem);
+
+            var result = _executor.Execute(inputEventArgs, isStarted: true);
+
+            Assert.IsTrue(result.ContainsKey(pressOnlyConfigItem.GUID));
+            Assert.AreEqual("RELEASE", pressOnlyConfigItem.RawValue);
+
+            _mockLogAppender.Verify(
+                appender => appender.log(It.Is<string>(msg => msg.Contains("Executing")), It.IsAny<LogSeverity>()),
+                Times.Never,
+                "Nothing was actually triggered - only RawValue reflects the physical event."
+            );
+        }
+
+        [TestMethod]
+        public void Execute_HoldEvent_ConfigWithoutMatchingAction_DoesNotUpdateRawValue()
+        {
+            // Unlike a physical RELEASE, a synthetic HOLD has no standing of its own - a config with
+            // no onHold must not show HOLD in RawValue just because it received the broadcast.
+            var serial = "SN-holdnomatch001";
+            var deviceName = "Button1";
+
+            var releaseOnlyConfigItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ReleaseOnlyConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                }
+            };
+            _configItems.Add(releaseOnlyConfigItem);
+
+            var holdEvent = CreateHoldEventArgs(serial, deviceName);
+            holdEvent.SyntheticDelayMs = 350;
+
+            var result = _executor.Execute(holdEvent, isStarted: true);
+
+            Assert.IsFalse(result.ContainsKey(releaseOnlyConfigItem.GUID));
+            Assert.IsNull(releaseOnlyConfigItem.RawValue);
+        }
+
+        [TestMethod]
         public void Execute_NotStarted_LogsPerConfigWithItsOwnResolvedEvent()
         {
             // Two configs on the same button, one bound only to onRelease, one only to onLongRelease -
@@ -1275,6 +1351,52 @@ namespace MobiFlight.Execution.Tests
                 appender => appender.log(It.Is<string>(msg => msg.Contains($@"Executing ""{configItem.Name}"". (HOLD:300ms)")), LogSeverity.Info),
                 Times.Once
             );
+        }
+
+        [TestMethod]
+        public void Execute_HoldEvent_ConfigWithoutOnHold_NeverExecutesOrUpdatesRawValue()
+        {
+            // A config with no onHold at all still has some HoldDelay field value (its unused
+            // default), which can coincidentally equal another config's real HoldDelay. It must never
+            // execute, and RawValue must never show HOLD for it - only an event that actually
+            // triggered its own action may touch RawValue.
+            var serial = "SN-noonhold001";
+            var deviceName = "Button1";
+
+            var withHold = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "WithHold",
+                button = new ButtonInputConfig { HoldDelay = 350, onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
+            };
+            var releaseOnly = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "ReleaseOnly",
+                // No onHold - HoldDelay keeps its unused default (350), same as WithHold's real one.
+                button = new ButtonInputConfig
+                {
+                    onRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                }
+            };
+            _configItems.Add(withHold);
+            _configItems.Add(releaseOnly);
+
+            var holdEvent = CreateHoldEventArgs(serial, deviceName);
+            holdEvent.SyntheticDelayMs = 350;
+
+            var result = _executor.Execute(holdEvent, isStarted: true);
+
+            Assert.IsTrue(result.ContainsKey(withHold.GUID));
+            Assert.IsFalse(result.ContainsKey(releaseOnly.GUID), "ReleaseOnly has no onHold - a HOLD event must never reach it.");
+            Assert.IsNull(releaseOnly.RawValue, "RawValue must stay untouched - HOLD never triggered an action on this config.");
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -5,6 +5,7 @@ using MobiFlight.ProSim;
 using MobiFlight.SimConnectMSFS;
 using MobiFlight.xplane;
 using Moq;
+using System.Xml;
 
 namespace MobiFlight.Execution.Tests
 {
@@ -583,6 +584,7 @@ namespace MobiFlight.Execution.Tests
 
             Assert.IsTrue(result.ContainsKey(pressOnlyConfigItem.GUID));
             Assert.AreEqual("RELEASE", pressOnlyConfigItem.RawValue);
+            Assert.AreEqual("1", pressOnlyConfigItem.Value, "Value should reflect the dispatched numeric event even without a matching action.");
 
             _mockLogAppender.Verify(
                 appender => appender.log(It.Is<string>(msg => msg.Contains("Executing")), It.IsAny<LogSeverity>()),
@@ -1633,5 +1635,57 @@ namespace MobiFlight.Execution.Tests
         }
 
         #endregion
+
+        private class RecordingInputAction : InputAction
+        {
+            public InputEventArgs LastArgs;
+
+            public override void execute(CacheCollection cacheCollection, InputEventArgs args, List<ConfigRefValue> configRefs)
+            {
+                LastArgs = args;
+            }
+
+            public override object Clone() => new RecordingInputAction();
+            public override void ReadXml(XmlReader reader) { }
+            public override void WriteXml(XmlWriter writer) { }
+        }
+
+        [TestMethod]
+        public void Execute_LongReleaseEvent_ActionAndValueReflectTheDispatchedEventNotTheRawOne()
+        {
+            // The action must see Value == LONG_RELEASE, not the raw RELEASE - modifiers, and
+            // anything reading e.Value afterwards, must work off the resolved event too.
+            var longRelease = new RecordingInputAction();
+
+            var inputEventArgs = new InputEventArgs
+            {
+                Controller = new Controller() { Serial = "123" },
+                InputType = DeviceType.Button,
+                Device = new DeviceReference() { Name = "Device1" },
+                Value = (int)MobiFlightButton.InputEvent.RELEASE,
+                HeldDurationMs = 900
+            };
+
+            var configItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("/ 123"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
+                Name = "TestConfig",
+                button = new ButtonInputConfig
+                {
+                    onLongRelease = longRelease,
+                    LongReleaseDelay = 300
+                }
+            };
+
+            _configItems.Add(configItem);
+
+            _executor.Execute(inputEventArgs, isStarted: true);
+
+            Assert.IsNotNull(longRelease.LastArgs, "onLongRelease must have executed.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, longRelease.LastArgs.Value);
+            Assert.AreEqual("2", configItem.Value, "cfg.Value must reflect the dispatched LONG_RELEASE, not the raw RELEASE.");
+        }
     }
 }

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -1029,7 +1029,7 @@ namespace MobiFlight.Execution.Tests
                 {
                     onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
                     HoldDelay = 123,
-                    RepeatDelay = 45 // below ButtonTimings.MinRepeatDelay - not enforced here, that's a config-authoring-time (UI) concern
+                    RepeatDelay = 45 // a low value, unclamped - that's a config-authoring-time (UI) concern, not this layer's
                 }
             };
             _configItems.Add(configItem);

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -136,7 +136,14 @@ namespace MobiFlight.Execution.Tests
                 Active = false,
                 Controller = SerialNumber.CreateController("/ 123"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
-                Name = "TestConfig"
+                Name = "TestConfig",
+                button = new ButtonInputConfig
+                {
+                    onPress = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                }
             };
 
             _configItems.Add(inactiveConfigItem);
@@ -200,16 +207,18 @@ namespace MobiFlight.Execution.Tests
         }
 
         [TestMethod]
-        public void Execute_LongReleaseWithoutOwnAction_LogsAndDisplaysAsRelease()
+        public void Execute_ConfigWithoutOnLongRelease_AlwaysDispatchesReleaseRegardlessOfHeldDuration()
         {
-            // A config with only onRelease (no onLongRelease) that receives a raw LONG_RELEASE must
-            // log and display RELEASE - what actually ran - not the raw LONG_RELEASE it fell back from.
+            // The raw event is always RELEASE (never LONG_RELEASE - see SyntheticButtonEventGenerator.
+            // Observe). A config with only onRelease must dispatch/log/display RELEASE no matter how
+            // long HeldDurationMs says the button was held - it has no onLongRelease to switch to.
             var inputEventArgs = new InputEventArgs
             {
                 Controller = new Controller() { Serial = "123" },
                 InputType = DeviceType.Button,
                 Device = new DeviceReference() { Name = "Device1" },
-                Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE
+                Value = (int)MobiFlightButton.InputEvent.RELEASE,
+                HeldDurationMs = 5000
             };
 
             var activeConfigItem = new InputConfigItem
@@ -237,6 +246,91 @@ namespace MobiFlight.Execution.Tests
             _mockLogAppender.Verify(
                 appender => appender.log(It.Is<string>(msg => msg.Contains($@"Executing ""{activeConfigItem.Name}"". (RELEASE)")), LogSeverity.Info),
                 Times.Once
+            );
+        }
+
+        [TestMethod]
+        public void Execute_ConfigWithOnLongRelease_DispatchesLongReleaseWhenHeldDurationExceedsItsOwnDelay()
+        {
+            var inputEventArgs = new InputEventArgs
+            {
+                Controller = new Controller() { Serial = "123" },
+                InputType = DeviceType.Button,
+                Device = new DeviceReference() { Name = "Device1" },
+                Value = (int)MobiFlightButton.InputEvent.RELEASE,
+                HeldDurationMs = 500
+            };
+
+            var activeConfigItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("/ 123"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
+                Name = "TestConfig",
+                button = new ButtonInputConfig
+                {
+                    onLongRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    },
+                    LongReleaseDelay = 300
+                }
+            };
+
+            _configItems.Add(activeConfigItem);
+
+            var result = _executor.Execute(inputEventArgs, isStarted: true);
+
+            Assert.HasCount(1, result);
+            Assert.AreEqual("LONG_RELEASE", activeConfigItem.RawValue, "RawValue stays the bare event name.");
+
+            _mockLogAppender.Verify(
+                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Executing ""{activeConfigItem.Name}"". (LONG_RELEASE:300ms)")), LogSeverity.Info),
+                Times.Once,
+                "The log shows the configured LongReleaseDelay, not how long the button was actually held."
+            );
+        }
+
+        [TestMethod]
+        public void Execute_ConfigWithOnLongRelease_DispatchesReleaseWhenHeldDurationIsUnderItsOwnDelay()
+        {
+            var inputEventArgs = new InputEventArgs
+            {
+                Controller = new Controller() { Serial = "123" },
+                InputType = DeviceType.Button,
+                Device = new DeviceReference() { Name = "Device1" },
+                Value = (int)MobiFlightButton.InputEvent.RELEASE,
+                HeldDurationMs = 100
+            };
+
+            var activeConfigItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("/ 123"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
+                Name = "TestConfig",
+                button = new ButtonInputConfig
+                {
+                    onLongRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    },
+                    LongReleaseDelay = 300
+                }
+            };
+
+            _configItems.Add(activeConfigItem);
+
+            var result = _executor.Execute(inputEventArgs, isStarted: true);
+
+            Assert.HasCount(1, result);
+            Assert.AreEqual("RELEASE", activeConfigItem.RawValue,
+                "Under its own LongReleaseDelay - stays RELEASE, and since onRelease isn't defined here, nothing actually executes.");
+
+            _mockLogAppender.Verify(
+                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Executing ""{activeConfigItem.Name}""")), LogSeverity.Info),
+                Times.Never,
+                "onLongRelease is the only action defined, and it must not fire before its own LongReleaseDelay has elapsed."
             );
         }
 
@@ -340,6 +434,13 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController("/ 123"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
                 Name = "TestConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                },
                 Preconditions = new PreconditionList()
                 {
                     new Precondition
@@ -383,7 +484,14 @@ namespace MobiFlight.Execution.Tests
                 Active = true,
                 Controller = SerialNumber.CreateController("/ 123"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
-                Name = "TestConfig"
+                Name = "TestConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                }
             };
 
             _configItems.Add(activeConfigItem);
@@ -395,7 +503,110 @@ namespace MobiFlight.Execution.Tests
             Assert.IsEmpty(result);
 
             _mockLogAppender.Verify(
-                appender => appender.log(It.Is<string>(msg => msg.Contains("skipping, MobiFlight not running.")), LogSeverity.Warn),
+                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Skipping ""{activeConfigItem.Name}"", MobiFlight not running.")), LogSeverity.Warn),
+                Times.Once
+            );
+        }
+
+        [TestMethod]
+        public void Execute_NotStarted_ConfigWithoutMatchingAction_LogsNothing()
+        {
+            // An onPress-only config seeing a RELEASE has nothing bound for it - no skip log should
+            // fire, since nothing was ever going to happen for this event regardless of isStarted.
+            var inputEventArgs = new InputEventArgs
+            {
+                Controller = new Controller() { Serial = "123" },
+                InputType = DeviceType.Button,
+                Device = new DeviceReference() { Name = "Device1" },
+                Value = (int)MobiFlightButton.InputEvent.RELEASE
+            };
+
+            var pressOnlyConfigItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("/ 123"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
+                Name = "PressOnlyConfig",
+                button = new ButtonInputConfig
+                {
+                    onPress = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                }
+            };
+
+            _configItems.Add(pressOnlyConfigItem);
+
+            var result = _executor.Execute(inputEventArgs, isStarted: false);
+
+            Assert.IsEmpty(result);
+
+            _mockLogAppender.Verify(
+                appender => appender.log(It.IsAny<string>(), It.IsAny<LogSeverity>()),
+                Times.Never
+            );
+        }
+
+        [TestMethod]
+        public void Execute_NotStarted_LogsPerConfigWithItsOwnResolvedEvent()
+        {
+            // Two configs on the same button, one bound only to onRelease, one only to onLongRelease -
+            // when MobiFlight isn't running, each must still be skipped with its own resolved label
+            // (RELEASE vs LONG_RELEASE), not a single generic message for the whole button.
+            var inputEventArgs = new InputEventArgs
+            {
+                Controller = new Controller() { Serial = "123" },
+                InputType = DeviceType.Button,
+                Device = new DeviceReference() { Name = "Device1" },
+                Value = (int)MobiFlightButton.InputEvent.RELEASE,
+                HeldDurationMs = 900
+            };
+
+            var releaseConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("/ 123"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
+                Name = "ReleaseConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                }
+            };
+
+            var longReleaseConfig = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("/ 123"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
+                Name = "LongReleaseConfig",
+                button = new ButtonInputConfig
+                {
+                    onLongRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    },
+                    LongReleaseDelay = 300
+                }
+            };
+
+            _configItems.Add(releaseConfig);
+            _configItems.Add(longReleaseConfig);
+
+            var result = _executor.Execute(inputEventArgs, isStarted: false);
+
+            Assert.IsEmpty(result);
+
+            _mockLogAppender.Verify(
+                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Skipping ""{releaseConfig.Name}"", MobiFlight not running.") && msg.Contains("RELEASE") && !msg.Contains("LONG_RELEASE")), LogSeverity.Warn),
+                Times.Once
+            );
+            _mockLogAppender.Verify(
+                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Skipping ""{longReleaseConfig.Name}"", MobiFlight not running.") && msg.Contains("LONG_RELEASE:300ms")), LogSeverity.Warn),
                 Times.Once
             );
         }
@@ -739,10 +950,8 @@ namespace MobiFlight.Execution.Tests
                 button = new ButtonInputConfig
                 {
                     onHold = new MSFS2020CustomInputAction { Command = "(>K:HoldCommand)", PresetId = "p1" },
-                    onLongRelease = new MSFS2020CustomInputAction { Command = "(>K:LongReleaseCommand)", PresetId = "p2" },
                     HoldDelay = 123,
-                    RepeatDelay = 45, // below ButtonTimings.MinRepeatDelay - not enforced here, that's a config-authoring-time (UI) concern
-                    LongReleaseDelay = 678
+                    RepeatDelay = 45 // below ButtonTimings.MinRepeatDelay - not enforced here, that's a config-authoring-time (UI) concern
                 }
             };
             _configItems.Add(configItem);
@@ -752,15 +961,14 @@ namespace MobiFlight.Execution.Tests
             Assert.HasCount(1, timings);
             Assert.AreEqual(123, timings[0].HoldDelay);
             Assert.AreEqual(45, timings[0].RepeatDelay, "No runtime clamping - the config's own value is used as-is.");
-            Assert.AreEqual(678, timings[0].LongReleaseDelay);
         }
 
         [TestMethod]
-        public void ResolveButtonTimingsPerConfig_ConfigWithoutOnHoldOrOnLongRelease_ContributesSentinelsNotUnusedDefaults()
+        public void ResolveButtonTimingsPerConfig_ConfigWithoutOnHold_ContributesSentinelNotUnusedDefault()
         {
-            // A config with only onRelease has unused HoldDelay/LongReleaseDelay fields still sitting
-            // at their defaults (350/350). Contributing those would keep HOLD/REPEAT/LONG_RELEASE alive
-            // for the whole button even after every config that actually wanted them is gone.
+            // A config with only onRelease has unused HoldDelay/RepeatDelay fields still sitting at
+            // their defaults (350/0). Contributing those would keep HOLD/REPEAT alive for the whole
+            // button even after every config that actually wanted them is gone.
             var serial = "SN-timings003";
             var deviceName = "Button1";
 
@@ -773,18 +981,14 @@ namespace MobiFlight.Execution.Tests
                 button = new ButtonInputConfig
                 {
                     onRelease = new MSFS2020CustomInputAction { Command = "(>K:ReleaseCommand)", PresetId = "p1" }
-                    // onHold/onLongRelease left null; their delays stay at unused defaults (350/0/350).
+                    // onHold left null; HoldDelay/RepeatDelay stay at unused defaults (350/0).
                 }
             };
             _configItems.Add(configItem);
 
             var timings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
 
-            Assert.HasCount(1, timings);
-            Assert.AreEqual(ButtonTimings.NoHold, timings[0].HoldDelay, "No onHold - HoldDelay must be disabled, not the unused 350 default.");
-            Assert.AreEqual(0, timings[0].RepeatDelay);
-            Assert.AreEqual(ButtonTimings.NoLongRelease, timings[0].LongReleaseDelay,
-                "No onLongRelease - onRelease dispatches identically either way, so LongReleaseDelay must be disabled too, not the unused 350 default.");
+            Assert.HasCount(0, timings, "No onHold anywhere on this button - it isn't bound for HOLD/REPEAT purposes at all.");
         }
 
         [TestMethod]
@@ -826,13 +1030,16 @@ namespace MobiFlight.Execution.Tests
             _executor.ClearCache(); // same invalidation ExecutionManager now performs on delete
 
             var afterDelete = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
-            Assert.IsFalse(afterDelete.Any(t => t.HoldDelay != ButtonTimings.NoHold),
-                "No remaining config defines onHold - nothing should be able to fire HOLD/REPEAT for this button anymore.");
+            Assert.HasCount(0, afterDelete,
+                "No remaining config defines onHold or onLongRelease - this button doesn't need tracking at all anymore.");
         }
 
         [TestMethod]
-        public void ResolveButtonTimingsPerConfig_DeletingTheOnlyOnLongReleaseConfig_LeavesNoLongReleaseBindingForTheButton()
+        public void ResolveButtonTimingsPerConfig_OnLongReleaseOnlyConfig_StillContributesNoHoldSentinel()
         {
+            // No onHold here, but the button still needs to be tracked (for HeldDurationMs on RELEASE -
+            // see ButtonInputConfig.ResolveDispatchedEvent) - so this must not be filtered out entirely,
+            // just contribute nothing usable for HOLD/REPEAT scheduling.
             var serial = "SN-timings005";
             var deviceName = "Button1";
 
@@ -848,29 +1055,12 @@ namespace MobiFlight.Execution.Tests
                     LongReleaseDelay = 300
                 }
             };
-            var releaseConfig = new InputConfigItem
-            {
-                Active = true,
-                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
-                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
-                Name = "ReleaseConfig",
-                button = new ButtonInputConfig
-                {
-                    onRelease = new MSFS2020CustomInputAction { Command = "(>K:ReleaseCommand)", PresetId = "p2" }
-                }
-            };
             _configItems.Add(longReleaseConfig);
-            _configItems.Add(releaseConfig);
 
-            var beforeDelete = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
-            Assert.IsTrue(beforeDelete.Any(t => t.LongReleaseDelay == 300), "LongReleaseConfig's own LongReleaseDelay must be present while it's bound.");
+            var timings = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
 
-            _configItems.Remove(longReleaseConfig);
-            _executor.ClearCache();
-
-            var afterDelete = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
-            Assert.IsFalse(afterDelete.Any(t => t.LongReleaseDelay != ButtonTimings.NoLongRelease),
-                "No remaining config defines onLongRelease - nothing should be able to reclassify RELEASE as LONG_RELEASE for this button anymore.");
+            Assert.HasCount(1, timings, "The button must still be tracked, even with nothing to schedule for HOLD/REPEAT.");
+            Assert.AreEqual(ButtonTimings.NoHold, timings[0].HoldDelay);
         }
 
         [TestMethod]
@@ -1000,7 +1190,7 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "FirstConfig",
-                button = new ButtonInputConfig { HoldDelay = 350, RepeatDelay = 0, LongReleaseDelay = 350 }
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" }, HoldDelay = 350, RepeatDelay = 0 }
             };
             var secondConfig = new InputConfigItem
             {
@@ -1008,7 +1198,7 @@ namespace MobiFlight.Execution.Tests
                 Controller = SerialNumber.CreateController($"TestModule / {serial}"),
                 Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
                 Name = "SecondConfig",
-                button = new ButtonInputConfig { HoldDelay = 350, RepeatDelay = 0, LongReleaseDelay = 350 }
+                button = new ButtonInputConfig { onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" }, HoldDelay = 350, RepeatDelay = 0 }
             };
             _configItems.Add(firstConfig);
             _configItems.Add(secondConfig);
@@ -1057,10 +1247,10 @@ namespace MobiFlight.Execution.Tests
         }
 
         [TestMethod]
-        public void Execute_HoldEvent_RawValueAndExecutingLogDoNotShowTheDelay()
+        public void Execute_HoldEvent_RawValueStaysBareButExecutingLogShowsTheDelay()
         {
-            // The delay is shown exactly once, in the raw "an event was raised" log line - not
-            // repeated in RawValue or the per-config "Executing" line.
+            // Stage 1 never shows HOLD at all anymore - this "Executing" line is the only place the
+            // delay that fired it is visible, so it belongs here. RawValue stays the bare event name.
             var serial = "SN-nodelay001";
             var deviceName = "Button1";
 
@@ -1082,7 +1272,7 @@ namespace MobiFlight.Execution.Tests
             Assert.AreEqual("HOLD", configItem.RawValue);
 
             _mockLogAppender.Verify(
-                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Executing ""{configItem.Name}"". (HOLD)")), LogSeverity.Info),
+                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Executing ""{configItem.Name}"". (HOLD:300ms)")), LogSeverity.Info),
                 Times.Once
             );
         }

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -1325,6 +1325,44 @@ namespace MobiFlight.Execution.Tests
         }
 
         [TestMethod]
+        public void Execute_RepeatEvent_SameRepeatDelayButDifferentHoldDelay_OnlyExecutesTheOriginatingConfig()
+        {
+            // Config B shares RepeatDelay=200 with config A but has a much longer HoldDelay - a REPEAT
+            // produced by A's binding must not reach B, even though RepeatDelay alone would match.
+            var serial = "SN-repeattarget001";
+            var deviceName = "Button1";
+
+            var fastHold = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "FastHoldConfig",
+                button = new ButtonInputConfig { HoldDelay = 300, RepeatDelay = 200, onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd1)", PresetId = "p1" } }
+            };
+            var slowHold = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController($"TestModule / {serial}"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, deviceName),
+                Name = "SlowHoldConfig",
+                button = new ButtonInputConfig { HoldDelay = 1000, RepeatDelay = 200, onHold = new MSFS2020CustomInputAction { Command = "(>K:Cmd2)", PresetId = "p2" } }
+            };
+            _configItems.Add(fastHold);
+            _configItems.Add(slowHold);
+
+            var repeatEvent = CreateHoldEventArgs(serial, deviceName);
+            repeatEvent.Value = (int)MobiFlightButton.InputEvent.REPEAT;
+            repeatEvent.SyntheticDelayMs = 200;
+            repeatEvent.SyntheticHoldDelayMs = 300; // this REPEAT came from FastHoldConfig's binding
+
+            var result = _executor.Execute(repeatEvent, isStarted: true);
+
+            Assert.IsTrue(result.ContainsKey(fastHold.GUID), "The originating binding's config must execute.");
+            Assert.IsFalse(result.ContainsKey(slowHold.GUID), "A config sharing RepeatDelay but not HoldDelay must not execute.");
+        }
+
+        [TestMethod]
         public void Execute_HoldEvent_RawValueStaysBareButExecutingLogShowsTheDelay()
         {
             // Stage 1 never shows HOLD at all anymore - this "Executing" line is the only place the

--- a/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
+++ b/tests/MobiFlightUnitTests/Base/InputEventExecutorTests.cs
@@ -200,6 +200,47 @@ namespace MobiFlight.Execution.Tests
         }
 
         [TestMethod]
+        public void Execute_LongReleaseWithoutOwnAction_LogsAndDisplaysAsRelease()
+        {
+            // A config with only onRelease (no onLongRelease) that receives a raw LONG_RELEASE must
+            // log and display RELEASE - what actually ran - not the raw LONG_RELEASE it fell back from.
+            var inputEventArgs = new InputEventArgs
+            {
+                Controller = new Controller() { Serial = "123" },
+                InputType = DeviceType.Button,
+                Device = new DeviceReference() { Name = "Device1" },
+                Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE
+            };
+
+            var activeConfigItem = new InputConfigItem
+            {
+                Active = true,
+                Controller = SerialNumber.CreateController("/ 123"),
+                Device = InputConfigItem.CreateInputDevice(InputConfigItem.TYPE_BUTTON, "Device1"),
+                Name = "TestConfig",
+                button = new ButtonInputConfig
+                {
+                    onRelease = new VariableInputAction()
+                    {
+                        Variable = new MobiFlightVariable() { Name = "TestVariable", Number = 100 }
+                    }
+                }
+            };
+
+            _configItems.Add(activeConfigItem);
+
+            var result = _executor.Execute(inputEventArgs, isStarted: true);
+
+            Assert.HasCount(1, result);
+            Assert.AreEqual("RELEASE", activeConfigItem.RawValue);
+
+            _mockLogAppender.Verify(
+                appender => appender.log(It.Is<string>(msg => msg.Contains($@"Executing ""{activeConfigItem.Name}"". (RELEASE)")), LogSeverity.Info),
+                Times.Once
+            );
+        }
+
+        [TestMethod]
         public void Execute_ConfigItemWithConfigReference_ExecutesSuccessfully()
         {
             // Arrange
@@ -724,8 +765,11 @@ namespace MobiFlight.Execution.Tests
         }
 
         [TestMethod]
-        public void ResolveButtonTimingsPerConfig_InactiveConfig_IsSkipped()
+        public void ResolveButtonTimingsPerConfig_InactiveConfig_IsStillReturned_ButExecuteSkipsIt()
         {
+            // Active/Precondition gating happens exclusively in Execute() now (see
+            // Execute_MatchingInactiveConfigItem_SkipsExecution) - resolving a binding only answers
+            // "is a config bound to this button," not "should it currently run."
             var serial = "SN-timings002";
             var deviceName = "Button1";
 
@@ -741,12 +785,17 @@ namespace MobiFlight.Execution.Tests
 
             var result = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
 
-            Assert.HasCount(0, result, "An inactive config must not govern timings, same as it does not govern execution.");
+            Assert.HasCount(1, result, "An inactive config is still bound to the button and must still get a timing binding.");
+            Assert.AreEqual(configItem.GUID, result[0].ConfigGuid);
+            Assert.AreEqual(999, result[0].Timings.HoldDelay);
         }
 
         [TestMethod]
-        public void ResolveButtonTimingsPerConfig_MultiModePanel_DifferentPreconditionGatedConfigsYieldDifferentDelays()
+        public void ResolveButtonTimingsPerConfig_MultiModePanel_BothModesAlwaysReturned_RegardlessOfCurrentMode()
         {
+            // Precondition gating no longer happens at this layer - every mode's config is bound to
+            // the button, always, each with its own HoldDelay. Execute() decides which one (if any)
+            // actually runs, using live precondition state at each fire.
             var serial = "SN-multimode";
             var deviceName = "Button1";
 
@@ -781,14 +830,14 @@ namespace MobiFlight.Execution.Tests
             _configItems.Add(modeBConfig);
 
             var bindingsInModeA = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
-            Assert.HasCount(1, bindingsInModeA, "Mode B's precondition is not satisfied, so only Mode A's config should match.");
-            Assert.AreEqual(200, bindingsInModeA[0].Timings.HoldDelay, "Mode A's precondition is satisfied, so its 200ms HoldDelay should apply.");
+            Assert.HasCount(2, bindingsInModeA, "Both configs are bound to this button regardless of which mode is currently selected.");
+            Assert.AreEqual(200, bindingsInModeA.Single(b => b.ConfigGuid == modeAConfig.GUID).Timings.HoldDelay);
+            Assert.AreEqual(800, bindingsInModeA.Single(b => b.ConfigGuid == modeBConfig.GUID).Timings.HoldDelay);
 
-            modeSwitch.Value = "ModeB"; // re-evaluated fresh each call, no cache invalidation needed
+            modeSwitch.Value = "ModeB"; // resolving bindings no longer depends on this at all
 
             var bindingsInModeB = _executor.ResolveButtonTimingsPerConfig(CreateButtonEventArgs(serial, deviceName, isOnPress: true));
-            Assert.HasCount(1, bindingsInModeB);
-            Assert.AreEqual(800, bindingsInModeB[0].Timings.HoldDelay, "Switching modes should change which HoldDelay applies to the same physical button.");
+            Assert.HasCount(2, bindingsInModeB, "Switching modes doesn't change which configs are bound - only Execute() cares about the current mode.");
         }
 
         [TestMethod]

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -269,7 +269,7 @@ namespace MobiFlight.InputConfig.Tests
         [TestMethod()]
         public void MatchesSyntheticDelay_Hold_ComparesAgainstOwnHoldDelay()
         {
-            var cfg = new ButtonInputConfig { HoldDelay = 300 };
+            var cfg = new ButtonInputConfig { onHold = new RecordingInputAction(), HoldDelay = 300 };
 
             Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.HOLD, SyntheticDelayMs = 300 }));
             Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.HOLD, SyntheticDelayMs = 900 }),
@@ -279,10 +279,22 @@ namespace MobiFlight.InputConfig.Tests
         [TestMethod()]
         public void MatchesSyntheticDelay_Repeat_ComparesAgainstOwnRepeatDelay()
         {
-            var cfg = new ButtonInputConfig { RepeatDelay = 10 }; // below the traditional floor - honored as-is, no clamping
+            var cfg = new ButtonInputConfig { onHold = new RecordingInputAction(), RepeatDelay = 10 }; // below the traditional floor - honored as-is, no clamping
 
             Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 10 }));
             Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 100 }));
+        }
+
+        [TestMethod()]
+        public void MatchesSyntheticDelay_NoOnHold_NeverMatchesEvenWithCoincidingDelay()
+        {
+            // A config with no onHold at all must never match HOLD/REPEAT, even if its leftover
+            // (unused) HoldDelay/RepeatDelay field values happen to coincide with another config's
+            // real delay - those fields are meaningless without onHold to dispatch to.
+            var cfg = new ButtonInputConfig { HoldDelay = 300, RepeatDelay = 10 };
+
+            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.HOLD, SyntheticDelayMs = 300 }));
+            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 10 }));
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -202,10 +202,12 @@ namespace MobiFlight.InputConfig.Tests
         private class RecordingInputAction : InputAction
         {
             public int ExecuteCount = 0;
+            public InputEventArgs LastArgs;
 
             public override void execute(CacheCollection cacheCollection, InputEventArgs args, List<ConfigRefValue> configRefs)
             {
                 ExecuteCount++;
+                LastArgs = args;
             }
 
             public override object Clone() => new RecordingInputAction();
@@ -277,6 +279,24 @@ namespace MobiFlight.InputConfig.Tests
 
             Assert.AreEqual(1, longRelease.ExecuteCount);
             Assert.AreEqual(0, release.ExecuteCount, "onLongRelease is configured, so it - not onRelease - must handle this.");
+        }
+
+        [TestMethod()]
+        public void Execute_LongReleaseWithoutOwnAction_NormalizesDispatchedValueToRelease()
+        {
+            // Several InputAction implementations substitute args.Value into their command (the "@"
+            // placeholder) - onRelease must see RELEASE, not the raw LONG_RELEASE it fell back from.
+            var release = new RecordingInputAction();
+            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release };
+            var originalArgs = new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE };
+
+            cfg.execute(new CacheCollection(), originalArgs, new List<ConfigRefValue>());
+
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, release.LastArgs.Value,
+                "onRelease must see a normalized RELEASE value, not the raw LONG_RELEASE it fell back from.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, originalArgs.Value,
+                "The caller's own args instance must not be mutated - normalization must happen on a clone.");
+            Assert.AreNotSame(originalArgs, release.LastArgs, "onRelease must receive a clone, not the caller's own args instance.");
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -277,12 +277,15 @@ namespace MobiFlight.InputConfig.Tests
         }
 
         [TestMethod()]
-        public void MatchesSyntheticDelay_Repeat_ComparesAgainstOwnRepeatDelay()
+        public void MatchesSyntheticDelay_Repeat_ComparesAgainstOwnHoldAndRepeatDelay()
         {
-            var cfg = new ButtonInputConfig { onHold = new RecordingInputAction(), RepeatDelay = 10 }; // below the traditional floor - honored as-is, no clamping
+            var cfg = new ButtonInputConfig { onHold = new RecordingInputAction(), HoldDelay = 300, RepeatDelay = 10 }; // RepeatDelay below the traditional floor - honored as-is, no clamping
 
-            Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 10 }));
-            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 100 }));
+            Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 10, SyntheticHoldDelayMs = 300 }));
+            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 100, SyntheticHoldDelayMs = 300 }),
+                "A different config's RepeatDelay must not match this one.");
+            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 10, SyntheticHoldDelayMs = 900 }),
+                "Same RepeatDelay but a different HoldDelay tier must not match - it's a different config's binding.");
         }
 
         [TestMethod()]
@@ -294,7 +297,7 @@ namespace MobiFlight.InputConfig.Tests
             var cfg = new ButtonInputConfig { HoldDelay = 300, RepeatDelay = 10 };
 
             Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.HOLD, SyntheticDelayMs = 300 }));
-            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 10 }));
+            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 10, SyntheticHoldDelayMs = 300 }));
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -253,6 +253,33 @@ namespace MobiFlight.InputConfig.Tests
         }
 
         [TestMethod()]
+        public void Execute_LongReleaseWithoutOwnAction_FallsBackToRelease()
+        {
+            // A latching switch held past LongReleaseDelay is reclassified LONG_RELEASE. A config
+            // that only defines onRelease (the common case before onLongRelease existed) must still
+            // fire it - it must not go silent just because onLongRelease isn't configured.
+            var release = new RecordingInputAction();
+            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release };
+
+            cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE }, new List<ConfigRefValue>());
+
+            Assert.AreEqual(1, release.ExecuteCount);
+        }
+
+        [TestMethod()]
+        public void Execute_LongReleaseWithOwnAction_DoesNotAlsoFireRelease()
+        {
+            var release = new RecordingInputAction();
+            var longRelease = new RecordingInputAction();
+            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release, onLongRelease = longRelease };
+
+            cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE }, new List<ConfigRefValue>());
+
+            Assert.AreEqual(1, longRelease.ExecuteCount);
+            Assert.AreEqual(0, release.ExecuteCount, "onLongRelease is configured, so it - not onRelease - must handle this.");
+        }
+
+        [TestMethod()]
         public void Execute_WithNoMatchingAction_DoesNotThrow()
         {
             ButtonInputConfig cfg = new ButtonInputConfig();

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -255,6 +255,46 @@ namespace MobiFlight.InputConfig.Tests
         }
 
         [TestMethod()]
+        [DataRow((int)MobiFlightButton.InputEvent.PRESS)]
+        [DataRow((int)MobiFlightButton.InputEvent.RELEASE)]
+        public void MatchesSyntheticDelay_NoDelayOnEvent_AlwaysMatches(int rawEvent)
+        {
+            var cfg = new ButtonInputConfig { HoldDelay = 300, RepeatDelay = 100, LongReleaseDelay = 300 };
+
+            var result = cfg.MatchesSyntheticDelay(new InputEventArgs { Value = rawEvent, SyntheticDelayMs = null });
+
+            Assert.IsTrue(result, "PRESS/RELEASE carry no delay to match - always applies.");
+        }
+
+        [TestMethod()]
+        public void MatchesSyntheticDelay_Hold_ComparesAgainstOwnHoldDelay()
+        {
+            var cfg = new ButtonInputConfig { HoldDelay = 300 };
+
+            Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.HOLD, SyntheticDelayMs = 300 }));
+            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.HOLD, SyntheticDelayMs = 900 }),
+                "A different config's HoldDelay must not match this one.");
+        }
+
+        [TestMethod()]
+        public void MatchesSyntheticDelay_Repeat_ComparesAgainstOwnRepeatDelay()
+        {
+            var cfg = new ButtonInputConfig { RepeatDelay = 10 }; // below the traditional floor - honored as-is, no clamping
+
+            Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 10 }));
+            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.REPEAT, SyntheticDelayMs = 100 }));
+        }
+
+        [TestMethod()]
+        public void MatchesSyntheticDelay_LongRelease_ComparesAgainstOwnLongReleaseDelay()
+        {
+            var cfg = new ButtonInputConfig { LongReleaseDelay = 200 };
+
+            Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE, SyntheticDelayMs = 200 }));
+            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE, SyntheticDelayMs = 800 }));
+        }
+
+        [TestMethod()]
         public void Execute_LongReleaseWithoutOwnAction_FallsBackToRelease()
         {
             // A latching switch held past LongReleaseDelay is reclassified LONG_RELEASE. A config

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfig/ButtonInputConfigTests.cs
@@ -286,57 +286,72 @@ namespace MobiFlight.InputConfig.Tests
         }
 
         [TestMethod()]
-        public void MatchesSyntheticDelay_LongRelease_ComparesAgainstOwnLongReleaseDelay()
+        public void MatchesSyntheticDelay_NonHoldRepeatEvent_AlwaysMatches()
         {
+            // MatchesSyntheticDelay only gates HOLD/REPEAT - RELEASE's LONG_RELEASE decision is made
+            // in ResolveDispatchedEvent instead, from HeldDurationMs, not SyntheticDelayMs.
             var cfg = new ButtonInputConfig { LongReleaseDelay = 200 };
 
-            Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE, SyntheticDelayMs = 200 }));
-            Assert.IsFalse(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE, SyntheticDelayMs = 800 }));
+            Assert.IsTrue(cfg.MatchesSyntheticDelay(new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.RELEASE, SyntheticDelayMs = 999 }));
         }
 
         [TestMethod()]
-        public void Execute_LongReleaseWithoutOwnAction_FallsBackToRelease()
+        public void Execute_ConfigWithoutOnLongRelease_AlwaysDispatchesReleaseRegardlessOfHeldDuration()
         {
-            // A latching switch held past LongReleaseDelay is reclassified LONG_RELEASE. A config
-            // that only defines onRelease (the common case before onLongRelease existed) must still
-            // fire it - it must not go silent just because onLongRelease isn't configured.
+            // A latching switch held a long time still arrives as plain RELEASE (see
+            // SyntheticButtonEventGenerator.Observe) - without onLongRelease, it never upgrades to
+            // LONG_RELEASE, however long HeldDurationMs says it was held. A config that only defines
+            // onRelease (the common case before onLongRelease existed) must still fire it.
             var release = new RecordingInputAction();
-            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release };
+            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release, LongReleaseDelay = 300 };
 
-            cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE }, new List<ConfigRefValue>());
+            cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.RELEASE, HeldDurationMs = 5000 }, new List<ConfigRefValue>());
 
             Assert.AreEqual(1, release.ExecuteCount);
         }
 
         [TestMethod()]
-        public void Execute_LongReleaseWithOwnAction_DoesNotAlsoFireRelease()
+        public void Execute_ConfigWithOnLongRelease_FiresLongReleaseNotReleaseWhenDurationExceedsDelay()
         {
             var release = new RecordingInputAction();
             var longRelease = new RecordingInputAction();
-            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release, onLongRelease = longRelease };
+            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release, onLongRelease = longRelease, LongReleaseDelay = 300 };
 
-            cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE }, new List<ConfigRefValue>());
+            cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.RELEASE, HeldDurationMs = 500 }, new List<ConfigRefValue>());
 
             Assert.AreEqual(1, longRelease.ExecuteCount);
-            Assert.AreEqual(0, release.ExecuteCount, "onLongRelease is configured, so it - not onRelease - must handle this.");
+            Assert.AreEqual(0, release.ExecuteCount, "Held past its own LongReleaseDelay with onLongRelease defined - it, not onRelease, must handle this.");
         }
 
         [TestMethod()]
-        public void Execute_LongReleaseWithoutOwnAction_NormalizesDispatchedValueToRelease()
+        public void Execute_ConfigWithOnLongRelease_DoesNotFireWhenDurationIsUnderDelay()
+        {
+            var release = new RecordingInputAction();
+            var longRelease = new RecordingInputAction();
+            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release, onLongRelease = longRelease, LongReleaseDelay = 300 };
+
+            cfg.execute(new CacheCollection(), new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.RELEASE, HeldDurationMs = 100 }, new List<ConfigRefValue>());
+
+            Assert.AreEqual(1, release.ExecuteCount, "Under its own LongReleaseDelay - a plain release, handled by onRelease.");
+            Assert.AreEqual(0, longRelease.ExecuteCount);
+        }
+
+        [TestMethod()]
+        public void Execute_ConfigWithOnLongRelease_NormalizesDispatchedValueToLongReleaseWithoutMutatingCallerArgs()
         {
             // Several InputAction implementations substitute args.Value into their command (the "@"
-            // placeholder) - onRelease must see RELEASE, not the raw LONG_RELEASE it fell back from.
-            var release = new RecordingInputAction();
-            ButtonInputConfig cfg = new ButtonInputConfig { onRelease = release };
-            var originalArgs = new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE };
+            // placeholder) - onLongRelease must see LONG_RELEASE, not the raw RELEASE it upgraded from.
+            var longRelease = new RecordingInputAction();
+            ButtonInputConfig cfg = new ButtonInputConfig { onLongRelease = longRelease, LongReleaseDelay = 300 };
+            var originalArgs = new InputEventArgs { Value = (int)MobiFlightButton.InputEvent.RELEASE, HeldDurationMs = 500 };
 
             cfg.execute(new CacheCollection(), originalArgs, new List<ConfigRefValue>());
 
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, release.LastArgs.Value,
-                "onRelease must see a normalized RELEASE value, not the raw LONG_RELEASE it fell back from.");
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, originalArgs.Value,
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, longRelease.LastArgs.Value,
+                "onLongRelease must see the normalized LONG_RELEASE value.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, originalArgs.Value,
                 "The caller's own args instance must not be mutated - normalization must happen on a clone.");
-            Assert.AreNotSame(originalArgs, release.LastArgs, "onRelease must receive a clone, not the caller's own args instance.");
+            Assert.AreNotSame(originalArgs, longRelease.LastArgs, "onLongRelease must receive a clone, not the caller's own args instance.");
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
@@ -380,6 +380,27 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
+        public void GetInputAction_Button_LongReleaseFallsBackToReleaseWhenNotConfigured()
+        {
+            var releaseAction = new VariableInputAction();
+
+            var config = new InputConfigItem
+            {
+                button = new ButtonInputConfig { onRelease = releaseAction }
+            };
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE
+            };
+
+            var result = config.GetInputAction(args);
+
+            Assert.AreSame(releaseAction, result, "No onLongRelease is configured, so this must fall back to onRelease - same as execute() does.");
+        }
+
+        [TestMethod()]
         public void GetInputAction_Button_ReturnsNullWhenActionIsNotConfigured()
         {
             var config = new InputConfigItem

--- a/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputConfigItemTests.cs
@@ -380,24 +380,47 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod()]
-        public void GetInputAction_Button_LongReleaseFallsBackToReleaseWhenNotConfigured()
+        public void GetInputAction_Button_ReleaseHeldPastDelayResolvesToReleaseWhenNoOnLongRelease()
         {
             var releaseAction = new VariableInputAction();
 
             var config = new InputConfigItem
             {
-                button = new ButtonInputConfig { onRelease = releaseAction }
+                button = new ButtonInputConfig { onRelease = releaseAction, LongReleaseDelay = 300 }
             };
 
             var args = new InputEventArgs
             {
                 InputType = DeviceType.Button,
-                Value = (int)MobiFlightButton.InputEvent.LONG_RELEASE
+                Value = (int)MobiFlightButton.InputEvent.RELEASE,
+                HeldDurationMs = 5000
             };
 
             var result = config.GetInputAction(args);
 
-            Assert.AreSame(releaseAction, result, "No onLongRelease is configured, so this must fall back to onRelease - same as execute() does.");
+            Assert.AreSame(releaseAction, result, "No onLongRelease is configured, so this never upgrades past RELEASE - same as execute() does.");
+        }
+
+        [TestMethod()]
+        public void GetInputAction_Button_ReleaseHeldPastDelayResolvesToLongReleaseWhenConfigured()
+        {
+            var longReleaseAction = new VariableInputAction();
+
+            var config = new InputConfigItem
+            {
+                button = new ButtonInputConfig { onLongRelease = longReleaseAction, LongReleaseDelay = 300 }
+            };
+
+            var args = new InputEventArgs
+            {
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.RELEASE,
+                HeldDurationMs = 500
+            };
+
+            var result = config.GetInputAction(args);
+
+            Assert.AreSame(longReleaseAction, result, "Held past its own LongReleaseDelay with onLongRelease defined - same as execute() does.");
         }
 
         [TestMethod()]

--- a/tests/MobiFlightUnitTests/MobiFlight/InputEventArgsTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputEventArgsTests.cs
@@ -406,28 +406,10 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
-        public void GetMsgEventLabel_SyntheticEvent_AppendsDelay()
-        {
-            var inputEvent = new InputEventArgs
-            {
-                Controller = new Base.Controller() { Name = "TestModule" },
-                Device = new Base.DeviceReference() { Name = "Button1", Label = "Button 1" },
-                InputType = DeviceType.Button,
-                Value = (int)MobiFlightButton.InputEvent.HOLD,
-                SyntheticDelayMs = 300
-            };
-
-            var result = inputEvent.GetMsgEventLabel();
-
-            Assert.AreEqual("TestModule => Button 1 => HOLD (300ms)", result);
-        }
-
-        [TestMethod]
         public void GetEventActionLabel_SyntheticEvent_DoesNotAppendDelay()
         {
-            // The delay is shown exactly once - in GetMsgEventLabel() (the raw "an event was raised"
-            // line). GetEventActionLabel() feeds RawValue and the per-config "Executing" line, which
-            // must not repeat it.
+            // The delay is shown in the per-config "Executing" line (InputEventExecutor.AppendSyntheticDelay),
+            // not here - GetEventActionLabel() feeds RawValue too, which must stay the bare event name.
             var inputEvent = new InputEventArgs
             {
                 Controller = new Base.Controller() { Name = "TestModule" },

--- a/tests/MobiFlightUnitTests/MobiFlight/InputEventArgsTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/InputEventArgsTests.cs
@@ -406,6 +406,43 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
+        public void GetMsgEventLabel_SyntheticEvent_AppendsDelay()
+        {
+            var inputEvent = new InputEventArgs
+            {
+                Controller = new Base.Controller() { Name = "TestModule" },
+                Device = new Base.DeviceReference() { Name = "Button1", Label = "Button 1" },
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.HOLD,
+                SyntheticDelayMs = 300
+            };
+
+            var result = inputEvent.GetMsgEventLabel();
+
+            Assert.AreEqual("TestModule => Button 1 => HOLD (300ms)", result);
+        }
+
+        [TestMethod]
+        public void GetEventActionLabel_SyntheticEvent_DoesNotAppendDelay()
+        {
+            // The delay is shown exactly once - in GetMsgEventLabel() (the raw "an event was raised"
+            // line). GetEventActionLabel() feeds RawValue and the per-config "Executing" line, which
+            // must not repeat it.
+            var inputEvent = new InputEventArgs
+            {
+                Controller = new Base.Controller() { Name = "TestModule" },
+                Device = new Base.DeviceReference() { Name = "Button1", Label = "Button 1" },
+                InputType = DeviceType.Button,
+                Value = (int)MobiFlightButton.InputEvent.HOLD,
+                SyntheticDelayMs = 300
+            };
+
+            var result = inputEvent.GetEventActionLabel();
+
+            Assert.AreEqual("HOLD", result);
+        }
+
+        [TestMethod]
         public void GetMsgEventLabel_EventWithExtPin_ReturnsCorrectFormat()
         {
             // Arrange

--- a/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
@@ -386,6 +386,31 @@ namespace MobiFlight.Tests
             Assert.AreEqual(100, _synthetic[1].SyntheticDelayMs);
         }
 
+        [TestMethod]
+        public void Tick_TwoConfigsWithSameRepeatDelayButDifferentHoldDelay_FireSeparateRepeatEvents()
+        {
+            // Same RepeatDelay must not collapse two bindings into one event when their HoldDelay
+            // differs - otherwise the binding that started repeating first would drag the other one's
+            // config along before its own HoldDelay ever elapsed.
+            _generator.ResolveTimings = e => new List<ButtonTimings>
+            {
+                new ButtonTimings(holdDelay: 300, repeatDelay: 200),
+                new ButtonTimings(holdDelay: 1000, repeatDelay: 200)
+            };
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick(); // HOLD for the 300ms binding only
+
+            _now = _now.AddMilliseconds(200); // total 500ms - the 1000ms binding hasn't fired HOLD yet
+            _generator.Tick();
+
+            Assert.HasCount(2, _synthetic, "Only the 300ms binding has started repeating.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[1].Value);
+            Assert.AreEqual(200, _synthetic[1].SyntheticDelayMs);
+            Assert.AreEqual(300, _synthetic[1].SyntheticHoldDelayMs, "The REPEAT must carry which HoldDelay tier produced it.");
+        }
+
         // RepeatDelay is used exactly as configured - no runtime floor. Enforcing a minimum is a
         // config-authoring-time (UI) concern, not something evaluated on every tick.
 

--- a/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
@@ -22,7 +22,7 @@ namespace MobiFlight.Tests
             _now = new DateTime(2026, 1, 1, 12, 0, 0);
             _generator = new SyntheticButtonEventGenerator(() => _now, NeverFiresIntervalMs)
             {
-                ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 300) }
+                ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 0) }
             };
             _synthetic = new List<InputEventArgs>();
             _generator.OnSyntheticEvent += (s, e) => _synthetic.Add(e);
@@ -91,7 +91,7 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_WithRepeatDelayElapsed_FiresRepeatAfterInitialHold()
         {
-            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 300) };
+            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
             _now = _now.AddMilliseconds(300);
@@ -108,7 +108,7 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_WithRepeatDelayElapsedTwice_FiresRepeatEachTime()
         {
-            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 300) };
+            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
             _now = _now.AddMilliseconds(300);
@@ -126,28 +126,57 @@ namespace MobiFlight.Tests
             Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[2].Value);
         }
 
+        // RELEASE is always raised exactly once, as plain RELEASE, carrying how long the button was
+        // held - LONG_RELEASE is a per-config dispatch-time decision (ButtonInputConfig.
+        // ResolveDispatchedEvent), never a reclassification of the raw event here. This is what fixes
+        // the double-RELEASE-log bug: with the old per-LongReleaseDelay grouping, a config with a real
+        // onLongRelease delay and a config without one (sentinel) produced two distinct groups even
+        // though, for a quick tap, both resolved to the same "plain RELEASE" outcome.
+
         [TestMethod]
-        public void Observe_ReleaseBeforeLongReleaseDelay_StaysRelease()
+        public void Observe_ReleaseShortlyAfterPress_StaysReleaseWithShortHeldDuration()
         {
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
-            _now = _now.AddMilliseconds(100); // < LongReleaseDelay (300)
+            _now = _now.AddMilliseconds(100);
             var result = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
 
             Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, result.Value);
-            Assert.IsNull(result.SyntheticDelayMs, "Plain RELEASE has no delay of its own to show.");
+            Assert.AreEqual(100, result.HeldDurationMs);
+            Assert.IsNull(result.SyntheticDelayMs, "SyntheticDelayMs is a HOLD/REPEAT concept - RELEASE never carries it.");
         }
 
         [TestMethod]
-        public void Observe_ReleaseAfterLongReleaseDelay_IsReclassifiedAsLongRelease()
+        public void Observe_ReleaseAfterLongHold_StillStaysReleaseAtThisLayer()
         {
+            // Held well past what used to be a LongReleaseDelay threshold - the generator itself never
+            // reclassifies; it just reports how long the hold was and lets each config decide.
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
-            _now = _now.AddMilliseconds(350); // > LongReleaseDelay (300)
+            _now = _now.AddMilliseconds(5000);
             var result = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
 
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, result.Value);
-            Assert.AreEqual(300, result.SyntheticDelayMs);
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, result.Value);
+            Assert.AreEqual(5000, result.HeldDurationMs);
+        }
+
+        [TestMethod]
+        public void Observe_ReleaseWithMultipleDistinctBindings_IsStillExactlyOneEvent()
+        {
+            // However many distinct HOLD/REPEAT settings are bound to this button, RELEASE doesn't
+            // fan out per binding anymore - there's nothing left for it to fan out over.
+            _generator.ResolveTimings = e => new List<ButtonTimings>
+            {
+                new ButtonTimings(holdDelay: 50, repeatDelay: 0),
+                new ButtonTimings(holdDelay: 900, repeatDelay: 100)
+            };
+            _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(1000);
+            var released = _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
+
+            Assert.HasCount(1, released);
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, released[0].Value);
         }
 
         [TestMethod]
@@ -218,7 +247,7 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void ResolveTimings_OverridesDefaultHoldDelayForThatPress()
         {
-            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(50, 0, 300) };
+            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(50, 0) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
             _now = _now.AddMilliseconds(50); // well under the generator's own 300ms default
@@ -232,7 +261,7 @@ namespace MobiFlight.Tests
         public void ResolveTimings_ReturningEmpty_ProducesNoSyntheticEvents()
         {
             // Resolver ran and found no config bound to this button - never track it, never fire
-            // HOLD/REPEAT/LONG_RELEASE for it, no matter how long it's held.
+            // HOLD/REPEAT for it, no matter how long it's held.
             _generator.ResolveTimings = e => new List<ButtonTimings>();
             var pressResult = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
             Assert.AreEqual((double)MobiFlightButton.InputEvent.PRESS, pressResult.Value, "PRESS must still pass through untouched.");
@@ -242,7 +271,8 @@ namespace MobiFlight.Tests
             Assert.HasCount(0, _synthetic, "No bound config means no HOLD, ever.");
 
             var releaseResult = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, releaseResult.Value, "Never reclassified as LONG_RELEASE - it was never tracked.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, releaseResult.Value);
+            Assert.IsNull(releaseResult.HeldDurationMs, "It was never tracked - no duration to report.");
         }
 
         [TestMethod]
@@ -252,7 +282,7 @@ namespace MobiFlight.Tests
             _generator.ResolveTimings = e =>
             {
                 callCount++;
-                return new List<ButtonTimings> { new ButtonTimings(300, 0, 300) };
+                return new List<ButtonTimings> { new ButtonTimings(300, 0) };
             };
 
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
@@ -274,8 +304,8 @@ namespace MobiFlight.Tests
             _generator.ResolveTimings = e => new List<ButtonTimings>
             {
                 e.Device.Name == "Btn1"
-                    ? new ButtonTimings(50, 0, 300)
-                    : new ButtonTimings(500, 0, 300)
+                    ? new ButtonTimings(50, 0)
+                    : new ButtonTimings(500, 0)
             };
 
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
@@ -288,15 +318,15 @@ namespace MobiFlight.Tests
             Assert.AreEqual("Btn1", _synthetic[0].Device.Name);
         }
 
-        // Two configs sharing a button, different delays - each still gets its own event.
+        // Two configs sharing a button, different delays - each still gets its own HOLD/REPEAT event.
 
         [TestMethod]
         public void ResolveTimings_TwoConfigsWithDifferentHoldDelay_OnlyTheOneWhoseDelayElapsedFires()
         {
             _generator.ResolveTimings = e => new List<ButtonTimings>
             {
-                new ButtonTimings(holdDelay: 50, repeatDelay: 0, longReleaseDelay: 300),
-                new ButtonTimings(holdDelay: 900, repeatDelay: 0, longReleaseDelay: 300)
+                new ButtonTimings(holdDelay: 50, repeatDelay: 0),
+                new ButtonTimings(holdDelay: 900, repeatDelay: 0)
             };
 
             _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
@@ -315,39 +345,16 @@ namespace MobiFlight.Tests
             Assert.AreEqual(900, _synthetic[1].SyntheticDelayMs);
         }
 
-        [TestMethod]
-        public void ResolveTimings_TwoConfigsWithDifferentLongReleaseDelay_ReleaseFansOutOneEventPerDelay()
-        {
-            _generator.ResolveTimings = e => new List<ButtonTimings>
-            {
-                new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 200),
-                new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 800)
-            };
-
-            _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
-
-            _now = _now.AddMilliseconds(300); // > 200ms, < 800ms
-            var released = _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
-
-            Assert.HasCount(2, released, "One release event must be produced per distinct LongReleaseDelay.");
-
-            var longRelease = released.Single(e => e.Value == (double)MobiFlightButton.InputEvent.LONG_RELEASE);
-            var plainRelease = released.Single(e => e.Value == (double)MobiFlightButton.InputEvent.RELEASE);
-
-            Assert.AreEqual(200, longRelease.SyntheticDelayMs, "300ms exceeds the 200ms threshold - that delay's group must see LONG_RELEASE.");
-            Assert.IsNull(plainRelease.SyntheticDelayMs, "300ms is under the 800ms threshold - that delay's group must see a plain RELEASE.");
-        }
-
-        // Two configs sharing the SAME delay - the actual grouping guarantee: one physical HOLD/
-        // REPEAT/LONG_RELEASE must not be logged/raised once per config bound to the button.
+        // Two configs sharing the SAME delay - one physical HOLD/REPEAT must not be logged/raised
+        // once per config bound to the button.
 
         [TestMethod]
         public void Tick_TwoConfigsWithSameHoldDelay_FireOneGroupedHoldEvent()
         {
             _generator.ResolveTimings = e => new List<ButtonTimings>
             {
-                new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 200),
-                new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 800) // differs only in LongReleaseDelay
+                new ButtonTimings(holdDelay: 300, repeatDelay: 0),
+                new ButtonTimings(holdDelay: 300, repeatDelay: 100) // differs only in RepeatDelay
             };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
@@ -363,8 +370,8 @@ namespace MobiFlight.Tests
         {
             _generator.ResolveTimings = e => new List<ButtonTimings>
             {
-                new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 200),
-                new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 800) // differs only in LongReleaseDelay
+                new ButtonTimings(holdDelay: 300, repeatDelay: 100),
+                new ButtonTimings(holdDelay: 300, repeatDelay: 100)
             };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
@@ -379,31 +386,13 @@ namespace MobiFlight.Tests
             Assert.AreEqual(100, _synthetic[1].SyntheticDelayMs);
         }
 
-        [TestMethod]
-        public void Observe_TwoConfigsWithSameLongReleaseDelay_FireOneGroupedReleaseEvent()
-        {
-            _generator.ResolveTimings = e => new List<ButtonTimings>
-            {
-                new ButtonTimings(holdDelay: 50, repeatDelay: 0, longReleaseDelay: 300), // differs only in HoldDelay
-                new ButtonTimings(holdDelay: 900, repeatDelay: 0, longReleaseDelay: 300)
-            };
-            _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
-
-            _now = _now.AddMilliseconds(350); // > 300ms
-            var released = _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
-
-            Assert.HasCount(1, released, "Both configs share LongReleaseDelay=300 - one LONG_RELEASE, not two.");
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, released[0].Value);
-            Assert.AreEqual(300, released[0].SyntheticDelayMs);
-        }
-
         // RepeatDelay is used exactly as configured - no runtime floor. Enforcing a minimum is a
         // config-authoring-time (UI) concern, not something evaluated on every tick.
 
         [TestMethod]
         public void ButtonTimingsConstructor_DoesNotClampRepeatDelay()
         {
-            var timings = new ButtonTimings(holdDelay: 300, repeatDelay: 10, longReleaseDelay: 300);
+            var timings = new ButtonTimings(holdDelay: 300, repeatDelay: 10);
 
             Assert.AreEqual(10, timings.RepeatDelay, "Clamping belongs at config-save time (UI), not runtime evaluation.");
         }
@@ -426,7 +415,7 @@ namespace MobiFlight.Tests
         {
             _generator.ResolveTimings = e => new List<ButtonTimings>
             {
-                new ButtonTimings(holdDelay: 300, repeatDelay: 10, longReleaseDelay: 300)
+                new ButtonTimings(holdDelay: 300, repeatDelay: 10)
             };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
@@ -461,7 +450,7 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_Repeat_PreservesDeviceLabelFromPress()
         {
-            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 300) };
+            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS, "Button 1"));
 
             _now = _now.AddMilliseconds(300);
@@ -481,18 +470,6 @@ namespace MobiFlight.Tests
             var released = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE, "Button 1"));
 
             Assert.AreEqual("Button 1", released.Device.Label);
-        }
-
-        [TestMethod]
-        public void Observe_LongRelease_PreservesDeviceLabel()
-        {
-            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS, "Button 1"));
-
-            _now = _now.AddMilliseconds(350); // > LongReleaseDelay (300)
-            var result = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE, "Button 1"));
-
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, result.Value);
-            Assert.AreEqual("Button 1", result.Device.Label);
         }
     }
 }

--- a/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
@@ -22,9 +22,7 @@ namespace MobiFlight.Tests
             _now = new DateTime(2026, 1, 1, 12, 0, 0);
             _generator = new SyntheticButtonEventGenerator(() => _now, NeverFiresIntervalMs)
             {
-                HoldDelay = 300,
-                LongReleaseDelay = 300,
-                RepeatDelay = 0
+                ResolveTimings = e => new List<ButtonBinding> { UntargetedBinding(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 300) }
             };
             _synthetic = new List<InputEventArgs>();
             _generator.OnSyntheticEvent += (s, e) => _synthetic.Add(e);
@@ -46,6 +44,10 @@ namespace MobiFlight.Tests
                 Value = (int)value
             };
         }
+
+        /// <summary>A binding with no owning config - broadcasts like a real event, same as an unconfigured device would with no generator involved at all.</summary>
+        private static ButtonBinding UntargetedBinding(int holdDelay, int repeatDelay, int longReleaseDelay) =>
+            new ButtonBinding(null, new ButtonTimings(holdDelay, repeatDelay, longReleaseDelay));
 
         /// <summary>Convenience for tests where exactly one config (or none) is expected to match.</summary>
         private InputEventArgs ObserveOne(InputEventArgs e) => _generator.Observe(e).Single();
@@ -73,7 +75,7 @@ namespace MobiFlight.Tests
             Assert.AreEqual((double)MobiFlightButton.InputEvent.HOLD, _synthetic[0].Value);
             Assert.AreEqual("S1", _synthetic[0].Controller.Serial);
             Assert.AreEqual("Btn1", _synthetic[0].Device.Name);
-            Assert.IsNull(_synthetic[0].TargetConfigGUID, "No resolver wired, so this is the untargeted fallback - broadcasts like a real event.");
+            Assert.IsNull(_synthetic[0].TargetConfigGUID, "The default test resolver returns an untargeted binding - broadcasts like a real event.");
         }
 
         [TestMethod]
@@ -93,7 +95,7 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_WithRepeatDelayElapsed_FiresRepeatAfterInitialHold()
         {
-            _generator.RepeatDelay = ButtonTimings.MinRepeatDelay;
+            _generator.ResolveTimings = e => new List<ButtonBinding> { UntargetedBinding(holdDelay: 300, repeatDelay: ButtonTimings.MinRepeatDelay, longReleaseDelay: 300) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
             _now = _now.AddMilliseconds(300);
@@ -110,7 +112,7 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_WithRepeatDelayElapsedTwice_FiresRepeatEachTime()
         {
-            _generator.RepeatDelay = ButtonTimings.MinRepeatDelay;
+            _generator.ResolveTimings = e => new List<ButtonBinding> { UntargetedBinding(holdDelay: 300, repeatDelay: ButtonTimings.MinRepeatDelay, longReleaseDelay: 300) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
             _now = _now.AddMilliseconds(300);
@@ -229,19 +231,20 @@ namespace MobiFlight.Tests
         }
 
         [TestMethod]
-        public void ResolveTimings_ReturningEmpty_FallsBackToGeneratorDefaults()
+        public void ResolveTimings_ReturningEmpty_ProducesNoSyntheticEvents()
         {
-            _generator.ResolveTimings = e => new List<ButtonBinding>(); // no active/precondition-satisfied config for this button
-            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+            // Resolver ran and found no config bound to this button - never track it, never fire
+            // HOLD/REPEAT/LONG_RELEASE for it, no matter how long it's held.
+            _generator.ResolveTimings = e => new List<ButtonBinding>();
+            var pressResult = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.PRESS, pressResult.Value, "PRESS must still pass through untouched.");
 
-            _now = _now.AddMilliseconds(100); // < the generator's 300ms default HoldDelay
+            _now = _now.AddMilliseconds(1000); // well past any default HoldDelay
             _generator.Tick();
-            Assert.HasCount(0, _synthetic);
+            Assert.HasCount(0, _synthetic, "No bound config means no HOLD, ever.");
 
-            _now = _now.AddMilliseconds(250); // now past 300ms total
-            _generator.Tick();
-            Assert.HasCount(1, _synthetic);
-            Assert.IsNull(_synthetic[0].TargetConfigGUID);
+            var releaseResult = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, releaseResult.Value, "Never reclassified as LONG_RELEASE - it was never tracked.");
         }
 
         [TestMethod]
@@ -374,7 +377,7 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_Repeat_PreservesDeviceLabelFromPress()
         {
-            _generator.RepeatDelay = ButtonTimings.MinRepeatDelay;
+            _generator.ResolveTimings = e => new List<ButtonBinding> { UntargetedBinding(holdDelay: 300, repeatDelay: ButtonTimings.MinRepeatDelay, longReleaseDelay: 300) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS, "Button 1"));
 
             _now = _now.AddMilliseconds(300);

--- a/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
@@ -415,27 +415,6 @@ namespace MobiFlight.Tests
         // config-authoring-time (UI) concern, not something evaluated on every tick.
 
         [TestMethod]
-        public void ButtonTimingsConstructor_DoesNotClampRepeatDelay()
-        {
-            var timings = new ButtonTimings(holdDelay: 300, repeatDelay: 10);
-
-            Assert.AreEqual(10, timings.RepeatDelay, "Clamping belongs at config-save time (UI), not runtime evaluation.");
-        }
-
-        [TestMethod]
-        [DataRow(0, 0, DisplayName = "0 (disabled) is exempt from the floor")]
-        [DataRow(1, ButtonTimings.MinRepeatDelay, DisplayName = "a tiny positive value is raised to the floor")]
-        [DataRow(ButtonTimings.MinRepeatDelay - 1, ButtonTimings.MinRepeatDelay, DisplayName = "just under the floor is raised to it")]
-        [DataRow(ButtonTimings.MinRepeatDelay, ButtonTimings.MinRepeatDelay, DisplayName = "exactly the floor is unchanged")]
-        [DataRow(900, 900, DisplayName = "comfortably above the floor is unchanged")]
-        public void ClampRepeatDelay_EnforcesTheFloor(int configured, int expected)
-        {
-            // The utility itself still exists, ready for config-authoring-time (UI) validation -
-            // just not called automatically anywhere in this runtime evaluation path anymore.
-            Assert.AreEqual(expected, ButtonTimings.ClampRepeatDelay(configured));
-        }
-
-        [TestMethod]
         public void Tick_RepeatDelayBelowTraditionalFloor_FiresAtTheConfiguredCadenceAsIs()
         {
             _generator.ResolveTimings = e => new List<ButtonTimings>

--- a/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/SyntheticButtonEventGeneratorTests.cs
@@ -22,7 +22,7 @@ namespace MobiFlight.Tests
             _now = new DateTime(2026, 1, 1, 12, 0, 0);
             _generator = new SyntheticButtonEventGenerator(() => _now, NeverFiresIntervalMs)
             {
-                ResolveTimings = e => new List<ButtonBinding> { UntargetedBinding(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 300) }
+                ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 300) }
             };
             _synthetic = new List<InputEventArgs>();
             _generator.OnSyntheticEvent += (s, e) => _synthetic.Add(e);
@@ -44,10 +44,6 @@ namespace MobiFlight.Tests
                 Value = (int)value
             };
         }
-
-        /// <summary>A binding with no owning config - broadcasts like a real event, same as an unconfigured device would with no generator involved at all.</summary>
-        private static ButtonBinding UntargetedBinding(int holdDelay, int repeatDelay, int longReleaseDelay) =>
-            new ButtonBinding(null, new ButtonTimings(holdDelay, repeatDelay, longReleaseDelay));
 
         /// <summary>Convenience for tests where exactly one config (or none) is expected to match.</summary>
         private InputEventArgs ObserveOne(InputEventArgs e) => _generator.Observe(e).Single();
@@ -75,7 +71,7 @@ namespace MobiFlight.Tests
             Assert.AreEqual((double)MobiFlightButton.InputEvent.HOLD, _synthetic[0].Value);
             Assert.AreEqual("S1", _synthetic[0].Controller.Serial);
             Assert.AreEqual("Btn1", _synthetic[0].Device.Name);
-            Assert.IsNull(_synthetic[0].TargetConfigGUID, "The default test resolver returns an untargeted binding - broadcasts like a real event.");
+            Assert.AreEqual(300, _synthetic[0].SyntheticDelayMs, "Carries the HoldDelay that fired it, for display and for a config to match itself against.");
         }
 
         [TestMethod]
@@ -95,13 +91,13 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_WithRepeatDelayElapsed_FiresRepeatAfterInitialHold()
         {
-            _generator.ResolveTimings = e => new List<ButtonBinding> { UntargetedBinding(holdDelay: 300, repeatDelay: ButtonTimings.MinRepeatDelay, longReleaseDelay: 300) };
+            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 300) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
             _now = _now.AddMilliseconds(300);
             _generator.Tick(); // first HOLD
 
-            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay);
+            _now = _now.AddMilliseconds(100);
             _generator.Tick(); // repeat
 
             Assert.HasCount(2, _synthetic);
@@ -112,16 +108,16 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_WithRepeatDelayElapsedTwice_FiresRepeatEachTime()
         {
-            _generator.ResolveTimings = e => new List<ButtonBinding> { UntargetedBinding(holdDelay: 300, repeatDelay: ButtonTimings.MinRepeatDelay, longReleaseDelay: 300) };
+            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 300) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
             _now = _now.AddMilliseconds(300);
             _generator.Tick(); // HOLD
 
-            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay);
+            _now = _now.AddMilliseconds(100);
             _generator.Tick(); // REPEAT #1
 
-            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay);
+            _now = _now.AddMilliseconds(100);
             _generator.Tick(); // REPEAT #2
 
             Assert.HasCount(3, _synthetic);
@@ -139,6 +135,7 @@ namespace MobiFlight.Tests
             var result = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
 
             Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, result.Value);
+            Assert.IsNull(result.SyntheticDelayMs, "Plain RELEASE has no delay of its own to show.");
         }
 
         [TestMethod]
@@ -150,6 +147,7 @@ namespace MobiFlight.Tests
             var result = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
 
             Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, result.Value);
+            Assert.AreEqual(300, result.SyntheticDelayMs);
         }
 
         [TestMethod]
@@ -220,14 +218,14 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void ResolveTimings_OverridesDefaultHoldDelayForThatPress()
         {
-            _generator.ResolveTimings = e => new List<ButtonBinding> { new ButtonBinding("cfgA", new ButtonTimings(50, 0, 300)) };
+            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(50, 0, 300) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
             _now = _now.AddMilliseconds(50); // well under the generator's own 300ms default
             _generator.Tick();
 
             Assert.HasCount(1, _synthetic, "The resolved 50ms HoldDelay should govern, not the generator's 300ms default.");
-            Assert.AreEqual("cfgA", _synthetic[0].TargetConfigGUID);
+            Assert.AreEqual(50, _synthetic[0].SyntheticDelayMs);
         }
 
         [TestMethod]
@@ -235,7 +233,7 @@ namespace MobiFlight.Tests
         {
             // Resolver ran and found no config bound to this button - never track it, never fire
             // HOLD/REPEAT/LONG_RELEASE for it, no matter how long it's held.
-            _generator.ResolveTimings = e => new List<ButtonBinding>();
+            _generator.ResolveTimings = e => new List<ButtonTimings>();
             var pressResult = ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
             Assert.AreEqual((double)MobiFlightButton.InputEvent.PRESS, pressResult.Value, "PRESS must still pass through untouched.");
 
@@ -254,7 +252,7 @@ namespace MobiFlight.Tests
             _generator.ResolveTimings = e =>
             {
                 callCount++;
-                return new List<ButtonBinding> { new ButtonBinding("cfgA", new ButtonTimings(300, 0, 300)) };
+                return new List<ButtonTimings> { new ButtonTimings(300, 0, 300) };
             };
 
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
@@ -273,11 +271,11 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void ResolveTimings_DifferentButtonsCanHaveDifferentDelays()
         {
-            _generator.ResolveTimings = e => new List<ButtonBinding>
+            _generator.ResolveTimings = e => new List<ButtonTimings>
             {
                 e.Device.Name == "Btn1"
-                    ? new ButtonBinding("cfgBtn1", new ButtonTimings(50, 0, 300))
-                    : new ButtonBinding("cfgBtn2", new ButtonTimings(500, 0, 300))
+                    ? new ButtonTimings(50, 0, 300)
+                    : new ButtonTimings(500, 0, 300)
             };
 
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
@@ -290,15 +288,15 @@ namespace MobiFlight.Tests
             Assert.AreEqual("Btn1", _synthetic[0].Device.Name);
         }
 
-        // Two configs on the same button - the case that needs targeting, not just resolving.
+        // Two configs sharing a button, different delays - each still gets its own event.
 
         [TestMethod]
-        public void ResolveTimings_TwoConfigsOnSameButton_OnlyTheOneWhoseDelayElapsedFires()
+        public void ResolveTimings_TwoConfigsWithDifferentHoldDelay_OnlyTheOneWhoseDelayElapsedFires()
         {
-            _generator.ResolveTimings = e => new List<ButtonBinding>
+            _generator.ResolveTimings = e => new List<ButtonTimings>
             {
-                new ButtonBinding("fastConfig", new ButtonTimings(holdDelay: 50, repeatDelay: 0, longReleaseDelay: 300)),
-                new ButtonBinding("slowConfig", new ButtonTimings(holdDelay: 900, repeatDelay: 0, longReleaseDelay: 300))
+                new ButtonTimings(holdDelay: 50, repeatDelay: 0, longReleaseDelay: 300),
+                new ButtonTimings(holdDelay: 900, repeatDelay: 0, longReleaseDelay: 300)
             };
 
             _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
@@ -306,43 +304,109 @@ namespace MobiFlight.Tests
             _now = _now.AddMilliseconds(50);
             _generator.Tick();
 
-            Assert.HasCount(1, _synthetic, "slowConfig's 900ms HoldDelay has not elapsed - it must not fire yet.");
-            Assert.AreEqual("fastConfig", _synthetic[0].TargetConfigGUID);
+            Assert.HasCount(1, _synthetic, "The 900ms delay has not elapsed - it must not fire yet.");
+            Assert.AreEqual(50, _synthetic[0].SyntheticDelayMs);
             Assert.AreEqual((double)MobiFlightButton.InputEvent.HOLD, _synthetic[0].Value);
 
             _now = _now.AddMilliseconds(850); // total 900ms
             _generator.Tick();
 
-            Assert.HasCount(2, _synthetic, "slowConfig's own HoldDelay has now elapsed.");
-            Assert.AreEqual("slowConfig", _synthetic[1].TargetConfigGUID);
+            Assert.HasCount(2, _synthetic, "The 900ms delay has now elapsed too.");
+            Assert.AreEqual(900, _synthetic[1].SyntheticDelayMs);
         }
 
         [TestMethod]
-        public void ResolveTimings_TwoConfigsOnSameButton_ReleaseFansOutOneEventPerConfig()
+        public void ResolveTimings_TwoConfigsWithDifferentLongReleaseDelay_ReleaseFansOutOneEventPerDelay()
         {
-            _generator.ResolveTimings = e => new List<ButtonBinding>
+            _generator.ResolveTimings = e => new List<ButtonTimings>
             {
-                new ButtonBinding("shortLongRelease", new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 200)),
-                new ButtonBinding("longLongRelease", new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 800))
+                new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 200),
+                new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 800)
             };
 
             _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
 
-            _now = _now.AddMilliseconds(300); // > shortLongRelease's 200ms, < longLongRelease's 800ms
+            _now = _now.AddMilliseconds(300); // > 200ms, < 800ms
             var released = _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
 
-            Assert.HasCount(2, released, "One release event must be produced per config bound to the button.");
+            Assert.HasCount(2, released, "One release event must be produced per distinct LongReleaseDelay.");
 
-            var forShort = released.Single(e => e.TargetConfigGUID == "shortLongRelease");
-            var forLong = released.Single(e => e.TargetConfigGUID == "longLongRelease");
+            var longRelease = released.Single(e => e.Value == (double)MobiFlightButton.InputEvent.LONG_RELEASE);
+            var plainRelease = released.Single(e => e.Value == (double)MobiFlightButton.InputEvent.RELEASE);
 
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, forShort.Value,
-                "300ms exceeds shortLongRelease's own 200ms threshold - this config must see LONG_RELEASE.");
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.RELEASE, forLong.Value,
-                "300ms is under longLongRelease's own 800ms threshold - this config must see a plain RELEASE, not LONG_RELEASE.");
+            Assert.AreEqual(200, longRelease.SyntheticDelayMs, "300ms exceeds the 200ms threshold - that delay's group must see LONG_RELEASE.");
+            Assert.IsNull(plainRelease.SyntheticDelayMs, "300ms is under the 800ms threshold - that delay's group must see a plain RELEASE.");
         }
 
-        // RepeatDelay floor - protects the sim API from a too-fast repeat.
+        // Two configs sharing the SAME delay - the actual grouping guarantee: one physical HOLD/
+        // REPEAT/LONG_RELEASE must not be logged/raised once per config bound to the button.
+
+        [TestMethod]
+        public void Tick_TwoConfigsWithSameHoldDelay_FireOneGroupedHoldEvent()
+        {
+            _generator.ResolveTimings = e => new List<ButtonTimings>
+            {
+                new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 200),
+                new ButtonTimings(holdDelay: 300, repeatDelay: 0, longReleaseDelay: 800) // differs only in LongReleaseDelay
+            };
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick();
+
+            Assert.HasCount(1, _synthetic, "Both configs share HoldDelay=300 - one HOLD, not two.");
+            Assert.AreEqual(300, _synthetic[0].SyntheticDelayMs);
+        }
+
+        [TestMethod]
+        public void Tick_TwoConfigsWithSameRepeatDelay_FireOneGroupedRepeatEvent()
+        {
+            _generator.ResolveTimings = e => new List<ButtonTimings>
+            {
+                new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 200),
+                new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 800) // differs only in LongReleaseDelay
+            };
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick(); // HOLD (grouped - one event)
+
+            _now = _now.AddMilliseconds(100);
+            _generator.Tick(); // REPEAT
+
+            Assert.HasCount(2, _synthetic, "Both configs share RepeatDelay=100 - one REPEAT, not two.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[1].Value);
+            Assert.AreEqual(100, _synthetic[1].SyntheticDelayMs);
+        }
+
+        [TestMethod]
+        public void Observe_TwoConfigsWithSameLongReleaseDelay_FireOneGroupedReleaseEvent()
+        {
+            _generator.ResolveTimings = e => new List<ButtonTimings>
+            {
+                new ButtonTimings(holdDelay: 50, repeatDelay: 0, longReleaseDelay: 300), // differs only in HoldDelay
+                new ButtonTimings(holdDelay: 900, repeatDelay: 0, longReleaseDelay: 300)
+            };
+            _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(350); // > 300ms
+            var released = _generator.Observe(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.RELEASE));
+
+            Assert.HasCount(1, released, "Both configs share LongReleaseDelay=300 - one LONG_RELEASE, not two.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, released[0].Value);
+            Assert.AreEqual(300, released[0].SyntheticDelayMs);
+        }
+
+        // RepeatDelay is used exactly as configured - no runtime floor. Enforcing a minimum is a
+        // config-authoring-time (UI) concern, not something evaluated on every tick.
+
+        [TestMethod]
+        public void ButtonTimingsConstructor_DoesNotClampRepeatDelay()
+        {
+            var timings = new ButtonTimings(holdDelay: 300, repeatDelay: 10, longReleaseDelay: 300);
+
+            Assert.AreEqual(10, timings.RepeatDelay, "Clamping belongs at config-save time (UI), not runtime evaluation.");
+        }
 
         [TestMethod]
         [DataRow(0, 0, DisplayName = "0 (disabled) is exempt from the floor")]
@@ -350,11 +414,31 @@ namespace MobiFlight.Tests
         [DataRow(ButtonTimings.MinRepeatDelay - 1, ButtonTimings.MinRepeatDelay, DisplayName = "just under the floor is raised to it")]
         [DataRow(ButtonTimings.MinRepeatDelay, ButtonTimings.MinRepeatDelay, DisplayName = "exactly the floor is unchanged")]
         [DataRow(900, 900, DisplayName = "comfortably above the floor is unchanged")]
-        public void ButtonTimings_ClampsRepeatDelayToTheFloor(int configured, int expected)
+        public void ClampRepeatDelay_EnforcesTheFloor(int configured, int expected)
         {
-            var timings = new ButtonTimings(holdDelay: 300, repeatDelay: configured, longReleaseDelay: 300);
+            // The utility itself still exists, ready for config-authoring-time (UI) validation -
+            // just not called automatically anywhere in this runtime evaluation path anymore.
+            Assert.AreEqual(expected, ButtonTimings.ClampRepeatDelay(configured));
+        }
 
-            Assert.AreEqual(expected, timings.RepeatDelay);
+        [TestMethod]
+        public void Tick_RepeatDelayBelowTraditionalFloor_FiresAtTheConfiguredCadenceAsIs()
+        {
+            _generator.ResolveTimings = e => new List<ButtonTimings>
+            {
+                new ButtonTimings(holdDelay: 300, repeatDelay: 10, longReleaseDelay: 300)
+            };
+            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
+
+            _now = _now.AddMilliseconds(300);
+            _generator.Tick(); // HOLD
+
+            _now = _now.AddMilliseconds(10); // the configured 10ms, honored as-is
+            _generator.Tick();
+
+            Assert.HasCount(2, _synthetic, "10ms has elapsed since HOLD - REPEAT fires at the configured cadence, unclamped.");
+            Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[1].Value);
+            Assert.AreEqual(10, _synthetic[1].SyntheticDelayMs);
         }
 
         // Device.Label - the value the log line displays. All of these are built by cloning
@@ -377,13 +461,13 @@ namespace MobiFlight.Tests
         [TestMethod]
         public void Tick_Repeat_PreservesDeviceLabelFromPress()
         {
-            _generator.ResolveTimings = e => new List<ButtonBinding> { UntargetedBinding(holdDelay: 300, repeatDelay: ButtonTimings.MinRepeatDelay, longReleaseDelay: 300) };
+            _generator.ResolveTimings = e => new List<ButtonTimings> { new ButtonTimings(holdDelay: 300, repeatDelay: 100, longReleaseDelay: 300) };
             ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS, "Button 1"));
 
             _now = _now.AddMilliseconds(300);
             _generator.Tick(); // HOLD
 
-            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay);
+            _now = _now.AddMilliseconds(100);
             _generator.Tick(); // REPEAT
 
             Assert.AreEqual("Button 1", _synthetic[1].Device.Label);
@@ -409,28 +493,6 @@ namespace MobiFlight.Tests
 
             Assert.AreEqual((double)MobiFlightButton.InputEvent.LONG_RELEASE, result.Value);
             Assert.AreEqual("Button 1", result.Device.Label);
-        }
-
-        [TestMethod]
-        public void ResolveTimings_RepeatDelayBelowFloor_ActualRepeatCadenceUsesFloorNotConfiguredValue()
-        {
-            _generator.ResolveTimings = e => new List<ButtonBinding>
-            {
-                new ButtonBinding("cfgA", new ButtonTimings(holdDelay: 300, repeatDelay: 10, longReleaseDelay: 300))
-            };
-            ObserveOne(ButtonEvent("S1", "Btn1", MobiFlightButton.InputEvent.PRESS));
-
-            _now = _now.AddMilliseconds(300);
-            _generator.Tick(); // HOLD
-
-            _now = _now.AddMilliseconds(10); // the configured (but floored) 10ms
-            _generator.Tick();
-            Assert.HasCount(1, _synthetic, "10ms is below the floor - no repeat yet.");
-
-            _now = _now.AddMilliseconds(ButtonTimings.MinRepeatDelay - 10); // total: the floor
-            _generator.Tick();
-            Assert.HasCount(2, _synthetic, "The floor has now elapsed since the HOLD - repeat fires.");
-            Assert.AreEqual((double)MobiFlightButton.InputEvent.REPEAT, _synthetic[1].Value);
         }
     }
 }


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
The new way of creating synthetic events didn't cover the case where a long release should trigger a release-action in case no long-release action is configured.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Release action is executed if no long-release action is assigned
- [x] Only physical events are logged (without specific config context)
- [x] The actual event that triggered the action of a config item 
  - [x] is displayed in the log 
  - [x] is displayed in the RawValue

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3319
