### PR TITLE
Use Serilog for logging

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,8 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="Newtonsoft.Json.Schema" Version="4.0.1" />
+    <PackageVersion Include="Serilog" Version="4.4.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageVersion Include="SharpDX" Version="4.2.0" />
     <PackageVersion Include="SharpDX.DirectInput" Version="4.2.0" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.9" />

--- a/src/MobiFlightConnector/Base/Log.cs
+++ b/src/MobiFlightConnector/Base/Log.cs
@@ -1,12 +1,12 @@
 ﻿using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using Serilog;
+using Serilog.Events;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.Serialization;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace MobiFlight
@@ -62,6 +62,23 @@ namespace MobiFlight
                 default:
                     severity = LogSeverity.Info;
                     return false;
+            }
+        }
+
+        public static LogEventLevel ToSerilogLevel(this LogSeverity severity)
+        {
+            switch (severity)
+            {
+                case LogSeverity.Debug:
+                    return LogEventLevel.Debug;
+                case LogSeverity.Info:
+                    return LogEventLevel.Information;
+                case LogSeverity.Warn:
+                    return LogEventLevel.Warning;
+                case LogSeverity.Error:
+                    return LogEventLevel.Error;
+                default:
+                    return LogEventLevel.Warning;
             }
         }
     }
@@ -172,18 +189,25 @@ namespace MobiFlight
 
     public class LogAppenderFile : ILogAppender
     {
-        private String FileName = "log.txt";
-        private StreamWriter writer = null;
-        // This delegate enables asynchronous calls for setting
-        // the text property on a TextBox control.
-        delegate void logCallback(string message, LogSeverity severity);
-
-        private static ReaderWriterLockSlim _readWriteLock = new ReaderWriterLockSlim();
+        private const string FileName = "log.txt";
+        private static readonly ILogger logger = CreateLogger();
 
         public LogAppenderFile()
         {
+        }
+
+        private static ILogger CreateLogger()
+        {
             if (File.Exists(FileName))
                 File.Delete(FileName);
+
+            return new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.File(
+                    FileName,
+                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff} [{Level:u3}] {Message:lj}{NewLine}{Exception}",
+                    shared: true)
+                .CreateLogger();
         }
 
         public void CopyToClipboard()
@@ -200,34 +224,9 @@ namespace MobiFlight
             }
         }
 
-        public async void log(string message, LogSeverity severity)
+        public void log(string message, LogSeverity severity)
         {
-            await Task.Run(() =>
-            {
-                // Set Status to Locked
-                _readWriteLock.EnterWriteLock();
-                try
-                {
-                    String msg = DateTime.Now + "(" + DateTime.Now.Millisecond + ")" + ": " + message;
-                    // Append text to the file
-                    using (StreamWriter sw = File.AppendText(FileName))
-                    {
-                        sw.WriteLine(msg);
-                        sw.Close();
-                    }
-                }
-                catch
-                {
-                    // Fix for https://github.com/MobiFlight/MobiFlight-Connector/issues/757
-                    // If something goes wrong writing to the log file it's just the log file, no need to crash
-                    // or do anything special. Just ignore the exception and keep going.
-                }
-                finally
-                {
-                    // Release lock
-                    _readWriteLock.ExitWriteLock();
-                }
-            });
+            logger.Write(severity.ToSerilogLevel(), "{LogMessage}", message);
         }
     }
 }

--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -54,6 +54,8 @@
 		<PackageReference Include="Microsoft.Web.WebView2" />
 		<PackageReference Include="Newtonsoft.Json" />
 		<PackageReference Include="Newtonsoft.Json.Schema" />
+		<PackageReference Include="Serilog" />
+		<PackageReference Include="Serilog.Sinks.File" />
 		<PackageReference Include="SharpDX" />
 		<PackageReference Include="SharpDX.DirectInput" />
 		<PackageReference Include="System.Management" />

--- a/src/MobiFlightConnector/UI/Dialogs/AboutForm.Designer.cs
+++ b/src/MobiFlightConnector/UI/Dialogs/AboutForm.Designer.cs
@@ -29,212 +29,221 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(AboutForm));
-            this.label1 = new System.Windows.Forms.Label();
-            this.button1 = new System.Windows.Forms.Button();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.linkLabel3 = new System.Windows.Forms.LinkLabel();
-            this.label4 = new System.Windows.Forms.Label();
-            this.linkLabel2 = new System.Windows.Forms.LinkLabel();
-            this.label3 = new System.Windows.Forms.Label();
-            this.label2 = new System.Windows.Forms.Label();
-            this.linkLabel1 = new System.Windows.Forms.LinkLabel();
-            this.panel2 = new System.Windows.Forms.Panel();
-            this.licenseReferenceControl10 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.licenseReferenceControl8 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.licenseReferenceControl6 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.licenseReferenceControl5 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.licenseReferenceControl2 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.licenseReferenceControl7 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.licenseReferenceControl4 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.licenseReferenceControl3 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.licenseReferenceControl1 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
-            this.label5 = new System.Windows.Forms.Label();
-            this.panel3 = new System.Windows.Forms.Panel();
-            this.label6 = new System.Windows.Forms.Label();
-            this.panel1.SuspendLayout();
-            this.panel2.SuspendLayout();
-            this.panel3.SuspendLayout();
-            this.SuspendLayout();
+            label1 = new System.Windows.Forms.Label();
+            button1 = new System.Windows.Forms.Button();
+            panel1 = new System.Windows.Forms.Panel();
+            linkLabel3 = new System.Windows.Forms.LinkLabel();
+            label4 = new System.Windows.Forms.Label();
+            linkLabel2 = new System.Windows.Forms.LinkLabel();
+            label3 = new System.Windows.Forms.Label();
+            label2 = new System.Windows.Forms.Label();
+            linkLabel1 = new System.Windows.Forms.LinkLabel();
+            panel2 = new System.Windows.Forms.Panel();
+            licenseReferenceControl9 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl10 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl8 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl6 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl5 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl2 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl7 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl4 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl3 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            licenseReferenceControl1 = new MobiFlight.UI.Panels.About.LicenseReferenceControl();
+            label5 = new System.Windows.Forms.Label();
+            panel3 = new System.Windows.Forms.Panel();
+            label6 = new System.Windows.Forms.Label();
+            panel1.SuspendLayout();
+            panel2.SuspendLayout();
+            panel3.SuspendLayout();
+            SuspendLayout();
             // 
             // label1
             // 
