### PR TITLE
Disabled HID controller still listed in "Peripherals" 

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
@@ -240,19 +240,24 @@ namespace MobiFlight
                 }
 
                 // Check against exclusion list
-                if (settingsExcludedJoysticks.Contains(js.Name))
+                if (TryExcludeJoystick(js, settingsExcludedJoysticks))
                 {
-                    Log.Instance.log($"Ignore attached joystick device: {js.Name}.", LogSeverity.Info);
-                    ExcludedJoysticks.Add(js);
+                    continue;
                 }
-                else
+
+                if (!Joysticks.TryAdd(js.Serial, js))
                 {
-                    Log.Instance.log($"Adding attached joystick device: {d.InstanceName} Buttons: {js.Capabilities.ButtonCount} Axis: {js.Capabilities.AxeCount}.", LogSeverity.Info);
-                    js.Connect(Handle);
-                    Joysticks.TryAdd(js.Serial, js);
-                    js.OnButtonPressed += Js_OnButtonPressed;
-                    js.OnDisconnected += Js_OnDisconnected;
+                    Log.Instance.log(
+                        $"Error adding DirectInput controller: {d.InstanceName} / {js.Serial}. Likely Joystick Serial conflict.",
+                        LogSeverity.Error
+                    );
+                    continue;
                 }
+
+                Log.Instance.log($"Adding attached joystick device: {d.InstanceName} Buttons: {js.Capabilities.ButtonCount} Axis: {js.Capabilities.AxeCount}.", LogSeverity.Info);
+                js.Connect(Handle);
+                js.OnButtonPressed += Js_OnButtonPressed;
+                js.OnDisconnected += Js_OnDisconnected;
             }
 
             ConnectHidController();
@@ -281,6 +286,17 @@ namespace MobiFlight
         {
             return excludedJoysticks.Contains(joystickName);
         }
+
+        /// <summary>Adds the joystick to the exclusion list if the user excluded it. Returns true when excluded.</summary>
+        internal bool TryExcludeJoystick(Joystick joystick, List<string> settingsExcludedJoysticks)
+        {
+            if (!IsExcludedJoystick(joystick.Name, settingsExcludedJoysticks)) return false;
+
+            Log.Instance.log($"Ignore attached joystick device: {joystick.Name}.", LogSeverity.Info);
+            ExcludedJoysticks.Add(joystick);
+            return true;
+        }
+
         private void ConnectHidController()
         {
             try
@@ -306,13 +322,8 @@ namespace MobiFlight
 
                         if (joystick == null) return;
 
-                        if (IsExcludedJoystick(joystick.Name, settingsExcludedJoysticks))
+                        if (TryExcludeJoystick(joystick, settingsExcludedJoysticks))
                         {
-                            Log.Instance.log(
-                                $"Ignore attached joystick device: {joystick.Name}.",
-                                LogSeverity.Info
-                            );
-                            ExcludedJoysticks.Add(joystick);
                             return;
                         }
 
@@ -325,6 +336,7 @@ namespace MobiFlight
                             return;
                         }
 
+                        Log.Instance.log($"Adding attached HID controller: {definition.InstanceName}", LogSeverity.Info);
                         joystick.Connect(new IntPtr());
                         joystick.OnButtonPressed += Js_OnButtonPressed;
                         joystick.OnDisconnected += Js_OnDisconnected;

--- a/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/JoystickManager.cs
@@ -312,6 +312,7 @@ namespace MobiFlight
                                 $"Ignore attached joystick device: {joystick.Name}.",
                                 LogSeverity.Info
                             );
+                            ExcludedJoysticks.Add(joystick);
                             return;
                         }
 

--- a/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickManagerTests.cs
+++ b/tests/MobiFlightUnitTests/MobiFlight/Joysticks/JoystickManagerTests.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using MobiFlight;
+using MobiFlight.Joysticks;
 using System.Collections.Generic;
 
 namespace MobiFlightUnitTests.MobiFlight.Joysticks
@@ -7,6 +8,19 @@ namespace MobiFlightUnitTests.MobiFlight.Joysticks
     [TestClass()]
     public class JoystickManagerTests
     {
+        /// <summary>Stands in for a joystick without requiring a DirectInput device.</summary>
+        class NamedJoystick : Joystick
+        {
+            private readonly string name;
+
+            public NamedJoystick(string name) : base(null, new JoystickDefinition { InstanceName = name })
+            {
+                this.name = name;
+            }
+
+            public override string Name => name;
+        }
+
         [TestMethod()]
         public void IsExcludedJoystick_WhenJoystickIsExcluded_ReturnsTrue()
         {
@@ -51,6 +65,32 @@ namespace MobiFlightUnitTests.MobiFlight.Joysticks
             );
 
             Assert.IsFalse(result);
+        }
+
+        [TestMethod()]
+        public void TryExcludeJoystick_WhenJoystickIsExcluded_AddsItToExcludedJoysticks()
+        {
+            var manager = new JoystickManager();
+            var joystick = new NamedJoystick("EFIS Cube");
+            var settingsExcludedJoysticks = new List<string> { "EFIS Cube" };
+
+            var result = manager.TryExcludeJoystick(joystick, settingsExcludedJoysticks);
+
+            Assert.IsTrue(result);
+            CollectionAssert.Contains(manager.GetExcludedJoysticks(), joystick);
+        }
+
+        [TestMethod()]
+        public void TryExcludeJoystick_WhenJoystickIsNotExcluded_DoesNotAddIt()
+        {
+            var manager = new JoystickManager();
+            var joystick = new NamedJoystick("FCU Cube");
+            var settingsExcludedJoysticks = new List<string> { "EFIS Cube" };
+
+            var result = manager.TryExcludeJoystick(joystick, settingsExcludedJoysticks);
+
+            Assert.IsFalse(result);
+            CollectionAssert.DoesNotContain(manager.GetExcludedJoysticks(), joystick);
         }
     }
 }


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
HID controllers can now be enabled/disabled correctly in "Peripherals".

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] After disabling, the controller still shows in peripherals list.

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
- [x] Unit tests available
  - [x] .NET backend
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3362

### Notes
related to #3308