### PR TITLE
Fix Switch Panel fallback serial classification

### DIFF
--- a/src/MobiFlightConnector/MobiFlight/Joysticks/Logitech/SwitchPanel.cs
+++ b/src/MobiFlightConnector/MobiFlight/Joysticks/Logitech/SwitchPanel.cs
@@ -28,7 +28,7 @@ namespace MobiFlight.Joysticks.Logitech
 
                 return !string.IsNullOrEmpty(CachedSerialNumber)
                     ? $"{SerialPrefix}{CachedSerialNumber}"
-                    : $"{Name.ToUpper().Replace(" ", "-")}-1234-ABCD-12345678";
+                    : $"{SerialPrefix}{Name.ToUpper().Replace(" ", "-")}-1234-ABCD-12345678";
             }
         }
 


### PR DESCRIPTION
### Summary

Ensures a Logitech/Saitek Switch Panel without a reported hardware serial number uses MobiFlight's standard `JS-` joystick prefix.

Without the prefix, MobiFlight classifies the panel as an Arcaze device when handling outputs. Testing or running a landing-gear LED output then attempts to parse its named output identifier as an Arcaze pin and raises a format exception, even when no flight simulator is running.

### Acceptance criteria

- [x] The Switch Panel fallback serial begins with `JS-`
- [x] Switch Panel outputs using the fallback serial are routed through the joystick output path
- [x] Existing focused controller tests pass

### DoD Checklist

- ~~[ ] Unit tests available~~
  - ~~[ ] .NET backend~~
  - ~~[ ] Frontend~~
- ~~[ ] Frontend tests~~
- ~~[ ] i18n - All user-facing strings are translated~~
  - ~~[ ] core (en,de,es)~~
  - ~~[ ] additional langs~~
- ~~[ ] documentation~~
  - ~~[ ] User docs (docs.mobiflight.com)~~
  - ~~[ ] Developer docs (e.g., readme.md)~~

## Related issues

Fixes #3372

### Out-of-scope

- Changes to Switch Panel HID input or output protocols
- Controller definitions or input/output mappings
- Profiles, simulator commands, or updater behavior

### Notes

The issue was reproduced with MobiFlight 11.2.0.6 and the simulator not running. The focused joystick/controller suite passes all 43 existing tests.