-            resources.ApplyResources(this.label1, "label1");
-            this.label1.Name = "label1";
+            resources.ApplyResources(label1, "label1");
+            label1.Name = "label1";
             // 
             // button1
             // 
-            resources.ApplyResources(this.button1, "button1");
-            this.button1.Name = "button1";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            resources.ApplyResources(button1, "button1");
+            button1.Name = "button1";
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += button1_Click;
             // 
             // panel1
             // 
-            this.panel1.Controls.Add(this.linkLabel3);
-            this.panel1.Controls.Add(this.label4);
-            this.panel1.Controls.Add(this.linkLabel2);
-            this.panel1.Controls.Add(this.label3);
-            this.panel1.Controls.Add(this.label2);
-            this.panel1.Controls.Add(this.linkLabel1);
-            resources.ApplyResources(this.panel1, "panel1");
-            this.panel1.Name = "panel1";
+            panel1.Controls.Add(linkLabel3);
+            panel1.Controls.Add(label4);
+            panel1.Controls.Add(linkLabel2);
+            panel1.Controls.Add(label3);
+            panel1.Controls.Add(label2);
+            panel1.Controls.Add(linkLabel1);
+            resources.ApplyResources(panel1, "panel1");
+            panel1.Name = "panel1";
             // 
             // linkLabel3
             // 
-            resources.ApplyResources(this.linkLabel3, "linkLabel3");
-            this.linkLabel3.Name = "linkLabel3";
-            this.linkLabel3.TabStop = true;
-            this.linkLabel3.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel1_LinkClicked);
+            resources.ApplyResources(linkLabel3, "linkLabel3");
+            linkLabel3.Name = "linkLabel3";
+            linkLabel3.TabStop = true;
+            linkLabel3.LinkClicked += linkLabel1_LinkClicked;
             // 
             // label4
             // 
-            resources.ApplyResources(this.label4, "label4");
-            this.label4.Name = "label4";
+            resources.ApplyResources(label4, "label4");
+            label4.Name = "label4";
             // 
             // linkLabel2
             // 
-            resources.ApplyResources(this.linkLabel2, "linkLabel2");
-            this.linkLabel2.Name = "linkLabel2";
-            this.linkLabel2.TabStop = true;
-            this.linkLabel2.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel1_LinkClicked);
+            resources.ApplyResources(linkLabel2, "linkLabel2");
+            linkLabel2.Name = "linkLabel2";
+            linkLabel2.TabStop = true;
+            linkLabel2.LinkClicked += linkLabel1_LinkClicked;
             // 
             // label3
             // 
-            resources.ApplyResources(this.label3, "label3");
-            this.label3.Name = "label3";
+            resources.ApplyResources(label3, "label3");
+            label3.Name = "label3";
             // 
             // label2
             // 
-            resources.ApplyResources(this.label2, "label2");
-            this.label2.Name = "label2";
+            resources.ApplyResources(label2, "label2");
+            label2.Name = "label2";
             // 
             // linkLabel1
             // 
-            resources.ApplyResources(this.linkLabel1, "linkLabel1");
-            this.linkLabel1.Name = "linkLabel1";
-            this.linkLabel1.TabStop = true;
-            this.linkLabel1.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.linkLabel1_LinkClicked);
+            resources.ApplyResources(linkLabel1, "linkLabel1");
+            linkLabel1.Name = "linkLabel1";
+            linkLabel1.TabStop = true;
+            linkLabel1.LinkClicked += linkLabel1_LinkClicked;
             // 
             // panel2
             // 
-            this.panel2.Controls.Add(this.label6);
-            this.panel2.Controls.Add(this.licenseReferenceControl10);
-            this.panel2.Controls.Add(this.licenseReferenceControl8);
-            this.panel2.Controls.Add(this.licenseReferenceControl6);
-            this.panel2.Controls.Add(this.licenseReferenceControl5);
-            this.panel2.Controls.Add(this.licenseReferenceControl2);
-            this.panel2.Controls.Add(this.licenseReferenceControl7);
-            this.panel2.Controls.Add(this.licenseReferenceControl4);
-            this.panel2.Controls.Add(this.licenseReferenceControl3);
-            this.panel2.Controls.Add(this.licenseReferenceControl1);
-            this.panel2.Controls.Add(this.label5);
-            resources.ApplyResources(this.panel2, "panel2");
-            this.panel2.Name = "panel2";
+            panel2.Controls.Add(label6);
+            panel2.Controls.Add(licenseReferenceControl9);
+            panel2.Controls.Add(licenseReferenceControl10);
+            panel2.Controls.Add(licenseReferenceControl8);
+            panel2.Controls.Add(licenseReferenceControl6);
+            panel2.Controls.Add(licenseReferenceControl5);
+            panel2.Controls.Add(licenseReferenceControl2);
+            panel2.Controls.Add(licenseReferenceControl7);
+            panel2.Controls.Add(licenseReferenceControl4);
+            panel2.Controls.Add(licenseReferenceControl3);
+            panel2.Controls.Add(licenseReferenceControl1);
+            panel2.Controls.Add(label5);
+            resources.ApplyResources(panel2, "panel2");
+            panel2.Name = "panel2";
+            // 
+            // licenseReferenceControl9
+            // 
+            resources.ApplyResources(licenseReferenceControl9, "licenseReferenceControl9");
+            licenseReferenceControl9.Library = "Serilog";
+            licenseReferenceControl9.LibraryLink = "https://github.com/serilog/serilog";
+            licenseReferenceControl9.LicenseLink = "https://github.com/serilog/serilog/blob/dev/LICENSE";
+            licenseReferenceControl9.Name = "licenseReferenceControl9";
             // 
             // licenseReferenceControl10
             // 
