### PR TITLE
use english news feed for non-core languages, and use english fallback if online feed cannot be loaded.

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
@@ -11,7 +11,6 @@ import {
 } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { fetchRemoteCommunityFeedWithFallback } from "@/lib/feed"
-// import { fetchRemoteCommunityFeed } from "@/lib/feed"
 import { useErrorFallbackTest } from "@/lib/hooks/useErrorFallbackTest"
 import { CommunityPost } from "@/types/feed"
 import { useQuery } from "@tanstack/react-query"

--- a/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
@@ -39,8 +39,7 @@ const CommunityMainCard = () => {
     import.meta.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl
   ).trim()
 
-  const language =
-    i18n.languages?.[0] || i18n.language || i18n.resolvedLanguage || "en"
+  const language = i18n.language || i18n.resolvedLanguage || "en"
 
   const remoteFeedQuery = useQuery({
     queryKey: ["community-feed", language, remoteFeedBaseUrl],

--- a/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/community/CommunityMainCard.tsx
@@ -10,7 +10,8 @@ import {
   CardTitle,
 } from "@/components/ui/card"
 import { ScrollArea } from "@/components/ui/scroll-area"
-import { fetchRemoteCommunityFeed } from "@/lib/feed"
+import { fetchRemoteCommunityFeedWithFallback } from "@/lib/feed"
+// import { fetchRemoteCommunityFeed } from "@/lib/feed"
 import { useErrorFallbackTest } from "@/lib/hooks/useErrorFallbackTest"
 import { CommunityPost } from "@/types/feed"
 import { useQuery } from "@tanstack/react-query"
@@ -31,25 +32,27 @@ const CommunityMainCard = () => {
     returnObjects: true,
   }) as CommunityPost[]
 
-  
-  // For local development, we are able to point the feed to a custom url 
+  // For local development, we are able to point the feed to a custom url
   // This url is optionally defined in the environment variable VITE_FEED_REMOTE_BASE_URL
   // If not set, the frontend will default to "https://mobiflight.com/feed" as the base url for the feed
   const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
-  const remoteFeedBaseUrl = (import.meta.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl).trim()
+  const remoteFeedBaseUrl = (
+    import.meta.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl
+  ).trim()
 
-  const language = i18n.resolvedLanguage || i18n.language || "en"
+  const language =
+    i18n.languages?.[0] || i18n.language || i18n.resolvedLanguage || "en"
 
   const remoteFeedQuery = useQuery({
     queryKey: ["community-feed", language, remoteFeedBaseUrl],
     queryFn: () =>
-      fetchRemoteCommunityFeed({
+      fetchRemoteCommunityFeedWithFallback({
         baseUrl: remoteFeedBaseUrl,
-        language
+        language,
       }),
   })
 
-  const displayedFeed = [ ...remoteFeedQuery.data ?? [], ...communityFeed ]
+  const displayedFeed = [...(remoteFeedQuery.data ?? []), ...communityFeed]
 
   const filteredFeed = displayedFeed.filter(
     (post) => post.tags.includes(activeFilter) || activeFilter === "all",

--- a/src/MobiFlightConnector/frontend/src/lib/feed.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/feed.ts
@@ -81,9 +81,7 @@ export const fetchRemoteCommunityFeedWithFallback = async ({
   const primaryLanguage = resolveLanguage(language)
   const fallbackLanguage = "en"
 
-  const languagesToTry = Array.from(
-    new Set([primaryLanguage, fallbackLanguage]),
-  )
+  const languagesToTry = [...new Set([primaryLanguage, fallbackLanguage])]
 
   let lastError: unknown
 

--- a/src/MobiFlightConnector/frontend/src/lib/feed.ts
+++ b/src/MobiFlightConnector/frontend/src/lib/feed.ts
@@ -73,6 +73,37 @@ const makeUrlAbsolute = (
   }
 }
 
+export const fetchRemoteCommunityFeedWithFallback = async ({
+  baseUrl,
+  language,
+  timeoutMs = 3000,
+}: FetchRemoteFeedOptions): Promise<CommunityPost[]> => {
+  const primaryLanguage = resolveLanguage(language)
+  const fallbackLanguage = "en"
+
+  const languagesToTry = Array.from(
+    new Set([primaryLanguage, fallbackLanguage]),
+  )
+
+  let lastError: unknown
+
+  for (const languageToTry of languagesToTry) {
+    try {
+      return await fetchRemoteCommunityFeed({
+        baseUrl,
+        language: languageToTry,
+        timeoutMs,
+      })
+    } catch (error) {
+      lastError = error
+    }
+  }
+
+  throw lastError instanceof Error
+    ? lastError
+    : new Error("Failed to load remote community feed")
+}
+
 export const fetchRemoteCommunityFeed = async ({
   baseUrl,
   language,

--- a/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/Dashboard.spec.ts
@@ -1307,6 +1307,47 @@ test.describe("Community Feed tests", () => {
     await expect(img4).toHaveAttribute("src", absoluteFeedImageUrl4)
   })
 
+  test.describe("Community Feed remote fallback tests", () => {
+    // For testing fallback behavior, we need to set the locale to Finnish, which is a non-core language
+    // By testing we can confirm that the community feed would fallback to online English feed first if the localized feed is unavailable
+    test.use({ locale: "fi-FI" })
+
+    test("Uses English online feed if localized online feed is unavailable", async ({
+      dashboardPage,
+      page,
+    }) => {
+      const remoteFeedDefaultBaseUrl = "https://mobiflight.com/feed"
+      const remoteFeedBaseUrl = (
+        process.env.VITE_FEED_REMOTE_BASE_URL ?? remoteFeedDefaultBaseUrl
+      ).trim()
+      // Mock the English online feed with a single post
+      const englishFallbackPosts = [
+        {
+          title: "English Online Fallback Post",
+          date: "2026-09-03",
+          content: ["This was loaded from the English online feed."],
+          tags: ["community"],
+        },
+      ]
+
+      await dashboardPage.disableDynamicFeed(remoteFeedBaseUrl, "fi")
+      await dashboardPage.mockDynamicFeed(
+        remoteFeedBaseUrl,
+        englishFallbackPosts,
+        "en",
+      )
+
+      await dashboardPage.gotoPage()
+      // Check that the English online fallback post is visible in the feed
+      await expect(page.getByText("English Online Fallback Post")).toBeVisible()
+
+      const feedItems = page.getByTestId("community-feed-item")
+      await expect(feedItems.first()).toContainText(
+        "English Online Fallback Post",
+      )
+    })
+  })
+
   test("Confirm button links are working correctly", async ({
     dashboardPage,
     page,

--- a/src/MobiFlightConnector/frontend/tests/fixtures/DashboardPage.ts
+++ b/src/MobiFlightConnector/frontend/tests/fixtures/DashboardPage.ts
@@ -19,23 +19,37 @@ export class DashboardPage {
     )
   }
 
-  async disableDynamicFeed(remoteFeedBaseUrl: string) {
-    await this.mobiFlightPage.page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
-      await route.fulfill({
-        status: 404,
-        contentType: "application/json",
-        body: JSON.stringify({}),
-      })
-    })
+  async disableDynamicFeed(remoteFeedBaseUrl: string, language = "en") {
+    const feedLanguage = language.split("-")[0]
+
+    await this.mobiFlightPage.page.route(
+      `${remoteFeedBaseUrl}/${feedLanguage}/feed.json`,
+      async (route) => {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({}),
+        })
+      },
+    )
   }
 
-  async mockDynamicFeed(remoteFeedBaseUrl: string, data: CommunityPost[]) {
-    await this.mobiFlightPage.page.route(`${remoteFeedBaseUrl}/en/feed.json`, async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ community: data }),
-      })
-    })
+  async mockDynamicFeed(
+    remoteFeedBaseUrl: string,
+    data: CommunityPost[],
+    language = "en",
+  ) {
+    const feedLanguage = language.split("-")[0]
+
+    await this.mobiFlightPage.page.route(
+      `${remoteFeedBaseUrl}/${feedLanguage}/feed.json`,
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ community: data }),
+        })
+      },
+    )
   }
 }


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
It was necessary to improve the community feed fallback behavior for non-core languages, because previously it relied on the bundled static fallback feed.

The app now tries to load the localized online feed first and if the feed is not available, it tries the English online feed next.

This helps users of non-core languages still receive current MobiFlight news and announcements, even when no localized online feed exists.

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Localized online feed is tried first
- [x] English online feed is used if the localized online feed cannot be loaded
- [x] Existing static feed fallback behavior still works
- [x] Non-core languages without their own `feed.json` still show community feed content

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Frontend tests
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3283 
relates #3271

### Out-of-scope
<!-- mention what is not covered by this PR -->
Server-side automatic translation of feed posts is not included in this PR.

This PR also does not add new static `feed.json` files for non-core languages.

### Notes
<!-- provide furhter information that might be of interest -->
The intended fallback order:

1. localized online feed
2. English online feed
3. localized static feed
4. English static feed