### PR TITLE
Enable debug symbols on release builds

### DIFF
--- a/src/MobiFlightConnector/MobiFlightConnector.csproj
+++ b/src/MobiFlightConnector/MobiFlightConnector.csproj
@@ -36,6 +36,8 @@
 		<CodeAnalysisIgnoreBuiltInRuleSets>false</CodeAnalysisIgnoreBuiltInRuleSets>
 		<CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
 		<NoWarn>$(NoWarn);WFO1000</NoWarn>
+		<DebugSymbols>true</DebugSymbols>
+		<DebugType>portable</DebugType>
 	</PropertyGroup>
 	<ItemGroup>
 		<Content Include="mobiflight.ico" />


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary

Following some recent issues around thread safety and deadlocking, this enables debug symbols on the release build to allow us to use ETW traces while troubleshooting elusive issues such as deadlocks, performance and general CPU-bound operations.

Now when a user experiences an issue we only need to have them generate a trace which we can then inspect via Windows Performance Analyzer or Superluminal.
     
## Related issues
<!-- fixes, relates to existing #issues -->
Implemented on the back of #3324 