### PR TITLE
Ensure Execution Manager is initialized early

### DIFF
--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -528,19 +528,6 @@ namespace MobiFlight.UI
 
             // Initialize the custom device configurations
             CustomDevices.CustomDeviceDefinitions.LoadDefinitions();
-
-            if (Properties.Settings.Default.Started == 0)
-            {
-                OnFirstStart();
-            }
-
-            if (Properties.Settings.Default.Started > 0 && (Properties.Settings.Default.Started % 30 == 0))
-            {
-                OnRepeatedStart();
-            }
-
-            Properties.Settings.Default.Started = Properties.Settings.Default.Started + 1;
-
             cmdLineParams = new CmdLineParams(Environment.GetCommandLineArgs());
             InitializeExecutionManager();
 
@@ -565,6 +552,22 @@ namespace MobiFlight.UI
             Refresh();
 
             await PublishStartupState();
+            OnStartupCompleted();
+        }
+
+        private void OnStartupCompleted()
+        {
+            if (Properties.Settings.Default.Started == 0)
+            {
+                OnFirstStart();
+            }
+
+            if (Properties.Settings.Default.Started > 0 && (Properties.Settings.Default.Started % 30 == 0))
+            {
+                OnRepeatedStart();
+            }
+
+            Properties.Settings.Default.Started = Properties.Settings.Default.Started + 1;
         }
 
         /// <summary>One-time boot tail - only ever called once, from OnFrontendReady.</summary>
@@ -597,6 +600,10 @@ namespace MobiFlight.UI
         {
             PublishSettings();
             PublishProjectList();
+
+            // Following messages all depend on an existing execManager instance.
+            if (execManager == null) return;
+
             MessageExchange.Instance.Publish(execManager.Project);
             MessageExchange.Instance.Publish(new ProjectStatus { HasChanged = ProjectHasUnsavedChanges });
             UpdateExecutionState();
@@ -966,7 +973,7 @@ namespace MobiFlight.UI
         private void Form1_FormClosed(object sender, FormClosedEventArgs e)
         {
             AppTelemetry.Instance.TrackShutdown();
-            execManager.Shutdown();
+            execManager?.Shutdown();
             SaveWindowPositionAndZoomLevel();
             Properties.Settings.Default.Save();
             runningStateBadge?.Dispose();
@@ -2584,7 +2591,7 @@ namespace MobiFlight.UI
 
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            execManager.Stop();
+            execManager?.Stop();
             if (ProjectHasUnsavedChanges && MessageBox.Show(
                        i18n._tr("uiMessageConfirmDiscardUnsaved"),
                        i18n._tr("uiMessageConfirmDiscardUnsavedTitle"),

--- a/src/MobiFlightConnector/UI/MainForm.cs
+++ b/src/MobiFlightConnector/UI/MainForm.cs
@@ -587,6 +587,8 @@ namespace MobiFlight.UI
 
             PublishSettings();
             await InitializeRecentProjectsListAsync();
+
+            if (execManager == null) return;
             MessageExchange.Instance.Publish(execManager.Project);
         }
 
@@ -2591,7 +2593,11 @@ namespace MobiFlight.UI
 
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
-            execManager?.Stop();
+            // Closing the form before the execManager
+            // means there is nothing we could ever save, so we just return here.
+            if (execManager == null) return;
+
+            execManager.Stop();
             if (ProjectHasUnsavedChanges && MessageBox.Show(
                        i18n._tr("uiMessageConfirmDiscardUnsaved"),
                        i18n._tr("uiMessageConfirmDiscardUnsavedTitle"),


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
Execution Manager now is initialized early as soon as Frontend reports ready. The blocking UI dialogs on first start or repeated start (Welcome Dialog, Donation Dialog) are now pushed towards the end.

### Screenshots / recordings
n/a

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Moved blocking onFirstStart and onRepeatedStart Dialogs to the end of the startup logic
- [x] Access of Execution Manager in Shutdown uses explicit null check and exits early in case it is hasn't been initialized.

### DoD Checklist
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3356 

### Out-of-scope
Refactoring of app state notifications. This is currently all done by the MainForm monster.

### Notes
OnFirstStart and OnRepeatedStart should not block and UI elements should be native react frontend components and not blocking WinForm Dialogs.