-            resources.ApplyResources(this.licenseReferenceControl10, "licenseReferenceControl10");
-            this.licenseReferenceControl10.Library = "websocket-sharp";
-            this.licenseReferenceControl10.LibraryLink = "https://github.com/PingmanTools/websocket-sharp/";
-            this.licenseReferenceControl10.LicenseLink = "https://github.com/PingmanTools/websocket-sharp/blob/master/LICENSE.txt";
-            this.licenseReferenceControl10.Name = "licenseReferenceControl10";
+            resources.ApplyResources(licenseReferenceControl10, "licenseReferenceControl10");
+            licenseReferenceControl10.Library = "websocket-sharp";
+            licenseReferenceControl10.LibraryLink = "https://github.com/PingmanTools/websocket-sharp/";
+            licenseReferenceControl10.LicenseLink = "https://github.com/PingmanTools/websocket-sharp/blob/master/LICENSE.txt";
+            licenseReferenceControl10.Name = "licenseReferenceControl10";
             // 
             // licenseReferenceControl8
             // 
-            resources.ApplyResources(this.licenseReferenceControl8, "licenseReferenceControl8");
-            this.licenseReferenceControl8.Library = "HidSharp";
-            this.licenseReferenceControl8.LibraryLink = "https://www.nuget.org/packages/HidSharp";
-            this.licenseReferenceControl8.LicenseLink = "https://www.zer7.com/files/oss/hidsharp/LICENSE.txt";
-            this.licenseReferenceControl8.Name = "licenseReferenceControl8";
+            resources.ApplyResources(licenseReferenceControl8, "licenseReferenceControl8");
+            licenseReferenceControl8.Library = "HidSharp";
+            licenseReferenceControl8.LibraryLink = "https://www.nuget.org/packages/HidSharp";
+            licenseReferenceControl8.LicenseLink = "https://www.zer7.com/files/oss/hidsharp/LICENSE.txt";
+            licenseReferenceControl8.Name = "licenseReferenceControl8";
             // 
             // licenseReferenceControl6
             // 
-            resources.ApplyResources(this.licenseReferenceControl6, "licenseReferenceControl6");
-            this.licenseReferenceControl6.Library = "MidiSlicer";
-            this.licenseReferenceControl6.LibraryLink = "https://github.com/codewitch-honey-crisis/MidiSlicer";
-            this.licenseReferenceControl6.LicenseLink = "https://www.codeproject.com/Articles/5272315/Midi-A-Windows-MIDI-Library-in-Cshar" +
-    "p";
-            this.licenseReferenceControl6.Name = "licenseReferenceControl6";
+            resources.ApplyResources(licenseReferenceControl6, "licenseReferenceControl6");
+            licenseReferenceControl6.Library = "MidiSlicer";
+            licenseReferenceControl6.LibraryLink = "https://github.com/codewitch-honey-crisis/MidiSlicer";
+            licenseReferenceControl6.LicenseLink = "https://www.codeproject.com/Articles/5272315/Midi-A-Windows-MIDI-Library-in-Csharp";
+            licenseReferenceControl6.Name = "licenseReferenceControl6";
             // 
             // licenseReferenceControl5
             // 
-            resources.ApplyResources(this.licenseReferenceControl5, "licenseReferenceControl5");
-            this.licenseReferenceControl5.Library = "X-Plane Connector";
-            this.licenseReferenceControl5.LibraryLink = "https://www.nuget.org/packages/XPlaneConnector/1.3.0";
-            this.licenseReferenceControl5.LicenseLink = "https://www.nuget.org/packages/XPlaneConnector/1.3.0/license";
-            this.licenseReferenceControl5.Name = "licenseReferenceControl5";
+            resources.ApplyResources(licenseReferenceControl5, "licenseReferenceControl5");
+            licenseReferenceControl5.Library = "X-Plane Connector";
+            licenseReferenceControl5.LibraryLink = "https://www.nuget.org/packages/XPlaneConnector/1.3.0";
+            licenseReferenceControl5.LicenseLink = "https://www.nuget.org/packages/XPlaneConnector/1.3.0/license";
+            licenseReferenceControl5.Name = "licenseReferenceControl5";
             // 
             // licenseReferenceControl2
             // 
-            resources.ApplyResources(this.licenseReferenceControl2, "licenseReferenceControl2");
-            this.licenseReferenceControl2.Library = "SharpDX";
-            this.licenseReferenceControl2.LibraryLink = "https://www.nuget.org/packages/SharpDX/";
-            this.licenseReferenceControl2.LicenseLink = "https://github.com/sharpdx/SharpDX/blob/master/LICENSE";
-            this.licenseReferenceControl2.Name = "licenseReferenceControl2";
+            resources.ApplyResources(licenseReferenceControl2, "licenseReferenceControl2");
+            licenseReferenceControl2.Library = "SharpDX";
+            licenseReferenceControl2.LibraryLink = "https://www.nuget.org/packages/SharpDX/";
+            licenseReferenceControl2.LicenseLink = "https://github.com/sharpdx/SharpDX/blob/master/LICENSE";
+            licenseReferenceControl2.Name = "licenseReferenceControl2";
             // 
             // licenseReferenceControl7
             // 
