### PR TITLE
docs(tests): document the correct frontend test credentials

### DIFF
--- a/src/MobiFlightConnector/frontend/tests/README.md
+++ b/src/MobiFlightConnector/frontend/tests/README.md
@@ -37,18 +37,23 @@ npx playwright install
 
 ## Environment Variables
 
-Create a `.env` file in the project root (see `.env.template` for required variables):
+Create a `.env` file in the frontend project root (`src/MobiFlightConnector/frontend/`, next to `.env.template`) with the credentials for the accounts the tests sign in with:
 
 ```
-TESTS_USER_EMAIL=your-test-email@example.com
-TESTS_USER_PASSWORD=your-password
-TESTS_USER_NAME=Your Name
+# Club member account
+TESTS_MEMBER_EMAIL=your-member-test-email@example.com
+TESTS_MEMBER_PASSWORD=your-member-password
+TESTS_MEMBER_NAME=Your Member Name
+
+# Basic account
+TESTS_BASIC_EMAIL=your-basic-test-email@example.com
+TESTS_BASIC_PASSWORD=your-basic-password
+TESTS_BASIC_NAME=Your Basic Name
 ```
 
 > [!NOTE] Never commit your real `.env` file to version control.
 
-Tests that require secrets will be **skipped** if the necessary environment variables are not set.
-
+Each account type is optional. If its variables are missing, the corresponding authentication setup and the tests that depend on it are **skipped**.
 ## CI and Secrets
 
 - In CI, secrets are injected as environment variables.


### PR DESCRIPTION
### Summary

The frontend test README listed `TESTS_USER_EMAIL` / `TESTS_USER_PASSWORD` / `TESTS_USER_NAME` as the variables to put in `.env`, but the tests never read those names. `tests/auth.setup.ts`, `tests/CommunityToolbar.spec.ts` and `tests/UserMenuItem.spec.ts` read `TESTS_MEMBER_*` and `TESTS_BASIC_*`, and both `.env.template` and `.github/workflows/playwright.yml` already use those names. Following the README left the variables unset, so the member/basic authentication setups were skipped silently and the authenticated tests never ran locally.

This updates the Environment Variables section to document the two account types with the variable names the code actually reads, and points at the correct `.env` location next to `.env.template`.

### Acceptance criteria

- [x] README documents the variable names read by `tests/auth.setup.ts`, `tests/CommunityToolbar.spec.ts` and `tests/UserMenuItem.spec.ts`
- [x] README no longer mentions `TESTS_USER_*`
- [x] Both the club member and the basic account credential sets are documented

### DoD Checklist

- [x] documentation
  - [x] User docs (docs.mobiflight.com) - not applicable
  - [x] Developer docs (e.g., readme.md)

## Related issues

fixes #3348

### Notes

Documentation-only change. Verified by extracting every `process.env.TESTS_*` usage from the three test files and diffing that set against the names documented in the README, against `.env.template`, and against the variable names injected in `.github/workflows/playwright.yml`. All four sets are now identical: `TESTS_MEMBER_EMAIL` / `TESTS_MEMBER_PASSWORD` / `TESTS_MEMBER_NAME` and `TESTS_BASIC_EMAIL` / `TESTS_BASIC_PASSWORD` / `TESTS_BASIC_NAME`.
