### PR TITLE
Log shows only one space as data even if multiple are send

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/LogPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/LogPanel.tsx
@@ -211,7 +211,7 @@ const LogPanel = () => {
                 </div>
                 <div
                   data-testid="log-entry-message"
-                  className="min-w-0 overflow-hidden text-ellipsis whitespace-pre"
+                  className="truncate whitespace-pre"
                 >
                   {entry.Message}
                 </div>

--- a/src/MobiFlightConnector/frontend/src/components/LogPanel.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/LogPanel.tsx
@@ -209,7 +209,12 @@ const LogPanel = () => {
                 >
                   {entry.Severity}
                 </div>
-                <div className="truncate">{entry.Message}</div>
+                <div
+                  data-testid="log-entry-message"
+                  className="min-w-0 overflow-hidden text-ellipsis whitespace-pre"
+                >
+                  {entry.Message}
+                </div>
               </div>
             ))
           )}

--- a/src/MobiFlightConnector/frontend/tests/LogPanel.spec.ts
+++ b/src/MobiFlightConnector/frontend/tests/LogPanel.spec.ts
@@ -47,7 +47,7 @@ test("Log entry messages appear in the panel", async ({
   await configListPage.mobiFlightPage.sendLogEntry(
     "info",
     "Hello from the test",
-    "2026-07-05T12:34:56.789Z"
+    "2026-07-05T12:34:56.789Z",
   )
 
   await configListPage.mobiFlightPage.openLogPanel()
@@ -57,7 +57,7 @@ test("Log entry messages appear in the panel", async ({
   await configListPage.mobiFlightPage.sendLogEntry(
     "info",
     "Single digit time components",
-    "2026-07-05T01:02:03.300Z"
+    "2026-07-05T01:02:03.300Z",
   )
 
   await expect(page.getByText("Single digit time components")).toBeVisible()
@@ -279,5 +279,30 @@ test.describe("Log panel - Toolbar tests", () => {
     await resetFilterButton.click()
     await expect(visibleEntry).toBeVisible()
     await expect(hiddenEntry).toBeVisible()
+  })
+
+  test("Log panel preserves consecutive spaces in log messages", async ({
+    configListPage,
+    page,
+  }) => {
+    await configListPage.gotoPage()
+
+    await configListPage.mobiFlightPage.sendLogEntry(
+      "info",
+      "Clear display: '        '",
+      "2026-07-05T12:34:56.789Z",
+    )
+
+    await configListPage.mobiFlightPage.openLogPanel()
+
+    const logEntry = page
+      .getByTestId("log-panel-content")
+      .locator('[data-severity="info"]')
+      .filter({ hasText: "Clear display" })
+
+    const message = logEntry.getByTestId("log-entry-message")
+
+    await expect(message).toHaveText("Clear display: '        '")
+    await expect(message).toHaveCSS("white-space", "pre")
   })
 })


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Previously, multiple spaces in a log message were collapsed by normal HTML whitespace rendering. This made log entries for cleared displays appear as if only one space had been sent, even when the actual log message contained multiple spaces.
The log panel now preserves consecutive spaces when rendering log messages, while keeping the existing truncation behavior for long log lines.

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
<img width="701" height="501" alt="Preseved_whitespace" src="https://github.com/user-attachments/assets/b574113c-dd77-4d88-aa21-51ad510b7eaa" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Consecutive spaces in log messages are preserved visually

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Frontend tests
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3195 

### Out-of-scope
<!-- mention what is not covered by this PR -->
This PR does not change how log messages are generated by the backend.
It also does not change the actual log data. The fix only affects how existing log messages are rendered in the frontend log panel.

### Notes
<!-- provide furhter information that might be of interest -->
The fix uses CSS whitespace handling instead of modifying the log message text itself. This avoids replacing spaces with special characters and keeps the original log message unchanged.