-            resources.ApplyResources(this.licenseReferenceControl7, "licenseReferenceControl7");
-            this.licenseReferenceControl7.Library = "NewtonSoft JSON.NET Schema";
-            this.licenseReferenceControl7.LibraryLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema";
-            this.licenseReferenceControl7.LicenseLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema/3.0.15/License";
-            this.licenseReferenceControl7.Name = "licenseReferenceControl7";
+            resources.ApplyResources(licenseReferenceControl7, "licenseReferenceControl7");
+            licenseReferenceControl7.Library = "NewtonSoft JSON.NET Schema";
+            licenseReferenceControl7.LibraryLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema";
+            licenseReferenceControl7.LicenseLink = "https://www.nuget.org/packages/Newtonsoft.Json.Schema/3.0.15/License";
+            licenseReferenceControl7.Name = "licenseReferenceControl7";
             // 
             // licenseReferenceControl4
             // 
-            resources.ApplyResources(this.licenseReferenceControl4, "licenseReferenceControl4");
-            this.licenseReferenceControl4.Library = "NewtonSoft JSON";
-            this.licenseReferenceControl4.LibraryLink = "https://www.nuget.org/packages/Newtonsoft.Json/";
-            this.licenseReferenceControl4.LicenseLink = "https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md";
-            this.licenseReferenceControl4.Name = "licenseReferenceControl4";
+            resources.ApplyResources(licenseReferenceControl4, "licenseReferenceControl4");
+            licenseReferenceControl4.Library = "NewtonSoft JSON";
+            licenseReferenceControl4.LibraryLink = "https://www.nuget.org/packages/Newtonsoft.Json/";
+            licenseReferenceControl4.LicenseLink = "https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md";
+            licenseReferenceControl4.Name = "licenseReferenceControl4";
             // 
             // licenseReferenceControl3
             // 
-            resources.ApplyResources(this.licenseReferenceControl3, "licenseReferenceControl3");
-            this.licenseReferenceControl3.Library = "FSUIPC Client DLL";
-            this.licenseReferenceControl3.LibraryLink = "https://www.nuget.org/packages/FSUIPCClientDLL/3.2.19";
-            this.licenseReferenceControl3.LicenseLink = "https://www.nuget.org/packages/FSUIPCClientDLL/3.2.19/license";
-            this.licenseReferenceControl3.Name = "licenseReferenceControl3";
+            resources.ApplyResources(licenseReferenceControl3, "licenseReferenceControl3");
+            licenseReferenceControl3.Library = "FSUIPC Client DLL";
+            licenseReferenceControl3.LibraryLink = "https://www.nuget.org/packages/FSUIPCClientDLL/3.2.19";
+            licenseReferenceControl3.LicenseLink = "https://www.nuget.org/packages/FSUIPCClientDLL/3.2.19/license";
+            licenseReferenceControl3.Name = "licenseReferenceControl3";
             // 
             // licenseReferenceControl1
             // 
-            resources.ApplyResources(this.licenseReferenceControl1, "licenseReferenceControl1");
-            this.licenseReferenceControl1.Library = "CmdMessenger";
-            this.licenseReferenceControl1.LibraryLink = "https://github.com/MobiFlight/Arduino-CmdMessenger/";
-            this.licenseReferenceControl1.LicenseLink = "https://github.com/MobiFlight/Arduino-CmdMessenger/blob/master/LICENSE.md";
-            this.licenseReferenceControl1.Name = "licenseReferenceControl1";
+            resources.ApplyResources(licenseReferenceControl1, "licenseReferenceControl1");
+            licenseReferenceControl1.Library = "CmdMessenger";
+            licenseReferenceControl1.LibraryLink = "https://github.com/MobiFlight/Arduino-CmdMessenger/";
+            licenseReferenceControl1.LicenseLink = "https://github.com/MobiFlight/Arduino-CmdMessenger/blob/master/LICENSE.md";
+            licenseReferenceControl1.Name = "licenseReferenceControl1";
             // 
             // label5
             // 
-            resources.ApplyResources(this.label5, "label5");
-            this.label5.Name = "label5";
+            resources.ApplyResources(label5, "label5");
+            label5.Name = "label5";
             // 
             // panel3
             // 
-            this.panel3.Controls.Add(this.button1);
-            resources.ApplyResources(this.panel3, "panel3");
-            this.panel3.Name = "panel3";
+            panel3.Controls.Add(button1);
+            resources.ApplyResources(panel3, "panel3");
+            panel3.Name = "panel3";
             // 
             // label6
             // 
-            resources.ApplyResources(this.label6, "label6");
-            this.label6.Name = "label6";
+            resources.ApplyResources(label6, "label6");
+            label6.Name = "label6";
             // 
             // AboutForm
             // 
             resources.ApplyResources(this, "$this");
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.panel3);
-            this.Controls.Add(this.panel2);
-            this.Controls.Add(this.panel1);
-            this.Controls.Add(this.label1);
-            this.Name = "AboutForm";
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
-            this.panel2.ResumeLayout(false);
-            this.panel2.PerformLayout();
-            this.panel3.ResumeLayout(false);
-            this.ResumeLayout(false);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            Controls.Add(panel3);
+            Controls.Add(panel2);
+            Controls.Add(panel1);
+            Controls.Add(label1);
+            Name = "AboutForm";
+            panel1.ResumeLayout(false);
+            panel1.PerformLayout();
+            panel2.ResumeLayout(false);
+            panel2.PerformLayout();
+            panel3.ResumeLayout(false);
+            ResumeLayout(false);
 
         }
 
@@ -261,6 +270,7 @@
         private Panels.About.LicenseReferenceControl licenseReferenceControl7;
         private Panels.About.LicenseReferenceControl licenseReferenceControl8;
         private Panels.About.LicenseReferenceControl licenseReferenceControl10;
+        private Panels.About.LicenseReferenceControl licenseReferenceControl9;
         private System.Windows.Forms.Label label6;
     }
 }

