### PR TITLE
Feed images have better aspect ratio on small screens

### DIFF
--- a/src/MobiFlightConnector/frontend/src/components/community/CommunityFeedItem.tsx
+++ b/src/MobiFlightConnector/frontend/src/components/community/CommunityFeedItem.tsx
@@ -34,18 +34,17 @@ const CommunityFeedItem = (props: CommunityFeedItemProps) => {
       className={cn(
         "border-muted 4xl:flex-row flex flex-row justify-between gap-8 border-b xl:flex-col",
       )}
-
       data-testid="community-feed-item"
     >
       {post.media && post.media.type === "image" && (
         <div
           className={cn(
-            "bg-background flex max-h-48 min-h-48 w-full items-center justify-center overflow-hidden rounded-lg border shadow-md sm:w-1/2 md:w-1/3 xl:w-full",
+            "bg-background flex w-full items-center justify-center overflow-hidden rounded-lg border shadow-md sm:w-1/2 md:w-1/3 xl:w-full",
             post.media.className || "",
           )}
         >
           <img
-            className={`max-h-60 w-full object-cover`}
+            className={`h-auto w-full object-contain`}
             src={post.media.src}
             alt={post.media.alt}
           />


### PR DESCRIPTION
<!-- 
please use branch name following the convention: 
#GITHUB_ISSUE/[descriptive-branch-name]
-->
### Summary
<!-- Describes the solution and what problem it addresses solved -->
<!-- This is also for regular, non-technical users -->
Fixes feed images being cropped and appearing with the wrong aspect ratio on smaller screen sizes.
The fixed height constraints on the image container were removed and feed images now scale with their natural aspect ratio.

### Screenshots / recordings
<!-- Before/After For UI changes; delete this section if not applicable -->
Before
<img width="1123" height="711" alt="be" src="https://github.com/user-attachments/assets/97f3b855-b230-456c-b227-50b44926793f" />

After
<img width="1124" height="712" alt="af" src="https://github.com/user-attachments/assets/1fa9eb04-63e1-4930-8ba9-1d0f4317bfde" />

### Acceptance criteria
<!-- List specific testable items here, e.g. use cases, features -->
<!-- This also serves as checklist during development -->
- [x] Feed images preserve their original aspect ratio
- [x] Feed images are not cropped on small screens
- [x] Images resize correctly when the application window width changes

### DoD Checklist
<!-- ~~strike irrelevant items~~ -->
     
## Related issues
<!-- fixes, relates to existing #issues -->
fixes #3351 

### Out-of-scope
<!-- mention what is not covered by this PR -->
Changes to feed content, image sources, or the overall Community Feed layout.

### Notes
<!-- provide furhter information that might be of interest -->
Verified manually by resizing the Community Feed at different window widths and checking that the rendered image aspect ratio remains consistent with the original image.