### PR TITLE
Enable Chromium tests by default in VSCode test explorer

### DIFF
--- a/src/MobiFlightConnector/frontend/playwright.config.ts
+++ b/src/MobiFlightConnector/frontend/playwright.config.ts
@@ -41,8 +41,6 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
-    // Setup project
-    { name: "setup", testMatch: /.*\.setup\.ts/ },
     {
       name: "chromium",
       use: {
@@ -51,6 +49,8 @@ export default defineConfig({
       },
       dependencies: ["setup"],
     },
+    // Setup project
+    { name: "setup", testMatch: /.*\.setup\.ts/ },
   ],
 
   /* Run your local dev server before starting the tests */
@@ -58,6 +58,6 @@ export default defineConfig({
     command: "npm run dev",
     url: "http://localhost:5173/",
     reuseExistingServer: !process.env.CI,
-    timeout: 20 * 1000
+    timeout: 20 * 1000,
   },
 })


### PR DESCRIPTION
### Summary
VSCode only enables the first project in a config by default. Our order was the setup stuff first, then the chromium project, so none of the chromium projects were enabled in the test explorer by default.

### Acceptance criteria
- [X] Chromium project is enabled on fresh devcontainer creation

### DoD Checklist
n/a
     
## Related issues
Fixes #3346

### Notes

The auth tests now show as disabled in the test explorer, but as best I can tell that has no impact on actually running the chromium tests.