--- a/src/MobiFlightConnector/UI/Dialogs/AboutForm.resx
+++ b/src/MobiFlightConnector/UI/Dialogs/AboutForm.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -117,7 +117,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
@@ -128,11 +128,15 @@
   <data name="label1.Location" type="System.Drawing.Point, System.Drawing">
     <value>0, 0</value>
   </data>
+  <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="label1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
+  </data>
   <data name="label1.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 0, 0</value>
+    <value>4, 3, 0, 0</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 88</value>
+    <value>404, 102</value>
   </data>
   <assembly alias="mscorlib" name="mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="label1.TabIndex" type="System.Int32, mscorlib">
@@ -150,7 +154,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>label1</value>
   </data>
   <data name="&gt;&gt;label1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label1.Parent" xml:space="preserve">
     <value>$this</value>
@@ -165,10 +169,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>NoControl</value>
   </data>
   <data name="button1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>268, 3</value>
+    <value>313, 3</value>
+  </data>
+  <data name="button1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 3, 4, 3</value>
   </data>
   <data name="button1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>75, 23</value>
+    <value>88, 27</value>
   </data>
   <data name="button1.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -180,13 +187,112 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>button1</value>
   </data>
   <data name="&gt;&gt;button1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Button, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Button, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;button1.Parent" xml:space="preserve">
     <value>panel3</value>
   </data>
   <data name="&gt;&gt;button1.ZOrder" xml:space="preserve">
     <value>0</value>
+  </data>
+  <data name="&gt;&gt;linkLabel3.Name" xml:space="preserve">
+    <value>linkLabel3</value>
+  </data>
+  <data name="&gt;&gt;linkLabel3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabel3.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel3.ZOrder" xml:space="preserve">
+    <value>0</value>
+  </data>
+  <data name="&gt;&gt;label4.Name" xml:space="preserve">
+    <value>label4</value>
+  </data>
+  <data name="&gt;&gt;label4.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label4.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;label4.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel2.Name" xml:space="preserve">
+    <value>linkLabel2</value>
+  </data>
+  <data name="&gt;&gt;linkLabel2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabel2.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel2.ZOrder" xml:space="preserve">
+    <value>2</value>
+  </data>
+  <data name="&gt;&gt;label3.Name" xml:space="preserve">
+    <value>label3</value>
+  </data>
+  <data name="&gt;&gt;label3.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label3.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;label3.ZOrder" xml:space="preserve">
+    <value>3</value>
+  </data>
+  <data name="&gt;&gt;label2.Name" xml:space="preserve">
+    <value>label2</value>
+  </data>
+  <data name="&gt;&gt;label2.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;label2.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;label2.ZOrder" xml:space="preserve">
+    <value>4</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Name" xml:space="preserve">
+    <value>linkLabel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.Parent" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
+    <value>5</value>
+  </data>
+  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
+    <value>0, 102</value>
+  </data>
+  <data name="panel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 3, 4, 3</value>
+  </data>
+  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
+    <value>404, 87</value>
+  </data>
+  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
+    <value>7</value>
+  </data>
+  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
+    <value>panel1</value>
+  </data>
+  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </data>
+  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
+    <value>$this</value>
+  </data>
+  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
+    <value>2</value>
   </data>
   <data name="linkLabel3.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
@@ -195,10 +301,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>NoControl</value>
   </data>
   <data name="linkLabel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>72, 47</value>
+    <value>84, 54</value>
+  </data>
+  <data name="linkLabel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="linkLabel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>102, 13</value>
+    <value>122, 15</value>
   </data>
   <data name="linkLabel3.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -213,7 +322,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>linkLabel3</value>
   </data>
   <data name="&gt;&gt;linkLabel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;linkLabel3.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -225,10 +334,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>NoControl</value>
   </data>
   <data name="label4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 43</value>
+    <value>6, 50</value>
+  </data>
+  <data name="label4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 22</value>
+    <value>71, 25</value>
   </data>
   <data name="label4.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -243,7 +355,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>label4</value>
   </data>
   <data name="&gt;&gt;label4.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label4.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -258,10 +370,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>NoControl</value>
   </data>
   <data name="linkLabel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>72, 26</value>
+    <value>84, 30</value>
+  </data>
+  <data name="linkLabel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="linkLabel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>110, 13</value>
+    <value>130, 15</value>
   </data>
   <data name="linkLabel2.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -276,7 +391,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>linkLabel2</value>
   </data>
   <data name="&gt;&gt;linkLabel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;linkLabel2.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -288,10 +403,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>NoControl</value>
   </data>
   <data name="label3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 22</value>
+    <value>6, 25</value>
+  </data>
+  <data name="label3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>63, 22</value>
+    <value>74, 25</value>
   </data>
   <data name="label3.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -306,7 +424,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>label3</value>
   </data>
   <data name="&gt;&gt;label3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label3.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -318,10 +436,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>NoControl</value>
   </data>
   <data name="label2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>5, 2</value>
+    <value>6, 2</value>
+  </data>
+  <data name="label2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>61, 23</value>
+    <value>71, 27</value>
   </data>
   <data name="label2.TabIndex" type="System.Int32, mscorlib">
     <value>1</value>
@@ -336,7 +457,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>label2</value>
   </data>
   <data name="&gt;&gt;label2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label2.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -351,10 +472,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>NoControl</value>
   </data>
   <data name="linkLabel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>72, 6</value>
+    <value>84, 7</value>
+  </data>
+  <data name="linkLabel1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="linkLabel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>148, 13</value>
+    <value>172, 15</value>
   </data>
   <data name="linkLabel1.TabIndex" type="System.Int32, mscorlib">
     <value>0</value>
@@ -369,7 +493,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>linkLabel1</value>
   </data>
   <data name="&gt;&gt;linkLabel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.LinkLabel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;linkLabel1.Parent" xml:space="preserve">
     <value>panel1</value>
@@ -377,44 +501,26 @@ Copyright 2014-2025 - Sebastian Moebius</value>
   <data name="&gt;&gt;linkLabel1.ZOrder" xml:space="preserve">
     <value>5</value>
   </data>
-  <data name="panel1.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
-    <value>Top</value>
-  </data>
-  <data name="panel1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 88</value>
-  </data>
-  <data name="panel1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 75</value>
-  </data>
-  <data name="panel1.TabIndex" type="System.Int32, mscorlib">
-    <value>7</value>
-  </data>
-  <data name="&gt;&gt;panel1.Name" xml:space="preserve">
-    <value>panel1</value>
-  </data>
-  <data name="&gt;&gt;panel1.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
-  </data>
-  <data name="&gt;&gt;panel1.Parent" xml:space="preserve">
-    <value>$this</value>
-  </data>
-  <data name="&gt;&gt;panel1.ZOrder" xml:space="preserve">
-    <value>2</value>
-  </data>
   <data name="label6.AutoSize" type="System.Boolean, mscorlib">
     <value>True</value>
   </data>
   <data name="label6.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
+  <data name="label6.ImeMode" type="System.Windows.Forms.ImeMode, System.Windows.Forms">
+    <value>NoControl</value>
+  </data>
   <data name="label6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 281</value>
+    <value>4, 327</value>
+  </data>
+  <data name="label6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>306, 13</value>
+    <value>339, 15</value>
   </data>
   <data name="label6.TabIndex" type="System.Int32, mscorlib">
-    <value>13</value>
+    <value>14</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
     <value>Thanks to Gijs de Rooij for providing the BoeingCDULarge font.</value>
@@ -423,7 +529,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>label6</value>
   </data>
   <data name="&gt;&gt;label6.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label6.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -431,14 +537,44 @@ Copyright 2014-2025 - Sebastian Moebius</value>
   <data name="&gt;&gt;label6.ZOrder" xml:space="preserve">
     <value>0</value>
   </data>
+  <data name="licenseReferenceControl9.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
+    <value>Top</value>
+  </data>
+  <data name="licenseReferenceControl9.Location" type="System.Drawing.Point, System.Drawing">
+    <value>4, 299</value>
+  </data>
+  <data name="licenseReferenceControl9.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 3, 5, 3</value>
+  </data>
+  <data name="licenseReferenceControl9.Size" type="System.Drawing.Size, System.Drawing">
+    <value>396, 28</value>
+  </data>
+  <data name="licenseReferenceControl9.TabIndex" type="System.Int32, mscorlib">
+    <value>13</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl9.Name" xml:space="preserve">
+    <value>licenseReferenceControl9</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl9.Type" xml:space="preserve">
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl9.Parent" xml:space="preserve">
+    <value>panel2</value>
+  </data>
+  <data name="&gt;&gt;licenseReferenceControl9.ZOrder" xml:space="preserve">
+    <value>1</value>
+  </data>
   <data name="licenseReferenceControl10.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl10.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 257</value>
+    <value>4, 271</value>
+  </data>
+  <data name="licenseReferenceControl10.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>5, 3, 5, 3</value>
   </data>
   <data name="licenseReferenceControl10.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl10.TabIndex" type="System.Int32, mscorlib">
     <value>12</value>
@@ -447,25 +583,25 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl10</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl10.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl10.Parent" xml:space="preserve">
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl10.ZOrder" xml:space="preserve">
-    <value>1</value>
+    <value>2</value>
   </data>
   <data name="licenseReferenceControl8.Dock" type="System.Windows.Forms.DockStyle, System.Windows.Forms">
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl8.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 209</value>
+    <value>4, 243</value>
   </data>
   <data name="licenseReferenceControl8.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
+    <value>4, 3, 12, 3</value>
   </data>
   <data name="licenseReferenceControl8.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl8.TabIndex" type="System.Int32, mscorlib">
     <value>10</value>
@@ -474,7 +610,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl8</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl8.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl8.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -486,13 +622,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl6.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 185</value>
+    <value>4, 215</value>
   </data>
   <data name="licenseReferenceControl6.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
+    <value>4, 3, 12, 3</value>
   </data>
   <data name="licenseReferenceControl6.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl6.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -501,7 +637,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl6</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl6.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl6.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -513,13 +649,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 161</value>
+    <value>4, 187</value>
   </data>
   <data name="licenseReferenceControl5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
+    <value>4, 3, 12, 3</value>
   </data>
   <data name="licenseReferenceControl5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl5.TabIndex" type="System.Int32, mscorlib">
     <value>6</value>
@@ -528,7 +664,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl5</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl5.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl5.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -540,13 +676,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 137</value>
+    <value>4, 159</value>
   </data>
   <data name="licenseReferenceControl2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
+    <value>4, 3, 12, 3</value>
   </data>
   <data name="licenseReferenceControl2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl2.TabIndex" type="System.Int32, mscorlib">
     <value>3</value>
@@ -555,7 +691,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl2</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl2.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl2.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -567,13 +703,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl7.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 113</value>
+    <value>4, 131</value>
   </data>
   <data name="licenseReferenceControl7.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
+    <value>4, 3, 12, 3</value>
   </data>
   <data name="licenseReferenceControl7.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl7.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -582,7 +718,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl7</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl7.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl7.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -594,13 +730,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl4.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 89</value>
+    <value>4, 103</value>
   </data>
   <data name="licenseReferenceControl4.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
+    <value>4, 3, 12, 3</value>
   </data>
   <data name="licenseReferenceControl4.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl4.TabIndex" type="System.Int32, mscorlib">
     <value>5</value>
@@ -609,7 +745,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl4</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl4.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl4.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -621,13 +757,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 65</value>
+    <value>4, 75</value>
   </data>
   <data name="licenseReferenceControl3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
+    <value>4, 3, 12, 3</value>
   </data>
   <data name="licenseReferenceControl3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl3.TabIndex" type="System.Int32, mscorlib">
     <value>4</value>
@@ -636,7 +772,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl3</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl3.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl3.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -648,13 +784,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Top</value>
   </data>
   <data name="licenseReferenceControl1.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 41</value>
+    <value>4, 47</value>
   </data>
   <data name="licenseReferenceControl1.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 3, 10, 3</value>
+    <value>4, 3, 12, 3</value>
   </data>
   <data name="licenseReferenceControl1.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 24</value>
+    <value>396, 28</value>
   </data>
   <data name="licenseReferenceControl1.TabIndex" type="System.Int32, mscorlib">
     <value>2</value>
@@ -663,7 +799,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>licenseReferenceControl1</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl1.Type" xml:space="preserve">
-    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Version=10.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>MobiFlight.UI.Panels.About.LicenseReferenceControl, MFConnector, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;licenseReferenceControl1.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -678,10 +814,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>NoControl</value>
   </data>
   <data name="label5.Location" type="System.Drawing.Point, System.Drawing">
-    <value>3, 0</value>
+    <value>4, 0</value>
+  </data>
+  <data name="label5.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="label5.Size" type="System.Drawing.Size, System.Drawing">
-    <value>340, 41</value>
+    <value>396, 47</value>
   </data>
   <data name="label5.TabIndex" type="System.Int32, mscorlib">
     <value>7</value>
@@ -696,7 +835,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>label5</value>
   </data>
   <data name="&gt;&gt;label5.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Label, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Label, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;label5.Parent" xml:space="preserve">
     <value>panel2</value>
@@ -708,13 +847,16 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Fill</value>
   </data>
   <data name="panel2.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 163</value>
+    <value>0, 189</value>
+  </data>
+  <data name="panel2.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 3, 4, 3</value>
   </data>
   <data name="panel2.Padding" type="System.Windows.Forms.Padding, System.Windows.Forms">
-    <value>3, 0, 3, 0</value>
+    <value>4, 0, 4, 0</value>
   </data>
   <data name="panel2.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 332</value>
+    <value>404, 382</value>
   </data>
   <data name="panel2.TabIndex" type="System.Int32, mscorlib">
     <value>8</value>
@@ -723,7 +865,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>panel2</value>
   </data>
   <data name="&gt;&gt;panel2.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panel2.Parent" xml:space="preserve">
     <value>$this</value>
@@ -735,10 +877,13 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>Bottom</value>
   </data>
   <data name="panel3.Location" type="System.Drawing.Point, System.Drawing">
-    <value>0, 466</value>
+    <value>0, 538</value>
+  </data>
+  <data name="panel3.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 3, 4, 3</value>
   </data>
   <data name="panel3.Size" type="System.Drawing.Size, System.Drawing">
-    <value>346, 29</value>
+    <value>404, 33</value>
   </data>
   <data name="panel3.TabIndex" type="System.Int32, mscorlib">
     <value>9</value>
@@ -747,7 +892,7 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>panel3</value>
   </data>
   <data name="&gt;&gt;panel3.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Panel, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Panel, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
   <data name="&gt;&gt;panel3.Parent" xml:space="preserve">
     <value>$this</value>
@@ -759,10 +904,10 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>True</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>6, 13</value>
+    <value>7, 15</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
-    <value>346, 495</value>
+    <value>404, 571</value>
   </data>
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -908,6 +1053,9 @@ Copyright 2014-2025 - Sebastian Moebius</value>
         AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
 </value>
   </data>
+  <data name="$this.Margin" type="System.Windows.Forms.Padding, System.Windows.Forms">
+    <value>4, 3, 4, 3</value>
+  </data>
   <data name="$this.Text" xml:space="preserve">
     <value>About MF Connector</value>
   </data>
@@ -915,6 +1063,6 @@ Copyright 2014-2025 - Sebastian Moebius</value>
     <value>AboutForm</value>
   </data>
   <data name="&gt;&gt;$this.Type" xml:space="preserve">
-    <value>System.Windows.Forms.Form, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Windows.Forms.Form, System.Windows.Forms, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </data>
 </root>

--- a/tests/MobiFlightUnitTests/Base/LogTests.cs
+++ b/tests/MobiFlightUnitTests/Base/LogTests.cs
@@ -1,0 +1,183 @@
+using Moq;
+using Serilog.Events;
+
+namespace MobiFlight.Base.Tests
+{
+    [TestClass]
+    public class LogTests
+    {
+        private Log _log;
+        private bool _originalEnabled;
+        private LogSeverity _originalSeverity;
+        private bool _originalLogJoystickAxis;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _log = Log.Instance;
+            _originalEnabled = _log.Enabled;
+            _originalSeverity = _log.Severity;
+            _originalLogJoystickAxis = _log.LogJoystickAxis;
+            _log.ClearAppenders();
+            _log.Enabled = false;
+            _log.Severity = LogSeverity.Info;
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _log.ClearAppenders();
+            _log.Enabled = _originalEnabled;
+            _log.Severity = _originalSeverity;
+            _log.LogJoystickAxis = _originalLogJoystickAxis;
+        }
+
+        [TestMethod]
+        [DataRow(LogSeverity.Debug, "DEBUG")]
+        [DataRow(LogSeverity.Info, "INFO")]
+        [DataRow(LogSeverity.Warn, "WARNING")]
+        [DataRow(LogSeverity.Error, "ERROR")]
+        public void PythonLogLevel_ReturnsExpectedValue(LogSeverity severity, string expected)
+        {
+            Assert.AreEqual(expected, severity.PythonLogLevel());
+        }
+
+        [TestMethod]
+        public void PythonLogLevel_UnknownSeverity_ReturnsWarning()
+        {
+            Assert.AreEqual("WARNING", ((LogSeverity)99).PythonLogLevel());
+        }
+
+        [TestMethod]
+        [DataRow("DEBUG", LogSeverity.Debug)]
+        [DataRow("INFO", LogSeverity.Info)]
+        [DataRow("WARNING", LogSeverity.Warn)]
+        [DataRow("ERROR", LogSeverity.Error)]
+        public void SeverityFromPythonLogLevel_ValidValue_ReturnsMatchingSeverity(string level, LogSeverity expected)
+        {
+            var converted = LogSeverityExtensions.SeverityFromPythonLogLevel(level, out var severity);
+
+            Assert.IsTrue(converted);
+            Assert.AreEqual(expected, severity);
+        }
+
+        [TestMethod]
+        public void SeverityFromPythonLogLevel_InvalidValue_ReturnsFalseAndInfo()
+        {
+            var converted = LogSeverityExtensions.SeverityFromPythonLogLevel("TRACE", out var severity);
+
+            Assert.IsFalse(converted);
+            Assert.AreEqual(LogSeverity.Info, severity);
+        }
+
+        [TestMethod]
+        [DataRow(LogSeverity.Debug, LogEventLevel.Debug)]
+        [DataRow(LogSeverity.Info, LogEventLevel.Information)]
+        [DataRow(LogSeverity.Warn, LogEventLevel.Warning)]
+        [DataRow(LogSeverity.Error, LogEventLevel.Error)]
+        public void ToSerilogLevel_ReturnsExpectedValue(LogSeverity severity, LogEventLevel expected)
+        {
+            Assert.AreEqual(expected, severity.ToSerilogLevel());
+        }
+
+        [TestMethod]
+        public void ToSerilogLevel_UnknownSeverity_ReturnsWarning()
+        {
+            Assert.AreEqual(LogEventLevel.Warning, ((LogSeverity)99).ToSerilogLevel());
+        }
+
+        [TestMethod]
+        public void Log_WhenDisabled_DoesNotNotifyAppender()
+        {
+            var appender = new Mock<ILogAppender>();
+            _log.AddAppender(appender.Object);
+
+            _log.log("message", LogSeverity.Error);
+
+            appender.Verify(a => a.log(It.IsAny<string>(), It.IsAny<LogSeverity>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void Log_BelowConfiguredSeverity_DoesNotNotifyAppender()
+        {
+            var appender = new Mock<ILogAppender>();
+            _log.AddAppender(appender.Object);
+            _log.Enabled = true;
+            _log.Severity = LogSeverity.Warn;
+
+            _log.log("message", LogSeverity.Info);
+
+            appender.Verify(a => a.log(It.IsAny<string>(), It.IsAny<LogSeverity>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void Log_EligibleMessage_NotifiesEveryAppender()
+        {
+            var firstAppender = new Mock<ILogAppender>();
+            var secondAppender = new Mock<ILogAppender>();
+            _log.AddAppender(firstAppender.Object);
+            _log.AddAppender(secondAppender.Object);
+            _log.Enabled = true;
+            _log.Severity = LogSeverity.Info;
+
+            _log.log("message", LogSeverity.Warn);
+
+            firstAppender.Verify(a => a.log("message", LogSeverity.Warn), Times.Once);
+            secondAppender.Verify(a => a.log("message", LogSeverity.Warn), Times.Once);
+        }
+
+        [TestMethod]
+        public void Log_DebugMessage_IncludesCallingMethod()
+        {
+            var appender = new Mock<ILogAppender>();
+            _log.AddAppender(appender.Object);
+            _log.Enabled = true;
+            _log.Severity = LogSeverity.Debug;
+
+            _log.log("message", LogSeverity.Debug);
+
+            appender.Verify(a => a.log(
+                It.Is<string>(message => message.StartsWith("LogTests.Log_DebugMessage_IncludesCallingMethod(): ") && message.EndsWith("message")),
+                LogSeverity.Debug),
+                Times.Once);
+        }
+
+        [TestMethod]
+        public void ClearAppenders_RemovesRegisteredAppenders()
+        {
+            var appender = new Mock<ILogAppender>();
+            _log.AddAppender(appender.Object);
+            _log.ClearAppenders();
+            _log.Enabled = true;
+
+            _log.log("message", LogSeverity.Info);
+
+            appender.Verify(a => a.log(It.IsAny<string>(), It.IsAny<LogSeverity>()), Times.Never);
+        }
+
+        [TestMethod]
+        public void LooksLikeExpression_RecognizesIndicatorsAndPlainText()
+        {
+            foreach (var indicator in Log.ExpressionIndicator)
+            {
+                Assert.IsTrue(Log.LooksLikeExpression($"value{indicator}value"));
+            }
+
+            Assert.IsFalse(Log.LooksLikeExpression("value"));
+            Assert.IsFalse(Log.LooksLikeExpression(String.Empty));
+        }
+
+        [TestMethod]
+        public void GetStatistics_ReturnsConfiguredLoggingValues()
+        {
+            _log.Enabled = true;
+            _log.Severity = LogSeverity.Error;
+
+            Dictionary<string, int> statistics = _log.GetStatistics();
+
+            Assert.HasCount(2, statistics);
+            Assert.AreEqual((int)LogSeverity.Error, statistics["Log.Level"]);
+            Assert.AreEqual(1, statistics["Log.Enabled"]);
+        }
+    }
+}


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary

Using Serilog for logging. It was originally thought that logging was saturating the thread pool as that too used Task.Run. Offloading to Serilog allows Serilog to handle log events in a more optimised fashion.
     
## Related issues
<!-- fixes, relates to existing #issues -->
Addresses some threadpool bound work as part of #3324 

### Out-of-scope

A full rewrite of logging has not be implemented in this change in order to keep the scope short.
